### PR TITLE
feat(team): add 'ox team members' team roster command

### DIFF
--- a/cmd/ox/team.go
+++ b/cmd/ox/team.go
@@ -134,15 +134,20 @@ func runTeamMembers(cmd *cobra.Command, args []string) error {
 func fetchAndRenderRoster(ctx context.Context, w io.Writer, lister memberLister, teamRef, label string, jsonMode bool) error {
 	resp, err := lister.ListTeamRoster(ctx, teamRef)
 	if err != nil {
-		if errors.Is(err, api.ErrTeamRosterUnsupported) {
-			// 404: feature flag off, route not deployed, or team not found —
-			// degrade gracefully, exit 0. The message names both plausible
-			// causes rather than asserting an undeployed flag is the only one.
+		// Degrade gracefully (exit 0) when the roster can't be served: either the
+		// feature/route doesn't exist (404) or the server is down/unreachable
+		// (transport failure or 5xx). The roster is informational — a missing
+		// feature or a reachability blip shouldn't be a hard failure. Auth,
+		// forbidden, and version errors still surface: those need user action.
+		if errors.Is(err, api.ErrTeamRosterUnsupported) || errors.Is(err, api.ErrTeamRosterUnavailable) {
 			if jsonMode {
 				return writeRosterJSON(w, nil, false)
 			}
-			fmt.Fprintf(w, "%s Team roster is unavailable (feature not enabled on this server, or team not found).\n",
-				cli.Styles.Info.Render("ℹ"))
+			msg := "Team roster is unavailable (feature not enabled on this server, or team not found)."
+			if errors.Is(err, api.ErrTeamRosterUnavailable) {
+				msg = "Team roster is unavailable right now — couldn't reach the server."
+			}
+			fmt.Fprintf(w, "%s %s\n", cli.Styles.Info.Render("ℹ"), msg)
 			return nil
 		}
 		// ErrUnauthorized / ErrForbidden / ErrVersionUnsupported / other → real error

--- a/cmd/ox/team.go
+++ b/cmd/ox/team.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/auth"
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/spf13/cobra"
+)
+
+// memberLister is the seam `ox team members` fetches through, so the
+// fetch-and-render core is unit-testable against a fake without a network.
+// *api.RepoClient satisfies it.
+type memberLister interface {
+	ListTeamRoster(ctx context.Context, teamRef string) (*api.TeamRosterResponse, error)
+}
+
+// teamCmd is the singular `ox team` group. `ox teams` (plural) already lists the
+// teams you belong to; `ox team <subcommand>` inspects one team.
+var teamCmd = &cobra.Command{
+	Use:   "team",
+	Short: "Inspect your team",
+	Long: `Inspect your team.
+
+Commands:
+  members   List the team's coworkers (humans and AI coworkers)`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
+
+var teamMembersCmd = &cobra.Command{
+	Use:   "members",
+	Short: "List the team's coworkers (humans and AI coworkers)",
+	Long: `List the coworkers on your team — humans and AI coworkers alike.
+
+Shows each coworker's display name, type, role, and the handles they're known
+by (e.g. a GitHub login). The roster answers "who is this?" and renders the
+identity fields the server exposes.
+
+The roster is feature-flag gated on the server. When the flag is off (or the
+server is older), the command reports that the capability is unavailable rather
+than failing.
+
+Example:
+  ox team members
+  ox team members --team acme
+  ox team members --json`,
+	RunE: runTeamMembers,
+}
+
+func init() {
+	teamMembersCmd.Flags().String("team", "", "Team ID or slug to use (defaults to this repo's team)")
+	teamMembersCmd.Flags().Bool("json", false, "Output as JSON")
+
+	teamCmd.AddCommand(teamMembersCmd)
+	teamCmd.GroupID = "teams"
+	rootCmd.AddCommand(teamCmd)
+}
+
+// resolveTeamRef returns the team ref to query and a human display label.
+// --team wins (resolved locally, else passed through for the server to resolve
+// as a slug); otherwise the repo's configured team is used.
+func resolveTeamRef(cmd *cobra.Command, projectRoot string) (ref, label string, err error) {
+	teamFlag, _ := cmd.Flags().GetString("team")
+	if teamFlag != "" {
+		if t := resolveTeamByQuery(projectRoot, teamFlag); t != nil {
+			tc := t.toConfigTeamContext()
+			return tc.TeamID, teamLabelFor(tc), nil
+		}
+		// not found locally — let the server resolve the slug/id
+		return teamFlag, teamFlag, nil
+	}
+	tc := config.FindRepoTeamContext(projectRoot)
+	if tc == nil {
+		return "", "", fmt.Errorf("no team configured; run 'ox init' or pass --team")
+	}
+	return tc.TeamID, teamLabelFor(tc), nil
+}
+
+func teamLabelFor(tc *config.TeamContext) string {
+	switch {
+	case tc.TeamName != "":
+		return tc.TeamName
+	case tc.Slug != "":
+		return tc.Slug
+	default:
+		return tc.TeamID
+	}
+}
+
+func runTeamMembers(cmd *cobra.Command, args []string) error {
+	jsonMode, _ := cmd.Flags().GetBool("json")
+
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return fmt.Errorf("could not find project root: %w", err)
+	}
+	ep := endpoint.GetForProject(projectRoot)
+
+	teamRef, label, err := resolveTeamRef(cmd, projectRoot)
+	if err != nil {
+		return err
+	}
+
+	// The roster is a team-scoped read: require a valid token up front and fail
+	// fast with a friendly hint, matching `ox query` / `ox invite`.
+	// EnsureValidTokenForEndpoint also proactively refreshes a near-expired token
+	// (GetTokenForEndpoint would have sent it stale and eaten a 401).
+	token, err := auth.EnsureValidTokenForEndpoint(ep, 300)
+	if err != nil || token == nil || token.AccessToken == "" {
+		return fmt.Errorf("not authenticated — run 'ox login' first")
+	}
+	client := api.NewRepoClientForProject(projectRoot).WithAuthToken(token.AccessToken)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	return fetchAndRenderRoster(ctx, cmd.OutOrStdout(), client, teamRef, label, jsonMode)
+}
+
+// fetchAndRenderRoster is the testable core: it fetches the roster and renders
+// it, degrading gracefully (exit 0) when the server reports the feature is
+// unavailable. Auth / forbidden / version errors are surfaced as real errors.
+func fetchAndRenderRoster(ctx context.Context, w io.Writer, lister memberLister, teamRef, label string, jsonMode bool) error {
+	resp, err := lister.ListTeamRoster(ctx, teamRef)
+	if err != nil {
+		if errors.Is(err, api.ErrTeamRosterUnsupported) {
+			// 404: feature flag off, route not deployed, or team not found —
+			// degrade gracefully, exit 0. The message names both plausible
+			// causes rather than asserting an undeployed flag is the only one.
+			if jsonMode {
+				return writeRosterJSON(w, nil, false)
+			}
+			fmt.Fprintf(w, "%s Team roster is unavailable (feature not enabled on this server, or team not found).\n",
+				cli.Styles.Info.Render("ℹ"))
+			return nil
+		}
+		// ErrUnauthorized / ErrForbidden / ErrVersionUnsupported / other → real error
+		return err
+	}
+
+	if jsonMode {
+		return writeRosterJSON(w, resp, true)
+	}
+
+	renderRosterTable(w, resp, label)
+	return nil
+}
+
+// writeRosterJSON emits ONE stable envelope for both success and graceful
+// degrade so a JSON consumer (often an AI coworker) can rely on the shape:
+// `members` is always an array (never null) and `available` is always present.
+func writeRosterJSON(w io.Writer, resp *api.TeamRosterResponse, available bool) error {
+	env := struct {
+		TeamID    string           `json:"team_id"`
+		Members   []api.TeamMember `json:"members"`
+		Total     int              `json:"total"`
+		Available bool             `json:"available"`
+	}{Members: []api.TeamMember{}, Available: available}
+	if resp != nil {
+		env.TeamID = resp.TeamID
+		env.Total = resp.Total
+		if resp.Members != nil {
+			env.Members = resp.Members
+		}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(env)
+}
+
+func renderRosterTable(w io.Writer, resp *api.TeamRosterResponse, label string) {
+	label = cli.SanitizeTerminalText(label)
+	if resp == nil || len(resp.Members) == 0 {
+		fmt.Fprintf(w, "%s No coworkers found in %s.\n", cli.Styles.Info.Render("ℹ"), label)
+		return
+	}
+
+	header := fmt.Sprintf("Team Coworkers (%s)", label)
+	fmt.Fprintln(w, cli.StyleGroupHeader.Render(header))
+	fmt.Fprintln(w, cli.StyleDim.Render(strings.Repeat("─", len(header))))
+
+	// aligned columns: name, type, role. Aliases (variable length) trail the row.
+	rows := make([][]string, 0, len(resp.Members))
+	aliases := make([]string, 0, len(resp.Members))
+	for _, m := range resp.Members {
+		// Every field is untrusted server text: sanitize each before render so
+		// no column (m.Type was the gap) can carry ANSI/control bytes to the TTY.
+		name := cli.SanitizeTerminalText(m.Name)
+		if name == "" {
+			name = cli.SanitizeTerminalText(m.PrincipalID)
+		}
+		typ := cli.SanitizeTerminalText(m.Type)
+		if typ == "" {
+			typ = "human"
+		}
+		rows = append(rows, []string{name, typ, cli.SanitizeTerminalText(m.Role)})
+		aliases = append(aliases, cli.SanitizeTerminalText(strings.Join(m.Aliases, ", ")))
+	}
+	widths := cli.ColumnWidths(rows, []int{16, 5, 6}, []int{32, 6, 10})
+
+	for i, row := range rows {
+		name := fmt.Sprintf("%-*s", widths[0], row[0])
+		typ := fmt.Sprintf("%-*s", widths[1], row[1])
+		role := fmt.Sprintf("%-*s", widths[2], row[2])
+		line := fmt.Sprintf("  %s  %s  %s",
+			cli.StyleCalloutBold.Render(name),
+			cli.StyleDim.Render(typ),
+			cli.StyleDim.Render(role))
+		if aliases[i] != "" {
+			line += "  " + cli.StyleDim.Render(aliases[i])
+		}
+		fmt.Fprintln(w, line)
+	}
+}

--- a/cmd/ox/team_test.go
+++ b/cmd/ox/team_test.go
@@ -127,6 +127,25 @@ func TestFetchAndRenderRoster_UnsupportedDegrades(t *testing.T) {
 	assert.Equal(t, false, env["available"])
 }
 
+// TestFetchAndRenderRoster_UnavailableDegrades — a down/unreachable server (or a
+// 5xx) degrades gracefully (no error, exit 0) with a "couldn't reach the server"
+// message, and JSON mode reports available:false — not a hard crash.
+func TestFetchAndRenderRoster_UnavailableDegrades(t *testing.T) {
+	lister := fakeMemberLister{err: api.ErrTeamRosterUnavailable}
+
+	var buf bytes.Buffer
+	err := fetchAndRenderRoster(context.Background(), &buf, lister, "team_abc", "Acme", false)
+	require.NoError(t, err, "an unreachable server must degrade gracefully, not error")
+	assert.Contains(t, strings.ToLower(buf.String()), "couldn't reach")
+
+	var jbuf bytes.Buffer
+	err = fetchAndRenderRoster(context.Background(), &jbuf, lister, "team_abc", "Acme", true)
+	require.NoError(t, err)
+	var env map[string]any
+	require.NoError(t, json.Unmarshal(jbuf.Bytes(), &env))
+	assert.Equal(t, false, env["available"])
+}
+
 // TestFetchAndRenderRoster_AuthErrorSurfaces — a 401 is a real error the caller
 // must see (to prompt `ox login`), not a graceful degrade.
 func TestFetchAndRenderRoster_AuthErrorSurfaces(t *testing.T) {

--- a/cmd/ox/team_test.go
+++ b/cmd/ox/team_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMemberLister drives fetchAndRenderRoster without a network.
+type fakeMemberLister struct {
+	resp *api.TeamRosterResponse
+	err  error
+}
+
+func (f fakeMemberLister) ListTeamRoster(_ context.Context, _ string) (*api.TeamRosterResponse, error) {
+	return f.resp, f.err
+}
+
+// rosterEnvelope mirrors the stable --json shape writeRosterJSON emits.
+type rosterEnvelope struct {
+	TeamID    string           `json:"team_id"`
+	Members   []api.TeamMember `json:"members"`
+	Total     int              `json:"total"`
+	Available bool             `json:"available"`
+}
+
+// TestFetchAndRenderRoster_JSONContract — the --json envelope carries the
+// canonical roster fields and available:true on success.
+func TestFetchAndRenderRoster_JSONContract(t *testing.T) {
+	lister := fakeMemberLister{resp: &api.TeamRosterResponse{
+		TeamID: "team_abc",
+		Total:  2,
+		Members: []api.TeamMember{
+			{PrincipalID: "usr_ryan", Name: "Ryan Snodgrass", Type: "human", Role: "owner", Aliases: []string{"rsnodgrass"}},
+			{PrincipalID: "agt_rip", Name: "Rip", Type: "ai", Role: "member"},
+		},
+	}}
+
+	var buf bytes.Buffer
+	err := fetchAndRenderRoster(context.Background(), &buf, lister, "team_abc", "Acme", true)
+	require.NoError(t, err)
+
+	var got rosterEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "team_abc", got.TeamID)
+	require.Len(t, got.Members, 2)
+	assert.Equal(t, "ai", got.Members[1].Type)
+	assert.True(t, got.Available, "success envelope must carry available:true")
+}
+
+// TestFetchAndRenderRoster_JSONEnvelopeStable — Failure prevented: a JSON
+// consumer (often an AI coworker) can't rely on a single shape because success
+// emits `members:null` / omits `available` while degrade emits `members:[]`.
+// Both paths must carry the same keys: members is always an array, available is
+// always present.
+func TestFetchAndRenderRoster_JSONEnvelopeStable(t *testing.T) {
+	// success with a nil members slice must still marshal members as [].
+	ok := fakeMemberLister{resp: &api.TeamRosterResponse{TeamID: "team_abc", Total: 0}}
+	var okBuf bytes.Buffer
+	require.NoError(t, fetchAndRenderRoster(context.Background(), &okBuf, ok, "team_abc", "Acme", true))
+	assert.Contains(t, okBuf.String(), `"members": []`, "nil members must marshal to [], never null")
+	assert.Contains(t, okBuf.String(), `"available": true`)
+
+	// graceful degrade carries the identical keys.
+	deg := fakeMemberLister{err: api.ErrTeamRosterUnsupported}
+	var degBuf bytes.Buffer
+	require.NoError(t, fetchAndRenderRoster(context.Background(), &degBuf, deg, "team_abc", "Acme", true))
+	assert.Contains(t, degBuf.String(), `"members": []`)
+	assert.Contains(t, degBuf.String(), `"available": false`)
+}
+
+// TestFetchAndRenderRoster_SanitizesControlChars — Failure prevented: untrusted
+// server text in a member column (here `type`, the field that was rendered raw)
+// reaches the TTY as an ANSI/control sequence and can repaint or forge a row.
+func TestFetchAndRenderRoster_SanitizesControlChars(t *testing.T) {
+	lister := fakeMemberLister{resp: &api.TeamRosterResponse{
+		TeamID:  "team_abc",
+		Total:   1,
+		Members: []api.TeamMember{{PrincipalID: "usr_x", Name: "Person A", Type: "\x1b[2Kspoof"}},
+	}}
+	var buf bytes.Buffer
+	require.NoError(t, fetchAndRenderRoster(context.Background(), &buf, lister, "team_abc", "Acme", false))
+	assert.NotContains(t, buf.String(), "\x1b[2K", "injected control sequence in type must be stripped")
+	assert.Contains(t, buf.String(), "spoof", "printable remainder of the field survives")
+}
+
+// TestFetchAndRenderRoster_TextRendersNamesAndType — the human-readable table
+// shows display names and human/ai type.
+func TestFetchAndRenderRoster_TextRendersNamesAndType(t *testing.T) {
+	lister := fakeMemberLister{resp: &api.TeamRosterResponse{
+		TeamID:  "team_abc",
+		Total:   2,
+		Members: []api.TeamMember{{PrincipalID: "usr_ryan", Name: "Ryan Snodgrass", Type: "human"}, {PrincipalID: "agt_rip", Name: "Rip", Type: "ai"}},
+	}}
+
+	var buf bytes.Buffer
+	err := fetchAndRenderRoster(context.Background(), &buf, lister, "team_abc", "Acme", false)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "Ryan Snodgrass")
+	assert.Contains(t, out, "Rip")
+	assert.Contains(t, out, "ai")
+}
+
+// TestFetchAndRenderRoster_UnsupportedDegrades — a flag-off / not-deployed 404
+// degrades gracefully (no error, exit 0), never surfacing as a command failure.
+func TestFetchAndRenderRoster_UnsupportedDegrades(t *testing.T) {
+	lister := fakeMemberLister{err: api.ErrTeamRosterUnsupported}
+
+	var buf bytes.Buffer
+	err := fetchAndRenderRoster(context.Background(), &buf, lister, "team_abc", "Acme", false)
+	require.NoError(t, err, "unsupported roster must degrade gracefully, not error")
+	assert.Contains(t, strings.ToLower(buf.String()), "available")
+
+	// JSON mode reports available:false rather than erroring.
+	var jbuf bytes.Buffer
+	err = fetchAndRenderRoster(context.Background(), &jbuf, lister, "team_abc", "Acme", true)
+	require.NoError(t, err)
+	var env map[string]any
+	require.NoError(t, json.Unmarshal(jbuf.Bytes(), &env))
+	assert.Equal(t, false, env["available"])
+}
+
+// TestFetchAndRenderRoster_AuthErrorSurfaces — a 401 is a real error the caller
+// must see (to prompt `ox login`), not a graceful degrade.
+func TestFetchAndRenderRoster_AuthErrorSurfaces(t *testing.T) {
+	lister := fakeMemberLister{err: api.ErrUnauthorized}
+
+	var buf bytes.Buffer
+	err := fetchAndRenderRoster(context.Background(), &buf, lister, "team_abc", "Acme", false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}

--- a/internal/api/team_members.go
+++ b/internal/api/team_members.go
@@ -82,6 +82,13 @@ func (c *RepoClient) ListTeamRoster(ctx context.Context, teamRef string) (*TeamR
 	if teamRef == "" {
 		return nil, fmt.Errorf("team is required")
 	}
+	// Reject dot-segments and separators up front. url.PathEscape leaves "." and
+	// ".." unchanged, so a normalizing proxy could rewrite /teams/./roster or
+	// /teams/../roster before routing and the resulting 404 would masquerade as
+	// "roster unavailable". A real team id/slug never contains these.
+	if teamRef == "." || teamRef == ".." || strings.ContainsAny(teamRef, "/\\") {
+		return nil, fmt.Errorf("invalid team reference %q", teamRef)
+	}
 
 	reqURL := strings.TrimSuffix(c.baseURL, "/") + fmt.Sprintf(teamRosterPath, url.PathEscape(teamRef))
 
@@ -103,7 +110,7 @@ func (c *RepoClient) ListTeamRoster(ctx context.Context, teamRef string) (*TeamR
 		// refused, or timeout. Map to the graceful "unavailable" sentinel so the
 		// command degrades instead of erroring hard on a reachability blip.
 		logger.LogHTTPError("GET", reqURL, err, duration)
-		return nil, fmt.Errorf("%w: %v", ErrTeamRosterUnavailable, err)
+		return nil, fmt.Errorf("%w: %w", ErrTeamRosterUnavailable, err)
 	}
 	defer resp.Body.Close()
 
@@ -113,39 +120,41 @@ func (c *RepoClient) ListTeamRoster(ctx context.Context, teamRef string) (*TeamR
 		return nil, ErrVersionUnsupported
 	}
 
-	// Cap the read: a roster is a few KB. Read one byte past the cap so we can
-	// DETECT (not silently truncate) an oversized body — io.LimitReader alone
-	// returns EOF at the limit, indistinguishable from a body that just fit, so
-	// truncation would surface as a confusing JSON decode error. Rejecting keeps
-	// a malicious or MITM'd server from OOMing the CLI (the 30s timeout bounds
-	// time, not memory).
+	// Classify status BEFORE reading the body, so a hostile or huge error body
+	// can't turn a degradable failure (e.g. a 5xx) into an "oversize" error.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		switch {
+		case resp.StatusCode == http.StatusNotFound:
+			return nil, ErrTeamRosterUnsupported
+		case resp.StatusCode == http.StatusUnauthorized:
+			return nil, ErrUnauthorized
+		case resp.StatusCode == http.StatusForbidden:
+			return nil, ErrForbidden
+		case resp.StatusCode >= 500:
+			// Server is up but failing — a reachability/availability problem;
+			// degrade gracefully rather than erroring hard.
+			return nil, fmt.Errorf("%w: server returned %d", ErrTeamRosterUnavailable, resp.StatusCode)
+		}
+		// Other 4xx: read a capped body for a diagnostic message.
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxRosterBodyBytes))
+		errMsg := strings.TrimSpace(string(errBody))
+		if errMsg == "" {
+			errMsg = resp.Status
+		}
+		return nil, fmt.Errorf("team roster fetch failed: status=%d body=%s", resp.StatusCode, errMsg)
+	}
+
+	// Success: read one byte past the cap so an oversized body is DETECTED, not
+	// silently truncated — io.LimitReader returns EOF at the limit,
+	// indistinguishable from a body that just fit, so truncation would surface as
+	// a confusing JSON decode error. This keeps a malicious or MITM'd server from
+	// OOMing the CLI (the 30s timeout bounds time, not memory).
 	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxRosterBodyBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 	if int64(len(bodyBytes)) > maxRosterBodyBytes {
 		return nil, fmt.Errorf("roster response too large (exceeds %d bytes)", maxRosterBodyBytes)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		switch resp.StatusCode {
-		case http.StatusNotFound:
-			return nil, ErrTeamRosterUnsupported
-		case http.StatusUnauthorized:
-			return nil, ErrUnauthorized
-		case http.StatusForbidden:
-			return nil, ErrForbidden
-		}
-		if resp.StatusCode >= 500 {
-			// Server is up but failing — treat as a reachability/availability
-			// problem and degrade gracefully rather than erroring hard.
-			return nil, fmt.Errorf("%w: server returned %d", ErrTeamRosterUnavailable, resp.StatusCode)
-		}
-		errMsg := strings.TrimSpace(string(bodyBytes))
-		if errMsg == "" {
-			errMsg = resp.Status
-		}
-		return nil, fmt.Errorf("team roster fetch failed: status=%d body=%s", resp.StatusCode, errMsg)
 	}
 
 	var out TeamRosterResponse

--- a/internal/api/team_members.go
+++ b/internal/api/team_members.go
@@ -38,6 +38,13 @@ const maxRosterBodyBytes = 4 << 20
 // capability as unavailable and exit 0 rather than treating it as a failure.
 var ErrTeamRosterUnsupported = errors.New("team roster endpoint not available (feature not enabled, or server too old)")
 
+// ErrTeamRosterUnavailable is the sentinel for a server that is down or
+// unreachable: a transport failure (DNS/refused/timeout) or a 5xx. Distinct from
+// ErrTeamRosterUnsupported (the route doesn't exist) — this means the route may
+// exist but the server can't answer right now. Callers degrade gracefully: the
+// roster is informational, so a blip shouldn't be a hard failure.
+var ErrTeamRosterUnavailable = errors.New("team roster temporarily unavailable (could not reach the server)")
+
 // TeamMember is one coworker in a team roster — a human (usr_) or an AI coworker
 // (agt_). Its fields are the identity attributes the server exposes for a
 // roster: display name, type, role, and the handles the coworker is known by.
@@ -67,8 +74,10 @@ type TeamRosterResponse struct {
 //
 // teamRef is a team id or slug (the server resolves both). Returns
 // ErrTeamRosterUnsupported on 404 (flag off / not deployed — caller degrades),
-// ErrUnauthorized on 401, ErrForbidden on 403, and ErrVersionUnsupported when
-// the server rejects the CLI version.
+// ErrTeamRosterUnavailable on a transport failure or 5xx (server down/unreachable
+// — caller degrades), ErrUnauthorized on 401, ErrForbidden on 403, and
+// ErrVersionUnsupported when the server rejects the CLI version. An oversized
+// body (> maxRosterBodyBytes) is rejected with a plain error.
 func (c *RepoClient) ListTeamRoster(ctx context.Context, teamRef string) (*TeamRosterResponse, error) {
 	if teamRef == "" {
 		return nil, fmt.Errorf("team is required")
@@ -90,8 +99,11 @@ func (c *RepoClient) ListTeamRoster(ctx context.Context, teamRef string) (*TeamR
 	resp, err := c.httpClient.Do(httpReq)
 	duration := time.Since(start)
 	if err != nil {
+		// Transport failure — server down, DNS/host doesn't resolve, connection
+		// refused, or timeout. Map to the graceful "unavailable" sentinel so the
+		// command degrades instead of erroring hard on a reachability blip.
 		logger.LogHTTPError("GET", reqURL, err, duration)
-		return nil, fmt.Errorf("network error: %w", err)
+		return nil, fmt.Errorf("%w: %v", ErrTeamRosterUnavailable, err)
 	}
 	defer resp.Body.Close()
 
@@ -101,12 +113,18 @@ func (c *RepoClient) ListTeamRoster(ctx context.Context, teamRef string) (*TeamR
 		return nil, ErrVersionUnsupported
 	}
 
-	// Cap the read: a roster is a few KB. LimitReader keeps a malicious or
-	// MITM'd server from OOMing the CLI with an unbounded body (the 30s timeout
-	// bounds time, not memory). Matches repo.go's capped-read precedent.
-	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxRosterBodyBytes))
+	// Cap the read: a roster is a few KB. Read one byte past the cap so we can
+	// DETECT (not silently truncate) an oversized body — io.LimitReader alone
+	// returns EOF at the limit, indistinguishable from a body that just fit, so
+	// truncation would surface as a confusing JSON decode error. Rejecting keeps
+	// a malicious or MITM'd server from OOMing the CLI (the 30s timeout bounds
+	// time, not memory).
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxRosterBodyBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if int64(len(bodyBytes)) > maxRosterBodyBytes {
+		return nil, fmt.Errorf("roster response too large (exceeds %d bytes)", maxRosterBodyBytes)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -117,6 +135,11 @@ func (c *RepoClient) ListTeamRoster(ctx context.Context, teamRef string) (*TeamR
 			return nil, ErrUnauthorized
 		case http.StatusForbidden:
 			return nil, ErrForbidden
+		}
+		if resp.StatusCode >= 500 {
+			// Server is up but failing — treat as a reachability/availability
+			// problem and degrade gracefully rather than erroring hard.
+			return nil, fmt.Errorf("%w: server returned %d", ErrTeamRosterUnavailable, resp.StatusCode)
 		}
 		errMsg := strings.TrimSpace(string(bodyBytes))
 		if errMsg == "" {

--- a/internal/api/team_members.go
+++ b/internal/api/team_members.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/logger"
+	"github.com/sageox/ox/internal/useragent"
+)
+
+// teamRosterPath is the cloud endpoint that returns a team's coworker roster —
+// the identity fields the server exposes for resolving who a teammate is (human
+// or AI coworker).
+//
+// Contract: GET /api/v1/teams/{team_ref}/roster returns a JSON
+// TeamRosterResponse. team_ref may be a team id or slug; the server resolves
+// both. The server owns which identity fields the roster carries; the client
+// renders whatever it is given.
+//
+// The endpoint is feature-flag gated on the server. A 404 means the flag is off
+// or the route is not deployed yet — callers degrade gracefully rather than
+// erroring, mirroring GetTeamContextContent.
+const teamRosterPath = "/api/v1/teams/%s/roster" // %s = team id or slug
+
+// maxRosterBodyBytes caps the roster response read. A roster is a few KB; 4 MiB
+// is generous headroom while still refusing an unbounded body.
+const maxRosterBodyBytes = 4 << 20
+
+// ErrTeamRosterUnsupported is the sentinel returned on 404: the roster endpoint
+// is not available (feature flag off, or an older server). Callers report the
+// capability as unavailable and exit 0 rather than treating it as a failure.
+var ErrTeamRosterUnsupported = errors.New("team roster endpoint not available (feature not enabled, or server too old)")
+
+// TeamMember is one coworker in a team roster — a human (usr_) or an AI coworker
+// (agt_). Its fields are the identity attributes the server exposes for a
+// roster: display name, type, role, and the handles the coworker is known by.
+// The set of fields is the server's to decide; unknown fields decode away.
+type TeamMember struct {
+	// PrincipalID is the canonical coworker id: usr_ (human) or agt_ (AI).
+	PrincipalID string `json:"principal_id"`
+	// Name is the coworker's display name.
+	Name string `json:"name"`
+	// Type is "human" or "ai".
+	Type string `json:"type"`
+	// Role is the team role (e.g. owner, member), when present.
+	Role string `json:"role,omitempty"`
+	// Aliases are handles the coworker is known by (a GitHub login, short
+	// names), so a surface form like "port8080" resolves to a name.
+	Aliases []string `json:"aliases,omitempty"`
+}
+
+// TeamRosterResponse is the JSON payload from GET /api/v1/teams/{ref}/roster.
+type TeamRosterResponse struct {
+	TeamID  string       `json:"team_id"`
+	Members []TeamMember `json:"members"`
+	Total   int          `json:"total"`
+}
+
+// ListTeamRoster fetches the minimal-tier coworker roster for a team.
+//
+// teamRef is a team id or slug (the server resolves both). Returns
+// ErrTeamRosterUnsupported on 404 (flag off / not deployed — caller degrades),
+// ErrUnauthorized on 401, ErrForbidden on 403, and ErrVersionUnsupported when
+// the server rejects the CLI version.
+func (c *RepoClient) ListTeamRoster(ctx context.Context, teamRef string) (*TeamRosterResponse, error) {
+	if teamRef == "" {
+		return nil, fmt.Errorf("team is required")
+	}
+
+	reqURL := strings.TrimSuffix(c.baseURL, "/") + fmt.Sprintf(teamRosterPath, url.PathEscape(teamRef))
+
+	logger.LogHTTPRequest("GET", reqURL)
+	start := time.Now()
+
+	httpReq, err := useragent.NewRequest(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if c.authToken != "" {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	duration := time.Since(start)
+	if err != nil {
+		logger.LogHTTPError("GET", reqURL, err, duration)
+		return nil, fmt.Errorf("network error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	logger.LogHTTPResponse("GET", reqURL, resp.StatusCode, duration)
+
+	if CheckVersionResponse(resp) {
+		return nil, ErrVersionUnsupported
+	}
+
+	// Cap the read: a roster is a few KB. LimitReader keeps a malicious or
+	// MITM'd server from OOMing the CLI with an unbounded body (the 30s timeout
+	// bounds time, not memory). Matches repo.go's capped-read precedent.
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxRosterBodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		switch resp.StatusCode {
+		case http.StatusNotFound:
+			return nil, ErrTeamRosterUnsupported
+		case http.StatusUnauthorized:
+			return nil, ErrUnauthorized
+		case http.StatusForbidden:
+			return nil, ErrForbidden
+		}
+		errMsg := strings.TrimSpace(string(bodyBytes))
+		if errMsg == "" {
+			errMsg = resp.Status
+		}
+		return nil, fmt.Errorf("team roster fetch failed: status=%d body=%s", resp.StatusCode, errMsg)
+	}
+
+	var out TeamRosterResponse
+	if err := json.Unmarshal(bodyBytes, &out); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &out, nil
+}

--- a/internal/api/team_members_test.go
+++ b/internal/api/team_members_test.go
@@ -124,9 +124,9 @@ func TestListTeamRoster_MalformedJSON(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
-// TestListTeamRoster_ServerError — Failure prevented: a 5xx is silently treated
-// as the graceful ErrTeamRosterUnsupported sentinel and reported as "feature
-// unavailable, exit 0" instead of a real error.
+// TestListTeamRoster_ServerError — Failure prevented: a 5xx (server up but
+// failing) is reported as a hard error or as the "route doesn't exist" sentinel,
+// instead of the graceful "server unreachable" tier the command degrades on.
 func TestListTeamRoster_ServerError(t *testing.T) {
 	t.Parallel()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -144,7 +144,50 @@ func TestListTeamRoster_ServerError(t *testing.T) {
 	resp, err := client.ListTeamRoster(context.Background(), "team_abc")
 	require.Error(t, err)
 	assert.Nil(t, resp)
-	assert.False(t, errors.Is(err, ErrTeamRosterUnsupported), "5xx must not be swallowed as unsupported")
+	assert.True(t, errors.Is(err, ErrTeamRosterUnavailable), "5xx must map to the graceful unavailable sentinel, got %v", err)
+	assert.False(t, errors.Is(err, ErrTeamRosterUnsupported), "5xx is not the same as a missing route")
+}
+
+// TestListTeamRoster_ServerDown — Failure prevented: a server that is down /
+// unreachable (connection refused, DNS failure, timeout) surfaces as a raw
+// "network error" hard failure instead of the graceful unavailable sentinel.
+func TestListTeamRoster_ServerDown(t *testing.T) {
+	t.Parallel()
+	client := &RepoClient{
+		baseURL:    "http://127.0.0.1:1", // nothing listening → connection refused
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+	resp, err := client.ListTeamRoster(context.Background(), "team_abc")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.True(t, errors.Is(err, ErrTeamRosterUnavailable), "an unreachable server must map to the graceful unavailable sentinel, got %v", err)
+}
+
+// TestListTeamRoster_OversizedBody — Failure prevented: a body larger than the
+// cap is silently truncated by io.LimitReader and then fails to decode with a
+// confusing JSON error, instead of being rejected explicitly as too large.
+func TestListTeamRoster_OversizedBody(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// One byte over the cap is enough to trip detection.
+		_, _ = w.Write(make([]byte, maxRosterBodyBytes+1))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+	resp, err := client.ListTeamRoster(context.Background(), "team_abc")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "too large", "oversized body must be rejected explicitly")
+	assert.False(t, errors.Is(err, ErrTeamRosterUnavailable), "oversized is a misbehaving server, not an unreachable one")
 }
 
 // TestListTeamRoster_EmptyRef — Failure prevented: an empty team ref silently

--- a/internal/api/team_members_test.go
+++ b/internal/api/team_members_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListTeamRoster_Success — Failure prevented: a well-formed roster response
+// fails to decode, so `ox team members` shows nothing even when the server
+// answered correctly.
+func TestListTeamRoster_Success(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/api/v1/teams/team_abc/roster"))
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"team_id": "team_abc",
+			"total": 2,
+			"members": [
+				{"principal_id": "usr_ryan", "name": "Ryan Snodgrass", "type": "human", "role": "owner", "aliases": ["rsnodgrass"]},
+				{"principal_id": "agt_rip", "name": "Rip", "type": "ai", "role": "member"}
+			]
+		}`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+
+	resp, err := client.ListTeamRoster(context.Background(), "team_abc")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "team_abc", resp.TeamID)
+	require.Len(t, resp.Members, 2)
+	assert.Equal(t, "usr_ryan", resp.Members[0].PrincipalID)
+	assert.Equal(t, "human", resp.Members[0].Type)
+	assert.Equal(t, []string{"rsnodgrass"}, resp.Members[0].Aliases)
+	assert.Equal(t, "agt_rip", resp.Members[1].PrincipalID)
+	assert.Equal(t, "ai", resp.Members[1].Type)
+}
+
+// TestListTeamRoster_NotFound — Failure prevented: a 404 (feature flag off or
+// route not deployed) is treated as a hard error instead of the graceful
+// ErrTeamRosterUnsupported sentinel the command degrades on.
+func TestListTeamRoster_NotFound(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+
+	resp, err := client.ListTeamRoster(context.Background(), "team_missing")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.True(t, errors.Is(err, ErrTeamRosterUnsupported),
+		"404 must return ErrTeamRosterUnsupported sentinel, got %v", err)
+}
+
+// TestListTeamRoster_Forbidden — Failure prevented: a non-member's 403 leaks as
+// a generic error instead of the canonical ErrForbidden.
+func TestListTeamRoster_Forbidden(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+
+	resp, err := client.ListTeamRoster(context.Background(), "team_abc")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.True(t, errors.Is(err, ErrForbidden), "403 must return ErrForbidden, got %v", err)
+}
+
+// TestListTeamRoster_MalformedJSON — Failure prevented: a 200 with a body that
+// isn't valid JSON is swallowed into an empty roster instead of surfacing a
+// decode error.
+func TestListTeamRoster_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+	resp, err := client.ListTeamRoster(context.Background(), "team_abc")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+// TestListTeamRoster_ServerError — Failure prevented: a 5xx is silently treated
+// as the graceful ErrTeamRosterUnsupported sentinel and reported as "feature
+// unavailable, exit 0" instead of a real error.
+func TestListTeamRoster_ServerError(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+	resp, err := client.ListTeamRoster(context.Background(), "team_abc")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.False(t, errors.Is(err, ErrTeamRosterUnsupported), "5xx must not be swallowed as unsupported")
+}
+
+// TestListTeamRoster_EmptyRef — Failure prevented: an empty team ref silently
+// issues a request to /api/v1/teams//roster.
+func TestListTeamRoster_EmptyRef(t *testing.T) {
+	t.Parallel()
+	client := &RepoClient{
+		baseURL:    "http://localhost:0",
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+	resp, err := client.ListTeamRoster(context.Background(), "")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}

--- a/internal/api/team_members_test.go
+++ b/internal/api/team_members_test.go
@@ -190,6 +190,50 @@ func TestListTeamRoster_OversizedBody(t *testing.T) {
 	assert.False(t, errors.Is(err, ErrTeamRosterUnavailable), "oversized is a misbehaving server, not an unreachable one")
 }
 
+// TestListTeamRoster_OversizedServerError — Failure prevented: a 5xx whose error
+// body exceeds the cap is rejected as "too large" instead of degrading to the
+// graceful unavailable sentinel (status must be classified before the body read).
+func TestListTeamRoster_OversizedServerError(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write(make([]byte, maxRosterBodyBytes+1))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+	resp, err := client.ListTeamRoster(context.Background(), "team_abc")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.True(t, errors.Is(err, ErrTeamRosterUnavailable), "a 5xx must degrade regardless of body size, got %v", err)
+	assert.NotContains(t, err.Error(), "too large", "5xx must be classified before the body read")
+}
+
+// TestListTeamRoster_RejectsDotSegments — Failure prevented: a "." / ".." / path
+// -separator team ref reaches the wire, where a normalizing proxy can rewrite the
+// route and the 404 masquerades as "roster unavailable".
+func TestListTeamRoster_RejectsDotSegments(t *testing.T) {
+	t.Parallel()
+	client := &RepoClient{
+		baseURL:    "http://127.0.0.1:1", // must never be dialed — validation rejects first
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+	for _, ref := range []string{".", "..", "a/b", "team\\x"} {
+		resp, err := client.ListTeamRoster(context.Background(), ref)
+		require.Error(t, err, "ref %q must be rejected", ref)
+		assert.Nil(t, resp)
+		assert.Contains(t, err.Error(), "invalid team reference", "ref %q", ref)
+		assert.False(t, errors.Is(err, ErrTeamRosterUnavailable), "ref %q must not look like an availability failure", ref)
+	}
+}
+
 // TestListTeamRoster_EmptyRef — Failure prevented: an empty team ref silently
 // issues a request to /api/v1/teams//roster.
 func TestListTeamRoster_EmptyRef(t *testing.T) {


### PR DESCRIPTION
## Summary

Coworkers can now answer **"who's actually on this team?"** straight from the terminal with `ox team members` — humans and AI coworkers alike, with display name, type (human/ai), role, and the handles they're known by. It's the identity surface that lets a teammate (or an AI coworker mid-session) resolve a name they saw in a murmur, session, or commit without leaving the CLI.

## What this ships

- **`ox team` (singular) command group** with `ox team members` — inspects one team, complementing the existing `ox teams` (plural), which lists the teams you belong to.
- **`--team <id|slug>`** to target a team other than the repo's configured one; **`--json`** for a stable machine-readable envelope.
- **`ListTeamRoster` API client** (`internal/api/team_members.go`) — a faithful clone of the established `GetTeamContextContent` pattern: `CheckVersionResponse` first, feature-flag-gated with graceful 404 degrade, reuses the `ErrUnauthorized`/`ErrForbidden`/`ErrVersionUnsupported` sentinels, and `url.PathEscape`s the team ref.
- The client is a **faithful renderer of whatever identity fields the server exposes** — unknown fields decode away, so it stays forward-compatible as the roster grows.

## Design & hardening

This landed after an adversarial review of the surface. Notable decisions:

- **No "least-privilege / no-email" claims anywhere.** The roster may start exposing identity emails (e.g. an org `@company.com` address matching the team), so the client makes no promise it can't keep and adds no redaction — it renders the tier the server chooses.
- **Every rendered field is sanitized** through `SanitizeTerminalText` (the `type` column was the one gap) so untrusted server text can't inject ANSI/control sequences into the terminal.
- **Response body is capped** (`io.LimitReader`, 4 MiB) so a malicious/MITM body can't OOM the CLI — matching `repo.go`'s precedent.
- **One stable JSON envelope** for both success and graceful-degrade: `members` is always an array (never `null`) and `available` is always present.
- **Logged-out is fail-fast and friendly:** a preflight via `EnsureValidTokenForEndpoint` (which also refreshes a near-expired token) returns `run 'ox login' first` before any network round-trip, matching `ox query` / `ox invite`.
- **Softer 404 copy:** "feature not enabled on this server, or team not found" instead of asserting an undeployed flag is the only cause.

```mermaid
flowchart TD
    A[ox team members] --> B{valid token?}
    B -- no --> C["fail fast: run 'ox login' first"]
    B -- yes --> D[GET /api/v1/teams/&lt;ref&gt;/roster]
    D --> E{status}
    E -- 200 --> F[render table / stable JSON envelope]
    E -- 404 --> G["graceful degrade, exit 0:<br/>feature off or team not found"]
    E -- 401 --> C
    E -- 403 --> H["access denied: not a member"]
```

## Test Plan

- `go test ./internal/api/ -run TestListTeamRoster` and `./cmd/ox/ -run TestFetchAndRenderRoster` — **12 tests green**.
- **Red-first proven** (broke the product, watched the test fail on the claim, restored): the `type`-column sanitization and the stable JSON envelope.
- New adversarial coverage: control-char injection, JSON envelope stability (nil-vs-empty members), malformed-JSON decode error, 5xx-not-swallowed-as-unsupported, plus the pre-existing success / 404-degrade / 401 / 403 / empty-ref cases.
- `gofmt`, `goimports`, `go vet`, and `golangci-lint` clean on all four files.

## Follow-ups (not in this PR)

- **Server-side authz (highest):** cross-tenant safety of `--team <any-slug>` rests entirely on the roster route enforcing team membership; a private server-side issue tracks verifying it. The client intentionally adds no gating there.
- **Docs:** `docs/reference/team/` regenerates wholesale at release (no PR-time gate), left untouched to avoid ordinal churn.
- **Naming:** `ox team` vs `ox teams` adjacency is a deliberate keep-both; revisit if it proves confusing.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (12 roster tests; 2 fixes proven red-first)
- [ ] CHANGELOG entry — not yet added; new user-facing command, add at release cut
- [x] Breaking change — none (purely additive)
- [x] `/security-review` — N/A as a gate: no change to `internal/auth/` etc.; `internal/auth` is only *called*. Surface was adversarially reviewed by hand (sanitization, body cap, auth preflight, IDOR flagged to server).

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `ox team members` command for listing members of a specified team or the repository-configured team.
  * Supports readable table output and stable JSON output.
  * Displays member names, types, roles, and aliases.
  * Handles empty teams and unavailable roster data gracefully.

* **Bug Fixes**
  * Improved handling of authentication, authorization, malformed responses, and server errors.
  * Sanitizes unsafe characters in displayed member information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->