### PR TITLE
fix(codedb): precise duplicate-column check + resumable schema migrations

### DIFF
--- a/internal/codedb/store/migration_adversarial_test.go
+++ b/internal/codedb/store/migration_adversarial_test.go
@@ -27,9 +27,13 @@ import (
 // Multiple openRawDB handles to one path model independent ox openers racing the
 // same codedb, so these tests must use the same connection config production
 // does or they measure a contention profile ox never sees.
+func rawDSN(dbPath string) string {
+	return dbPath + "?_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)&_pragma=cache_size(-65536)&_pragma=mmap_size(268435456)&_pragma=temp_store(MEMORY)"
+}
+
 func openRawDB(t *testing.T, dbPath string) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)&_pragma=cache_size(-65536)&_pragma=mmap_size(268435456)&_pragma=temp_store(MEMORY)")
+	db, err := sql.Open("sqlite", rawDSN(dbPath))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -142,7 +146,14 @@ func runConcurrentCreateSchema(t *testing.T, dbPath string, runners int) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			db := openRawDB(t, dbPath)
+			// Open inline (not via the t.Fatalf-ing openRawDB): testing.T.FailNow
+			// must run on the test goroutine, so failures here are routed through
+			// errs and reported by the caller below.
+			db, err := sql.Open("sqlite", rawDSN(dbPath))
+			if err != nil {
+				errs[i] = err
+				return
+			}
 			defer func() { _ = db.Close() }()
 			<-begin // release together to maximize overlap
 			errs[i] = createSchemaWithRetry(db)

--- a/internal/codedb/store/migration_adversarial_test.go
+++ b/internal/codedb/store/migration_adversarial_test.go
@@ -1,0 +1,361 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	sqlite "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+// This file holds the adversarial coverage for schema creation and migration:
+// crash-at-every-step recovery, model-based convergence from any starting state,
+// data-conservation under concurrent migration, and a stress loop. It sits above
+// the targeted per-migration tests in migration_test.go — those prove a single
+// fix; these prove the whole schema layer holds under fault and contention.
+
+// openRawDB opens a bare SQLite connection with the exact production DSN that
+// openSQLite (store.go) uses — including synchronous(NORMAL), which shortens the
+// WAL write-lock hold and is load-bearing for concurrent openers to clear
+// busy_timeout instead of returning SQLITE_BUSY — without applying any schema.
+// Multiple openRawDB handles to one path model independent ox openers racing the
+// same codedb, so these tests must use the same connection config production
+// does or they measure a contention profile ox never sees.
+func openRawDB(t *testing.T, dbPath string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)&_pragma=cache_size(-65536)&_pragma=mmap_size(268435456)&_pragma=temp_store(MEMORY)")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	return db
+}
+
+// schemaShape is a comparable fingerprint of a codedb's structure: each table's
+// column set and the full index set. Column and index lists are sorted (via SQL
+// ORDER BY) so two shapes are equal iff the schemas are structurally identical,
+// regardless of the order statements ran in.
+type schemaShape struct {
+	columns map[string][]string
+	indexes []string
+}
+
+func snapshotSchema(t *testing.T, db *sql.DB) schemaShape {
+	t.Helper()
+	shape := schemaShape{columns: make(map[string][]string)}
+	for _, table := range queryStrings(t, db,
+		`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`) {
+		shape.columns[table] = queryStrings(t, db, `SELECT name FROM pragma_table_info(?) ORDER BY name`, table)
+	}
+	shape.indexes = queryStrings(t, db,
+		`SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
+	return shape
+}
+
+func queryStrings(t *testing.T, db *sql.DB, query string, args ...any) []string {
+	t.Helper()
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		t.Fatalf("query %q: %v", query, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	return out
+}
+
+func requireIntegrityOK(t *testing.T, db *sql.DB) {
+	t.Helper()
+	var result string
+	if err := db.QueryRow(`PRAGMA integrity_check`).Scan(&result); err != nil {
+		t.Fatalf("integrity_check: %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("integrity_check = %q, want ok", result)
+	}
+}
+
+// goldenSchema is the reference shape: what a clean, single-threaded CreateSchema
+// produces. Every chaos scenario below must converge to exactly this.
+func goldenSchema(t *testing.T) schemaShape {
+	t.Helper()
+	db := openRawDB(t, filepath.Join(t.TempDir(), "golden.db"))
+	defer func() { _ = db.Close() }()
+	if err := CreateSchema(db); err != nil {
+		t.Fatalf("golden CreateSchema: %v", err)
+	}
+	return snapshotSchema(t, db)
+}
+
+// createSchemaWithRetry models the production caller of openSQLite, which
+// retries a transient SQLITE_BUSY / SQLITE_LOCKED from a cold concurrent create
+// rather than giving up — 16 openers hitting the first write to a brand-new DB
+// file in lockstep can momentarily contend the file-creation lock past
+// busy_timeout. Per #758 this retry is exactly the caller-side fix ("the caller
+// had no retry — that was our bug"). Only lock-contention is retried; any other
+// error (e.g. a reintroduced duplicate-column failure) is returned immediately
+// so genuine regressions still surface.
+func createSchemaWithRetry(db *sql.DB) error {
+	const maxAttempts = 25
+	var err error
+	for range maxAttempts {
+		if err = CreateSchema(db); err == nil || !isLockContention(err) {
+			return err
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return err
+}
+
+func isLockContention(err error) bool {
+	var sqErr *sqlite.Error
+	if !errors.As(err, &sqErr) {
+		return false
+	}
+	return sqErr.Code() == sqlite3.SQLITE_BUSY || sqErr.Code() == sqlite3.SQLITE_LOCKED
+}
+
+// runConcurrentCreateSchema fires `runners` independent openers that all call
+// CreateSchema (with production-style busy retry) on the same path at once, and
+// reports any non-transient error. Each opener owns its own connection,
+// mirroring separate ox processes racing one codedb.
+func runConcurrentCreateSchema(t *testing.T, dbPath string, runners int) {
+	t.Helper()
+	var wg sync.WaitGroup
+	errs := make([]error, runners)
+	begin := make(chan struct{})
+	for i := range runners {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			db := openRawDB(t, dbPath)
+			defer func() { _ = db.Close() }()
+			<-begin // release together to maximize overlap
+			errs[i] = createSchemaWithRetry(db)
+		}(i)
+	}
+	close(begin)
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("runner %d CreateSchema: %v", i, err)
+		}
+	}
+}
+
+// TestMigrations_ResumeFromEveryCrashPoint is the crash-at-every-step recovery
+// proof for the ALTER-based migrations. Each ALTER auto-commits, so a process
+// killed mid-migration leaves the first k columns present and the rest absent.
+// For every prefix k, the test recreates that post-crash state, re-runs the
+// migration twice (proving convergence AND idempotency), and asserts every
+// column landed.
+//
+// Failure prevented: a migration that short-circuits on a guard column and
+// never completes from a partial state — the class of bug fixed for
+// migrateAddTypeInfo. A single hand-picked partial state (see
+// TestMigrateAddTypeInfo_ResumesPartialMigration) proves one point; this proves
+// the whole prefix matrix for all three ALTER migrations.
+func TestMigrations_ResumeFromEveryCrashPoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: SQLite migration")
+	}
+
+	type step struct{ column, ddl string }
+	migrations := []struct {
+		name  string
+		run   func(*sql.DB) error
+		table string
+		steps []step
+	}{
+		{"edge_version", migrateAddEdgeVersion, "blobs", []step{
+			{"edge_version", `ALTER TABLE blobs ADD COLUMN edge_version INTEGER NOT NULL DEFAULT 0`},
+		}},
+		{"type_info", migrateAddTypeInfo, "symbols", []step{
+			{"signature", `ALTER TABLE symbols ADD COLUMN signature TEXT`},
+			{"return_type", `ALTER TABLE symbols ADD COLUMN return_type TEXT`},
+			{"params", `ALTER TABLE symbols ADD COLUMN params TEXT`},
+		}},
+		{"comments_parsed", migrateAddComments, "blobs", []step{
+			{"comments_parsed", `ALTER TABLE blobs ADD COLUMN comments_parsed INTEGER NOT NULL DEFAULT 0`},
+		}},
+	}
+
+	for _, m := range migrations {
+		for k := 0; k <= len(m.steps); k++ {
+			t.Run(fmt.Sprintf("%s/crash_after_%d", m.name, k), func(t *testing.T) {
+				db, _ := createOldSchemaDB(t)
+				defer func() { _ = db.Close() }()
+
+				// Reproduce the post-crash state: the first k ALTERs landed.
+				for i := 0; i < k; i++ {
+					if _, err := db.Exec(m.steps[i].ddl); err != nil {
+						t.Fatalf("seed crash prefix %d: %v", i, err)
+					}
+				}
+
+				// Resume; a second run must also succeed (idempotent).
+				for run := 0; run < 2; run++ {
+					if err := m.run(db); err != nil {
+						t.Fatalf("resume run %d after crash_after_%d: %v", run, k, err)
+					}
+				}
+
+				for _, s := range m.steps {
+					if !columnExists(t, db, m.table, s.column) {
+						t.Errorf("%s.%s missing after resuming crash_after_%d", m.table, s.column, k)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestCreateSchema_ConvergesFromAnyState is the model-based convergence proof:
+// whatever state a codedb starts in and however many openers call CreateSchema
+// at once, the result must equal the golden schema of a clean single-threaded
+// create AND pass integrity_check. This generalizes the concurrent-open race
+// past the three ALTER columns to the entire schema, and exercises
+// migrateAddGitHubTables / migrateAddPRCommits that the targeted tests do not
+// touch.
+//
+// The {v1, runners=1} case doubles as the fresh-vs-migrated equivalence check: a
+// historical V1 database brought up through every migration ends up structurally
+// identical to a freshly created one — proof that old installs are not left with
+// a permanently different schema.
+func TestCreateSchema_ConvergesFromAnyState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: SQLite migration")
+	}
+
+	golden := goldenSchema(t)
+
+	starts := []struct {
+		name  string
+		setup func(t *testing.T, db *sql.DB)
+	}{
+		{"empty", func(t *testing.T, db *sql.DB) {}},
+		{"v1", func(t *testing.T, db *sql.DB) {
+			if _, err := db.Exec(baseSchemaV1); err != nil {
+				t.Fatalf("seed v1: %v", err)
+			}
+		}},
+		{"already_created", func(t *testing.T, db *sql.DB) {
+			if err := CreateSchema(db); err != nil {
+				t.Fatalf("seed already-created: %v", err)
+			}
+		}},
+		{"partial_type_info", func(t *testing.T, db *sql.DB) {
+			if _, err := db.Exec(baseSchemaV1); err != nil {
+				t.Fatalf("seed v1: %v", err)
+			}
+			if _, err := db.Exec(`ALTER TABLE symbols ADD COLUMN signature TEXT`); err != nil {
+				t.Fatalf("seed partial migration: %v", err)
+			}
+		}},
+	}
+
+	for _, start := range starts {
+		for _, runners := range []int{1, 4, 16} {
+			t.Run(fmt.Sprintf("%s/runners_%d", start.name, runners), func(t *testing.T) {
+				dbPath := filepath.Join(t.TempDir(), "metadata.db")
+
+				// Persist the starting state on its own connection first, then let
+				// the concurrent openers race from that on-disk state.
+				seed := openRawDB(t, dbPath)
+				start.setup(t, seed)
+				if err := seed.Close(); err != nil {
+					t.Fatalf("close seed: %v", err)
+				}
+
+				runConcurrentCreateSchema(t, dbPath, runners)
+
+				verify := openRawDB(t, dbPath)
+				defer func() { _ = verify.Close() }()
+				requireIntegrityOK(t, verify)
+				if got := snapshotSchema(t, verify); !reflect.DeepEqual(got, golden) {
+					t.Errorf("schema from %s (runners=%d) diverged from golden\n got=%+v\nwant=%+v",
+						start.name, runners, got, golden)
+				}
+			})
+		}
+	}
+}
+
+// TestData_SurvivesConcurrentMigration is the conservation proof: rows written
+// before a migration must still be present after concurrent openers run
+// CreateSchema. The #758 failure mode was a codedb that answered every query
+// with zero results; a schema-shape assertion alone would not catch data being
+// dropped or hidden, so this counts real rows through the migration under
+// contention.
+func TestData_SurvivesConcurrentMigration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: SQLite migration")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+	const wantRepos = 25
+
+	seed := openRawDB(t, dbPath)
+	if _, err := seed.Exec(baseSchemaV1); err != nil {
+		t.Fatalf("seed v1: %v", err)
+	}
+	for i := range wantRepos {
+		if _, err := seed.Exec(`INSERT INTO repos (name, path) VALUES (?, ?)`, fmt.Sprintf("repo-%d", i), "/p"); err != nil {
+			t.Fatalf("seed repo %d: %v", i, err)
+		}
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("close seed: %v", err)
+	}
+
+	runConcurrentCreateSchema(t, dbPath, 16)
+
+	verify := openRawDB(t, dbPath)
+	defer func() { _ = verify.Close() }()
+	var got int
+	if err := verify.QueryRow(`SELECT COUNT(*) FROM repos`).Scan(&got); err != nil {
+		t.Fatalf("count repos: %v", err)
+	}
+	if got != wantRepos {
+		t.Errorf("repos after concurrent migration = %d, want %d (rows lost or hidden by migration)", got, wantRepos)
+	}
+}
+
+// TestCreateSchema_ConcurrentStress reruns the worst-case concurrent create many
+// times inside one test, so a timing-dependent corruption that slips a single
+// pass — like the read-during-schema-change regression caught during this work —
+// gets many chances to surface under -race, without relying on `go test -count`.
+func TestCreateSchema_ConcurrentStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: SQLite migration")
+	}
+
+	golden := goldenSchema(t)
+	const iterations = 8
+	for iter := range iterations {
+		dbPath := filepath.Join(t.TempDir(), "metadata.db")
+		runConcurrentCreateSchema(t, dbPath, 16)
+
+		verify := openRawDB(t, dbPath)
+		requireIntegrityOK(t, verify)
+		if got := snapshotSchema(t, verify); !reflect.DeepEqual(got, golden) {
+			_ = verify.Close()
+			t.Fatalf("iteration %d: schema diverged from golden", iter)
+		}
+		_ = verify.Close()
+	}
+}

--- a/internal/codedb/store/migration_adversarial_test.go
+++ b/internal/codedb/store/migration_adversarial_test.go
@@ -141,6 +141,7 @@ func runConcurrentCreateSchema(t *testing.T, dbPath string, runners int) {
 	t.Helper()
 	var wg sync.WaitGroup
 	errs := make([]error, runners)
+	ready := make(chan struct{}, runners)
 	begin := make(chan struct{})
 	for i := range runners {
 		wg.Add(1)
@@ -152,12 +153,20 @@ func runConcurrentCreateSchema(t *testing.T, dbPath string, runners int) {
 			db, err := sql.Open("sqlite", rawDSN(dbPath))
 			if err != nil {
 				errs[i] = err
+				ready <- struct{}{} // still report ready so the barrier below completes
 				return
 			}
 			defer func() { _ = db.Close() }()
-			<-begin // release together to maximize overlap
+			ready <- struct{}{} // opened and parked at the barrier
+			<-begin             // released together to maximize overlap
 			errs[i] = createSchemaWithRetry(db)
 		}(i)
+	}
+	// Wait until every worker has opened and is parked before releasing, so the
+	// openers actually start CreateSchema together instead of trickling in while
+	// close(begin) races their sql.Open.
+	for range runners {
+		<-ready
 	}
 	close(begin)
 	wg.Wait()

--- a/internal/codedb/store/migration_test.go
+++ b/internal/codedb/store/migration_test.go
@@ -760,24 +760,73 @@ func TestIsDuplicateColumnError(t *testing.T) {
 	if dupErr == nil {
 		t.Fatal("expected a duplicate-column error on the second ALTER")
 	}
-
-	if !isDuplicateColumnError(dupErr, "signature") {
-		t.Errorf("duplicate on signature should match column=signature, got err=%v", dupErr)
-	}
-	if isDuplicateColumnError(dupErr, "return_type") {
-		t.Error("must NOT swallow a duplicate reported for signature when adding return_type")
-	}
-	if isDuplicateColumnError(nil, "signature") {
-		t.Error("nil is not a duplicate-column error")
-	}
-
-	// A different sqlite error (same generic SQLITE_ERROR code, different
-	// message) must not be mistaken for a duplicate-column error.
-	_, otherErr := db.Exec(`ALTER TABLE definitely_no_such_table ADD COLUMN x TEXT`)
-	if otherErr == nil {
+	// A different sqlite error (same generic SQLITE_ERROR code, different message)
+	// must not be mistaken for a duplicate-column error.
+	_, missingTableErr := db.Exec(`ALTER TABLE definitely_no_such_table ADD COLUMN x TEXT`)
+	if missingTableErr == nil {
 		t.Fatal("expected an error for a missing table")
 	}
-	if isDuplicateColumnError(otherErr, "x") {
-		t.Errorf("a non-duplicate error must not be treated as duplicate-column: %v", otherErr)
+
+	cases := []struct {
+		name   string
+		err    error
+		column string
+		want   bool
+	}{
+		{"matches the exact column", dupErr, "signature", true},
+		{"rejects a different column", dupErr, "return_type", false},
+		// "sign" is a prefix of "signature": a substring match would wrongly
+		// accept it, silently swallowing a real duplicate on another column.
+		{"rejects a column that is a prefix of the real one", dupErr, "sign", false},
+		{"rejects nil", nil, "signature", false},
+		{"rejects a non-duplicate sqlite error", missingTableErr, "x", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDuplicateColumnError(tc.err, tc.column); got != tc.want {
+				t.Errorf("isDuplicateColumnError(%v, %q) = %v, want %v", tc.err, tc.column, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMigrateAddTypeInfo_PreservesParsedOnReopen guards the parsed-state
+// invalidation against firing on every open. migrateAddTypeInfo resets parsed=0
+// to force a reparse when it first adds the type-info columns; it must NOT do so
+// when the schema is already current, because CreateSchema runs on every
+// Open/OpenSQLOnly — otherwise each reopen wipes parsed state and triggers a
+// full, needless reparse.
+//
+// Failure prevented: simply reopening a codedb silently invalidates every parsed
+// language blob.
+func TestMigrateAddTypeInfo_PreservesParsedOnReopen(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: SQLite migration")
+	}
+
+	db, _ := createOldSchemaDB(t)
+	defer func() { _ = db.Close() }()
+
+	// First migration adds the columns and (correctly) invalidates parsed.
+	if err := migrateAddTypeInfo(db); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+
+	// Mark a language blob parsed, as a completed indexing pass would.
+	if _, err := db.Exec(`INSERT INTO blobs (content_hash, language, parsed) VALUES ('h', 'go', 1)`); err != nil {
+		t.Fatalf("seed parsed blob: %v", err)
+	}
+
+	// Reopen path: run the migration again against the now-current schema.
+	if err := migrateAddTypeInfo(db); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+
+	var parsed int
+	if err := db.QueryRow(`SELECT parsed FROM blobs WHERE content_hash='h'`).Scan(&parsed); err != nil {
+		t.Fatalf("read parsed: %v", err)
+	}
+	if parsed != 1 {
+		t.Errorf("parsed reset to %d on a no-op reopen; must stay 1", parsed)
 	}
 }

--- a/internal/codedb/store/migration_test.go
+++ b/internal/codedb/store/migration_test.go
@@ -640,10 +640,16 @@ func TestAddColumnMigrations_ConcurrentRace(t *testing.T) {
 		migrate func(*sql.DB) error
 		table   string
 		columns []string
+		// syncColumn is the one column each racer parks on to force the race.
+		// migrateAddTypeInfo adds three columns via addColumnIfMissing, so the
+		// hook fires once per column; parking on only the first keeps the
+		// bounded ready channel from overflowing while still guaranteeing all
+		// racers hit the check-then-ALTER window together.
+		syncColumn string
 	}{
-		{"edge_version", migrateAddEdgeVersion, "blobs", []string{"edge_version"}},
-		{"type_info", migrateAddTypeInfo, "symbols", []string{"signature", "return_type", "params"}},
-		{"comments_parsed", migrateAddComments, "blobs", []string{"comments_parsed"}},
+		{"edge_version", migrateAddEdgeVersion, "blobs", []string{"edge_version"}, "edge_version"},
+		{"type_info", migrateAddTypeInfo, "symbols", []string{"signature", "return_type", "params"}, "signature"},
+		{"comments_parsed", migrateAddComments, "blobs", []string{"comments_parsed"}, "comments_parsed"},
 	}
 
 	for _, tc := range cases {
@@ -655,7 +661,10 @@ func TestAddColumnMigrations_ConcurrentRace(t *testing.T) {
 			ready := make(chan struct{}, racers)
 			release := make(chan struct{})
 
-			testAddColumnRaceHook = func() {
+			testAddColumnRaceHook = func(column string) {
+				if column != tc.syncColumn {
+					return
+				}
 				ready <- struct{}{}
 				<-release
 			}
@@ -691,5 +700,84 @@ func TestAddColumnMigrations_ConcurrentRace(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestMigrateAddTypeInfo_ResumesPartialMigration proves migrateAddTypeInfo is
+// resumable. It adds three columns (signature, return_type, params); the older
+// form guarded all three behind a single existence check on signature, so a
+// database left with signature but not the other two — a process that crashed
+// between ALTERs, or an older ox that only ever added signature — would
+// short-circuit on the guard and never gain return_type/params.
+//
+// Failure prevented: symbols.return_type / symbols.params silently never exist,
+// and every type-info query returns empty forever with no error to flag it.
+func TestMigrateAddTypeInfo_ResumesPartialMigration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: SQLite migration")
+	}
+
+	db, _ := createOldSchemaDB(t)
+	defer func() { _ = db.Close() }()
+
+	// Simulate a migration that died after the first ALTER: signature landed,
+	// return_type and params did not.
+	if _, err := db.Exec(`ALTER TABLE symbols ADD COLUMN signature TEXT`); err != nil {
+		t.Fatalf("seed partial migration: %v", err)
+	}
+
+	if err := migrateAddTypeInfo(db); err != nil {
+		t.Fatalf("migrateAddTypeInfo on partially migrated schema: %v", err)
+	}
+
+	for _, col := range []string{"signature", "return_type", "params"} {
+		if !columnExists(t, db, "symbols", col) {
+			t.Errorf("symbols.%s missing after resuming a partial migration", col)
+		}
+	}
+}
+
+// TestIsDuplicateColumnError pins the precision of the duplicate-column guard:
+// it must swallow a duplicate ONLY for the exact column being added, so a
+// genuine schema bug that reports a duplicate on a different column, or any
+// other error, still fails the migration loudly.
+//
+// Failure prevented: an over-broad match (e.g. plain substring on the message)
+// silently eating a real error and leaving a half-built schema.
+func TestIsDuplicateColumnError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: SQLite migration")
+	}
+
+	db, _ := createOldSchemaDB(t)
+	defer func() { _ = db.Close() }()
+
+	// Provoke a real "duplicate column name: signature" from the driver.
+	if _, err := db.Exec(`ALTER TABLE symbols ADD COLUMN signature TEXT`); err != nil {
+		t.Fatalf("seed column: %v", err)
+	}
+	_, dupErr := db.Exec(`ALTER TABLE symbols ADD COLUMN signature TEXT`)
+	if dupErr == nil {
+		t.Fatal("expected a duplicate-column error on the second ALTER")
+	}
+
+	if !isDuplicateColumnError(dupErr, "signature") {
+		t.Errorf("duplicate on signature should match column=signature, got err=%v", dupErr)
+	}
+	if isDuplicateColumnError(dupErr, "return_type") {
+		t.Error("must NOT swallow a duplicate reported for signature when adding return_type")
+	}
+	if isDuplicateColumnError(nil, "signature") {
+		t.Error("nil is not a duplicate-column error")
+	}
+
+	// A different sqlite error (same generic SQLITE_ERROR code, different
+	// message) must not be mistaken for a duplicate-column error.
+	_, otherErr := db.Exec(`ALTER TABLE definitely_no_such_table ADD COLUMN x TEXT`)
+	if otherErr == nil {
+		t.Fatal("expected an error for a missing table")
+	}
+	if isDuplicateColumnError(otherErr, "x") {
+		t.Errorf("a non-duplicate error must not be treated as duplicate-column: %v", otherErr)
 	}
 }

--- a/internal/codedb/store/schema.go
+++ b/internal/codedb/store/schema.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 
 	sqlite "modernc.org/sqlite"
@@ -30,7 +31,20 @@ func isDuplicateColumnError(err error, column string) bool {
 	if !errors.As(err, &sqErr) || sqErr.Code() != sqlite3.SQLITE_ERROR {
 		return false
 	}
-	return strings.Contains(sqErr.Error(), "duplicate column name: "+column)
+	// SQLite formats this as "duplicate column name: <col>" (modernc appends a
+	// trailing " (code)"). Compare the column exactly — a substring check would
+	// let "sign" match "signature".
+	const marker = "duplicate column name: "
+	msg := sqErr.Error()
+	idx := strings.Index(msg, marker)
+	if idx < 0 {
+		return false
+	}
+	reported := msg[idx+len(marker):]
+	if end := strings.IndexAny(reported, " \t\r\n"); end >= 0 {
+		reported = reported[:end]
+	}
+	return reported == column
 }
 
 // columnDDL pairs a column name with the ALTER statement that adds it.
@@ -55,35 +69,42 @@ type columnDDL struct {
 // The check-then-ALTER is not atomic, so two openers can both observe a column
 // missing and both ALTER; the loser's "duplicate column name" is success, not
 // failure (see isDuplicateColumnError and #758).
-func addColumnsIfMissing(db *sql.DB, table string, cols []columnDDL) error {
+// addColumnsIfMissing reports whether it added any column (added), which callers
+// use to gate one-shot backfills that must run only when the migration did real
+// work — not on every reopen of an already-current schema.
+func addColumnsIfMissing(db *sql.DB, table string, cols []columnDDL) (added bool, err error) {
 	existing, err := existingColumns(db, table)
 	if err != nil {
-		return err
+		return false, err
 	}
 	for _, c := range cols {
 		if existing[c.name] {
 			continue
 		}
+		// A column observed missing here is being applied by this call, whether
+		// our own ALTER wins or a concurrent caller's does; either way the
+		// migration is doing real work.
+		added = true
 		addColumnRaceHook(c.name)
-		if _, err := db.Exec(c.ddl); err != nil && !isDuplicateColumnError(err, c.name) {
-			return err
+		if _, execErr := db.Exec(c.ddl); execErr != nil && !isDuplicateColumnError(execErr, c.name) {
+			return added, fmt.Errorf("add column %s.%s: %w", table, c.name, execErr)
 		}
 	}
-	return nil
+	return added, nil
 }
 
 // existingColumns returns the set of column names currently defined on table.
 func existingColumns(db *sql.DB, table string) (map[string]bool, error) {
 	rows, err := db.Query(`SELECT name FROM pragma_table_info(?)`, table)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read columns of %s: %w", table, err)
 	}
 	defer func() { _ = rows.Close() }()
 	cols := make(map[string]bool)
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan column of %s: %w", table, err)
 		}
 		cols[name] = true
 	}
@@ -338,7 +359,7 @@ func CreateSchema(db *sql.DB) error {
 // current resolver version after edges are populated, and ParseSymbols stamps
 // new blobs at the current version inline.
 func migrateAddEdgeVersion(db *sql.DB) error {
-	if err := addColumnsIfMissing(db, "blobs", []columnDDL{
+	if _, err := addColumnsIfMissing(db, "blobs", []columnDDL{
 		{"edge_version", `ALTER TABLE blobs ADD COLUMN edge_version INTEGER NOT NULL DEFAULT 0`},
 	}); err != nil {
 		return err
@@ -355,17 +376,26 @@ func migrateAddTypeInfo(db *sql.DB) error {
 	// migration is resumable: the previous single-guard-on-signature form left
 	// return_type/params permanently absent if a process died (or was an older
 	// ox) after only the first ALTER landed.
-	if err := addColumnsIfMissing(db, "symbols", []columnDDL{
+	added, err := addColumnsIfMissing(db, "symbols", []columnDDL{
 		{"signature", `ALTER TABLE symbols ADD COLUMN signature TEXT`},
 		{"return_type", `ALTER TABLE symbols ADD COLUMN return_type TEXT`},
 		{"params", `ALTER TABLE symbols ADD COLUMN params TEXT`},
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
-	// Idempotent regardless of race/resume outcome: re-marking already-reset rows
-	// as unparsed is a no-op, so concurrent callers stepping on this is harmless.
-	_, err := db.Exec(`UPDATE blobs SET parsed = 0 WHERE language IS NOT NULL`)
-	return err
+	// Invalidate parsed state only when a type-info column was actually added
+	// (first migration, or a resumed partial one) so existing blobs get reparsed
+	// to populate it. CreateSchema runs on every Open/OpenSQLOnly, so doing this
+	// unconditionally would reset parsed=0 for every language blob on each
+	// reopen and force a needless full reparse.
+	if !added {
+		return nil
+	}
+	if _, err := db.Exec(`UPDATE blobs SET parsed = 0 WHERE language IS NOT NULL`); err != nil {
+		return fmt.Errorf("invalidate parsed blobs after type-info migration: %w", err)
+	}
+	return nil
 }
 
 // migrateAddComments creates the comments table and adds the comments_parsed
@@ -399,7 +429,7 @@ func migrateAddComments(db *sql.DB) error {
 	}
 
 	// add comments_parsed column to blobs if missing
-	if err := addColumnsIfMissing(db, "blobs", []columnDDL{
+	if _, err := addColumnsIfMissing(db, "blobs", []columnDDL{
 		{"comments_parsed", `ALTER TABLE blobs ADD COLUMN comments_parsed INTEGER NOT NULL DEFAULT 0`},
 	}); err != nil {
 		return err

--- a/internal/codedb/store/schema.go
+++ b/internal/codedb/store/schema.go
@@ -2,35 +2,111 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"strings"
+
+	sqlite "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
 // isDuplicateColumnError reports whether err is SQLite's "duplicate column
-// name" error — the signature a losing `ALTER TABLE ADD COLUMN` gets when a
-// concurrent caller already added the same column. SQLite has no `ADD COLUMN
-// IF NOT EXISTS`, so every migration below checks column existence and then
-// ALTERs in two separate statements; on a brand-new database two openers
-// (e.g. `ox index code` racing another `Open`/`OpenSQLOnly` of the same
-// freshly created codedb — see #758) can both observe the column missing and
-// both attempt the ALTER. The loser's failure here does not mean anything is
-// wrong — it means the column exists now, which is exactly what was wanted —
-// so it must not fail the whole CreateSchema call.
-func isDuplicateColumnError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "duplicate column name")
+// name: <column>" error for the exact column just attempted — the signature a
+// losing `ALTER TABLE ADD COLUMN` gets when a concurrent caller already added
+// that column. SQLite has no `ADD COLUMN IF NOT EXISTS`, so every migration
+// checks column existence and then ALTERs in two separate statements; on a
+// brand-new database two openers (e.g. `ox index code` racing another
+// `Open`/`OpenSQLOnly` of the same freshly created codedb — see #758) can both
+// observe the column missing and both attempt the ALTER. The loser's failure
+// here means the column exists now, which is exactly what was wanted, so it must
+// not fail the whole CreateSchema call.
+//
+// The match is deliberately narrow: a typed *sqlite.Error carrying the generic
+// SQLITE_ERROR code whose message names the column we tried to add. Requiring
+// the column name stops a duplicate on some *other* column (a real schema bug)
+// from being silently swallowed; the type+code check stops an unrelated error
+// whose text merely contains the phrase from slipping through.
+func isDuplicateColumnError(err error, column string) bool {
+	var sqErr *sqlite.Error
+	if !errors.As(err, &sqErr) || sqErr.Code() != sqlite3.SQLITE_ERROR {
+		return false
+	}
+	return strings.Contains(sqErr.Error(), "duplicate column name: "+column)
 }
 
-// testAddColumnRaceHook, when non-nil, is invoked by each ALTER-based
-// migration immediately after it observes a column as missing and before it
-// attempts the ALTER. Production code always leaves this nil (zero-cost).
-// Tests use it to force the #758 race window deterministically — pausing N
-// goroutines right after they've all observed "missing" and releasing them
-// together — rather than betting on goroutine scheduling to hit a
-// microsecond-wide window on its own.
-var testAddColumnRaceHook func()
+// columnDDL pairs a column name with the ALTER statement that adds it.
+type columnDDL struct {
+	name string
+	ddl  string
+}
 
-func addColumnRaceHook() {
+// addColumnsIfMissing adds each of cols to table that is not already present.
+// It reads the current column set once, then issues ALTERs only for the columns
+// still missing. This makes a multi-column migration resumable: a process that
+// crashed (or an older ox) after adding only some of its columns adds the rest
+// on the next run, instead of a single guard column short-circuiting the whole
+// migration and leaving the schema permanently partial.
+//
+// The single up-front read is deliberate. Checking each column immediately
+// before its own ALTER interleaves schema reads with the concurrent ALTERs of
+// other openers on a fresh codedb, and that contention corrupted a 16-way
+// fresh-open race in testing. Reading once keeps the hot path as cheap as the
+// original single guarded check while still recovering a partial schema.
+//
+// The check-then-ALTER is not atomic, so two openers can both observe a column
+// missing and both ALTER; the loser's "duplicate column name" is success, not
+// failure (see isDuplicateColumnError and #758).
+func addColumnsIfMissing(db *sql.DB, table string, cols []columnDDL) error {
+	existing, err := existingColumns(db, table)
+	if err != nil {
+		return err
+	}
+	for _, c := range cols {
+		if existing[c.name] {
+			continue
+		}
+		addColumnRaceHook(c.name)
+		if _, err := db.Exec(c.ddl); err != nil && !isDuplicateColumnError(err, c.name) {
+			return err
+		}
+	}
+	return nil
+}
+
+// existingColumns returns the set of column names currently defined on table.
+func existingColumns(db *sql.DB, table string) (map[string]bool, error) {
+	rows, err := db.Query(`SELECT name FROM pragma_table_info(?)`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	cols := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		cols[name] = true
+	}
+	return cols, rows.Err()
+}
+
+// testAddColumnRaceHook, when non-nil, is invoked by addColumnsIfMissing
+// immediately before it attempts the ALTER for a still-missing column, passed
+// that column's name. Production always leaves this nil
+// (a lock-free read of a package global, effectively zero cost). Tests use it to
+// force the #758 race window deterministically — pausing N goroutines right
+// after they have all observed "missing" and releasing them together — rather
+// than betting on goroutine scheduling to hit a microsecond-wide window.
+//
+// It MUST only ever be set from a test that does NOT call t.Parallel():
+// production reads this global lock-free from concurrent migration goroutines,
+// so a parallel test that writes it while another test's migrations read it is a
+// data race on this variable.
+var testAddColumnRaceHook func(column string)
+
+func addColumnRaceHook(column string) {
 	if testAddColumnRaceHook != nil {
-		testAddColumnRaceHook()
+		testAddColumnRaceHook(column)
 	}
 }
 
@@ -262,49 +338,33 @@ func CreateSchema(db *sql.DB) error {
 // current resolver version after edges are populated, and ParseSymbols stamps
 // new blobs at the current version inline.
 func migrateAddEdgeVersion(db *sql.DB) error {
-	var exists bool
-	err := db.QueryRow(`SELECT COUNT(*) > 0 FROM pragma_table_info('blobs') WHERE name='edge_version'`).Scan(&exists)
-	if err != nil {
-		return err
-	}
-	if exists {
-		return nil
-	}
-	addColumnRaceHook()
-	if _, err := db.Exec(`ALTER TABLE blobs ADD COLUMN edge_version INTEGER NOT NULL DEFAULT 0`); err != nil && !isDuplicateColumnError(err) {
+	if err := addColumnsIfMissing(db, "blobs", []columnDDL{
+		{"edge_version", `ALTER TABLE blobs ADD COLUMN edge_version INTEGER NOT NULL DEFAULT 0`},
+	}); err != nil {
 		return err
 	}
 	// Index supports the backfill scan: find blobs needing edges fast.
-	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_blobs_edge_version ON blobs(edge_version)`)
+	_, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_blobs_edge_version ON blobs(edge_version)`)
 	return err
 }
 
 // migrateAddTypeInfo adds signature, return_type, and params columns to the
 // symbols table for databases created before those columns existed.
 func migrateAddTypeInfo(db *sql.DB) error {
-	var exists bool
-	err := db.QueryRow(`SELECT COUNT(*) > 0 FROM pragma_table_info('symbols') WHERE name='signature'`).Scan(&exists)
-	if err != nil {
+	// Each column is added independently (see addColumnsIfMissing) so the
+	// migration is resumable: the previous single-guard-on-signature form left
+	// return_type/params permanently absent if a process died (or was an older
+	// ox) after only the first ALTER landed.
+	if err := addColumnsIfMissing(db, "symbols", []columnDDL{
+		{"signature", `ALTER TABLE symbols ADD COLUMN signature TEXT`},
+		{"return_type", `ALTER TABLE symbols ADD COLUMN return_type TEXT`},
+		{"params", `ALTER TABLE symbols ADD COLUMN params TEXT`},
+	}); err != nil {
 		return err
 	}
-	if exists {
-		return nil
-	}
-	addColumnRaceHook()
-
-	alters := []string{
-		`ALTER TABLE symbols ADD COLUMN signature TEXT`,
-		`ALTER TABLE symbols ADD COLUMN return_type TEXT`,
-		`ALTER TABLE symbols ADD COLUMN params TEXT`,
-	}
-	for _, s := range alters {
-		if _, err := db.Exec(s); err != nil && !isDuplicateColumnError(err) {
-			return err
-		}
-	}
-	// Idempotent regardless of race outcome: re-marking already-reset rows as
-	// unparsed is a no-op, so concurrent callers stepping on this is harmless.
-	_, err = db.Exec(`UPDATE blobs SET parsed = 0 WHERE language IS NOT NULL`)
+	// Idempotent regardless of race/resume outcome: re-marking already-reset rows
+	// as unparsed is a no-op, so concurrent callers stepping on this is harmless.
+	_, err := db.Exec(`UPDATE blobs SET parsed = 0 WHERE language IS NOT NULL`)
 	return err
 }
 
@@ -339,16 +399,10 @@ func migrateAddComments(db *sql.DB) error {
 	}
 
 	// add comments_parsed column to blobs if missing
-	var colExists bool
-	err = db.QueryRow(`SELECT COUNT(*) > 0 FROM pragma_table_info('blobs') WHERE name='comments_parsed'`).Scan(&colExists)
-	if err != nil {
+	if err := addColumnsIfMissing(db, "blobs", []columnDDL{
+		{"comments_parsed", `ALTER TABLE blobs ADD COLUMN comments_parsed INTEGER NOT NULL DEFAULT 0`},
+	}); err != nil {
 		return err
-	}
-	if !colExists {
-		addColumnRaceHook()
-		if _, err := db.Exec(`ALTER TABLE blobs ADD COLUMN comments_parsed INTEGER NOT NULL DEFAULT 0`); err != nil && !isDuplicateColumnError(err) {
-			return err
-		}
 	}
 
 	// index for fast unparsed-comments lookups


### PR DESCRIPTION
Follow-up hardening to #792 (the concurrent schema-migration fix). It closes two remaining ways a cold `ox index code` could still leave a codedb subtly wrong — a mis-swallowed error hiding a real schema bug, and a crash mid-migration leaving columns permanently absent — and removes a latent test-only data-race footgun. No customer-visible behavior change; the value is a closed class of "silent empty/partial index that answers every query with zero results" incidents (the #758 failure family).

## What this ships

- **Precise duplicate-column detection.** `isDuplicateColumnError` was a substring match on *any* error text (`strings.Contains(err, "duplicate column name")`). It now requires a typed `*sqlite.Error` with the generic `SQLITE_ERROR` code **and** a message naming the exact column being added (`duplicate column name: <column>`). A duplicate reported for a *different* column — a genuine schema bug — is no longer silently swallowed. Resolves the open CodeRabbit thread on #792.
- **Resumable multi-column migrations.** `migrateAddTypeInfo` guarded three `ALTER`s behind a single existence check on `signature`; a process that crashed after the first `ALTER` (or an older ox that only ever added `signature`) left `return_type`/`params` **permanently** absent. New `addColumnsIfMissing` reads the column set once and adds only what is missing, so the migration is resumable.
- **Documented test-hook invariant** (nit #1): `testAddColumnRaceHook` must never be set from a `t.Parallel()` test — production reads it lock-free from concurrent migration goroutines, so a parallel write would be a data race.

## Why "read the column set once" (design note)

The first cut of the resumable fix checked each column immediately before its own `ALTER`. Under a 16-way fresh-open race that interleaves `pragma_table_info` reads with the concurrent `ALTER`s of other openers, which corrupted the database (`SQLITE_BUSY` → disk I/O error) — caught by the existing `TestCreateSchema_ConcurrentFreshOpen`. Reading the column set once, up front, keeps the hot path as cheap as the original single guarded check while still recovering a partial schema.

```mermaid
flowchart TD
    A[migrateAddTypeInfo on a DB with signature only] --> B{guard: signature exists?}
    B -- "old: yes -> return nil" --> C[return_type / params never added<br/>permanent partial schema]
    B -- "new: read full column set once" --> D[ALTER only the missing columns]
    D --> E[return_type + params added<br/>schema complete, resumable]
```

## Test Plan

Red-first proofs — each fix neutered, its guarding test watched fail, then restored:

- **Race tolerance:** neuter the duplicate swallow → `TestAddColumnMigrations_ConcurrentRace` red (losing `ALTER`s error out) → restore → green.
- **Column precision:** make the match ignore the column → `TestIsDuplicateColumnError` red on the wrong-column assertion → restore → green.
- **Resumability:** restore the old single-guard short-circuit → `TestMigrateAddTypeInfo_ResumesPartialMigration` red (`return_type`/`params` missing) → restore → green.

New/changed tests:

- `TestMigrateAddTypeInfo_ResumesPartialMigration` — seeds a partial schema (signature only), asserts all three columns after a re-run.
- `TestIsDuplicateColumnError` — real driver errors: swallows the matching column, rejects a different column, rejects `nil`, rejects a non-duplicate `SQLITE_ERROR`.
- `TestAddColumnMigrations_ConcurrentRace` — hook is now column-aware; each case parks racers on one `syncColumn` so per-column hook fires don't overflow the bounded channel.

Gates:

- `go test ./internal/codedb/... -race` — green, and the previously-failing `TestCreateSchema_ConcurrentFreshOpen` passes 3× under `-race`.
- `go build ./...` clean; `golangci-lint run ./internal/codedb/store/` — 0 issues.
- No `go.mod`/`go.sum` change — `modernc.org/sqlite/lib` (for `SQLITE_ERROR`) is a subpackage of the already-required `modernc.org/sqlite`.

## Adversarial coverage (added to this branch)

New `migration_adversarial_test.go` proves the whole schema layer holds under fault and contention — not just the three fixed functions:

- **Crash-at-every-step** (`TestMigrations_ResumeFromEveryCrashPoint`): for each ALTER migration and every prefix of its columns, reproduce the post-crash state, re-run twice, assert convergence + idempotency.
- **Model-based convergence** (`TestCreateSchema_ConvergesFromAnyState`): from {empty, V1, already-created, partially-migrated} × {1, 4, 16 concurrent openers}, the schema must equal a clean single-threaded create's golden snapshot **and** pass `integrity_check`. Exercises `migrateAddGitHubTables`/`migrateAddPRCommits` too; the {V1, runners=1} case is the fresh-vs-migrated equivalence proof.
- **Data conservation** (`TestData_SurvivesConcurrentMigration`): rows written before the migration are still present/queryable after a 16-way concurrent `CreateSchema` — guards the #758 "answers zero results" symptom directly, not just schema shape.
- **Stress loop** (`TestCreateSchema_ConcurrentStress`): reruns the 16-way create many times in one test so a timing-dependent corruption gets many chances under `-race`, without relying on `go test -count`.

Concurrent openers use the exact production `openSQLite` DSN and retry only transient `SQLITE_BUSY`/`SQLITE_LOCKED` (cold-file lock contention 16 openers hit on a brand-new DB file), matching the production caller per #758; any non-lock error still fails immediately so a reintroduced duplicate-column regression surfaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database schema migrations to safely resume after partial completion or interruptions.
  * Prevented unrelated duplicate-column errors from being treated as successful migrations.
  * Increased reliability when adding multiple columns during upgrades.
  * Preserved existing data and parsed information during concurrent or repeated migrations.

* **Tests**
  * Expanded coverage for migration recovery, retries, crash points, and duplicate-column handling.
  * Added stress and integrity testing for concurrent schema creation and upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->