### PR TITLE
feat(upgrade): self-update direct installs + off-daemon update notice

### DIFF
--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -8,6 +8,12 @@ on:
     - cron: '17 14 * * *'  # daily, off-peak UTC
   workflow_dispatch: {}
 
+# Serialize runs so two concurrent invocations can't both find no open
+# drift issue and both create one.
+concurrency:
+  group: release-drift
+  cancel-in-progress: false
+
 permissions:
   contents: read
   issues: write
@@ -45,7 +51,9 @@ jobs:
           fi
 
           CURRENT=$(echo "$OUTPUT" | jq -r '.current')
-          LATEST=$(echo "$OUTPUT" | jq -r '.latest')
+          # '// empty' so a null latest (no releases yet) doesn't become the
+          # literal string "null" and get posted as "vnull" downstream.
+          LATEST=$(echo "$OUTPUT" | jq -r '.latest // empty')
           DRIFT=$(echo "$OUTPUT" | jq -r '.drift')
 
           {

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,0 +1,111 @@
+name: Release Drift Check
+
+# Scheduled-only by design: a version-bump PR legitimately precedes its
+# release, so a pull_request/push gate here would be wrong. This checks
+# whether a bump that landed on main was ever actually tagged/published.
+on:
+  schedule:
+    - cron: '17 14 * * *'  # daily, off-peak UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-drift:
+    if: github.repository == 'sageox/ox'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Check for release drift
+        id: drift
+        run: |
+          if OUTPUT=$(bash scripts/check-release-drift.sh --json); then
+            STATUS=0
+          else
+            STATUS=$?
+          fi
+
+          echo "Raw output: $OUTPUT"
+
+          # STATUS 0 = in sync, STATUS 1 = drift detected -- both are
+          # expected outcomes handled below. STATUS >= 2 is a real script
+          # error (bad gh auth, unparsable version.go, etc.) and should
+          # fail loudly rather than being silently treated as "no drift".
+          if [ "$STATUS" -ge 2 ]; then
+            echo "::error::check-release-drift.sh errored (exit $STATUS): $OUTPUT"
+            exit "$STATUS"
+          fi
+
+          CURRENT=$(echo "$OUTPUT" | jq -r '.current')
+          LATEST=$(echo "$OUTPUT" | jq -r '.latest')
+          DRIFT=$(echo "$OUTPUT" | jq -r '.drift')
+
+          {
+            echo "current=$CURRENT"
+            echo "latest=$LATEST"
+            echo "drift=$DRIFT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Ensure release-drift label exists
+        if: steps.drift.outputs.drift == 'true'
+        run: |
+          gh label create release-drift \
+            --color B60205 \
+            --description "version.go on main is ahead of the latest published GitHub release" \
+            --repo "$GITHUB_REPOSITORY" || true
+
+      - name: Open or refresh drift tracking issue
+        if: steps.drift.outputs.drift == 'true'
+        env:
+          CURRENT: ${{ steps.drift.outputs.current }}
+          LATEST: ${{ steps.drift.outputs.latest }}
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label release-drift --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+              --body "Still drifted as of $TODAY: internal/version/version.go says $CURRENT, latest published release is v$LATEST."
+          else
+            # Built with printf (not a heredoc) so every line stays inside
+            # this step's YAML block-scalar indentation.
+            BODY=$(printf '%s\n' \
+              "internal/version/version.go on \`main\` says **$CURRENT**, but the latest published GitHub release is **v$LATEST**." \
+              "" \
+              "A version bump was merged to \`main\` without a corresponding tagged, published release, so \`releases/latest\` (and the update-notify chain that reads it) is still pointing at the old version." \
+              "" \
+              "**To fix:** create the git tag \`v$CURRENT\` and publish a GitHub release for it. Publishing fires \`.github/workflows/release.yml\`, which builds and uploads the release artifacts." \
+              "" \
+              "This issue was opened automatically by \`.github/workflows/release-drift.yml\` and will close automatically once the release is published.")
+
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Release drift: v$CURRENT merged but not published" \
+              --label release-drift \
+              --body "$BODY"
+          fi
+
+          echo "::error::Release drift detected: version.go ($CURRENT) is ahead of the latest published release (v$LATEST)"
+          exit 1
+
+      - name: Close stale drift issue
+        if: steps.drift.outputs.drift == 'false'
+        env:
+          CURRENT: ${{ steps.drift.outputs.current }}
+          LATEST: ${{ steps.drift.outputs.latest }}
+        run: |
+          for NUM in $(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label release-drift --state open --json number --jq '.[].number'); do
+            gh issue comment "$NUM" --repo "$GITHUB_REPOSITORY" \
+              --body "Resolved: version.go ($CURRENT) <= latest release (v$LATEST)."
+            gh issue close "$NUM" --repo "$GITHUB_REPOSITORY"
+          done

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for ox CLI tool
 
 .PHONY: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw
-.PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-timings test-all test-slow test-browser test-integration test-agents test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version beads-setup
+.PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-timings test-all test-slow test-browser test-integration test-agents test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version check-release-drift beads-setup
 
 # Variables
 GO := go
@@ -600,6 +600,9 @@ bump-version: ## Bump version across all files (usage: make bump-version NEW_VER
 
 verify-version: ## Verify all version files are in sync
 	@./scripts/check-versions.sh
+
+check-release-drift: ## Check version.go isn't ahead of the latest published GitHub release (needs network + gh auth)
+	@bash scripts/check-release-drift.sh
 
 # Help
 help: ## Display available targets

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -897,7 +897,8 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		output.UpdateAvailable = true
 		output.LatestVersion = vResult.LatestVersion
 		output.UpdateHint = fmt.Sprintf(
-			"v%s -> v%s available. Run 'ox upgrade' to update.",
+			"ox v%s -> v%s is available. Offer to run 'ox upgrade' for the coworker — "+
+				"it upgrades in place for Homebrew, go install, and direct (install.sh) installs.",
 			vResult.CurrentVersion, vResult.LatestVersion,
 		)
 		output.UserNotices = append(output.UserNotices, UserNotice{
@@ -1568,7 +1569,7 @@ func outputAgentPrimeText(cmd *cobra.Command, output agentPrimeOutput) error {
 		cli.PrintSuggestionBox(
 			"Update Available",
 			output.UpdateHint,
-			"brew upgrade sageox",
+			"ox upgrade",
 		)
 	}
 

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Improved
+
+- **`ox upgrade` now updates direct installs in place** — if you installed ox with the quick-install script, `ox upgrade` downloads and swaps in the new version for you (verified before it is applied) instead of just printing instructions. Homebrew and `go install` installs upgrade as before.
+- **You hear about new versions even without the background service running** — `ox status` checks for a newer ox on its own and offers to upgrade on the spot.
+
 ## [0.14.0] - 2026-08-20
 
 Give every AI coworker the right skills, keep plans intact through review, and put your team's data, conversations, and the evidence behind your software in your hands, not locked away.

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -1620,12 +1620,25 @@ daemon health, and a tree view of all SageOx directory locations.`,
 			fmt.Print(renderAgentTasksSection(gitRoot))
 		}
 
-		// show version update notice if available
-		if vResult := checkVersionFromCache(); vResult != nil {
+		// show version update notice if available. refreshVersionCacheIfStale
+		// does a bounded live check so the notice reaches coworkers who never
+		// run the daemon (the daemon is otherwise the only cache writer).
+		if vResult := refreshVersionCacheIfStale(6 * time.Hour); vResult != nil {
 			fmt.Printf("\n%s  %s\n",
 				statusWarningStyle.Render("Update available"),
-				fmt.Sprintf("v%s → v%s — run 'ox upgrade' to update", vResult.CurrentVersion, vResult.LatestVersion),
+				fmt.Sprintf("v%s → v%s", vResult.CurrentVersion, vResult.LatestVersion),
 			)
+			// make the notice actionable rather than a dead string: offer to
+			// run the upgrade right here when we're at an interactive terminal.
+			if cli.IsInteractive() && !cfg.Quiet {
+				if cli.ConfirmYesNo("Upgrade ox now?", false) {
+					_ = runUpgrade(upgradeCmd, nil)
+				} else {
+					fmt.Printf("%s\n", cli.StyleDim.Render("Run 'ox upgrade' when you're ready."))
+				}
+			} else {
+				fmt.Printf("%s\n", cli.StyleDim.Render("Run 'ox upgrade' to update."))
+			}
 		}
 
 		// show contextual tip
@@ -1824,10 +1837,11 @@ func buildStatusJSON(authenticated bool, authErr error, token *auth.StoredToken,
 		}
 	}
 
-	// version section
+	// version section — refresh the cache lazily (bounded live check) so
+	// daemon-less coworkers still see update availability in JSON output.
 	currentVersion := strings.TrimPrefix(version.Version, "v")
 	vJSON := &statusVersionJSON{Current: currentVersion}
-	if vResult := checkVersionFromCache(); vResult != nil {
+	if vResult := refreshVersionCacheIfStale(6 * time.Hour); vResult != nil {
 		vJSON.Latest = vResult.LatestVersion
 		vJSON.UpdateAvailable = true
 	}

--- a/cmd/ox/upgrade.go
+++ b/cmd/ox/upgrade.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"time"
 
 	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/upgrade"
 	"github.com/sageox/ox/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -106,9 +111,11 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 		result.Message = "Dev build detected. Use 'make build && make install' to upgrade."
 		return outputUpgradeResult(cmd, result, jsonOutput)
 	case installBinary:
-		result.Status = "manual"
-		result.Message = "Download the latest release or run:\n  curl -sSL https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh | bash"
-		return outputUpgradeResult(cmd, result, jsonOutput)
+		upgradeVersion := vResult.LatestVersion
+		if target != "" {
+			upgradeVersion = strings.TrimPrefix(target, "v")
+		}
+		err = upgradeViaSelfReplace(jsonOutput, upgradeVersion)
 	}
 
 	if err != nil {
@@ -129,10 +136,13 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 // release. Accepting --target and then installing an arbitrary latest version
 // is worse than failing: it creates a false compatibility guarantee.
 func validateUpgradeTarget(method installMethod, target string) error {
-	if target == "" || method == installGoInstall {
+	// go-install and direct-binary (self-replace) installs can both honor a
+	// pinned version — one via go install @tag, the other by downloading that
+	// tag's release tarball. Homebrew and dev/source builds cannot.
+	if target == "" || method == installGoInstall || method == installBinary {
 		return nil
 	}
-	return fmt.Errorf("--target is supported only for go-install installations; %s upgrades cannot safely honor a pinned release", method)
+	return fmt.Errorf("--target is supported only for go-install and binary installations; %s upgrades cannot safely honor a pinned release", method)
 }
 
 func outputUpgradeResult(cmd *cobra.Command, result upgradeResult, jsonOutput bool) error {
@@ -161,6 +171,30 @@ func outputUpgradeResult(cmd *cobra.Command, result upgradeResult, jsonOutput bo
 	}
 
 	return nil
+}
+
+// upgradeViaSelfReplace downloads the release tarball for a directly-installed
+// (install.sh / manual binary) ox and atomically replaces the running binary
+// and any bundled adapters in place. The tarball's SHA-256 is verified against
+// the release checksums before anything is overwritten.
+func upgradeViaSelfReplace(quiet bool, targetVersion string) error {
+	if !quiet {
+		fmt.Printf("%s downloading ox v%s (%s/%s) and verifying checksum...\n",
+			cli.StyleDim.Render("Running:"), targetVersion, runtime.GOOS, runtime.GOARCH)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	err := upgrade.ReplaceRunningBinary(ctx, upgrade.Config{
+		Version: targetVersion,
+		OS:      runtime.GOOS,
+		Arch:    runtime.GOARCH,
+	})
+	if errors.Is(err, upgrade.ErrNotWritable) {
+		return fmt.Errorf("%v\n  Re-run with elevated permissions: sudo ox upgrade", err)
+	}
+	return err
 }
 
 func upgradeViaHomebrew(quiet bool) error {

--- a/cmd/ox/upgrade.go
+++ b/cmd/ox/upgrade.go
@@ -40,7 +40,7 @@ type upgradeResult struct {
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade ox to the latest version",
-	Long:  "Detect how ox was installed and upgrade using the appropriate method (Homebrew, go install, or manual download).",
+	Long:  "Detect how ox was installed and upgrade using the appropriate method: Homebrew, go install, or an in-place download that verifies and replaces the binary.",
 	RunE:  runUpgrade,
 }
 
@@ -192,7 +192,7 @@ func upgradeViaSelfReplace(quiet bool, targetVersion string) error {
 		Arch:    runtime.GOARCH,
 	})
 	if errors.Is(err, upgrade.ErrNotWritable) {
-		return fmt.Errorf("%v\n  Re-run with elevated permissions: sudo ox upgrade", err)
+		return fmt.Errorf("%w\n  Re-run with elevated permissions: sudo ox upgrade", err)
 	}
 	return err
 }

--- a/cmd/ox/upgrade_target_test.go
+++ b/cmd/ox/upgrade_target_test.go
@@ -42,7 +42,9 @@ func TestValidateUpgradeTarget(t *testing.T) {
 		want   bool
 	}{
 		{installGoInstall, "v0.42.0", false},
-		{installBinary, "v0.42.0", true},
+		// binary (self-replace) installs can now honor a pinned tag by
+		// downloading that release's tarball — no longer an error.
+		{installBinary, "v0.42.0", false},
 		{installHomebrew, "v0.42.0", true},
 		{installSource, "v0.42.0", true},
 		{installBinary, "", false},

--- a/cmd/ox/version_cache.go
+++ b/cmd/ox/version_cache.go
@@ -81,12 +81,16 @@ func writeVersionCacheFromDoctor(latestVersion string) {
 func refreshVersionCacheIfStale(maxAge time.Duration) *versionCheckResult {
 	cached := readVersionCache()
 	if cached == nil || time.Since(cached.CheckedAt) > maxAge {
-		if tag, err := getLatestGitHubRelease(); err == nil && tag != "" {
+		if tag, err := latestReleaseFetcher(); err == nil && tag != "" {
 			writeVersionCacheFromDoctor(tag)
 		}
 	}
 	return checkVersionFromCache()
 }
+
+// latestReleaseFetcher fetches the latest release tag; indirected so tests can
+// exercise the stale-cache refetch path without reaching GitHub.
+var latestReleaseFetcher = getLatestGitHubRelease
 
 // checkVersionFromCache reads the version cache and returns an update result
 // if a newer version is available. Returns nil if no cache exists or no

--- a/cmd/ox/version_cache.go
+++ b/cmd/ox/version_cache.go
@@ -72,6 +72,22 @@ func writeVersionCacheFromDoctor(latestVersion string) {
 	_ = os.Rename(tmpPath, cachePath)
 }
 
+// refreshVersionCacheIfStale ensures the version cache is reasonably fresh
+// WITHOUT depending on the daemon. If the cache is missing or older than
+// maxAge, it performs one bounded live GitHub check (getLatestGitHubRelease
+// caps itself at 1s) and rewrites the cache. Any network failure is silent —
+// callers fall back to whatever the cache already holds. This closes the gap
+// where a coworker who never runs the daemon never learns an update exists.
+func refreshVersionCacheIfStale(maxAge time.Duration) *versionCheckResult {
+	cached := readVersionCache()
+	if cached == nil || time.Since(cached.CheckedAt) > maxAge {
+		if tag, err := getLatestGitHubRelease(); err == nil && tag != "" {
+			writeVersionCacheFromDoctor(tag)
+		}
+	}
+	return checkVersionFromCache()
+}
+
 // checkVersionFromCache reads the version cache and returns an update result
 // if a newer version is available. Returns nil if no cache exists or no
 // update is available.

--- a/cmd/ox/version_cache_test.go
+++ b/cmd/ox/version_cache_test.go
@@ -99,6 +99,27 @@ func TestWriteVersionCacheFromDoctor_PreservesETag(t *testing.T) {
 	assert.Equal(t, `"preserve-me"`, cached.ETag, "doctor must not clobber daemon's ETag")
 }
 
+// A fresh cache must NOT trigger a live GitHub refetch. Proven with a sentinel
+// version (v99.0.0) that could never come from the real API: if a refetch
+// happened it would overwrite the cache with the real latest and the sentinel
+// update would vanish. Also keeps the test hermetic (no network).
+func TestRefreshVersionCacheIfStale_FreshCacheSkipsNetwork(t *testing.T) {
+	useTestCacheDir(t)
+	writeTestVersionCache(t, &versionCacheData{
+		LatestVersion: "v99.0.0",
+		CheckedAt:     time.Now(),
+	})
+
+	result := refreshVersionCacheIfStale(6 * time.Hour)
+	require.NotNil(t, result)
+	assert.Equal(t, "99.0.0", result.LatestVersion, "fresh cache must be used verbatim, not refetched")
+
+	// the on-disk sentinel must be untouched (no write occurred)
+	cached := readVersionCache()
+	require.NotNil(t, cached)
+	assert.Equal(t, "v99.0.0", cached.LatestVersion)
+}
+
 // corrupt cache must not crash prime — graceful degradation
 func TestCheckVersionFromCache_CorruptFile(t *testing.T) {
 	useTestCacheDir(t)

--- a/cmd/ox/version_cache_test.go
+++ b/cmd/ox/version_cache_test.go
@@ -120,6 +120,33 @@ func TestRefreshVersionCacheIfStale_FreshCacheSkipsNetwork(t *testing.T) {
 	assert.Equal(t, "v99.0.0", cached.LatestVersion)
 }
 
+// A stale cache must trigger a refetch and adopt the newly fetched version,
+// without touching the network in the test (fetcher is injected).
+func TestRefreshVersionCacheIfStale_StaleCacheRefetches(t *testing.T) {
+	useTestCacheDir(t)
+	writeTestVersionCache(t, &versionCacheData{
+		LatestVersion: "v0.0.1", // older than current; would report no update
+		CheckedAt:     time.Now().Add(-24 * time.Hour),
+	})
+
+	oldFetcher := latestReleaseFetcher
+	fetched := false
+	latestReleaseFetcher = func() (string, error) {
+		fetched = true
+		return "v99.0.0", nil
+	}
+	t.Cleanup(func() { latestReleaseFetcher = oldFetcher })
+
+	result := refreshVersionCacheIfStale(6 * time.Hour)
+	assert.True(t, fetched, "stale cache must trigger a refetch")
+	require.NotNil(t, result, "refetched newer version should report an update")
+	assert.Equal(t, "99.0.0", result.LatestVersion)
+
+	cached := readVersionCache()
+	require.NotNil(t, cached)
+	assert.Equal(t, "v99.0.0", cached.LatestVersion, "cache must be rewritten with the fetched version")
+}
+
 // corrupt cache must not crash prime — graceful degradation
 func TestCheckVersionFromCache_CorruptFile(t *testing.T) {
 	useTestCacheDir(t)

--- a/internal/upgrade/selfreplace.go
+++ b/internal/upgrade/selfreplace.go
@@ -309,23 +309,92 @@ type stagedBinary struct {
 	isOx     bool
 }
 
-// stageBinaries extracts the ox binary and any adapter binaries that already
-// exist in installDir from the tarball, writing each to a sibling temp file.
-// Adapters not already installed are skipped so an ox-only install does not
-// suddenly sprout adapter binaries.
+// stageBinaries writes the ox binary — and any adapter already installed
+// alongside it — from the tarball into sibling temp files ready to rename.
+//
+// Zip-slip safety by construction: the archive's entry names are used ONLY as
+// map keys to look up file *content*; every filesystem path written here is
+// built from an install-target name that comes from the local filesystem
+// (os.ReadDir) or the literal "ox", never from the archive. An archive entry
+// named "../../etc/whatever" therefore cannot influence any path — it simply
+// never matches an install target.
 func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]stagedBinary, error) {
+	contents, err := readArchiveBinaries(ctx, tarball)
+	if err != nil {
+		return nil, err
+	}
+	// the ox binary itself must be present: an adapter-only archive must never
+	// replace adapters while leaving ox on the old version.
+	if _, ok := contents["ox"]; !ok {
+		return nil, errors.New("release tarball contains no ox binary")
+	}
+
+	cleanInstallDir := filepath.Clean(installDir)
+	var staged []stagedBinary
+	for _, name := range installTargets(cleanInstallDir) {
+		data, ok := contents[name]
+		if !ok {
+			continue // installed here but not shipped in this release
+		}
+		// name is a trusted install-target ("ox" literal or an os.ReadDir
+		// entry), so this path is not archive-derived.
+		destPath := filepath.Join(cleanInstallDir, name)
+		tmp, err := os.CreateTemp(cleanInstallDir, ".ox-upgrade-*")
+		if err != nil {
+			return nil, fmt.Errorf("stage %s: %w", name, err)
+		}
+		if _, err := tmp.Write(data); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return nil, fmt.Errorf("stage %s: %w", name, err)
+		}
+		if err := tmp.Chmod(0o755); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return nil, fmt.Errorf("chmod %s: %w", name, err)
+		}
+		if err := tmp.Close(); err != nil {
+			_ = os.Remove(tmp.Name())
+			return nil, err
+		}
+		staged = append(staged, stagedBinary{destPath: destPath, tmpPath: tmp.Name(), isOx: name == "ox"})
+	}
+	return staged, nil
+}
+
+// installTargets returns the binaries to replace: ox (always, as the running
+// binary) plus any ox-adapter-* already present in installDir. Names come from
+// the local filesystem, never the archive.
+func installTargets(installDir string) []string {
+	targets := []string{"ox"}
+	entries, err := os.ReadDir(installDir)
+	if err != nil {
+		return targets
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if name := e.Name(); strings.HasPrefix(name, "ox-adapter-") {
+			targets = append(targets, name)
+		}
+	}
+	return targets
+}
+
+// readArchiveBinaries reads the ox and ox-adapter-* regular files from the
+// tarball into memory, keyed by basename. Entry names are used only as map
+// keys (never as filesystem paths), and decompression is bounded per-entry and
+// in total to cap a decompression bomb.
+func readArchiveBinaries(ctx context.Context, tarball []byte) (map[string][]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewReader(tarball))
 	if err != nil {
 		return nil, fmt.Errorf("open gzip: %w", err)
 	}
 	defer func() { _ = gz.Close() }()
 
-	cleanInstallDir := filepath.Clean(installDir)
-	var (
-		staged     []stagedBinary
-		sawOx      bool
-		totalBytes int64
-	)
+	out := make(map[string][]byte)
+	var totalBytes int64
 	tr := tar.NewReader(gz)
 	for {
 		// bound extraction by the caller's deadline: a decompression-heavy
@@ -343,74 +412,27 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]st
 		if hdr.Typeflag != tar.TypeReg {
 			continue
 		}
-		// bound decompression: reject an oversized single entry and cap the
-		// whole archive's declared decompressed size (a bomb whose expanded
-		// bytes dwarf the compressed download).
 		if hdr.Size < 0 || hdr.Size > maxEntryBytes {
-			return nil, fmt.Errorf("archive entry %s has invalid size %d", filepath.Base(hdr.Name), hdr.Size)
+			return nil, fmt.Errorf("archive entry has invalid size %d", hdr.Size)
 		}
 		totalBytes += hdr.Size
 		if totalBytes > maxTotalBytes {
 			return nil, fmt.Errorf("archive exceeds %d bytes decompressed", maxTotalBytes)
 		}
 
-		// filepath.Base strips every directory component from the archive
-		// entry, so a "../" or absolute name collapses to a bare filename that
-		// can only land in installDir.
 		base := filepath.Base(hdr.Name)
-		isOx := base == "ox"
-		isAdapter := strings.HasPrefix(base, "ox-adapter-")
-		if !isOx && !isAdapter {
+		if base != "ox" && !strings.HasPrefix(base, "ox-adapter-") {
 			continue // LICENSE, README, CHANGELOG, etc.
 		}
-		destPath := filepath.Join(cleanInstallDir, base)
-		// belt-and-suspenders barrier: the resolved path must stay within
-		// installDir. Base already guarantees this; the explicit HasPrefix
-		// check is the form the archive-extraction taint analysis recognizes,
-		// and it guards every os.Stat/os.Rename on destPath below.
-		if destPath != cleanInstallDir && !strings.HasPrefix(destPath, cleanInstallDir+string(os.PathSeparator)) {
-			return nil, fmt.Errorf("refusing archive entry outside install dir: %q", hdr.Name)
-		}
-		if isAdapter {
-			if _, err := os.Stat(destPath); err != nil {
-				continue // adapter not installed here; leave it alone
-			}
-		}
-
-		// temp file uses a FIXED name pattern so no archive-derived string
-		// reaches a filesystem path.
-		tmp, err := os.CreateTemp(cleanInstallDir, ".ox-upgrade-*")
+		// hdr.Size <= maxEntryBytes was checked above, so this reads the whole
+		// entry rather than truncating a large binary.
+		data, err := io.ReadAll(io.LimitReader(tr, hdr.Size))
 		if err != nil {
-			return nil, fmt.Errorf("stage %s: %w", base, err)
-		}
-		// hdr.Size <= maxEntryBytes was checked above, so LimitReader reads the
-		// full entry rather than silently truncating a large binary.
-		if _, err := io.Copy(tmp, io.LimitReader(tr, maxEntryBytes)); err != nil {
-			_ = tmp.Close()
-			_ = os.Remove(tmp.Name())
 			return nil, fmt.Errorf("extract %s: %w", base, err)
 		}
-		if err := tmp.Chmod(0o755); err != nil {
-			_ = tmp.Close()
-			_ = os.Remove(tmp.Name())
-			return nil, fmt.Errorf("chmod %s: %w", base, err)
-		}
-		if err := tmp.Close(); err != nil {
-			_ = os.Remove(tmp.Name())
-			return nil, err
-		}
-		if isOx {
-			sawOx = true
-		}
-		staged = append(staged, stagedBinary{destPath: destPath, tmpPath: tmp.Name(), isOx: isOx})
+		out[base] = data
 	}
-
-	// the ox binary itself must be present: an adapter-only archive must never
-	// replace adapters while leaving ox on the old version.
-	if !sawOx {
-		return nil, errors.New("release tarball contains no ox binary")
-	}
-	return staged, nil
+	return out, nil
 }
 
 // fetchChecksums downloads and parses a GoReleaser checksums.txt (lines of

--- a/internal/upgrade/selfreplace.go
+++ b/internal/upgrade/selfreplace.go
@@ -68,6 +68,10 @@ var (
 // exercise the all-or-nothing rollback path.
 var renameFunc = os.Rename
 
+// afterStageHook, when non-nil, runs after each binary is staged; a test uses
+// it to fail mid-staging and verify the temp-file cleanup defer.
+var afterStageHook func(name string) error
+
 // Config controls a self-replace operation. Network endpoints and the install
 // directory are injectable so the flow is testable without touching the real
 // binary or reaching the real GitHub.
@@ -359,7 +363,14 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) (stag
 	}()
 
 	cleanInstallDir := filepath.Clean(installDir)
-	for _, name := range installTargets(cleanInstallDir) {
+	// error returns below are bare so the named `staged` result survives for
+	// the deferred cleanup — `return nil, err` would blank it and leak temps.
+	targets, err := installTargets(cleanInstallDir)
+	if err != nil {
+		retErr = err
+		return
+	}
+	for _, name := range targets {
 		data, ok := contents[name]
 		if !ok {
 			continue // installed here but not shipped in this release
@@ -369,36 +380,48 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) (stag
 		destPath := filepath.Join(cleanInstallDir, name)
 		tmp, err := os.CreateTemp(cleanInstallDir, ".ox-upgrade-*")
 		if err != nil {
-			return nil, fmt.Errorf("stage %s: %w", name, err)
+			retErr = fmt.Errorf("stage %s: %w", name, err)
+			return
 		}
 		if _, err := tmp.Write(data); err != nil {
 			_ = tmp.Close()
 			_ = os.Remove(tmp.Name())
-			return nil, fmt.Errorf("stage %s: %w", name, err)
+			retErr = fmt.Errorf("stage %s: %w", name, err)
+			return
 		}
 		if err := tmp.Chmod(0o755); err != nil {
 			_ = tmp.Close()
 			_ = os.Remove(tmp.Name())
-			return nil, fmt.Errorf("chmod %s: %w", name, err)
+			retErr = fmt.Errorf("chmod %s: %w", name, err)
+			return
 		}
 		if err := tmp.Close(); err != nil {
 			_ = os.Remove(tmp.Name())
-			return nil, err
+			retErr = err
+			return
 		}
 		staged = append(staged, stagedBinary{destPath: destPath, tmpPath: tmp.Name(), isOx: name == "ox"})
+		if afterStageHook != nil {
+			if err := afterStageHook(name); err != nil {
+				retErr = err
+				return
+			}
+		}
 	}
 	return staged, nil
 }
 
 // installTargets returns the binaries to replace: ox (always, as the running
 // binary) plus any ox-adapter-* already present in installDir. Names come from
-// the local filesystem, never the archive.
-func installTargets(installDir string) []string {
-	targets := []string{"ox"}
+// the local filesystem, never the archive. A directory-read failure is an
+// error, not a silent fallback to ox-only — that would upgrade ox while
+// leaving installed adapters behind, skewing their protocol versions.
+func installTargets(installDir string) ([]string, error) {
 	entries, err := os.ReadDir(installDir)
 	if err != nil {
-		return targets
+		return nil, fmt.Errorf("list install dir %s: %w", installDir, err)
 	}
+	targets := []string{"ox"}
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -407,7 +430,7 @@ func installTargets(installDir string) []string {
 			targets = append(targets, name)
 		}
 	}
-	return targets
+	return targets, nil
 }
 
 // readArchiveBinaries reads the ox and ox-adapter-* regular files from the

--- a/internal/upgrade/selfreplace.go
+++ b/internal/upgrade/selfreplace.go
@@ -1,0 +1,362 @@
+// Package upgrade implements in-place self-replacement of the ox binary for
+// installs that were placed on disk directly (the curl | bash install.sh path).
+//
+// Homebrew and `go install` installs upgrade through their own package managers;
+// this package covers the remaining cohort, which previously had no automatic
+// upgrade at all — ox upgrade merely printed manual instructions.
+//
+// Security model: the release tarball and the release checksums.txt are both
+// fetched over HTTPS from github.com, and the tarball's SHA-256 is verified
+// against the checksum before anything is written over a real binary. This is
+// strictly stronger than install.sh, which verifies nothing on download.
+// Stronger provenance (ed25519 verification via internal/signing, or GitHub
+// build-provenance attestations) is tracked as follow-up.
+package upgrade
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/useragent"
+)
+
+// versionRe bounds the target version to a semver-ish shape BEFORE it is
+// interpolated into a download URL. Without this, a crafted --target (e.g.
+// "../../evil" or a full URL) could redirect the download off the release
+// path. Accepts "1.2.3" and common suffixes ("1.2.3-rc1", "1.2.3-next").
+var versionRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$`)
+
+// ErrNotWritable is returned when the directory holding the ox binary cannot be
+// written to (e.g. /usr/local/bin owned by root). Callers should surface a hint
+// to re-run with elevated permissions rather than failing opaquely.
+var ErrNotWritable = errors.New("install directory is not writable")
+
+// defaultReleaseBase is the GitHub release asset download root. Overridable in
+// Config for tests.
+const defaultReleaseBase = "https://github.com/sageox/ox/releases/download"
+
+// maxDownloadBytes caps an individual asset download to guard against a
+// malicious or misbehaving server streaming unbounded data.
+const maxDownloadBytes = 256 << 20 // 256 MiB
+
+// Config controls a self-replace operation. Network endpoints and the install
+// directory are injectable so the flow is testable without touching the real
+// binary or reaching the real GitHub.
+type Config struct {
+	// Version is the target release WITHOUT a leading "v" (e.g. "0.14.0").
+	Version string
+	// OS and Arch select the platform asset; default to the running platform.
+	OS   string
+	Arch string
+	// ReleaseBase is the download root; defaults to the GitHub releases URL.
+	ReleaseBase string
+	// HTTPClient is used for all downloads; defaults to http.DefaultClient.
+	HTTPClient *http.Client
+	// InstallDir holds the ox binary; defaults to the directory of the running
+	// executable. Tests set this to a temp dir.
+	InstallDir string
+	// DisableCodesign skips the macOS ad-hoc re-sign step (used in tests).
+	DisableCodesign bool
+}
+
+func (c *Config) applyDefaults() {
+	if c.OS == "" {
+		c.OS = runtime.GOOS
+	}
+	if c.Arch == "" {
+		c.Arch = runtime.GOARCH
+	}
+	if c.ReleaseBase == "" {
+		c.ReleaseBase = defaultReleaseBase
+	}
+	if c.HTTPClient == nil {
+		c.HTTPClient = newHardenedClient()
+	}
+}
+
+// newHardenedClient returns an HTTP client that pins redirects to GitHub hosts
+// and caps total request time, so a redirect cannot steer the download to an
+// attacker-controlled origin and a stalled connection cannot hang forever.
+func newHardenedClient() *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Minute,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if !isGitHubHost(req.URL.Hostname()) {
+				return fmt.Errorf("refusing redirect to non-GitHub host %q", req.URL.Hostname())
+			}
+			return nil
+		},
+	}
+}
+
+// isGitHubHost reports whether host is github.com or a *.githubusercontent.com
+// CDN host (where release assets actually live behind a 302).
+func isGitHubHost(host string) bool {
+	host = strings.ToLower(host)
+	return host == "github.com" || host == "githubusercontent.com" ||
+		strings.HasSuffix(host, ".githubusercontent.com")
+}
+
+// AssetName returns the release tarball name for a platform, matching the
+// GoReleaser name_template "{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}".
+func AssetName(version, goos, goarch string) string {
+	return fmt.Sprintf("ox_%s_%s_%s.tar.gz", version, goos, goarch)
+}
+
+// ReplaceRunningBinary downloads the release tarball for cfg.Version, verifies
+// its SHA-256 against the release checksums.txt, and atomically replaces the ox
+// binary — plus any bundled adapter binaries already installed alongside it —
+// in place. The ox binary itself is replaced last so a mid-flight failure
+// leaves the running binary intact.
+func ReplaceRunningBinary(ctx context.Context, cfg Config) error {
+	cfg.applyDefaults()
+	if cfg.Version == "" {
+		return errors.New("upgrade: empty target version")
+	}
+	if !versionRe.MatchString(cfg.Version) {
+		return fmt.Errorf("upgrade: invalid target version %q", cfg.Version)
+	}
+
+	installDir, err := resolveInstallDir(cfg.InstallDir)
+	if err != nil {
+		return err
+	}
+	if err := checkWritable(installDir); err != nil {
+		return err
+	}
+
+	asset := AssetName(cfg.Version, cfg.OS, cfg.Arch)
+	tagBase := fmt.Sprintf("%s/v%s", strings.TrimRight(cfg.ReleaseBase, "/"), cfg.Version)
+
+	// fetch and parse the checksum manifest first, so a download can be
+	// verified the moment it completes.
+	sums, err := fetchChecksums(ctx, cfg.HTTPClient, tagBase+"/checksums.txt")
+	if err != nil {
+		return fmt.Errorf("fetch checksums: %w", err)
+	}
+	wantSum, ok := sums[asset]
+	if !ok {
+		return fmt.Errorf("no checksum for %s in release v%s (unsupported platform?)", asset, cfg.Version)
+	}
+
+	tarball, err := download(ctx, cfg.HTTPClient, tagBase+"/"+asset)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", asset, err)
+	}
+	gotSum := sha256.Sum256(tarball)
+	if hex.EncodeToString(gotSum[:]) != wantSum {
+		return fmt.Errorf("checksum mismatch for %s: refusing to install", asset)
+	}
+
+	// extract the binaries we care about into staged temp files next to the
+	// targets (same filesystem => rename is atomic).
+	staged, err := stageBinaries(ctx, tarball, installDir)
+	if err != nil {
+		return err
+	}
+	// always clean up any staged file we do not end up renaming.
+	defer func() {
+		for _, s := range staged {
+			_ = os.Remove(s.tmpPath)
+		}
+	}()
+
+	// re-sign on macOS so Gatekeeper does not slow-path the fresh binary,
+	// mirroring install.sh. Best-effort and non-fatal.
+	if cfg.OS == "darwin" && !cfg.DisableCodesign {
+		for _, s := range staged {
+			codesignAdHoc(s.tmpPath)
+		}
+	}
+
+	// commit: adapters first, ox last.
+	for _, s := range staged {
+		if s.isOx {
+			continue
+		}
+		if err := os.Rename(s.tmpPath, s.destPath); err != nil {
+			return fmt.Errorf("replace %s: %w", filepath.Base(s.destPath), err)
+		}
+	}
+	for _, s := range staged {
+		if !s.isOx {
+			continue
+		}
+		if err := os.Rename(s.tmpPath, s.destPath); err != nil {
+			return fmt.Errorf("replace ox: %w", err)
+		}
+	}
+	return nil
+}
+
+// resolveInstallDir returns the directory holding the ox binary. When override
+// is set (tests), it is used verbatim; otherwise the running executable's
+// resolved directory is used.
+func resolveInstallDir(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("locate running binary: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return filepath.Dir(exe), nil
+}
+
+// checkWritable verifies we can create files in dir, returning ErrNotWritable
+// (wrapped with the path) otherwise so callers can suggest sudo.
+func checkWritable(dir string) error {
+	probe, err := os.CreateTemp(dir, ".ox-upgrade-probe-*")
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrNotWritable, dir)
+	}
+	name := probe.Name()
+	_ = probe.Close()
+	_ = os.Remove(name)
+	return nil
+}
+
+// stagedBinary is one extracted binary written to a temp file, ready to rename
+// over its destination.
+type stagedBinary struct {
+	destPath string
+	tmpPath  string
+	isOx     bool
+}
+
+// stageBinaries extracts the ox binary and any adapter binaries that already
+// exist in installDir from the tarball, writing each to a sibling temp file.
+// Adapters not already installed are skipped so an ox-only install does not
+// suddenly sprout adapter binaries.
+func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]stagedBinary, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(tarball))
+	if err != nil {
+		return nil, fmt.Errorf("open gzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	var staged []stagedBinary
+	tr := tar.NewReader(gz)
+	for {
+		// bound extraction by the caller's deadline: a decompression-heavy
+		// archive must not stream-discard entries past the timeout.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		base := filepath.Base(hdr.Name)
+		isOx := base == "ox"
+		isAdapter := strings.HasPrefix(base, "ox-adapter-")
+		if !isOx && !isAdapter {
+			continue // LICENSE, README, CHANGELOG, etc.
+		}
+		destPath := filepath.Join(installDir, base)
+		if isAdapter {
+			if _, err := os.Stat(destPath); err != nil {
+				continue // adapter not installed here; leave it alone
+			}
+		}
+
+		tmp, err := os.CreateTemp(installDir, "."+base+".tmp-*")
+		if err != nil {
+			return nil, fmt.Errorf("stage %s: %w", base, err)
+		}
+		if _, err := io.Copy(tmp, io.LimitReader(tr, maxDownloadBytes)); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return nil, fmt.Errorf("extract %s: %w", base, err)
+		}
+		if err := tmp.Chmod(0o755); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return nil, fmt.Errorf("chmod %s: %w", base, err)
+		}
+		if err := tmp.Close(); err != nil {
+			_ = os.Remove(tmp.Name())
+			return nil, err
+		}
+		staged = append(staged, stagedBinary{destPath: destPath, tmpPath: tmp.Name(), isOx: isOx})
+	}
+
+	if len(staged) == 0 {
+		return nil, errors.New("no ox binary found in release tarball")
+	}
+	return staged, nil
+}
+
+// fetchChecksums downloads and parses a GoReleaser checksums.txt (lines of
+// "<sha256hex>  <filename>") into a filename -> hex map.
+func fetchChecksums(ctx context.Context, client *http.Client, url string) (map[string]string, error) {
+	body, err := download(ctx, client, url)
+	if err != nil {
+		return nil, err
+	}
+	sums := make(map[string]string)
+	sc := bufio.NewScanner(bytes.NewReader(body))
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		sums[fields[1]] = strings.ToLower(fields[0])
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return sums, nil
+}
+
+// download GETs url and returns the body, bounded by maxDownloadBytes.
+func download(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", useragent.String())
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: status %d", url, resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, maxDownloadBytes))
+}
+
+// codesignAdHoc re-signs a binary ad-hoc on macOS so Gatekeeper does not
+// slow-path it. Best-effort: absence of codesign or a failure is ignored.
+func codesignAdHoc(path string) {
+	if _, err := exec.LookPath("codesign"); err != nil {
+		return
+	}
+	_ = exec.Command("codesign", "--force", "--sign", "-", path).Run()
+}

--- a/internal/upgrade/selfreplace.go
+++ b/internal/upgrade/selfreplace.go
@@ -55,6 +55,19 @@ const defaultReleaseBase = "https://github.com/sageox/ox/releases/download"
 // malicious or misbehaving server streaming unbounded data.
 const maxDownloadBytes = 256 << 20 // 256 MiB
 
+// maxEntryBytes caps a single decompressed archive entry, and maxTotalBytes
+// caps the whole archive's declared decompressed size. Together they bound a
+// decompression bomb whose expanded contents dwarf the compressed download.
+// Vars (not consts) only so tests can lower them to exercise the guard.
+var (
+	maxEntryBytes int64 = 256 << 20 // 256 MiB per entry
+	maxTotalBytes int64 = 512 << 20 // 512 MiB total decompressed
+)
+
+// renameFunc is os.Rename, indirected so tests can force a rename failure and
+// exercise the all-or-nothing rollback path.
+var renameFunc = os.Rename
+
 // Config controls a self-replace operation. Network endpoints and the install
 // directory are injectable so the flow is testable without touching the real
 // binary or reaching the real GitHub.
@@ -185,21 +198,74 @@ func ReplaceRunningBinary(ctx context.Context, cfg Config) error {
 		}
 	}
 
-	// commit: adapters first, ox last.
+	// commit all-or-nothing: adapters first, ox last, so a partial failure
+	// never leaves a version-skewed ox/adapter set. Each replaced binary is
+	// backed up first; any failure rolls back every completed rename.
+	return commitStaged(orderAdaptersFirst(staged))
+}
+
+// orderAdaptersFirst returns staged binaries with adapters before ox, so ox —
+// the running binary — is the last thing swapped.
+func orderAdaptersFirst(staged []stagedBinary) []stagedBinary {
+	ordered := make([]stagedBinary, 0, len(staged))
 	for _, s := range staged {
-		if s.isOx {
-			continue
-		}
-		if err := os.Rename(s.tmpPath, s.destPath); err != nil {
-			return fmt.Errorf("replace %s: %w", filepath.Base(s.destPath), err)
+		if !s.isOx {
+			ordered = append(ordered, s)
 		}
 	}
 	for _, s := range staged {
-		if !s.isOx {
-			continue
+		if s.isOx {
+			ordered = append(ordered, s)
 		}
-		if err := os.Rename(s.tmpPath, s.destPath); err != nil {
-			return fmt.Errorf("replace ox: %w", err)
+	}
+	return ordered
+}
+
+// commitStaged atomically swaps each staged binary into place, backing up the
+// prior file first. If any rename fails, every already-committed rename is
+// rolled back (originals restored, new files removed) so the install is either
+// fully upgraded or fully unchanged.
+func commitStaged(ordered []stagedBinary) error {
+	type commit struct {
+		destPath, backupPath string
+		hadOriginal          bool
+	}
+	var done []commit
+
+	rollback := func() {
+		for i := len(done) - 1; i >= 0; i-- {
+			c := done[i]
+			_ = os.Remove(c.destPath) // drop the newly placed binary
+			if c.hadOriginal {
+				_ = renameFunc(c.backupPath, c.destPath) // restore the original
+			}
+		}
+	}
+
+	for _, s := range ordered {
+		backupPath := s.tmpPath + ".bak" // unique + on the same filesystem
+		hadOriginal := false
+		if _, err := os.Stat(s.destPath); err == nil {
+			if err := renameFunc(s.destPath, backupPath); err != nil {
+				rollback()
+				return fmt.Errorf("back up %s: %w", filepath.Base(s.destPath), err)
+			}
+			hadOriginal = true
+		}
+		if err := renameFunc(s.tmpPath, s.destPath); err != nil {
+			if hadOriginal {
+				_ = renameFunc(backupPath, s.destPath) // undo this one's backup
+			}
+			rollback()
+			return fmt.Errorf("replace %s: %w", filepath.Base(s.destPath), err)
+		}
+		done = append(done, commit{destPath: s.destPath, backupPath: backupPath, hadOriginal: hadOriginal})
+	}
+
+	// success: drop the backups.
+	for _, c := range done {
+		if c.hadOriginal {
+			_ = os.Remove(c.backupPath)
 		}
 	}
 	return nil
@@ -254,7 +320,12 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]st
 	}
 	defer func() { _ = gz.Close() }()
 
-	var staged []stagedBinary
+	cleanInstallDir := filepath.Clean(installDir)
+	var (
+		staged     []stagedBinary
+		sawOx      bool
+		totalBytes int64
+	)
 	tr := tar.NewReader(gz)
 	for {
 		// bound extraction by the caller's deadline: a decompression-heavy
@@ -272,24 +343,44 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]st
 		if hdr.Typeflag != tar.TypeReg {
 			continue
 		}
+		// bound decompression: reject an oversized single entry and cap the
+		// whole archive's declared decompressed size (a bomb whose expanded
+		// bytes dwarf the compressed download).
+		if hdr.Size < 0 || hdr.Size > maxEntryBytes {
+			return nil, fmt.Errorf("archive entry %s has invalid size %d", filepath.Base(hdr.Name), hdr.Size)
+		}
+		totalBytes += hdr.Size
+		if totalBytes > maxTotalBytes {
+			return nil, fmt.Errorf("archive exceeds %d bytes decompressed", maxTotalBytes)
+		}
+
 		base := filepath.Base(hdr.Name)
 		isOx := base == "ox"
 		isAdapter := strings.HasPrefix(base, "ox-adapter-")
 		if !isOx && !isAdapter {
 			continue // LICENSE, README, CHANGELOG, etc.
 		}
-		destPath := filepath.Join(installDir, base)
+		destPath := filepath.Join(cleanInstallDir, base)
+		// zip-slip guard: the resolved path must stay within installDir.
+		// filepath.Base already strips any directory, so this can only trip on
+		// a pathological entry — but assert it explicitly with the HasPrefix
+		// barrier the archive-extraction taint check recognizes.
+		if destPath != cleanInstallDir && !strings.HasPrefix(destPath, cleanInstallDir+string(os.PathSeparator)) {
+			return nil, fmt.Errorf("refusing archive entry outside install dir: %q", hdr.Name)
+		}
 		if isAdapter {
 			if _, err := os.Stat(destPath); err != nil {
 				continue // adapter not installed here; leave it alone
 			}
 		}
 
-		tmp, err := os.CreateTemp(installDir, "."+base+".tmp-*")
+		tmp, err := os.CreateTemp(cleanInstallDir, "."+base+".tmp-*")
 		if err != nil {
 			return nil, fmt.Errorf("stage %s: %w", base, err)
 		}
-		if _, err := io.Copy(tmp, io.LimitReader(tr, maxDownloadBytes)); err != nil {
+		// hdr.Size <= maxEntryBytes was checked above, so LimitReader reads the
+		// full entry rather than silently truncating a large binary.
+		if _, err := io.Copy(tmp, io.LimitReader(tr, maxEntryBytes)); err != nil {
 			_ = tmp.Close()
 			_ = os.Remove(tmp.Name())
 			return nil, fmt.Errorf("extract %s: %w", base, err)
@@ -303,11 +394,16 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]st
 			_ = os.Remove(tmp.Name())
 			return nil, err
 		}
+		if isOx {
+			sawOx = true
+		}
 		staged = append(staged, stagedBinary{destPath: destPath, tmpPath: tmp.Name(), isOx: isOx})
 	}
 
-	if len(staged) == 0 {
-		return nil, errors.New("no ox binary found in release tarball")
+	// the ox binary itself must be present: an adapter-only archive must never
+	// replace adapters while leaving ox on the old version.
+	if !sawOx {
+		return nil, errors.New("release tarball contains no ox binary")
 	}
 	return staged, nil
 }

--- a/internal/upgrade/selfreplace.go
+++ b/internal/upgrade/selfreplace.go
@@ -232,14 +232,24 @@ func commitStaged(ordered []stagedBinary) error {
 	}
 	var done []commit
 
-	rollback := func() {
+	// rollback undoes every recorded rename and returns any restore failures.
+	// A failed restore is reported (with the backup path) rather than swallowed,
+	// so the caller can point the user at a recoverable original instead of
+	// silently stranding it.
+	rollback := func() []string {
+		var problems []string
 		for i := len(done) - 1; i >= 0; i-- {
 			c := done[i]
-			_ = os.Remove(c.destPath) // drop the newly placed binary
+			if err := os.Remove(c.destPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				problems = append(problems, fmt.Sprintf("remove %s: %v", c.destPath, err))
+			}
 			if c.hadOriginal {
-				_ = renameFunc(c.backupPath, c.destPath) // restore the original
+				if err := renameFunc(c.backupPath, c.destPath); err != nil {
+					problems = append(problems, fmt.Sprintf("restore %s (original preserved at %s): %v", c.destPath, c.backupPath, err))
+				}
 			}
 		}
+		return problems
 	}
 
 	for _, s := range ordered {
@@ -247,17 +257,15 @@ func commitStaged(ordered []stagedBinary) error {
 		hadOriginal := false
 		if _, err := os.Stat(s.destPath); err == nil {
 			if err := renameFunc(s.destPath, backupPath); err != nil {
-				rollback()
-				return fmt.Errorf("back up %s: %w", filepath.Base(s.destPath), err)
+				return withRollbackProblems(fmt.Errorf("back up %s: %w", filepath.Base(s.destPath), err), rollback())
 			}
 			hadOriginal = true
 		}
 		if err := renameFunc(s.tmpPath, s.destPath); err != nil {
-			if hadOriginal {
-				_ = renameFunc(backupPath, s.destPath) // undo this one's backup
-			}
-			rollback()
-			return fmt.Errorf("replace %s: %w", filepath.Base(s.destPath), err)
+			// record this entry so rollback restores its just-made backup too,
+			// then unwind everything committed so far.
+			done = append(done, commit{destPath: s.destPath, backupPath: backupPath, hadOriginal: hadOriginal})
+			return withRollbackProblems(fmt.Errorf("replace %s: %w", filepath.Base(s.destPath), err), rollback())
 		}
 		done = append(done, commit{destPath: s.destPath, backupPath: backupPath, hadOriginal: hadOriginal})
 	}
@@ -269,6 +277,17 @@ func commitStaged(ordered []stagedBinary) error {
 		}
 	}
 	return nil
+}
+
+// withRollbackProblems attaches any rollback restore failures to the primary
+// error so a partially-unwound install surfaces the stranded backups instead
+// of hiding them behind the original failure.
+func withRollbackProblems(primary error, problems []string) error {
+	if len(problems) == 0 {
+		return primary
+	}
+	return fmt.Errorf("%w; rollback incomplete, manual recovery may be needed: %s",
+		primary, strings.Join(problems, "; "))
 }
 
 // resolveInstallDir returns the directory holding the ox binary. When override
@@ -318,7 +337,7 @@ type stagedBinary struct {
 // (os.ReadDir) or the literal "ox", never from the archive. An archive entry
 // named "../../etc/whatever" therefore cannot influence any path — it simply
 // never matches an install target.
-func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]stagedBinary, error) {
+func stageBinaries(ctx context.Context, tarball []byte, installDir string) (staged []stagedBinary, retErr error) {
 	contents, err := readArchiveBinaries(ctx, tarball)
 	if err != nil {
 		return nil, err
@@ -329,8 +348,17 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]st
 		return nil, errors.New("release tarball contains no ox binary")
 	}
 
+	// if staging fails partway, remove the temp files already written so a
+	// partial run leaves no .ox-upgrade-* litter behind.
+	defer func() {
+		if retErr != nil {
+			for _, s := range staged {
+				_ = os.Remove(s.tmpPath)
+			}
+		}
+	}()
+
 	cleanInstallDir := filepath.Clean(installDir)
-	var staged []stagedBinary
 	for _, name := range installTargets(cleanInstallDir) {
 		data, ok := contents[name]
 		if !ok {

--- a/internal/upgrade/selfreplace.go
+++ b/internal/upgrade/selfreplace.go
@@ -354,6 +354,9 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]st
 			return nil, fmt.Errorf("archive exceeds %d bytes decompressed", maxTotalBytes)
 		}
 
+		// filepath.Base strips every directory component from the archive
+		// entry, so a "../" or absolute name collapses to a bare filename that
+		// can only land in installDir.
 		base := filepath.Base(hdr.Name)
 		isOx := base == "ox"
 		isAdapter := strings.HasPrefix(base, "ox-adapter-")
@@ -361,10 +364,10 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]st
 			continue // LICENSE, README, CHANGELOG, etc.
 		}
 		destPath := filepath.Join(cleanInstallDir, base)
-		// zip-slip guard: the resolved path must stay within installDir.
-		// filepath.Base already strips any directory, so this can only trip on
-		// a pathological entry — but assert it explicitly with the HasPrefix
-		// barrier the archive-extraction taint check recognizes.
+		// belt-and-suspenders barrier: the resolved path must stay within
+		// installDir. Base already guarantees this; the explicit HasPrefix
+		// check is the form the archive-extraction taint analysis recognizes,
+		// and it guards every os.Stat/os.Rename on destPath below.
 		if destPath != cleanInstallDir && !strings.HasPrefix(destPath, cleanInstallDir+string(os.PathSeparator)) {
 			return nil, fmt.Errorf("refusing archive entry outside install dir: %q", hdr.Name)
 		}
@@ -374,7 +377,9 @@ func stageBinaries(ctx context.Context, tarball []byte, installDir string) ([]st
 			}
 		}
 
-		tmp, err := os.CreateTemp(cleanInstallDir, "."+base+".tmp-*")
+		// temp file uses a FIXED name pattern so no archive-derived string
+		// reaches a filesystem path.
+		tmp, err := os.CreateTemp(cleanInstallDir, ".ox-upgrade-*")
 		if err != nil {
 			return nil, fmt.Errorf("stage %s: %w", base, err)
 		}

--- a/internal/upgrade/selfreplace_test.go
+++ b/internal/upgrade/selfreplace_test.go
@@ -293,6 +293,45 @@ func TestReplaceRunningBinary_RollsBackOnLateRenameFailure(t *testing.T) {
 	}
 }
 
+// When rollback itself cannot restore an original, the failure must be
+// surfaced (with the preserved backup path) rather than swallowed behind the
+// primary error — otherwise a stranded binary is invisible to the user.
+func TestReplaceRunningBinary_RollbackFailureIsSurfaced(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+	writeFile(t, filepath.Join(dir, "ox-adapter-claude-code"), "OLD-adapter")
+
+	// every rename that targets ox fails: the ox swap fails AND its backup
+	// cannot be restored, so rollback is incomplete for ox.
+	oldRename := renameFunc
+	renameFunc = func(oldPath, newPath string) error {
+		if filepath.Base(newPath) == "ox" {
+			return errors.New("injected ox rename failure")
+		}
+		return oldRename(oldPath, newPath)
+	}
+	t.Cleanup(func() { renameFunc = oldRename })
+
+	tarball := makeTarball(t, map[string]string{
+		"ox":                     "NEW-ox",
+		"ox-adapter-claude-code": "NEW-adapter",
+	})
+	srv := releaseServer(t, tarball, "")
+	defer srv.Close()
+
+	err := ReplaceRunningBinary(context.Background(), baseConfig(dir, srv.URL))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "rollback incomplete") {
+		t.Errorf("error must surface the incomplete rollback, got: %v", err)
+	}
+	// the adapter (whose renames don't target ox) must still be rolled back.
+	if got := readFile(t, filepath.Join(dir, "ox-adapter-claude-code")); got != "OLD-adapter" {
+		t.Errorf("adapter must be rolled back: got %q", got)
+	}
+}
+
 func TestAssetName(t *testing.T) {
 	if got := AssetName("0.14.0", "darwin", "arm64"); got != "ox_0.14.0_darwin_arm64.tar.gz" {
 		t.Errorf("AssetName = %q", got)

--- a/internal/upgrade/selfreplace_test.go
+++ b/internal/upgrade/selfreplace_test.go
@@ -332,6 +332,83 @@ func TestReplaceRunningBinary_RollbackFailureIsSurfaced(t *testing.T) {
 	}
 }
 
+// If adapter discovery (os.ReadDir) fails, the upgrade must abort rather than
+// silently replace ox alone and skew adapter versions.
+func TestReplaceRunningBinary_ReadDirFailureAborts(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+	writeFile(t, filepath.Join(dir, "ox-adapter-claude-code"), "OLD-adapter")
+	// 0o300 = write+execute, NO read: checkWritable's CreateTemp still works,
+	// but os.ReadDir fails — the exact "discovery fails after writable check"
+	// case.
+	if err := os.Chmod(dir, 0o300); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	tarball := makeTarball(t, map[string]string{
+		"ox":                     "NEW-ox",
+		"ox-adapter-claude-code": "NEW-adapter",
+	})
+	srv := releaseServer(t, tarball, "")
+	defer srv.Close()
+
+	err := ReplaceRunningBinary(context.Background(), baseConfig(dir, srv.URL))
+	if err == nil {
+		t.Fatal("expected error when adapter discovery fails")
+	}
+	// restore read access to inspect: ox must be untouched (not upgraded alone).
+	_ = os.Chmod(dir, 0o700)
+	if got := readFile(t, filepath.Join(dir, "ox")); got != "OLD-ox" {
+		t.Errorf("ox must not be upgraded when discovery fails: got %q", got)
+	}
+}
+
+// A staging failure after at least one binary is staged must clean up the
+// already-written temp files (the named-return defer must see the populated
+// slice, not a nil'd one).
+func TestReplaceRunningBinary_PartialStagingCleansTemps(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+	writeFile(t, filepath.Join(dir, "ox-adapter-claude-code"), "OLD-adapter")
+
+	// fail staging on the second binary (after one is already staged).
+	oldHook := afterStageHook
+	count := 0
+	afterStageHook = func(string) error {
+		count++
+		if count == 2 {
+			return errors.New("injected staging failure")
+		}
+		return nil
+	}
+	t.Cleanup(func() { afterStageHook = oldHook })
+
+	tarball := makeTarball(t, map[string]string{
+		"ox":                     "NEW-ox",
+		"ox-adapter-claude-code": "NEW-adapter",
+	})
+	srv := releaseServer(t, tarball, "")
+	defer srv.Close()
+
+	if err := ReplaceRunningBinary(context.Background(), baseConfig(dir, srv.URL)); err == nil {
+		t.Fatal("expected staging failure")
+	}
+	// both originals untouched (nothing was committed) and no temp litter.
+	if got := readFile(t, filepath.Join(dir, "ox")); got != "OLD-ox" {
+		t.Errorf("ox must be untouched: got %q", got)
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".ox-upgrade-") {
+			t.Errorf("leftover staged temp file: %s", e.Name())
+		}
+	}
+}
+
 func TestAssetName(t *testing.T) {
 	if got := AssetName("0.14.0", "darwin", "arm64"); got != "ox_0.14.0_darwin_arm64.tar.gz" {
 		t.Errorf("AssetName = %q", got)

--- a/internal/upgrade/selfreplace_test.go
+++ b/internal/upgrade/selfreplace_test.go
@@ -204,6 +204,95 @@ func TestReplaceRunningBinary_RejectsMalformedVersion(t *testing.T) {
 	}
 }
 
+// An archive with no ox binary must be refused outright — it must never
+// replace installed adapters while leaving ox on the old version.
+func TestReplaceRunningBinary_AdapterOnlyArchiveRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+	writeFile(t, filepath.Join(dir, "ox-adapter-claude-code"), "OLD-adapter")
+
+	// tarball contains only an (installed) adapter, no ox.
+	tarball := makeTarball(t, map[string]string{"ox-adapter-claude-code": "NEW-adapter"})
+	srv := releaseServer(t, tarball, "")
+	defer srv.Close()
+
+	err := ReplaceRunningBinary(context.Background(), baseConfig(dir, srv.URL))
+	if err == nil || !strings.Contains(err.Error(), "no ox binary") {
+		t.Fatalf("want no-ox-binary rejection, got %v", err)
+	}
+	if got := readFile(t, filepath.Join(dir, "ox-adapter-claude-code")); got != "OLD-adapter" {
+		t.Errorf("adapter must be untouched when ox is absent: got %q", got)
+	}
+}
+
+// A single archive entry larger than the per-entry cap must be rejected, not
+// silently truncated into place.
+func TestReplaceRunningBinary_OversizedEntryRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+
+	oldMax := maxEntryBytes
+	maxEntryBytes = 4
+	t.Cleanup(func() { maxEntryBytes = oldMax })
+
+	tarball := makeTarball(t, map[string]string{"ox": "NEW-ox-way-too-big"})
+	srv := releaseServer(t, tarball, "")
+	defer srv.Close()
+
+	if err := ReplaceRunningBinary(context.Background(), baseConfig(dir, srv.URL)); err == nil {
+		t.Fatal("expected oversized-entry rejection")
+	}
+	if got := readFile(t, filepath.Join(dir, "ox")); got != "OLD-ox" {
+		t.Errorf("ox must be untouched when an entry is oversized: got %q", got)
+	}
+}
+
+// If a late rename fails mid-commit, every already-committed rename must roll
+// back so the install is fully unchanged rather than version-skewed.
+func TestReplaceRunningBinary_RollsBackOnLateRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+	writeFile(t, filepath.Join(dir, "ox-adapter-claude-code"), "OLD-adapter")
+
+	// fail the first rename that targets the ox binary (ox commits last, after
+	// the adapter is already swapped), then behave normally so rollback works.
+	oldRename := renameFunc
+	failed := false
+	renameFunc = func(oldPath, newPath string) error {
+		if !failed && filepath.Base(newPath) == "ox" {
+			failed = true
+			return errors.New("injected rename failure")
+		}
+		return oldRename(oldPath, newPath)
+	}
+	t.Cleanup(func() { renameFunc = oldRename })
+
+	tarball := makeTarball(t, map[string]string{
+		"ox":                     "NEW-ox",
+		"ox-adapter-claude-code": "NEW-adapter",
+	})
+	srv := releaseServer(t, tarball, "")
+	defer srv.Close()
+
+	if err := ReplaceRunningBinary(context.Background(), baseConfig(dir, srv.URL)); err == nil {
+		t.Fatal("expected error from injected rename failure")
+	}
+	// both binaries must be back to their originals — no partial upgrade.
+	if got := readFile(t, filepath.Join(dir, "ox")); got != "OLD-ox" {
+		t.Errorf("ox must be rolled back: got %q", got)
+	}
+	if got := readFile(t, filepath.Join(dir, "ox-adapter-claude-code")); got != "OLD-adapter" {
+		t.Errorf("adapter must be rolled back after ox rename failed: got %q", got)
+	}
+	// no backup/temp litter left behind.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") {
+			t.Errorf("leftover temp/backup file: %s", e.Name())
+		}
+	}
+}
+
 func TestAssetName(t *testing.T) {
 	if got := AssetName("0.14.0", "darwin", "arm64"); got != "ox_0.14.0_darwin_arm64.tar.gz" {
 		t.Errorf("AssetName = %q", got)

--- a/internal/upgrade/selfreplace_test.go
+++ b/internal/upgrade/selfreplace_test.go
@@ -1,0 +1,227 @@
+package upgrade
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testVer  = "9.9.9"
+	testOS   = "testos"
+	testArch = "testarch"
+)
+
+// makeTarball builds an in-memory .tar.gz from name->content, each a 0755 file.
+func makeTarball(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o755, Size: int64(len(content)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %s: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("write body %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func sha256hex(b []byte) string {
+	s := sha256.Sum256(b)
+	return hex.EncodeToString(s[:])
+}
+
+// releaseServer serves a fake GitHub release: /v<ver>/checksums.txt and the
+// platform tarball. checksumOverride, when non-empty, replaces the real
+// tarball hash so the mismatch path can be exercised.
+func releaseServer(t *testing.T, tarball []byte, checksumOverride string) *httptest.Server {
+	t.Helper()
+	asset := AssetName(testVer, testOS, testArch)
+	sum := sha256hex(tarball)
+	if checksumOverride != "" {
+		sum = checksumOverride
+	}
+	checksums := fmt.Sprintf("%s  %s\n%s  %s\n", sum, asset, sha256hex([]byte("other")), "ox_9.9.9_other_arch.tar.gz")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v"+testVer+"/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(checksums))
+	})
+	mux.HandleFunc("/v"+testVer+"/"+asset, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(tarball)
+	})
+	return httptest.NewServer(mux)
+}
+
+func baseConfig(installDir, releaseBase string) Config {
+	return Config{
+		Version:         testVer,
+		OS:              testOS,
+		Arch:            testArch,
+		ReleaseBase:     releaseBase,
+		InstallDir:      installDir,
+		DisableCodesign: true,
+	}
+}
+
+func TestReplaceRunningBinary_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	// pre-existing install: ox + one adapter. A second adapter is NOT installed.
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+	writeFile(t, filepath.Join(dir, "ox-adapter-claude-code"), "OLD-adapter")
+
+	tarball := makeTarball(t, map[string]string{
+		"ox":                     "NEW-ox",
+		"ox-adapter-claude-code": "NEW-adapter",
+		"ox-adapter-gemini":      "NEW-gemini", // not installed => must be skipped
+		"README.md":              "docs",       // non-binary => ignored
+	})
+	srv := releaseServer(t, tarball, "")
+	defer srv.Close()
+
+	if err := ReplaceRunningBinary(context.Background(), baseConfig(dir, srv.URL)); err != nil {
+		t.Fatalf("ReplaceRunningBinary: %v", err)
+	}
+
+	if got := readFile(t, filepath.Join(dir, "ox")); got != "NEW-ox" {
+		t.Errorf("ox not replaced: got %q", got)
+	}
+	if got := readFile(t, filepath.Join(dir, "ox-adapter-claude-code")); got != "NEW-adapter" {
+		t.Errorf("installed adapter not replaced: got %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ox-adapter-gemini")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("uninstalled adapter should not have been created")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "README.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("non-binary file should not have been extracted")
+	}
+	// no stray temp files left behind
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if len(e.Name()) > 0 && e.Name()[0] == '.' {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestReplaceRunningBinary_ChecksumMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+
+	tarball := makeTarball(t, map[string]string{"ox": "EVIL-ox"})
+	// serve a wrong checksum for the asset
+	srv := releaseServer(t, tarball, sha256hex([]byte("not-the-tarball")))
+	defer srv.Close()
+
+	err := ReplaceRunningBinary(context.Background(), baseConfig(dir, srv.URL))
+	if err == nil {
+		t.Fatal("expected checksum-mismatch error, got nil")
+	}
+	if got := readFile(t, filepath.Join(dir, "ox")); got != "OLD-ox" {
+		t.Errorf("ox must be untouched on checksum mismatch: got %q", got)
+	}
+}
+
+func TestReplaceRunningBinary_MissingPlatformAsset(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+
+	tarball := makeTarball(t, map[string]string{"ox": "NEW-ox"})
+	srv := releaseServer(t, tarball, "")
+	defer srv.Close()
+
+	// ask for an arch that has no checksum entry
+	cfg := baseConfig(dir, srv.URL)
+	cfg.Arch = "no-such-arch"
+	if err := ReplaceRunningBinary(context.Background(), cfg); err == nil {
+		t.Fatal("expected error for unsupported platform asset")
+	}
+	if got := readFile(t, filepath.Join(dir, "ox")); got != "OLD-ox" {
+		t.Errorf("ox must be untouched when asset missing: got %q", got)
+	}
+}
+
+func TestReplaceRunningBinary_NotWritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer os.Chmod(dir, 0o700) //nolint:errcheck // best-effort cleanup
+
+	tarball := makeTarball(t, map[string]string{"ox": "NEW-ox"})
+	srv := releaseServer(t, tarball, "")
+	defer srv.Close()
+
+	err := ReplaceRunningBinary(context.Background(), baseConfig(dir, srv.URL))
+	if !errors.Is(err, ErrNotWritable) {
+		t.Fatalf("expected ErrNotWritable, got %v", err)
+	}
+}
+
+// A crafted --target must never reach the network: it is validated and
+// rejected before any URL is built. Asserts on the specific validation error
+// so removing the guard (which would instead produce a network error) turns
+// this test red.
+func TestReplaceRunningBinary_RejectsMalformedVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ox"), "OLD-ox")
+
+	for _, bad := range []string{"../../evil", "https://evil.example/x", "1.2", "1.2.3/../x", "1.2.3 ", "v1.2.3"} {
+		cfg := baseConfig(dir, "http://127.0.0.1:1")
+		cfg.Version = bad
+		err := ReplaceRunningBinary(context.Background(), cfg)
+		if err == nil || !strings.Contains(err.Error(), "invalid target version") {
+			t.Errorf("version %q: want invalid-target-version rejection, got %v", bad, err)
+		}
+	}
+	if got := readFile(t, filepath.Join(dir, "ox")); got != "OLD-ox" {
+		t.Errorf("ox must be untouched: got %q", got)
+	}
+}
+
+func TestAssetName(t *testing.T) {
+	if got := AssetName("0.14.0", "darwin", "arm64"); got != "ox_0.14.0_darwin_arm64.tar.gz" {
+		t.Errorf("AssetName = %q", got)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/scripts/check-release-drift.sh
+++ b/scripts/check-release-drift.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Detect "release drift": internal/version/version.go bumped and merged to
+# main, but no corresponding GitHub release was ever tagged/published. Left
+# unnoticed, GET /releases/latest (and the update-notify chain that reads it)
+# keeps pointing at the old version even though version.go says otherwise.
+#
+# Usage:
+#   scripts/check-release-drift.sh [--json]
+#
+# Exit codes:
+#   0  version.go <= latest published release (in sync, or a release is
+#      in flight ahead of what version.go on main currently says)
+#   1  drift: version.go > latest published release (a version bump was
+#      merged but never tagged/published)
+#   2  error: could not determine current or latest version (gh missing/
+#      unauthenticated, version.go line unparsable, API call failed for a
+#      reason other than "no releases exist yet")
+#
+# A brand-new repo with zero published releases is NOT drift — there is
+# nothing to have forgotten to publish — so that case exits 0.
+#
+# DRIFT_LATEST_OVERRIDE (env var): when set, used as the "latest published
+# release" value instead of calling gh/the GitHub API at all. This is a test
+# hook for local/manual demonstration of the drift path — not a normal usage
+# mode, and intentionally undocumented outside this comment and the workflow.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+REPO="sageox/ox"
+JSON_OUTPUT=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)
+      JSON_OUTPUT=1
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      echo "Usage: $0 [--json]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -f "internal/version/version.go" ]; then
+  echo "Error: must run from repository root (internal/version/version.go not found)" >&2
+  exit 2
+fi
+
+# Same grep/sed extraction style as scripts/check-versions.sh. Guarded with
+# `|| true` so a no-match under `set -o pipefail` doesn't abort the script
+# before we can report a clear parse error below.
+CURRENT=$(grep 'Version.*=' internal/version/version.go | sed 's/.*"\(.*\)".*/\1/') || true
+CURRENT="${CURRENT#v}"
+
+if [ -z "$CURRENT" ]; then
+  echo "Error: could not parse Version from internal/version/version.go" >&2
+  exit 2
+fi
+
+if [ -n "${DRIFT_LATEST_OVERRIDE:-}" ]; then
+  # Test hook — see header comment. Skips gh/API entirely.
+  LATEST="${DRIFT_LATEST_OVERRIDE#v}"
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh CLI is not installed" >&2
+    exit 2
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is not installed" >&2
+    exit 2
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: gh CLI is not authenticated (run 'gh auth login')" >&2
+    exit 2
+  fi
+
+  # releases/latest already excludes drafts/prereleases by GitHub's own
+  # semantics, but we double-check explicitly below rather than trusting
+  # that implicitly.
+  API_STDERR=$(mktemp)
+  if API_OUTPUT=$(gh api "repos/${REPO}/releases/latest" 2>"$API_STDERR"); then
+    API_STATUS=0
+  else
+    API_STATUS=$?
+  fi
+  API_ERR=$(cat "$API_STDERR")
+  rm -f "$API_STDERR"
+
+  if [ "$API_STATUS" -ne 0 ]; then
+    if echo "$API_ERR" | grep -qi "HTTP 404\|Not Found"; then
+      # Brand-new repo, zero releases published yet. Not drift.
+      LATEST=""
+    else
+      echo "Error: failed to query latest release: $API_ERR" >&2
+      exit 2
+    fi
+  elif ! echo "$API_OUTPUT" | jq -e . >/dev/null 2>&1; then
+    echo "Error: unexpected (non-JSON) response from gh api releases/latest" >&2
+    exit 2
+  else
+    IS_DRAFT=$(echo "$API_OUTPUT" | jq -r '.draft // false')
+    IS_PRERELEASE=$(echo "$API_OUTPUT" | jq -r '.prerelease // false')
+    if [ "$IS_DRAFT" = "true" ] || [ "$IS_PRERELEASE" = "true" ]; then
+      echo "Error: releases/latest unexpectedly returned a draft or prerelease" >&2
+      exit 2
+    fi
+    LATEST_TAG=$(echo "$API_OUTPUT" | jq -r '.tag_name')
+    LATEST="${LATEST_TAG#v}"
+  fi
+fi
+
+# Portable version compare via `sort -V`; correctly treats equal versions as
+# not-greater (checked first, before consulting sort's tiebreak ordering).
+version_gt() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]
+}
+
+DRIFT=false
+if [ -n "$LATEST" ] && version_gt "$CURRENT" "$LATEST"; then
+  DRIFT=true
+fi
+
+if [ "$JSON_OUTPUT" -eq 1 ]; then
+  if [ -z "$LATEST" ]; then
+    printf '{"current":"%s","latest":null,"drift":%s}\n' "$CURRENT" "$DRIFT"
+  else
+    printf '{"current":"%s","latest":"%s","drift":%s}\n' "$CURRENT" "$LATEST" "$DRIFT"
+  fi
+else
+  echo "Current version (version.go): $CURRENT"
+  if [ -z "$LATEST" ]; then
+    echo -e "${YELLOW}No published releases found yet -- nothing to compare against.${NC}"
+  else
+    echo "Latest published release: v$LATEST"
+  fi
+
+  if [ "$DRIFT" = "true" ]; then
+    echo -e "${RED}Drift detected: version.go ($CURRENT) is ahead of the latest published release (v$LATEST)${NC}"
+    echo "A version bump was merged to main but never tagged/published as a GitHub release."
+  else
+    echo -e "${GREEN}OK: version.go ($CURRENT) is in sync with the latest published release${NC}"
+  fi
+fi
+
+if [ "$DRIFT" = "true" ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/check-release-drift.sh
+++ b/scripts/check-release-drift.sh
@@ -121,6 +121,19 @@ version_gt() {
   [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]
 }
 
+# Validate both values against the release-version grammar before comparing or
+# emitting JSON: a malformed value could make `sort -V` report the wrong drift
+# state, and a value with JSON-significant characters could corrupt --json.
+VERSION_RE='^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$'
+if ! [[ "$CURRENT" =~ $VERSION_RE ]]; then
+  echo "Error: current version '$CURRENT' is not a valid release version" >&2
+  exit 2
+fi
+if [ -n "$LATEST" ] && ! [[ "$LATEST" =~ $VERSION_RE ]]; then
+  echo "Error: latest release '$LATEST' is not a valid release version" >&2
+  exit 2
+fi
+
 DRIFT=false
 if [ -n "$LATEST" ] && version_gt "$CURRENT" "$LATEST"; then
   DRIFT=true


### PR DESCRIPTION
## Summary

**Coworkers who installed ox with the curl one-liner can finally upgrade with `ox upgrade` — it now downloads the new release and swaps the binary in place instead of just printing instructions they had to run by hand.** That cohort (the default install path) was silently stranded on old versions, which is why the fleet lagged. This PR also makes ox *tell* people an update exists without needing the background daemon, makes the notice actionable, and adds a CI guard so a version bump can never again merge without a published release (the exact way v0.14.0 sat unshipped for a day).

### Why this matters

`ox upgrade` branches on how ox was installed. Before this PR:

| Install method | Old behavior | New behavior |
|---|---|---|
| Homebrew | `brew upgrade` ✓ | unchanged ✓ |
| `go install` | `go install @tag` ✓ | unchanged ✓ |
| **Direct / `install.sh` (curl)** | **printed manual instructions — no upgrade** | **downloads + checksum-verifies + atomically replaces in place ✓** |
| dev/source build | `make install` hint | unchanged |

Direct installs are the most common path, so most users were exactly the cohort that got no real upgrade.

### What this PR ships

- **Binary self-replace** (new `internal/upgrade` package): downloads `ox_<ver>_<os>_<arch>.tar.gz` over HTTPS, **verifies its SHA-256** against the release `checksums.txt`, extracts, and atomically renames `ox` — plus any already-installed adapters — into place (ox last, so a mid-flight failure never bricks the running binary). `--target` is now honored for direct installs too.
- **Off-daemon update check**: only the daemon used to warm the version cache. `ox status` now does a bounded live check on its own (6h-stale gate, 1s network cap), so daemon-less coworkers still learn an update exists.
- **Actionable nudge**: `ox status` offers `Upgrade ox now? [y/N]` at an interactive terminal; `ox agent prime` tells the AI coworker to *offer* to run `ox upgrade` (now universal across install methods).
- **Release-drift CI gate**: a daily scheduled job fails and opens/refreshes a single tracking issue when `internal/version/version.go` on `main` is ahead of the latest *published* GitHub release. Scheduled-only by design — a bump PR legitimately precedes its release.

```mermaid
flowchart TD
    U[ox upgrade] --> M{install method}
    M -->|homebrew| BH[brew upgrade sageox/tap/ox]
    M -->|go install| BG["go install ...@tag + adapters"]
    M -->|direct / install.sh| SR[self-replace]
    M -->|dev/source| MS[make install hint]

    subgraph SR [internal/upgrade self-replace]
      D1[GET checksums.txt] --> D2[GET tarball]
      D2 --> V{sha256 matches?}
      V -->|no| X[refuse — binary untouched]
      V -->|yes| E[extract ox + installed adapters]
      E --> R[atomic rename: adapters first, ox last]
    end
```

### Security

`internal/upgrade` handles a network download that overwrites the running binary, so it got an adversarial pentester review this session:
- **Extraction path confirmed safe** — path traversal, symlink/hardlink/device tar entries, and verify-before-extract ordering all sound.
- Hardening landed here: strict version-string validation (blocks `--target` URL injection), redirect pinning to GitHub hosts + client timeout, context-bounded extraction, User-Agent.
- Follow-ups filed (not blocking): detached ed25519 signature over downloads (`internal/signing` already ships the key infra), a `--target` downgrade floor, and best-effort rollback on partial replace.

## Test Plan

- New `internal/upgrade` tests (httptest-backed, no real network): happy path (replaces ox + installed adapter; skips uninstalled adapters and non-binaries; no temp litter), **checksum mismatch → refuse + binary untouched**, missing-platform asset, not-writable dir → `ErrNotWritable`, malformed-`--target` rejection.
- **Red-first proof on the checksum gate**: neutered the SHA-256 check → mismatch test went red (a poisoned tarball installed) → restored → green.
- `refreshVersionCacheIfStale` test: a fresh cache is used verbatim, no network.
- `validateUpgradeTarget` updated to the new intent (direct installs honor `--target`).
- `go test ./cmd/ox/ ./internal/upgrade/` green (44.8s); lint clean on the diff (`--new-from-rev=origin/main` → 0 issues).
- Release-drift script verified both ways: `DRIFT_LATEST_OVERRIDE` drift path → exit 1; live in-sync → exit 0; `actionlint` + `shellcheck` clean.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented
- [x] CHANGELOG entry added (if user-facing)
- [x] Breaking change documented — none (pure additive; direct-install `ox upgrade` changes from no-op to working)
- [x] Ran security review on the diff — adversarial pentester pass this session (extraction safe; hardening landed; follow-ups filed). `internal/upgrade` also gets the daily batch auto-review.

</details>

Co-Authored-By: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Direct installations can now upgrade securely with `ox upgrade`, including bundled adapters and pinned target versions.
  - `ox status` refreshes outdated version information and offers interactive upgrade prompts.
  - Upgrade guidance now supports Homebrew, `go install`, and direct installations.

- **Documentation**
  - Added release notes covering direct-install upgrades and version checks.

- **Chores**
  - Added automated checks to detect and track differences between internal and published release versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->