### PR TITLE
feat(pr): slash divider between SageOx wordmark and team in credit line

### DIFF
--- a/internal/prheader/prheader.go
+++ b/internal/prheader/prheader.go
@@ -22,7 +22,9 @@
 // So the line is built from the primitives that survive: a <blockquote> card
 // (left accent bar + subtle tint — the one card-like chrome GitHub allows), a
 // theme-adaptive <picture> wordmark (the only mechanism that swaps by
-// prefers-color-scheme), <a>, <sub>, <b>, <br>, and &nbsp;/&middot; entities.
+// prefers-color-scheme), <a>, <sub>, <b>, <br>, and &nbsp;/&middot; entities. Two
+// dividers carry meaning: a slash joins the wordmark to the team name (the
+// owner/team breadcrumb — containment), a middle dot divides the peer links.
 // The wordmark is an <img>, so it can link to the team page AND keep its brand
 // color — a text <a> cannot, since GitHub forces every link to its own blue, so
 // the team name stays plain <b> text and the actionable Session/Plan links are
@@ -165,9 +167,11 @@ func Render(in Input) string {
 
 	// Team name as plain muted <b> text, not a link: a reviewer reads it as chrome
 	// and the wordmark already routes to the team page. Non-breaking so it never
-	// wraps mid-name.
+	// wraps mid-name. Joined to the wordmark by a SLASH, not the peer dot: the
+	// team lives *within* the brand (the owner/team breadcrumb), while the links
+	// that follow are peers.
 	if showTeam {
-		row.WriteString(sep())
+		row.WriteString(hierSep())
 		row.WriteString("<b>")
 		row.WriteString(noWrap(escapeHTML(teamName)))
 		row.WriteString("</b>")
@@ -196,9 +200,16 @@ func Render(in Input) string {
 	return b.String()
 }
 
-// sep is the calm category divider — a non-breaking middle dot, the Linear/Apple
-// separator, never a shields.io pipe.
+// sep is the calm PEER divider — a non-breaking middle dot, the Linear/Apple
+// separator, never a shields.io pipe. It divides sibling categories: the team,
+// the sessions, the plans.
 func sep() string { return "&nbsp;&middot;&nbsp;" }
+
+// hierSep is the CONTAINMENT divider — a non-breaking slash, the owner/team
+// breadcrumb every reviewer already reads (GitHub org/repo, Linear Team/Project).
+// It joins the wordmark to the team name so "SageOx / SageOx Internal" reads as
+// one unit — the team within the brand — distinct from the peer links after it.
+func hierSep() string { return "&nbsp;/&nbsp;" }
 
 // wordmark builds the theme-adaptive <picture>, wrapped in an <a> to the team
 // page when one is known. An unlinked wordmark (teamURL == "") still renders.

--- a/internal/prheader/prheader_test.go
+++ b/internal/prheader/prheader_test.go
@@ -47,7 +47,7 @@ func TestRender_full(t *testing.T) {
 		`<source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png">`,
 		`src="https://sageox.ai/sageox-wordmark-light.png"`,
 		`<a href="https://sageox.ai/t/sageox-internal">`, // wordmark links to the team page
-		"<b>SageOx&nbsp;Internal</b>",                    // team name is muted text, not a link
+		"&nbsp;/&nbsp;<b>SageOx&nbsp;Internal</b>",       // wordmark->team joined by a SLASH (containment breadcrumb)
 		`<a href="https://sageox.ai/c/ses_9f2a3c">Session&nbsp;1</a>`,
 		`<a href="https://sageox.ai/c/ses_7c1b8d">Session&nbsp;2</a>`,
 		`<a href="https://sageox.ai/plan/pln_4d8e2f">Plan</a>`, // one plan => unnumbered
@@ -57,7 +57,10 @@ func TestRender_full(t *testing.T) {
 	mustNotContain(t, got,
 		`<a href="https://sageox.ai/t/sageox-internal"><b>`,
 		"Guided&nbsp;by&nbsp;SageOx", "prior&nbsp;art", "collision", "expert",
+		"&middot;&nbsp;<b>SageOx", // team is slash-joined now, not middot-joined
 	)
+	// Peer links keep the middle dot (whisper caption divides its stats with it too).
+	mustContain(t, got, "&middot;")
 	// Sessions grouped by whitespace, not a divider.
 	mustContain(t, got, "Session&nbsp;1</a>&nbsp;&nbsp;<a")
 	// Markers wrap the whole thing on their own lines.
@@ -76,7 +79,8 @@ func TestRender_dedupBrandTeamName(t *testing.T) {
 		in.TeamName = name
 		got := Render(in)
 		mustContain(t, got, "<picture>", `<a href="https://sageox.ai/c/ses_9f2a3c">`)
-		mustNotContain(t, got, "<b>") // team-name text omitted entirely
+		mustNotContain(t, got, "<b>")           // team-name text omitted entirely
+		mustNotContain(t, got, "&nbsp;/&nbsp;") // ...and no orphan hierarchy slash
 	}
 	// A team whose name merely CONTAINS the brand still renders (not an exact match).
 	in := baseInput()


### PR DESCRIPTION
## Summary

A reviewer opening a PR now reads the credit line as a familiar **owner / team breadcrumb** — the same shape as GitHub `org / repo` and Linear `Team / Project` — so the provenance parses at a glance instead of reading as a flat list of equals.

Before, every segment of the `ox pr header` credit line was joined by the same middle dot:

```
SageOx · SageOx Internal · Session · Plan
```

That flattens a relationship that is not flat — **SageOx Internal is a team _within_ SageOx**, while Session/Plan are peer artifacts the work produced. One divider for two different relationships forces the reader to decode the structure.

Now the wordmark→team boundary uses a slash and the peer links keep the dot, so the two dividers *encode* the hierarchy:

```
SageOx / SageOx Internal · Session · Plan
```

**What changed (`internal/prheader/`):**

- **Added `hierSep()`** → `&nbsp;/&nbsp;` (containment divider), alongside the existing `sep()` → `&nbsp;&middot;&nbsp;` (peer divider).
- **Swapped one boundary:** the wordmark→team segment now uses `hierSep()`. `writeLinks` category dividers and the whisper stat divider are untouched.
- **Doc comments** on `sep()` and the package header now name the two dividers and why they differ.
- Plain ASCII `/` guarded by `&nbsp;` — matches the GitHub/Linear breadcrumb, survives GitHub's PR-body sanitizer, and needs no CSS (which PR bodies strip).

**Edge cases hold:**

- **Team == brand** (dogfood team literally "SageOx"): the `<b>` team segment and its leading slash are both suppressed → `SageOx · Session`. No orphan slash.
- **No team name:** slash only renders when a team does; links lead with the peer dot.

## Test Plan

- Updated `internal/prheader/prheader_test.go`: `TestRender_full` asserts `&nbsp;/&nbsp;<b>SageOx&nbsp;Internal</b>` and that the team is no longer middot-joined; `TestRender_dedupBrandTeamName` asserts no orphan slash when team == brand.
- **Red-first proof:** neutered `hierSep()`→`sep()`, both new assertions went red (`slash missing` + `middot present`); restored → green.
- `go test ./internal/prheader/... ./cmd/ox/` green · `go build ./...` ok · `golangci-lint` 0 issues.
- `pr-credit-line.feature` deliberately markup-agnostic → unchanged.

**Follow-up (separate, not in this PR):** the lowercase `guided by` kicker is present in code (`prheader.go`, shipped in #801) but appears absent in a live-rendered PR body — needs a GitHub render check to decide stale-body vs. sanitizer strip of `<sub>…</sub><br>`.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented
- [x] CHANGELOG entry added (if user-facing) — N/A: cosmetic divider in a not-yet-released `ox pr header` (added in #801, unreleased)
- [x] Breaking change documented — N/A: no behavior/flag/API change
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: pure markup string change, no auth/mcp/session/upgrade/go.sum surface

</details>

Co-authored-by: SageOx <ox@sageox.ai>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789942183&installation_model_id=433550&pr_number=805&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F805&signature=c3d7dfe9a0a87ee896af49dbd09dcd40961b1ef54e34a3cf3f1192a1f6466d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated pull request header formatting to display team names as slash-separated breadcrumbs after the linked wordmark.
  * Preserved middle-dot separators between peer links and statistics.
  * Prevented orphan separators when the team name matches the brand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->