### PR TITLE
docs(readme): swap "The loop" for a live Latest Project Activity mural

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,9 @@ a teammate already in the same files, and proposes a plan **enriched** with
 collisions, prior art, and who owns the area. All of it because every session is
 recorded to a shared, queryable **Ledger**.
 
-## The loop
+## Latest Project Activity
 
-```mermaid
-flowchart LR
-    REC["Record at sageox.ai<br/>discussions, decisions"]
-    KB["Knowledge Bubbles<br/>team context plus ledger"]
-    PRIME["ox agent prime<br/>loads context"]
-    WORK["AI Coworker session"]
-    CAP["Session captured<br/>to the Ledger"]
-    REC --> KB --> PRIME --> WORK --> CAP --> KB
-```
-
-Record a discussion once. It's distilled into **Knowledge Bubbles** — your team's
-shared memory. The next time anyone primes a coding session, that context flows
-in. The session itself is captured back to the **Ledger**, so the next coworker
-inherits it too. Context compounds instead of evaporating.
+![SageOx — latest project activity](https://www.sageox.ai/api/v1/public/mural/vio0F88wcSd9grV3piwmisVtNA_rWF-ta8gpGJ_tf1g)
 
 ## Works with your coding agent
 


### PR DESCRIPTION
## Summary

Anyone landing on the repo now sees a **live picture of what the project is actually doing right now** — a SageOx activity mural — instead of a static conceptual loop diagram. The README's hero area shows the product is alive, not just described.

- Replaced the `## The loop` section (heading, Mermaid record→prime→session→Ledger flow, and its explanatory paragraph) with a new `## Latest Project Activity` section.
- New section embeds the SageOx public mural endpoint as its only content, sitting directly below the Ledger intro and above "Works with your coding agent."
- Net: **+2 / −15** lines in `README.md`. No other files touched.

### Heads-up: image content-type

- The mural URL returns a valid **JPEG** (verified magic bytes `ff d8 ff`, HTTP 200, ~2.2 MB) but currently serves `Content-Type: application/octet-stream`.
- GitHub renders README images through its **camo** proxy, which only proxies responses whose content-type starts with `image/`. Until the endpoint returns `image/jpeg`, the image may show as broken in GitHub's rendered README.
- Root fix is server-side on the mural API (private-owner). The repo owner has indicated this remote-serving fix is in progress.

## Test Plan

- `grep -n "Latest Project Activity" README.md` → new heading present.
- `grep -n "## The loop" README.md` → old section gone; other Mermaid diagrams in the repo untouched.
- Confirm the image renders in GitHub's rendered README once the mural endpoint serves `image/jpeg`.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — N/A, docs-only README change
- [ ] CHANGELOG entry added (if user-facing) — N/A, no CLI behavior change
- [ ] Breaking change documented — N/A
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A, docs-only, touches none of the security-sensitive paths

</details>

Co-authored-by: SageOx <ox@sageox.ai>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789951449&installation_model_id=433550&pr_number=807&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F807&signature=067c1f14f64d470cbd626810c9450e657f8f928790fce82ce22c345b7dd6c20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the “The loop” workflow explanation and diagram with a “Latest Project Activity” section.
  * Added an activity image to provide a visual overview of recent project updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->