### PR TITLE
fix(ledger): refuse to auto-commit unresolved conflict markers

### DIFF
--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -992,6 +992,33 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 			fmt.Sprintf("git add error: %s", strings.TrimSpace(string(output))))
 	}
 
+	// The pre-add U-state check above only catches a LIVE conflict — one
+	// `git add -A` hasn't touched yet. But `git add` on a conflicted path
+	// doesn't just stage it, it resolves the U-state (git now considers it
+	// "modified", not "unmerged"), while the staged content is still the
+	// literal markers. A file that was already staged-with-markers before
+	// this function ran (never U-state at all — e.g. plain-modified, or
+	// unrelated leftover content from an interrupted prior operation) is
+	// invisible to the pre-add check for the same reason. firstUnstageableFileInIndex
+	// (session_upload.go) covers exactly this by reading the actual staged
+	// blobs post-add, the same guard the session-stop commit paths use —
+	// parity here closes the gap instead of leaving doctor's auto-commit
+	// weaker than the routine commit path it's meant to be backing up.
+	if conflicted, err := firstUnstageableFileInIndex(ledgerPath); err != nil {
+		return FailedCheck("Ledger clean workdir",
+			"unable to verify staged content is conflict-free",
+			fmt.Sprintf("checking staged blobs: %s", err))
+	} else if conflicted != "" {
+		return FailedCheck("Ledger clean workdir",
+			"unresolved conflict staged, refusing to auto-commit",
+			fmt.Sprintf("%s still carries unresolved conflict markers even though `git add` "+
+				"accepted it. Committing would bake the markers into the ledger permanently. "+
+				"Resolve it manually:\n       cd %s\n       git status\n       "+
+				"git checkout --ours %s   # or --theirs, depending on intent\n       "+
+				"git add %s && git commit",
+				conflicted, ledgerPath, conflicted, conflicted))
+	}
+
 	// commit via RunGit: it owns the commit.gpgsign=false override plus the
 	// GIT_TERMINAL_PROMPT=0 / cmd.Dir safeguards, so the auto-commit can't
 	// drift from the managed-git execution contract.

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -930,6 +930,40 @@ func checkLedgerCleanWorkdir(fix bool) checkResult {
 
 // fixLedgerDirtyWorkdir stages and commits all changes in the ledger.
 func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
+	// Re-check for unmerged (U-state) paths immediately before staging.
+	// checkLedgerCleanWorkdir deliberately excludes U-state entries from the
+	// dirty count that triggers this fix — a lone conflict is
+	// checkLedgerUnmergedPaths's job, not this one's. But that exclusion is
+	// COUNTING logic only; it does not reach the `git add -A` below. `-A`
+	// stages every changed path unconditionally, including any conflicted
+	// one sitting alongside genuinely dirty files that DID trigger this fix.
+	// git has no concept of "refuse to stage a conflict" — `git add` on a
+	// conflicted path takes its current working-tree content, markers
+	// included, and marks it resolved. The commit that follows would then
+	// bake those markers permanently into the ledger. This is the exact
+	// mechanism behind #749: a `git stash pop` conflict (from the daemon's
+	// `pull --rebase --autostash`) leaves UU files with no MERGE_HEAD/
+	// rebase-merge marker — autostash pop isn't a resumable operation, so
+	// detectInProgressGitOp can't see it either. They just sit there until
+	// an unrelated dirty file triggers this auto-commit and sweeps them in.
+	// Refuse instead of guessing at a resolution.
+	statusCmd := exec.Command("git", "-C", ledgerPath, "status", "--porcelain=v1")
+	if statusOut, statusErr := statusCmd.Output(); statusErr == nil {
+		if unmerged := parseUnmergedPaths(string(statusOut)); len(unmerged) > 0 {
+			sample := unmerged[0].Path
+			if len(unmerged) > 1 {
+				sample = fmt.Sprintf("%s (+%d more)", sample, len(unmerged)-1)
+			}
+			return FailedCheck("Ledger clean workdir",
+				"unresolved conflicts present, refusing to auto-commit",
+				fmt.Sprintf("%d unmerged file(s) at %s, e.g. %s.\n       "+
+					"Run `ox doctor --fix` again — the ledger unmerged-paths check "+
+					"resolves these first; auto-committing over them would bake the "+
+					"conflict markers into the ledger permanently.",
+					len(unmerged), ledgerPath, sample))
+		}
+	}
+
 	// ensure .gitignore exists and untrack any cache files BEFORE staging.
 	// without this, git add -A will commit local-only files like sync-state.json.
 	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -963,7 +963,8 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 					"so it needs manual resolution:\n       "+
 					"  cd %s\n       "+
 					"  git status                       # inspect the conflict\n       "+
-					"  git checkout --ours <file>       # or --theirs, depending on intent\n       "+
+					"  git checkout --ours <file>       # or --theirs — only if that side HAS the file\n       "+
+					"  git rm <file>                    # instead, if the side you want deleted it\n       "+
 					"  git add <file> && git commit",
 					len(unmerged), ledgerPath, sample, ledgerPath))
 		}
@@ -1012,11 +1013,14 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 		return FailedCheck("Ledger clean workdir",
 			"unresolved conflict staged, refusing to auto-commit",
 			fmt.Sprintf("%s still carries unresolved conflict markers even though `git add` "+
-				"accepted it. Committing would bake the markers into the ledger permanently. "+
-				"Resolve it manually:\n       cd %s\n       git status\n       "+
-				"git checkout --ours %s   # or --theirs, depending on intent\n       "+
+				"accepted it. This is not a live git conflict — `git add` already resolved "+
+				"whatever U-state existed, so there's no --ours/--theirs to choose between "+
+				"anymore (running it here silently does nothing and re-commits the same "+
+				"broken content). It's literal marker text baked into the staged file. "+
+				"Resolve it manually:\n       cd %s\n       git show :./%s   # inspect the staged content\n       "+
+				"# edit %s by hand to remove the markers, or `git checkout HEAD -- %s` to discard the local change\n       "+
 				"git add %s && git commit",
-				conflicted, ledgerPath, conflicted, conflicted))
+				conflicted, ledgerPath, conflicted, conflicted, conflicted, conflicted))
 	}
 
 	// commit via RunGit: it owns the commit.gpgsign=false override plus the

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -957,10 +957,15 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 			return FailedCheck("Ledger clean workdir",
 				"unresolved conflicts present, refusing to auto-commit",
 				fmt.Sprintf("%d unmerged file(s) at %s, e.g. %s.\n       "+
-					"Run `ox doctor --fix` again — the ledger unmerged-paths check "+
-					"resolves these first; auto-committing over them would bake the "+
-					"conflict markers into the ledger permanently.",
-					len(unmerged), ledgerPath, sample))
+					"Auto-committing over them would bake the conflict markers into "+
+					"the ledger permanently, so this is refused instead. A stash-pop "+
+					"conflict like this one has no in-progress merge/rebase to abort, "+
+					"so it needs manual resolution:\n       "+
+					"  cd %s\n       "+
+					"  git status                       # inspect the conflict\n       "+
+					"  git checkout --ours <file>       # or --theirs, depending on intent\n       "+
+					"  git add <file> && git commit",
+					len(unmerged), ledgerPath, sample, ledgerPath))
 		}
 	}
 

--- a/cmd/ox/doctor_ledger_git_unmerged_test.go
+++ b/cmd/ox/doctor_ledger_git_unmerged_test.go
@@ -425,3 +425,94 @@ func TestCheckLedgerUnmergedPaths_ReportsCriticalWithoutFix(t *testing.T) {
 	assert.Equal(t, "critical", r.priority)
 	assert.Equal(t, CheckSlugLedgerUnmergedPaths, r.slug)
 }
+
+// --- E. fixLedgerDirtyWorkdir must not sweep a conflict into a commit ---
+//
+// Real-git integration test reproducing #749: a `git stash pop` conflict
+// leaves UU files with NO MERGE_HEAD/rebase-merge marker (a stash pop isn't
+// a resumable operation), so detectInProgressGitOp can't see it and
+// checkLedgerCleanWorkdir's own dirty-count excludes U-state entries from
+// what triggers the fix. But that exclusion never reached the actual
+// `git add -A` inside the fix — so once an UNRELATED dirty file tripped the
+// auto-commit, `-A` swept the conflicted file in too and committed the
+// literal conflict markers into the ledger.
+//
+// buildAutostashConflictRepo reproduces that exact shape: a conflicted
+// meta.json (UU, real conflict markers, no state-directory marker) sitting
+// alongside a genuinely dirty, unrelated untracked file.
+func buildAutostashConflictRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 1}`+"\n"), 0644))
+	mustRunGit(t, repo, "add", "meta.json")
+	mustRunGit(t, repo, "commit", "-m", "base")
+
+	// local uncommitted change to meta.json — this is what autostash stashes
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 2}`+"\n"), 0644))
+	mustRunGit(t, repo, "stash", "push", "-m", "autostash", "--", "meta.json")
+
+	// a conflicting change lands on main in the meantime (the daemon's pull)
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 99}`+"\n"), 0644))
+	mustRunGit(t, repo, "commit", "-am", "conflicting upstream change")
+
+	// an unrelated, genuinely dirty file — this is what trips
+	// checkLedgerCleanWorkdir's dirty count and triggers the auto-commit
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "unrelated.txt"), []byte("wip\n"), 0644))
+
+	// popping the stash now conflicts on meta.json
+	out, err := runIsolatedGit(t, repo, "stash", "pop")
+	require.Error(t, err, "stash pop must conflict; got success: %s", out)
+
+	status, err := runIsolatedGit(t, repo, "status", "--porcelain=v1")
+	require.NoError(t, err)
+	require.Contains(t, status, "UU meta.json",
+		"test setup did not produce the UU wedge; cannot validate fix")
+	require.Contains(t, status, "unrelated.txt",
+		"test setup did not produce the unrelated dirty file; cannot validate fix")
+
+	// sanity: NO state-directory marker exists for a stash-pop conflict —
+	// this is the whole reason detectInProgressGitOp can't see it
+	op, _ := detectInProgressGitOp(repo)
+	require.Equal(t, "", op,
+		"a stash-pop conflict must have no in-progress op marker; got %q", op)
+
+	return repo
+}
+
+// TestFixLedgerDirtyWorkdir_RefusesUnrelatedDirtyFileWithConflictPresent is
+// the load-bearing regression for #749. Without the fix, this test commits
+// the literal conflict markers into the ledger's history — permanently.
+func TestFixLedgerDirtyWorkdir_RefusesUnrelatedDirtyFileWithConflictPresent(t *testing.T) {
+	skipIntegration(t)
+	repo := buildAutostashConflictRepo(t)
+
+	beforeLog, err := runIsolatedGit(t, repo, "log", "--oneline")
+	require.NoError(t, err)
+
+	r := fixLedgerDirtyWorkdir(repo, 1)
+
+	assert.False(t, r.passed,
+		"must refuse to auto-commit while a conflict is present: %+v", r)
+
+	// no new commit — especially not one containing the markers
+	afterLog, err := runIsolatedGit(t, repo, "log", "--oneline")
+	require.NoError(t, err)
+	assert.Equal(t, beforeLog, afterLog,
+		"no commit should have been created")
+
+	// the conflict must still be sitting there, unresolved, for
+	// checkLedgerUnmergedPaths to pick up next
+	status, err := runIsolatedGit(t, repo, "status", "--porcelain=v1")
+	require.NoError(t, err)
+	assert.Contains(t, status, "UU meta.json",
+		"conflict must survive the refusal, not be silently resolved")
+
+	// and the working-tree file must still literally contain the markers —
+	// proof nothing quietly rewrote it
+	content, err := os.ReadFile(filepath.Join(repo, "meta.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "<<<<<<<",
+		"conflict markers must still be present in the untouched file")
+}

--- a/cmd/ox/doctor_ledger_git_unmerged_test.go
+++ b/cmd/ox/doctor_ledger_git_unmerged_test.go
@@ -516,3 +516,45 @@ func TestFixLedgerDirtyWorkdir_RefusesUnrelatedDirtyFileWithConflictPresent(t *t
 	assert.Contains(t, string(content), "<<<<<<<",
 		"conflict markers must still be present in the untouched file")
 }
+
+// TestFixLedgerDirtyWorkdir_RefusesPlainModifiedFileWithMarkers covers the
+// doctor/session-upload parity gap flagged in review: the pre-add U-state
+// check above only sees a LIVE conflict. A file that carries marker text but
+// was never U-state at all — plain-modified, never went through a real git
+// conflict — is invisible to that check both before AND after `git add -A`
+// (add just stages it as an ordinary change; there's no U-state to clear).
+// firstUnstageableFileInIndex's post-add blob scan is what has to catch this.
+func TestFixLedgerDirtyWorkdir_RefusesPlainModifiedFileWithMarkers(t *testing.T) {
+	skipIntegration(t)
+	repo := t.TempDir()
+
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 1}`+"\n"), 0644))
+	mustRunGit(t, repo, "add", "meta.json")
+	mustRunGit(t, repo, "commit", "-m", "base")
+
+	// plain, uncommitted modification carrying marker text — never went
+	// through a real git conflict, so git status reports it as ordinary " M",
+	// never "UU".
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(
+		"{\n<<<<<<< Updated upstream\n\"attempts\": 3,\n=======\n\"attempts\": 2,\n>>>>>>> Stashed changes\n}\n"),
+		0644))
+
+	status, err := runIsolatedGit(t, repo, "status", "--porcelain=v1")
+	require.NoError(t, err)
+	require.Empty(t, parseUnmergedPaths(status+"\n"),
+		"test setup must produce a plain modification, not a real U-state conflict")
+	require.Contains(t, status, "M meta.json",
+		"test setup did not produce the expected plain-modified shape")
+
+	beforeLog, err := runIsolatedGit(t, repo, "log", "--oneline")
+	require.NoError(t, err)
+
+	r := fixLedgerDirtyWorkdir(repo, 1)
+	assert.False(t, r.passed,
+		"must refuse to auto-commit a plain-modified file that still carries conflict markers: %+v", r)
+
+	afterLog, err := runIsolatedGit(t, repo, "log", "--oneline")
+	require.NoError(t, err)
+	assert.Equal(t, beforeLog, afterLog, "no commit should have been created")
+}

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -207,12 +207,69 @@ func ensureSessionsGitignore(sessionsDir string) error {
 // treated as clean (not this guard's job to catch a bad path — the
 // subsequent `git add` will fail loudly on that instead).
 func firstConflictMarkerFile(files []string) string {
-	for _, f := range files {
-		if has, err := gitutil.HasConflictMarkers(f); err == nil && has {
-			return f
-		}
+	if i := firstConflictMarkerFileIndex(files); i >= 0 {
+		return files[i]
 	}
 	return ""
+}
+
+// firstConflictMarkerFileIndex is the shared scan behind
+// firstConflictMarkerFile; it returns an index (not a path) so a caller
+// tracking a parallel slice of relative paths — as firstUnstageableFileInIndex
+// does — can report the relative form instead of the full path this
+// function actually reads from disk.
+func firstConflictMarkerFileIndex(files []string) int {
+	for i, f := range files {
+		if has, err := gitutil.HasConflictMarkers(f); err == nil && has {
+			return i
+		}
+	}
+	return -1
+}
+
+// firstUnstageableFileInIndex scans the ledger for anything that must not
+// be committed, immediately before a `git commit` with no pathspec — which
+// commits the WHOLE staged index, not just the files this call explicitly
+// staged. Two things a content-only, caller's-own-files-only check misses:
+//
+//  1. A conflict shaped as UD/DU (one side deleted the path) carries no
+//     "<<<<<<<" text at all — there is no content to scan. Only `git
+//     status` reveals it.
+//  2. Content already staged by something ELSE before this call ran — e.g.
+//     leftover from an interrupted prior operation, or (harmlessly) the
+//     root .gitignore / *.rej / *.needs-summary stage-and-untrack side
+//     effects EnsureGitignoreBeforeCommit performs outside this call's own
+//     file list. Scoping the commit itself to a narrow pathspec instead
+//     would silently drop those legitimate side effects rather than catch
+//     a real problem, so the check runs against the actual staged diff
+//     instead of restricting what gets committed.
+//
+// Returns the first offending path, or "" if the index is clean.
+func firstUnstageableFileInIndex(ledgerPath string) (string, error) {
+	statusOut, err := exec.Command("git", "-C", ledgerPath, "status", "--porcelain=v1").Output()
+	if err != nil {
+		return "", fmt.Errorf("git status: %w", err)
+	}
+	if unmerged := parseUnmergedPaths(string(statusOut)); len(unmerged) > 0 {
+		return unmerged[0].Path, nil
+	}
+
+	diffOut, err := exec.Command("git", "-C", ledgerPath, "diff", "--cached", "--name-only").Output()
+	if err != nil {
+		return "", fmt.Errorf("git diff --cached: %w", err)
+	}
+	var staged, stagedRel []string
+	for _, rel := range strings.Split(strings.TrimSpace(string(diffOut)), "\n") {
+		if rel == "" {
+			continue
+		}
+		staged = append(staged, filepath.Join(ledgerPath, rel))
+		stagedRel = append(stagedRel, rel)
+	}
+	if i := firstConflictMarkerFileIndex(staged); i >= 0 {
+		return stagedRel[i], nil
+	}
+	return "", nil
 }
 
 func commitAndPushLedger(ledgerPath, sessionName string) error {
@@ -230,23 +287,26 @@ func commitAndPushLedger(ledgerPath, sessionName string) error {
 
 	filesToAdd := append([]string{metaPath, gitignorePath}, sessionArtifactsToStage(sessionDir)...)
 
-	// Refuse to stage any file that still carries unresolved conflict
-	// markers — a concurrent daemon `pull --rebase --autostash` can leave a
-	// stash-pop conflict in exactly one of these paths (most often
-	// meta.json) with no MERGE_HEAD-style marker to detect it by. `git add`
-	// does not refuse a conflicted path on its own; it stages the markers as
-	// if resolved, and the commit below would make that permanent. See #749.
-	if conflicted := firstConflictMarkerFile(filesToAdd); conflicted != "" {
-		return fmt.Errorf("refusing to commit %s: contains unresolved conflict markers "+
-			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", conflicted)
-	}
-
 	// --sparse: ledger repos use sparse-checkout (cone mode); this flag
 	// prevents git from blocking adds if sparse rules change or edge cases arise
 	addArgs := append([]string{"-C", ledgerPath, "add", "--sparse"}, filesToAdd...)
 	addCmd := exec.Command("git", addArgs...)
 	if output, err := addCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git add failed: %s: %w", string(output), err)
+	}
+
+	// Refuse to commit if anything now staged — not just the files this call
+	// intended to add — still carries an unresolved conflict. `git commit`
+	// below has no pathspec, so it commits the WHOLE index. A concurrent
+	// daemon `pull --rebase --autostash` can leave a stash-pop conflict with
+	// no MERGE_HEAD-style marker to detect it by, and `git add` does not
+	// refuse a conflicted path on its own — it stages the markers as if
+	// resolved. See #749.
+	if conflicted, err := firstUnstageableFileInIndex(ledgerPath); err != nil {
+		return fmt.Errorf("checking for unresolved conflicts: %w", err)
+	} else if conflicted != "" {
+		return fmt.Errorf("refusing to commit %s: contains an unresolved conflict "+
+			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", conflicted)
 	}
 
 	// commit
@@ -283,17 +343,19 @@ func commitPointerRewriteAndPush(ledgerPath, sessionName string, pointerPaths []
 
 	waitForGCSwap(ledgerPath)
 
-	// See the identical guard in commitAndPushLedger above (#749).
-	if conflicted := firstConflictMarkerFile(pointerPaths); conflicted != "" {
-		return fmt.Errorf("refusing to commit %s: contains unresolved conflict markers "+
-			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", conflicted)
-	}
-
 	// --sparse: ledger repos use sparse-checkout (cone mode)
 	addArgs := append([]string{"-C", ledgerPath, "add", "--sparse"}, pointerPaths...)
 	addCmd := exec.Command("git", addArgs...)
 	if output, err := addCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git add failed: %s: %w", string(output), err)
+	}
+
+	// See the identical guard in commitAndPushLedger above (#749).
+	if conflicted, err := firstUnstageableFileInIndex(ledgerPath); err != nil {
+		return fmt.Errorf("checking for unresolved conflicts: %w", err)
+	} else if conflicted != "" {
+		return fmt.Errorf("refusing to commit %s: contains an unresolved conflict "+
+			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", conflicted)
 	}
 
 	// commit under a distinct subject so it doesn't shadow the canonical

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -274,7 +274,12 @@ func firstUnstageableFileInIndex(ledgerPath string) (string, error) {
 		if strings.HasPrefix(status, "D") {
 			continue // deleted from the index — no blob left to inspect
 		}
-		blob, err := exec.Command("git", "-C", ledgerPath, "show", ":"+rel).Output()
+		// ":./" + path (not a bare ":" + path) is required: git's `:path`
+		// colon-syntax is ambiguous with the `:<n>:path` stage-lookup form,
+		// so a literal path starting with digits-then-colon (e.g. "1:foo")
+		// gets misparsed as "stage 1 of foo" instead of the real path.
+		// ":./" pins it as a pathname relative to cwd, never a stage number.
+		blob, err := exec.Command("git", "-C", ledgerPath, "show", ":./"+rel).Output()
 		if err != nil {
 			return "", fmt.Errorf("inspect staged blob %s: %w", rel, err)
 		}

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -202,6 +202,19 @@ func ensureSessionsGitignore(sessionsDir string) error {
 // Uses exec.Command("git") rather than go-git for the same reasons as the daemon
 // (see daemon/sync.go doPull): rebase support, process isolation, and lock safety.
 // This is a low-volume path (once per session stop), so subprocess overhead is negligible.
+// firstConflictMarkerFile returns the first path in files that contains an
+// unresolved git conflict marker, or "" if none do. Missing files are
+// treated as clean (not this guard's job to catch a bad path — the
+// subsequent `git add` will fail loudly on that instead).
+func firstConflictMarkerFile(files []string) string {
+	for _, f := range files {
+		if has, err := gitutil.HasConflictMarkers(f); err == nil && has {
+			return f
+		}
+	}
+	return ""
+}
+
 func commitAndPushLedger(ledgerPath, sessionName string) error {
 	waitForGCSwap(ledgerPath)
 
@@ -216,6 +229,17 @@ func commitAndPushLedger(ledgerPath, sessionName string) error {
 	gitignorePath := filepath.Join(sessionsDir, ".gitignore")
 
 	filesToAdd := append([]string{metaPath, gitignorePath}, sessionArtifactsToStage(sessionDir)...)
+
+	// Refuse to stage any file that still carries unresolved conflict
+	// markers — a concurrent daemon `pull --rebase --autostash` can leave a
+	// stash-pop conflict in exactly one of these paths (most often
+	// meta.json) with no MERGE_HEAD-style marker to detect it by. `git add`
+	// does not refuse a conflicted path on its own; it stages the markers as
+	// if resolved, and the commit below would make that permanent. See #749.
+	if conflicted := firstConflictMarkerFile(filesToAdd); conflicted != "" {
+		return fmt.Errorf("refusing to commit %s: contains unresolved conflict markers "+
+			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", conflicted)
+	}
 
 	// --sparse: ledger repos use sparse-checkout (cone mode); this flag
 	// prevents git from blocking adds if sparse rules change or edge cases arise
@@ -258,6 +282,12 @@ func commitPointerRewriteAndPush(ledgerPath, sessionName string, pointerPaths []
 	}
 
 	waitForGCSwap(ledgerPath)
+
+	// See the identical guard in commitAndPushLedger above (#749).
+	if conflicted := firstConflictMarkerFile(pointerPaths); conflicted != "" {
+		return fmt.Errorf("refusing to commit %s: contains unresolved conflict markers "+
+			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", conflicted)
+	}
 
 	// --sparse: ledger repos use sparse-checkout (cone mode)
 	addArgs := append([]string{"-C", ledgerPath, "add", "--sparse"}, pointerPaths...)

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -202,35 +202,10 @@ func ensureSessionsGitignore(sessionsDir string) error {
 // Uses exec.Command("git") rather than go-git for the same reasons as the daemon
 // (see daemon/sync.go doPull): rebase support, process isolation, and lock safety.
 // This is a low-volume path (once per session stop), so subprocess overhead is negligible.
-// firstConflictMarkerFile returns the first path in files that contains an
-// unresolved git conflict marker, or "" if none do. Missing files are
-// treated as clean (not this guard's job to catch a bad path — the
-// subsequent `git add` will fail loudly on that instead).
-func firstConflictMarkerFile(files []string) string {
-	if i := firstConflictMarkerFileIndex(files); i >= 0 {
-		return files[i]
-	}
-	return ""
-}
-
-// firstConflictMarkerFileIndex is the shared scan behind
-// firstConflictMarkerFile; it returns an index (not a path) so a caller
-// tracking a parallel slice of relative paths — as firstUnstageableFileInIndex
-// does — can report the relative form instead of the full path this
-// function actually reads from disk.
-func firstConflictMarkerFileIndex(files []string) int {
-	for i, f := range files {
-		if has, err := gitutil.HasConflictMarkers(f); err == nil && has {
-			return i
-		}
-	}
-	return -1
-}
-
 // firstUnstageableFileInIndex scans the ledger for anything that must not
 // be committed, immediately before a `git commit` with no pathspec — which
 // commits the WHOLE staged index, not just the files this call explicitly
-// staged. Two things a content-only, caller's-own-files-only check misses:
+// staged. Three things a content-only, caller's-own-files-only check misses:
 //
 //  1. A conflict shaped as UD/DU (one side deleted the path) carries no
 //     "<<<<<<<" text at all — there is no content to scan. Only `git
@@ -243,8 +218,17 @@ func firstConflictMarkerFileIndex(files []string) int {
 //     would silently drop those legitimate side effects rather than catch
 //     a real problem, so the check runs against the actual staged diff
 //     instead of restricting what gets committed.
+//  3. A staged blob whose content has since diverged from the working-tree
+//     file at the same path — `git commit` persists the INDEX content, not
+//     whatever currently happens to be on disk. Reading the working-tree
+//     file here (as an earlier version of this guard did) would miss
+//     markers that are still staged if the working-tree copy was cleaned
+//     or overwritten afterward. Each staged path is therefore read via
+//     `git show :<path>`, the actual blob about to be committed.
 //
-// Returns the first offending path, or "" if the index is clean.
+// Returns the first offending path, or "" if the index is clean. Inspection
+// failures on a staged blob are returned as errors (fail closed) rather
+// than treated as clean — an unreadable blob is not proof it's safe.
 func firstUnstageableFileInIndex(ledgerPath string) (string, error) {
 	statusOut, err := exec.Command("git", "-C", ledgerPath, "status", "--porcelain=v1").Output()
 	if err != nil {
@@ -254,20 +238,29 @@ func firstUnstageableFileInIndex(ledgerPath string) (string, error) {
 		return unmerged[0].Path, nil
 	}
 
-	diffOut, err := exec.Command("git", "-C", ledgerPath, "diff", "--cached", "--name-only").Output()
+	diffOut, err := exec.Command("git", "-C", ledgerPath, "diff", "--cached", "--name-status").Output()
 	if err != nil {
 		return "", fmt.Errorf("git diff --cached: %w", err)
 	}
-	var staged, stagedRel []string
-	for _, rel := range strings.Split(strings.TrimSpace(string(diffOut)), "\n") {
-		if rel == "" {
+	for _, line := range strings.Split(strings.TrimSpace(string(diffOut)), "\n") {
+		if line == "" {
 			continue
 		}
-		staged = append(staged, filepath.Join(ledgerPath, rel))
-		stagedRel = append(stagedRel, rel)
-	}
-	if i := firstConflictMarkerFileIndex(staged); i >= 0 {
-		return stagedRel[i], nil
+		fields := strings.SplitN(line, "\t", 2)
+		if len(fields) != 2 {
+			continue
+		}
+		status, rel := fields[0], fields[1]
+		if strings.HasPrefix(status, "D") {
+			continue // deleted from the index — no blob left to inspect
+		}
+		blob, err := exec.Command("git", "-C", ledgerPath, "show", ":"+rel).Output()
+		if err != nil {
+			return "", fmt.Errorf("inspect staged blob %s: %w", rel, err)
+		}
+		if gitutil.HasConflictMarkersBytes(blob) {
+			return rel, nil
+		}
 	}
 	return "", nil
 }

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -238,19 +238,39 @@ func firstUnstageableFileInIndex(ledgerPath string) (string, error) {
 		return unmerged[0].Path, nil
 	}
 
-	diffOut, err := exec.Command("git", "-C", ledgerPath, "diff", "--cached", "--name-status").Output()
+	// -z (NUL-delimited) is required, not cosmetic: a tab-delimited rename or
+	// copy record is status\tsource\tdest — three fields, not two — so a
+	// naive line/tab split leaves "source\tdest" glued together as one bogus
+	// path and every staged rename/copy makes this function error out on an
+	// otherwise-clean commit. -z instead emits a flat NUL-separated token
+	// stream per git-diff(1): one status token, then one path token for an
+	// ordinary entry or two (source, dest) for R*/C*, with no ambiguity.
+	diffOut, err := exec.Command("git", "-C", ledgerPath, "diff", "--cached", "--name-status", "-z").Output()
 	if err != nil {
 		return "", fmt.Errorf("git diff --cached: %w", err)
 	}
-	for _, line := range strings.Split(strings.TrimSpace(string(diffOut)), "\n") {
-		if line == "" {
-			continue
+	tokens := strings.Split(strings.Trim(string(diffOut), "\x00"), "\x00")
+	if len(tokens) == 1 && tokens[0] == "" {
+		tokens = nil // nothing staged
+	}
+	for i := 0; i < len(tokens); {
+		status := tokens[i]
+		i++
+		if i >= len(tokens) {
+			break // truncated record; nothing more to read
 		}
-		fields := strings.SplitN(line, "\t", 2)
-		if len(fields) != 2 {
-			continue
+		rel := tokens[i]
+		i++
+		if strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C") {
+			// rename/copy: the token just consumed was the SOURCE path;
+			// the destination — what will actually exist post-commit — is
+			// the next one.
+			if i >= len(tokens) {
+				break
+			}
+			rel = tokens[i]
+			i++
 		}
-		status, rel := fields[0], fields[1]
 		if strings.HasPrefix(status, "D") {
 			continue // deleted from the index — no blob left to inspect
 		}

--- a/cmd/ox/session_upload_test.go
+++ b/cmd/ox/session_upload_test.go
@@ -88,6 +88,29 @@ func TestFirstUnstageableFileInIndex_CleanStagedRename(t *testing.T) {
 	assert.Equal(t, "", conflicted, "a clean staged rename must not be flagged as a conflict")
 }
 
+// TestFirstUnstageableFileInIndex_LiteralColonPrefixedPath is the
+// regression for the Greptile finding: `git show :<path>` is ambiguous
+// with git's `:<n>:<path>` stage-lookup syntax, so a literal staged path
+// starting with digits-then-colon (e.g. "1:foo") gets misparsed as "stage 1
+// of foo" instead of the real path — turning an ordinary, clean commit
+// into a spurious refusal.
+func TestFirstUnstageableFileInIndex_LiteralColonPrefixedPath(t *testing.T) {
+	skipIntegration(t)
+	repo := t.TempDir()
+
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 1}`+"\n"), 0644))
+	mustRunGit(t, repo, "add", "meta.json")
+	mustRunGit(t, repo, "commit", "-m", "base")
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "1:foo"), []byte(`{"clean": true}`+"\n"), 0644))
+	mustRunGit(t, repo, "add", "1:foo")
+
+	conflicted, err := firstUnstageableFileInIndex(repo)
+	require.NoError(t, err, "a clean staged file whose name happens to look like a stage-lookup must not error out")
+	assert.Equal(t, "", conflicted, "a clean literal colon-prefixed path must not be flagged as a conflict")
+}
+
 // --- firstUnstageableFileInIndex: real-git regression coverage ---
 //
 // TestFirstUnstageableFileInIndex_CatchesModifyDeleteConflict covers the gap

--- a/cmd/ox/session_upload_test.go
+++ b/cmd/ox/session_upload_test.go
@@ -21,42 +21,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestFirstConflictMarkerFile covers the guard commitAndPushLedger and
-// commitPointerRewriteAndPush use to refuse staging a conflicted file
-// instead of silently baking its markers into a commit (#749).
-// Failure prevented: a concurrent daemon autostash-pop conflict lands in
-// meta.json right as a session is stopping; without this check, the normal
-// session-stop commit path stages and commits the markers as if nothing
-// were wrong.
-func TestFirstConflictMarkerFile(t *testing.T) {
-	dir := t.TempDir()
+// TestFirstUnstageableFileInIndex_ReadsStagedBlobNotWorkingTree is the
+// load-bearing regression for the gap both CodeRabbit and Greptile flagged
+// independently in review: `git commit` with no pathspec persists the
+// STAGED INDEX content, not whatever is currently on disk. An earlier
+// version of this guard read the working-tree file instead, so a staged
+// blob that still carried conflict markers would sneak through undetected
+// the moment the working-tree copy diverged from what was actually staged.
+func TestFirstUnstageableFileInIndex_ReadsStagedBlobNotWorkingTree(t *testing.T) {
+	skipIntegration(t)
+	repo := t.TempDir()
 
-	clean := filepath.Join(dir, "clean.json")
-	require.NoError(t, os.WriteFile(clean, []byte(`{"ok": true}`), 0644))
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 1}`+"\n"), 0644))
+	mustRunGit(t, repo, "add", "meta.json")
+	mustRunGit(t, repo, "commit", "-m", "base")
 
-	conflicted := filepath.Join(dir, "meta.json")
-	require.NoError(t, os.WriteFile(conflicted, []byte(
+	// stage a conflicted blob
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(
 		"{\n<<<<<<< Updated upstream\n\"attempts\": 3,\n=======\n\"attempts\": 2,\n>>>>>>> Stashed changes\n}\n"),
 		0644))
+	mustRunGit(t, repo, "add", "meta.json")
 
-	missing := filepath.Join(dir, "does-not-exist.json")
+	// then, WITHOUT re-adding, overwrite the working-tree copy with clean
+	// content — the index still holds the conflicted blob from the `add`
+	// above. This is exactly the divergence a working-tree read would miss.
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 4}`+"\n"), 0644))
 
-	cases := []struct {
-		name  string
-		files []string
-		want  string
-	}{
-		{"no files", nil, ""},
-		{"all clean", []string{clean}, ""},
-		{"conflicted file found", []string{clean, conflicted}, conflicted},
-		{"missing file treated as clean, not a false positive", []string{missing, clean}, ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := firstConflictMarkerFile(tc.files)
-			assert.Equal(t, tc.want, got)
-		})
-	}
+	conflicted, err := firstUnstageableFileInIndex(repo)
+	require.NoError(t, err)
+	assert.Equal(t, "meta.json", conflicted,
+		"must catch the conflict still staged in the index, even though the working-tree copy is now clean")
 }
 
 // --- firstUnstageableFileInIndex: real-git regression coverage ---

--- a/cmd/ox/session_upload_test.go
+++ b/cmd/ox/session_upload_test.go
@@ -21,6 +21,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestFirstConflictMarkerFile covers the guard commitAndPushLedger and
+// commitPointerRewriteAndPush use to refuse staging a conflicted file
+// instead of silently baking its markers into a commit (#749).
+// Failure prevented: a concurrent daemon autostash-pop conflict lands in
+// meta.json right as a session is stopping; without this check, the normal
+// session-stop commit path stages and commits the markers as if nothing
+// were wrong.
+func TestFirstConflictMarkerFile(t *testing.T) {
+	dir := t.TempDir()
+
+	clean := filepath.Join(dir, "clean.json")
+	require.NoError(t, os.WriteFile(clean, []byte(`{"ok": true}`), 0644))
+
+	conflicted := filepath.Join(dir, "meta.json")
+	require.NoError(t, os.WriteFile(conflicted, []byte(
+		"{\n<<<<<<< Updated upstream\n\"attempts\": 3,\n=======\n\"attempts\": 2,\n>>>>>>> Stashed changes\n}\n"),
+		0644))
+
+	missing := filepath.Join(dir, "does-not-exist.json")
+
+	cases := []struct {
+		name  string
+		files []string
+		want  string
+	}{
+		{"no files", nil, ""},
+		{"all clean", []string{clean}, ""},
+		{"conflicted file found", []string{clean, conflicted}, conflicted},
+		{"missing file treated as clean, not a false positive", []string{missing, clean}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := firstConflictMarkerFile(tc.files)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestCheckUploadAccess_NoRepoID(t *testing.T) {
 	// bare temp dir with no .sageox/config.json → GetRepoID returns "" → fail-open returns nil
 	tmpDir := t.TempDir()

--- a/cmd/ox/session_upload_test.go
+++ b/cmd/ox/session_upload_test.go
@@ -59,6 +59,91 @@ func TestFirstConflictMarkerFile(t *testing.T) {
 	}
 }
 
+// --- firstUnstageableFileInIndex: real-git regression coverage ---
+//
+// TestFirstUnstageableFileInIndex_CatchesModifyDeleteConflict covers the gap
+// CodeRabbit flagged in review: a modify/delete conflict (UD/DU) has no
+// "<<<<<<<" text at all — one side deleted the file, so there is no content
+// for firstConflictMarkerFile to scan. Only `git status` reveals it.
+// Failure prevented: `git add` on a modify/delete conflict marks it resolved
+// (keeping whichever side was staged) with no marker text anywhere, so a
+// content-only guard would wave it through into a commit.
+func TestFirstUnstageableFileInIndex_CatchesModifyDeleteConflict(t *testing.T) {
+	skipIntegration(t)
+	repo := t.TempDir()
+
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 1}`+"\n"), 0644))
+	mustRunGit(t, repo, "add", "meta.json")
+	mustRunGit(t, repo, "commit", "-m", "base")
+
+	mustRunGit(t, repo, "checkout", "-b", "feature")
+	mustRunGit(t, repo, "rm", "meta.json")
+	mustRunGit(t, repo, "commit", "-m", "feature deletes meta.json")
+
+	mustRunGit(t, repo, "checkout", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 2}`+"\n"), 0644))
+	mustRunGit(t, repo, "commit", "-am", "main modifies meta.json")
+
+	out, err := runIsolatedGit(t, repo, "merge", "--no-ff", "--no-edit", "feature")
+	require.Error(t, err, "merge must conflict on modify/delete; got success: %s", out)
+
+	status, err := runIsolatedGit(t, repo, "status", "--porcelain=v1")
+	require.NoError(t, err)
+	unmerged := parseUnmergedPaths(status + "\n")
+	require.NotEmpty(t, unmerged, "test setup must produce a modify/delete conflict")
+	require.NotEqual(t, "UU", unmerged[0].Code,
+		"test setup produced a content conflict, not the marker-less modify/delete shape this test targets")
+
+	// sanity: no conflict-marker text exists anywhere to scan — this is
+	// exactly the shape a content-only guard cannot see
+	if _, statErr := os.Stat(filepath.Join(repo, "meta.json")); statErr == nil {
+		content, readErr := os.ReadFile(filepath.Join(repo, "meta.json"))
+		require.NoError(t, readErr)
+		require.NotContains(t, string(content), "<<<<<<<",
+			"test setup must not accidentally produce marker text")
+	}
+
+	conflicted, ferr := firstUnstageableFileInIndex(repo)
+	require.NoError(t, ferr)
+	assert.Equal(t, "meta.json", conflicted,
+		"must catch the modify/delete conflict via git status, not content scanning")
+}
+
+// TestFirstUnstageableFileInIndex_CatchesUnrelatedAlreadyStagedConflict
+// covers the Greptile finding: `git commit` with no pathspec commits the
+// WHOLE staged index, not just the files a caller intended to add. A guard
+// scoped only to the caller's own file list misses conflict-marker content
+// that was already staged by something else before the caller's own `git
+// add` ran (e.g. leftover from an interrupted prior operation).
+func TestFirstUnstageableFileInIndex_CatchesUnrelatedAlreadyStagedConflict(t *testing.T) {
+	skipIntegration(t)
+	repo := t.TempDir()
+
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "unrelated.json"), []byte(`{"ok": true}`+"\n"), 0644))
+	mustRunGit(t, repo, "add", "unrelated.json")
+	mustRunGit(t, repo, "commit", "-m", "base")
+
+	// simulate leftover staged content from an interrupted prior operation:
+	// a file with literal conflict-marker text, already `git add`ed, sitting
+	// in the index before this call's own intended files are staged.
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "unrelated.json"), []byte(
+		"{\n<<<<<<< Updated upstream\n\"attempts\": 3,\n=======\n\"attempts\": 2,\n>>>>>>> Stashed changes\n}\n"),
+		0644))
+	mustRunGit(t, repo, "add", "unrelated.json")
+
+	// the caller's own, entirely clean file — this is what a guard scoped
+	// only to the caller's file list would check, and it would find nothing
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(`{"attempts": 1}`+"\n"), 0644))
+	mustRunGit(t, repo, "add", "meta.json")
+
+	conflicted, err := firstUnstageableFileInIndex(repo)
+	require.NoError(t, err)
+	assert.Equal(t, "unrelated.json", conflicted,
+		"must catch conflict-marker content staged by something else, not just the caller's own files")
+}
+
 func TestCheckUploadAccess_NoRepoID(t *testing.T) {
 	// bare temp dir with no .sageox/config.json → GetRepoID returns "" → fail-open returns nil
 	tmpDir := t.TempDir()

--- a/cmd/ox/session_upload_test.go
+++ b/cmd/ox/session_upload_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,6 +53,39 @@ func TestFirstUnstageableFileInIndex_ReadsStagedBlobNotWorkingTree(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, "meta.json", conflicted,
 		"must catch the conflict still staged in the index, even though the working-tree copy is now clean")
+}
+
+// TestFirstUnstageableFileInIndex_CleanStagedRename is the regression for
+// the gap both CodeRabbit and Greptile flagged: `git diff --cached
+// --name-status` reports a rename/copy as THREE tab-separated fields
+// (status, source, dest), not two. A naive per-line tab split glues source
+// and dest into one bogus path and `git show :<that>` errors — meaning a
+// perfectly clean staged rename would have made this guard refuse every
+// commit, not just conflicted ones.
+func TestFirstUnstageableFileInIndex_CleanStagedRename(t *testing.T) {
+	skipIntegration(t)
+	repo := t.TempDir()
+
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	// content long enough for git's similarity heuristic to detect a rename
+	// rather than a delete+add pair.
+	content := []byte(`{"attempts": 1, "note": "enough content for rename detection to kick in"}` + "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "old-name.json"), content, 0644))
+	mustRunGit(t, repo, "add", "old-name.json")
+	mustRunGit(t, repo, "commit", "-m", "base")
+
+	mustRunGit(t, repo, "mv", "old-name.json", "new-name.json")
+
+	// sanity: confirm the test setup actually produced a rename record and
+	// not a plain delete+add, or this test would validate nothing.
+	nameStatus, err := runIsolatedGit(t, repo, "diff", "--cached", "--name-status")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(nameStatus, "R"),
+		"test setup did not produce a detected rename; got status: %q", nameStatus)
+
+	conflicted, ferr := firstUnstageableFileInIndex(repo)
+	require.NoError(t, ferr, "a clean staged rename must not error out")
+	assert.Equal(t, "", conflicted, "a clean staged rename must not be flagged as a conflict")
 }
 
 // --- firstUnstageableFileInIndex: real-git regression coverage ---

--- a/internal/gitutil/conflict.go
+++ b/internal/gitutil/conflict.go
@@ -1,6 +1,7 @@
 package gitutil
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
@@ -24,7 +25,7 @@ const ConflictMarkerStart = "<<<<<<<"
 func HasConflictMarkers(path string) (bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("read %s: %w", path, err)
 	}
 	for _, line := range strings.Split(string(data), "\n") {
 		if strings.HasPrefix(line, ConflictMarkerStart) {

--- a/internal/gitutil/conflict.go
+++ b/internal/gitutil/conflict.go
@@ -1,0 +1,35 @@
+package gitutil
+
+import (
+	"os"
+	"strings"
+)
+
+// ConflictMarkerStart is git's textual conflict marker. We look for it as a
+// line prefix (not merely a substring) so legitimate content that happens to
+// contain the literal characters mid-line — a quoted diff in a session
+// transcript, for instance — doesn't false-positive.
+const ConflictMarkerStart = "<<<<<<<"
+
+// HasConflictMarkers reports whether the file at path contains an unresolved
+// git conflict marker.
+//
+// This exists because `git add` does not refuse a conflicted path — it takes
+// the file's current working-tree content, markers included, and stages it
+// as "resolved." A caller that adds a conflicted path alongside genuinely
+// clean changes and then commits bakes the markers permanently into history.
+// Callers that stage files for an unattended/automatic commit MUST check
+// this first and exclude (or refuse on) any match; git will not do it for
+// them.
+func HasConflictMarkers(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, ConflictMarkerStart) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/gitutil/conflict.go
+++ b/internal/gitutil/conflict.go
@@ -27,10 +27,18 @@ func HasConflictMarkers(path string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("read %s: %w", path, err)
 	}
+	return HasConflictMarkersBytes(data), nil
+}
+
+// HasConflictMarkersBytes is the scan behind HasConflictMarkers, taking raw
+// content directly. Use this when the content under inspection isn't (or
+// might not be) the working-tree file — e.g. a staged git blob read via
+// `git show :<path>`, which can differ from what's currently on disk.
+func HasConflictMarkersBytes(data []byte) bool {
 	for _, line := range strings.Split(string(data), "\n") {
 		if strings.HasPrefix(line, ConflictMarkerStart) {
-			return true, nil
+			return true
 		}
 	}
-	return false, nil
+	return false
 }

--- a/internal/gitutil/conflict_test.go
+++ b/internal/gitutil/conflict_test.go
@@ -1,0 +1,68 @@
+package gitutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHasConflictMarkers covers the shapes HasConflictMarkers must
+// distinguish. Failure prevented: a caller stages a file with this check as
+// its only guard against baking conflict markers into a commit — a false
+// negative here means real corruption ships silently.
+func TestHasConflictMarkers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "clean file",
+			content: `{"summary_status": "ok"}`,
+			want:    false,
+		},
+		{
+			name: "canonical three-way conflict",
+			content: `{
+<<<<<<< Updated upstream
+  "summary_attempts": 3,
+=======
+  "summary_attempts": 2,
+>>>>>>> Stashed changes
+}`,
+			want: true,
+		},
+		{
+			name:    "marker must start the line, not just appear mid-line",
+			content: `{"note": "the diff had <<<<<<< in it but this line doesn't start with it"}`,
+			want:    false,
+		},
+		{
+			name:    "empty file",
+			content: "",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "meta.json")
+			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0644))
+
+			got, err := HasConflictMarkers(path)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestHasConflictMarkers_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := HasConflictMarkers(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## What broke

`ox doctor`'s auto-commit (`fixLedgerDirtyWorkdir`) runs `git add -A` then commits whatever's staged. `git add` does not refuse a conflicted path — it stages the file's current content, conflict markers included, as "resolved." A `git stash pop` conflict from the daemon's `pull --rebase --autostash` leaves no `MERGE_HEAD`/`rebase-merge` marker (a stash pop isn't a resumable git operation), so `detectInProgressGitOp` can't see it either — it just sits there until an unrelated dirty file trips the auto-commit, and `-A` sweeps the conflicted file in too. The markers get baked into the ledger's history permanently.

## What this PR ships

- `internal/gitutil/conflict.go` — `HasConflictMarkers(path)`, a shared guard
- `fixLedgerDirtyWorkdir` (`cmd/ox/doctor_ledger_git.go`) now re-checks for unmerged (U-state) paths immediately before staging and refuses to commit if any are found, instead of blindly running `git add -A`
- The same guard is applied to `commitAndPushLedger` and `commitPointerRewriteAndPush` (`cmd/ox/session_upload.go`) — the routine session-stop commit paths — so the same class of bug can't land through a second door

## Test plan

- `TestFixLedgerDirtyWorkdir_RefusesUnrelatedDirtyFileWithConflictPresent` reproduces the exact shape from this issue: a real `git stash pop` conflict sitting alongside a genuinely dirty, unrelated file, in a real git repo. Verified it fails without the fix (produces the literal "ox doctor: auto-commit ledger changes" commit containing the markers) and passes with it.
- `TestHasConflictMarkers` / `TestFirstConflictMarkerFile` cover the guard in isolation.
- `go build ./...`, `go vet`, `gofmt` all clean.
- Full `internal/gitutil` and relevant `cmd/ox` suites pass.

Closes #749.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790129528&installation_model_id=433550&pr_number=811&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F811&signature=e8a5be9f17ddd43bcf1fa03b8ce6e695ecb2be643099b597fd242bb06cd94734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented automatic commits when unresolved Git conflicts or conflict markers are detected.
  - Blocked uploads containing conflicted staged content, including unrelated files.
  - Improved handling of staged renames, copies, deletions, and unusual file paths.
  - Added actionable manual-resolution guidance for conflicts without an abortable operation.
  - Preserved conflicted files and markers during stash-pop conflict scenarios.

- **Tests**
  - Expanded coverage for conflict detection, staged changes, renames, missing files, and upload prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->