### PR TITLE
docs(readme): remove ai-human-docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SageOx CLI (`ox`)
 
-[![docs: ai-human-docs](https://raw.githubusercontent.com/rsnodgrass/ai-human-docs/main/badges/ai-human-docs.svg)](https://github.com/rsnodgrass/ai-human-docs)
-
 **The hivemind for human–agent teams.** SageOx makes your team's decisions,
 conventions, and architectural intent persistent — and loads them automatically
 into every coding session, human or AI.


### PR DESCRIPTION
## Summary

- **Cleaner front door:** the first thing a README visitor sees is now the product's value line ("The hivemind for human–agent teams."), not a third-party status badge pointing at an external `rsnodgrass/ai-human-docs` repo.
- **Removes a stray external dependency:** this badge was the **only** reference to `ai-human-docs` anywhere in the repo — no submodules, CI workflows, or build steps relied on it — so this fully removes the dependency, not just the visible link.

> Scope note: this branch's broader intent — an upgrade-encouragement email campaign — is **server-side (private-owner follow-up)**; no public CLI code ships in this PR.

## Test Plan

- `grep -rin ai-human-docs .` → no matches remain.
- README renders with the value line directly beneath the `# SageOx CLI (ox)` title (verified diff: badge line + its trailing blank removed, 2 deletions).

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — **N/A** (docs-only, no code paths touched)
- [x] CHANGELOG entry added (if user-facing) — **N/A** (README cleanup, no CLI behavior change)
- [x] Breaking change documented — **none**
- [x] Ran `/security-review` on the diff, **or** N/A documented — **N/A** (docs-only; touches none of `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, `go.sum`)

</details>

Co-authored-by: SageOx <ox@sageox.ai>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790195663&installation_model_id=433550&pr_number=814&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F814&signature=94ed8d2fc0dfef822ff40f29fa9c9f074292052d41641f8347684ea5bcdca242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the AI-generated content badge and link from the README introduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->