### PR TITLE
fix(plan): ox plan save no longer loses large plans (#810)

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1427,7 +1427,9 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		// the first failure). Always commit whatever pointers DID land — any
 		// rewritten pointer left uncommitted re-opens the autostash race for
 		// that file, even if other files in the same call failed.
-		written, writeErr := lfs.WritePointerFiles(sessionDir, meta.Files)
+		// AssertUploaded: meta.Files is the persisted manifest whose blobs were
+		// uploaded before the push that just succeeded above.
+		written, writeErr := lfs.WritePointerFiles(sessionDir, lfs.AssertUploadedManifest(meta.Files))
 		if len(written) > 0 {
 			// Commit the pointer rewrite so it doesn't sit dirty in the worktree.
 			// A dirty worktree here races against the daemon's sync-timer pull:

--- a/cmd/ox/doctor_plan_pointers.go
+++ b/cmd/ox/doctor_plan_pointers.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// CheckSlugPlanPointersMissing detects captured plans whose plan.html is an LFS
+// pointer with no backing blob in the content store.
+const CheckSlugPlanPointersMissing = "plan-pointers-missing"
+
+const planPointersCheckName = "plan content"
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:     CheckSlugPlanPointersMissing,
+		Name:     planPointersCheckName,
+		Category: "Plans",
+		// Suggested, not Auto: the fix rewrites unpushed history (blank + squash).
+		// A bare `ox doctor` must not do that unasked.
+		FixLevel:    FixLevelSuggested,
+		Description: "Detects captured plans whose plan.html LFS pointer has no blob in the store (which wedges the ledger push)",
+		Run:         checkPlanPointersMissing,
+	})
+}
+
+// planPointer is one captured plan whose plan.html is an LFS pointer.
+type planPointer struct {
+	Name    string // dated-slug dir name
+	RelPath string // plan.html path relative to the ledger
+	ref     lfs.FileRef
+}
+
+// checkPlanPointersMissing reports plan.html pointers whose blob is absent from
+// the remote store.
+//
+// # Why this check exists
+//
+// Until the GH #810 fix, `ox plan save` wrote a plan.html LFS pointer for a large
+// render WITHOUT uploading the blob. The render was lost, and the committed
+// pointer made GitLab's pre-receive hook reject every subsequent push (`LFS
+// objects are missing`) — wedging the whole team's ledger. The self-healing
+// reconcile that would have surfaced and cleared it only ever walked sessions/,
+// so a poisoned plan pointer was invisible; one real ledger sat unpushable for 43
+// commits. This check walks data/plans/ so an operator can SEE the wedge, and
+// `--fix` runs the (now plan-aware) reconcile to clear it.
+//
+// A missing-blob plan pointer is unrecoverable — the bytes were never stored
+// anywhere — so the only repair is to blank the dead pointer and squash it out of
+// the push pack, which is exactly what the reconcile does.
+func checkPlanPointersMissing(fix bool) checkResult {
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(planPointersCheckName, "no ledger found", "")
+	}
+
+	pointers := collectPlanHTMLPointers(filepath.Join(ledgerPath, "data", "plans"), ledgerPath)
+	if len(pointers) == 0 {
+		return PassedCheck(planPointersCheckName, "no plan pointers to verify")
+	}
+
+	client, err := lfs.NewClientFromLedger(ledgerPath, endpoint.GetForProject(findGitRoot()))
+	if err != nil {
+		// Can't verify without the store; a dehydrated clone with reachable
+		// pointers is normal, so this is a skip, not a failure.
+		return SkippedCheck(planPointersCheckName, "cannot reach the content store to verify plan blobs", err.Error())
+	}
+
+	missing := planPointersMissingOnRemote(client, pointers)
+	if len(missing) == 0 {
+		return PassedCheck(planPointersCheckName, fmt.Sprintf("all %d plan pointer(s) backed by the store", len(pointers)))
+	}
+
+	if !fix {
+		return planPointersWarning(missing)
+	}
+	return repairPlanPointers(ledgerPath, missing)
+}
+
+// collectPlanHTMLPointers finds every data/plans/<dir>/plan.html that is an LFS
+// pointer (a plain plan.html — the common, healthy case — is skipped).
+func collectPlanHTMLPointers(plansDir, ledgerPath string) []planPointer {
+	entries, err := os.ReadDir(plansDir)
+	if err != nil {
+		return nil
+	}
+	var out []planPointer
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		htmlPath := filepath.Join(plansDir, e.Name(), planHTMLFileName)
+		if !lfs.IsPointerFile(htmlPath) {
+			continue
+		}
+		ref, err := lfs.ReadPointerFile(htmlPath)
+		if err != nil {
+			continue
+		}
+		rel, _ := filepath.Rel(ledgerPath, htmlPath)
+		out = append(out, planPointer{Name: e.Name(), RelPath: rel, ref: ref})
+	}
+	return out
+}
+
+// planHTMLFileName mirrors internal/plan's planHTMLFile (unexported there).
+const planHTMLFileName = "plan.html"
+
+// planPointersMissingOnRemote batch-checks which pointer OIDs are absent from the
+// remote store. Only a 404 proves absence — a transient 401/429/5xx says nothing,
+// so those are treated as "present" rather than false-alarming (mirrors the
+// reconcile's guard). On any batch error it returns nil (optimistic: never invent
+// a wedge that isn't confirmed).
+func planPointersMissingOnRemote(client *lfs.Client, pointers []planPointer) []planPointer {
+	oidToIdx := make(map[string][]int, len(pointers))
+	var objs []lfs.BatchObject
+	for i, p := range pointers {
+		oid := p.ref.BareOID()
+		if _, seen := oidToIdx[oid]; !seen {
+			objs = append(objs, lfs.BatchObject{OID: oid, Size: p.ref.Size})
+		}
+		oidToIdx[oid] = append(oidToIdx[oid], i)
+	}
+
+	const batchChunkSize = 50 // keep the Batch API body under WAF limits
+	missingIdx := make(map[int]bool)
+	for start := 0; start < len(objs); start += batchChunkSize {
+		end := start + batchChunkSize
+		if end > len(objs) {
+			end = len(objs)
+		}
+		resp, err := client.BatchDownload(objs[start:end])
+		if err != nil {
+			return nil
+		}
+		for _, obj := range resp.Objects {
+			if obj.Error == nil || obj.Error.Code != http.StatusNotFound {
+				continue
+			}
+			for _, idx := range oidToIdx[obj.OID] {
+				missingIdx[idx] = true
+			}
+		}
+	}
+
+	var out []planPointer
+	for idx := range missingIdx {
+		out = append(out, pointers[idx])
+	}
+	return out
+}
+
+func planPointersWarning(missing []planPointer) checkResult {
+	var sb strings.Builder
+	sb.WriteString("These captured plans have a plan.html LFS pointer whose blob is missing from the content store.\n")
+	sb.WriteString("The bytes were never uploaded (a pre-fix `ox plan save` of a render above 256KB), so the render is ")
+	sb.WriteString("unrecoverable — and the missing blob makes the ledger reject every push.\n")
+	shown := min(len(missing), 5)
+	for _, p := range missing[:shown] {
+		fmt.Fprintf(&sb, "  %s\n", p.Name)
+	}
+	if len(missing) > shown {
+		fmt.Fprintf(&sb, "  ... and %d more\n", len(missing)-shown)
+	}
+	sb.WriteString("\nRun `ox doctor --fix` to blank the dead pointers and unblock the push.")
+	return checkResult{
+		name:    planPointersCheckName,
+		warning: true,
+		message: fmt.Sprintf("%d plan render(s) missing from the store (push blocked)", len(missing)),
+		detail:  sb.String(),
+	}
+}
+
+// repairPlanPointers runs the plan-aware reconcile, which blanks the orphaned
+// pointers and squashes them out of the unpushed pack so the push can proceed.
+func repairPlanPointers(ledgerPath string, missing []planPointer) checkResult {
+	res, err := lfs.ReconcileUnpushedPointers(context.Background(), ledgerPath, endpoint.GetForProject(findGitRoot()), slog.Default())
+	if err != nil {
+		return checkResult{
+			name:    planPointersCheckName,
+			warning: true,
+			message: fmt.Sprintf("%d plan pointer(s) missing; reconcile failed", len(missing)),
+			detail:  err.Error(),
+		}
+	}
+	return PassedCheck(planPointersCheckName,
+		fmt.Sprintf("reconciled %d orphaned pointer(s); ledger push unblocked", res.Replaced))
+}

--- a/cmd/ox/doctor_plan_pointers_test.go
+++ b/cmd/ox/doctor_plan_pointers_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPlanPointersMissingOnRemote_Only404IsMissing pins the guard that keeps the
+// doctor check honest: ONLY a 404 proves a blob is absent. A transient 401 (token
+// expired) or 5xx says nothing, and treating it as "missing" would report a live
+// plan as unrecoverable — and, if the same logic drove the reconcile, blank it to
+// zero bytes. Mirrors the reconcile's 404-only rule.
+func TestPlanPointersMissingOnRemote_Only404IsMissing(t *testing.T) {
+	oidPresent := lfs.ComputeOID([]byte("present-blob"))
+	oidMissing := lfs.ComputeOID([]byte("missing-blob"))
+	oidFlaky := lfs.ComputeOID([]byte("flaky-blob"))
+
+	// per-OID batch-download outcome: 0 == present (no error)
+	codes := map[string]int{oidPresent: 0, oidMissing: http.StatusNotFound, oidFlaky: http.StatusUnauthorized}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Objects []struct {
+				OID  string `json:"oid"`
+				Size int64  `json:"size"`
+			} `json:"objects"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		type oerr struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		type obj struct {
+			OID   string `json:"oid"`
+			Size  int64  `json:"size"`
+			Error *oerr  `json:"error,omitempty"`
+		}
+		resp := struct {
+			Transfer string `json:"transfer"`
+			Objects  []obj  `json:"objects"`
+		}{Transfer: "basic"}
+		for _, o := range req.Objects {
+			ob := obj{OID: o.OID, Size: o.Size}
+			if code := codes[o.OID]; code != 0 {
+				ob.Error = &oerr{Code: code, Message: "x"}
+			}
+			resp.Objects = append(resp.Objects, ob)
+		}
+		w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+	client := lfs.NewClient(srv.URL, "oauth2", "token")
+
+	pointers := []planPointer{
+		{Name: "p-present", ref: lfs.FileRef{Storage: "lfs", OID: "sha256:" + oidPresent, Size: 10}},
+		{Name: "p-missing", ref: lfs.FileRef{Storage: "lfs", OID: "sha256:" + oidMissing, Size: 20}},
+		{Name: "p-flaky", ref: lfs.FileRef{Storage: "lfs", OID: "sha256:" + oidFlaky, Size: 30}},
+	}
+
+	missing := planPointersMissingOnRemote(client, pointers)
+	require.Len(t, missing, 1, "only the 404 pointer is genuinely missing; the 401 is inconclusive")
+	assert.Equal(t, "p-missing", missing[0].Name)
+}
+
+// TestCollectPlanHTMLPointers_SkipsPlainAndNonPlans verifies the walk only
+// collects data/plans/<dir>/plan.html files that are actually LFS pointers — a
+// plain plan.html (the healthy common case) and other files are ignored.
+func TestCollectPlanHTMLPointers_SkipsPlainAndNonPlans(t *testing.T) {
+	ledger := t.TempDir()
+	plansDir := filepath.Join(ledger, "data", "plans")
+
+	// a pointer plan.html — collected
+	ptrDir := filepath.Join(plansDir, "2026-08-24-ptr")
+	require.NoError(t, os.MkdirAll(ptrDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(ptrDir, "plan.html"),
+		[]byte(lfs.FormatPointer("sha256:"+lfs.ComputeOID([]byte("big")), 999)), 0o644))
+
+	// a plain plan.html — ignored
+	plainDir := filepath.Join(plansDir, "2026-08-24-plain")
+	require.NoError(t, os.MkdirAll(plainDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(plainDir, "plan.html"),
+		[]byte("<html>real content</html>"), 0o644))
+	// its meta.json must never be mistaken for a pointer
+	require.NoError(t, os.WriteFile(filepath.Join(plainDir, "meta.json"), []byte(`{"topic":"x"}`), 0o644))
+
+	got := collectPlanHTMLPointers(plansDir, ledger)
+	require.Len(t, got, 1)
+	assert.Equal(t, "2026-08-24-ptr", got[0].Name)
+}

--- a/cmd/ox/doctor_session_dehydrated_test.go
+++ b/cmd/ox/doctor_session_dehydrated_test.go
@@ -36,7 +36,7 @@ func dehydratedLedger(t *testing.T, name string) (ledgerPath, sessionDir string)
 func writeStubbedSession(t *testing.T, sessionDir, name string, meta *lfs.SessionMeta) {
 	t.Helper()
 	require.NoError(t, lfs.WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"),
-		lfs.FileRef{OID: "sha256:abc123", Size: 4242}))
+		lfs.AssertUploaded(lfs.FileRef{OID: "sha256:abc123", Size: 4242})))
 	if meta == nil {
 		meta = lfs.NewSessionMeta(name, "testuser", "a1", "claude-code", time.Now().UTC()).Build()
 	}

--- a/cmd/ox/doctor_session_id_divergence_test.go
+++ b/cmd/ox/doctor_session_id_divergence_test.go
@@ -368,9 +368,9 @@ func TestScanSessionIDDivergence_DehydratedRawSkipped(t *testing.T) {
 	dir := filepath.Join(sessionsDir, "dehydrated")
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	writeTestSessionMeta(t, sessionsDir, "dehydrated", sessionid.GenerateSessionID())
-	require.NoError(t, lfs.WritePointerFile(filepath.Join(dir, "raw.jsonl"), lfs.FileRef{
+	require.NoError(t, lfs.WritePointerFile(filepath.Join(dir, "raw.jsonl"), lfs.AssertUploaded(lfs.FileRef{
 		OID: "sha256:" + strings.Repeat("a", 64), Size: 4096,
-	}))
+	})))
 
 	result, err := scanSessionIDDivergence(sessionsDir)
 	require.NoError(t, err)

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -405,9 +405,10 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 		return fmt.Errorf("commit and push: %w", err)
 	}
 
-	// push succeeded — now safe to replace content files with LFS pointer stubs
+	// push succeeded — now safe to replace content files with LFS pointer stubs.
+	// AssertUploaded: this retry path uploaded meta.Files' blobs before the push.
 	if len(meta.Files) > 0 {
-		if _, err := lfs.WritePointerFiles(sessionDir, meta.Files); err != nil {
+		if _, err := lfs.WritePointerFiles(sessionDir, lfs.AssertUploadedManifest(meta.Files)); err != nil {
 			slog.Warn("LFS pointer file write failed after push", "error", err, "session", orphan.SessionName)
 		}
 	}

--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -302,7 +302,8 @@ func runImport(cmd *cobra.Command, args []string) error {
 	if hasText {
 		pointerFiles["extracted.md"] = textRef
 	}
-	if _, err := lfs.WritePointerFiles(docDir, pointerFiles); err != nil {
+	// AssertUploaded: srcRef/textRef blobs were uploaded via BatchUpload/UploadAll above.
+	if _, err := lfs.WritePointerFiles(docDir, lfs.AssertUploadedManifest(pointerFiles)); err != nil {
 		return fmt.Errorf("write pointer files: %w", err)
 	}
 

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/identity"
+	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/plan"
 	"github.com/spf13/cobra"
 )
@@ -249,6 +251,26 @@ func savePlanWithProvenance(gitRoot string, in plan.Input, result plan.Result, h
 	return savePlanArtifacts(gitRoot, in, result, html, "")
 }
 
+// planLFSClient builds an LFS client for the project's ledger, or nil when one
+// can't be resolved (not logged in, offline, no configured remote). A nil client
+// makes plan.DehydrateHTML leave plan.html plain — safe, and never fatal to a
+// save: the plain render is still retrievable and pushable.
+func planLFSClient(gitRoot string) *lfs.Client {
+	ctx, err := config.LoadProjectContext(gitRoot)
+	if err != nil || ctx == nil {
+		return nil
+	}
+	ledgerPath := ctx.DefaultLedgerPath()
+	if ledgerPath == "" {
+		return nil
+	}
+	client, err := lfs.NewClientFromLedger(ledgerPath, endpoint.GetForProject(gitRoot))
+	if err != nil {
+		return nil
+	}
+	return client
+}
+
 // savePlanArtifacts is savePlanWithProvenance with an explicit primary artifact
 // kind: "" = markdown-primary (html, if any, is a generated render), plan.
 // PrimaryHTML = the html IS the authored plan of record and in.Raw is the
@@ -309,6 +331,21 @@ func savePlanArtifacts(gitRoot string, in plan.Input, result plan.Result, html [
 	// call twelve lines down logs at Warn.
 	if err := appendProducedPlan(gitRoot, recState, slug); err != nil {
 		slog.Warn("plan: reverse link (produced_plans) failed", "error", err, "slug", slug)
+	}
+
+	// Dehydrate a large plan.html to an LFS pointer BEFORE committing, so the
+	// commit carries a pointer and dehydrated clones stay lean — but only after
+	// the blob is uploaded, so a pointer whose object is missing never reaches the
+	// remote (the GH #810 wedge). Best-effort: on any failure the plain plan.html
+	// Save wrote stays on disk and is committed as-is (retrievable and pushable),
+	// deferring dehydration to a later save / doctor. Small renders and offline
+	// saves stay plain by design.
+	if html != nil {
+		if pointerized, derr := plan.DehydrateHTML(dir, html, planLFSClient(gitRoot)); derr != nil {
+			slog.Warn("plan: plan.html LFS dehydration failed, committing plain", "error", derr, "dir", dir)
+		} else if pointerized {
+			slog.Debug("plan: plan.html dehydrated to LFS pointer", "dir", dir)
+		}
 	}
 
 	// durability: commit + push the plan dir now (sync). Best-effort — a push

--- a/cmd/ox/plan_commit.go
+++ b/cmd/ox/plan_commit.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/gitutil"
 )
 
 // errBackfillCommitFailed marks a commitPlanBackfillToLedger failure at or
@@ -43,6 +44,16 @@ func commitPlanToLedger(gitRoot, planDir string) error {
 	ledgerPath := ctx.DefaultLedgerPath()
 	if ledgerPath == "" {
 		return fmt.Errorf("no ledger configured for %q: cannot commit plan", gitRoot)
+	}
+
+	// Mid-rebase safety belongs at index-mutation time, not just push time. An
+	// unguarded `git add` during a conflicted rebase marks the conflict resolved,
+	// and the following commit consumes the replay step — silently destroying
+	// whatever was being replayed (see .claude/rules/cache-only-design.md).
+	// pushLedger guards its own push, but the add+commit below mutate the index
+	// BEFORE that guard runs, so a plan save mid-rebase needs this check here.
+	if err := gitutil.IsSafeForGitOps(ledgerPath); err != nil {
+		return fmt.Errorf("ledger not safe for plan commit (%s): %w", ledgerPath, err)
 	}
 
 	// ensure .gitignore is in place before any commit to prevent cache leakage

--- a/cmd/ox/plan_render_test.go
+++ b/cmd/ox/plan_render_test.go
@@ -147,7 +147,7 @@ func TestEmitRenderedHTML_FallsBackFromPointerToFreshBytes(t *testing.T) {
 	savedDir := t.TempDir()
 	htmlPath := filepath.Join(savedDir, "plan.html")
 	ref := lfs.NewFileRef([]byte(strings.Repeat("x", 400_000)))
-	if err := lfs.WritePointerFile(htmlPath, ref); err != nil {
+	if err := lfs.WritePointerFile(htmlPath, lfs.AssertUploaded(ref)); err != nil {
 		t.Fatalf("write pointer: %v", err)
 	}
 

--- a/cmd/ox/session_content_test.go
+++ b/cmd/ox/session_content_test.go
@@ -37,10 +37,10 @@ func TestOpenSessionContent_PrefersCacheWhenInPlaceIsPointer(t *testing.T) {
 
 	// in-place: LFS pointer (this is the state for any session synced from
 	// the ledger, ever).
-	if err := lfs.WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"), lfs.FileRef{
+	if err := lfs.WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"), lfs.AssertUploaded(lfs.FileRef{
 		OID:  "deadbeef" + "1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 		Size: 4096,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -78,10 +78,10 @@ func TestOpenSessionContent_ReturnsErrorWhenFullyDehydrated(t *testing.T) {
 	}
 
 	// in-place: pointer; cache: empty.
-	if err := lfs.WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"), lfs.FileRef{
+	if err := lfs.WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"), lfs.AssertUploaded(lfs.FileRef{
 		OID:  "feedface" + "1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 		Size: 1024,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/ox/session_draft_git_test.go
+++ b/cmd/ox/session_draft_git_test.go
@@ -937,7 +937,7 @@ func TestDraftLifecycle_EndToEnd_ManifestMatchesTree(t *testing.T) {
 
 	require.NoError(t, commitAndPushLedger(f.ledgerPath, sessionName))
 	// Content becomes pointers only after the push succeeds.
-	_, err = lfs.WritePointerFiles(sessionDir, refs)
+	_, err = lfs.WritePointerFiles(sessionDir, lfs.AssertUploadedManifest(refs))
 	require.NoError(t, err)
 	require.NoError(t, commitPointerRewriteAndPush(f.ledgerPath, sessionName,
 		[]string{filepath.Join("sessions", sessionName, "raw.jsonl"),

--- a/cmd/ox/session_migrate_lfs.go
+++ b/cmd/ox/session_migrate_lfs.go
@@ -92,8 +92,9 @@ func migrateSessionToLFS(projectRoot, ledgerPath, sessionPath, sessionName strin
 		return fmt.Errorf("no files uploaded")
 	}
 
-	// replace content files with LFS pointer files
-	_, err = lfs.WritePointerFiles(sessionPath, fileRefs)
+	// replace content files with LFS pointer files.
+	// AssertUploaded: uploadSessionLFS uploaded these blobs at line above.
+	_, err = lfs.WritePointerFiles(sessionPath, lfs.AssertUploadedManifest(fileRefs))
 	if err != nil {
 		return fmt.Errorf("write pointer files: %w", err)
 	}

--- a/cmd/ox/session_regenerate_hydration_test.go
+++ b/cmd/ox/session_regenerate_hydration_test.go
@@ -41,10 +41,10 @@ func TestResolveContentPath_CacheOnlyDesign(t *testing.T) {
 		sess := t.TempDir()
 		cache := t.TempDir()
 		// in-place: LFS pointer
-		if err := lfs.WritePointerFile(filepath.Join(sess, "raw.jsonl"), lfs.FileRef{
+		if err := lfs.WritePointerFile(filepath.Join(sess, "raw.jsonl"), lfs.AssertUploaded(lfs.FileRef{
 			OID:  "deadbeef" + "1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 			Size: 1024,
-		}); err != nil {
+		})); err != nil {
 			t.Fatal(err)
 		}
 		// cache: real content
@@ -61,10 +61,10 @@ func TestResolveContentPath_CacheOnlyDesign(t *testing.T) {
 	t.Run("in-place pointer + no cache returns empty (caller must hydrate)", func(t *testing.T) {
 		sess := t.TempDir()
 		cache := t.TempDir()
-		if err := lfs.WritePointerFile(filepath.Join(sess, "raw.jsonl"), lfs.FileRef{
+		if err := lfs.WritePointerFile(filepath.Join(sess, "raw.jsonl"), lfs.AssertUploaded(lfs.FileRef{
 			OID:  "feedface" + "1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 			Size: 2048,
-		}); err != nil {
+		})); err != nil {
 			t.Fatal(err)
 		}
 		got := lfs.ResolveContentPath(sess, cache, "raw.jsonl")

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -1208,7 +1208,9 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 	// push succeeded — now safe to replace content files with LFS pointer stubs
 	// and commit the pointer rewrite so the remote ledger has pointers (not blobs)
 	if pushed && len(fileRefs) > 0 {
-		written, err := lfs.WritePointerFiles(payload.SessionDir, fileRefs)
+		// AssertUploaded: fileRefs' blobs were uploaded to LFS by UploadSessionFiles
+		// and the pointer rewrite happens only after a successful push.
+		written, err := lfs.WritePointerFiles(payload.SessionDir, lfs.AssertUploadedManifest(fileRefs))
 		if err != nil {
 			h.logger.Warn("LFS pointer file write failed after push", "session", sessionName, "err", err)
 		} else if len(written) > 0 {
@@ -1662,7 +1664,9 @@ func (h *SessionFinalizeHandler) processUploadOnly(payload *SessionFinalizePaylo
 	// on failure the cache is the only surviving copy of the session content
 	if pushed {
 		if len(fileRefs) > 0 {
-			written, err := lfs.WritePointerFiles(payload.SessionDir, fileRefs)
+			// AssertUploaded: fileRefs' blobs were uploaded by UploadSessionFiles;
+			// pointer rewrite is gated on the successful push above.
+			written, err := lfs.WritePointerFiles(payload.SessionDir, lfs.AssertUploadedManifest(fileRefs))
 			if err != nil {
 				h.logger.Warn("upload-only: LFS pointer write failed after push", "session", sessionName, "err", err)
 			} else if len(written) > 0 {

--- a/internal/daemon/agentwork/session_finalize_pointer_commit_test.go
+++ b/internal/daemon/agentwork/session_finalize_pointer_commit_test.go
@@ -71,7 +71,7 @@ func TestPointerRewrite_CommittedAfterPush(t *testing.T) {
 	runGitCmd(t, clonePath, "push")
 
 	// now write pointer files and commit them (the code under test)
-	written, err := lfs.WritePointerFiles(sessionDir, fileRefs)
+	written, err := lfs.WritePointerFiles(sessionDir, lfs.AssertUploadedManifest(fileRefs))
 	if err != nil {
 		t.Fatalf("WritePointerFiles: %v", err)
 	}

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1592,13 +1592,63 @@ func (s *SyncScheduler) drainMurmurOutbox(ctx context.Context) {
 // pushMurmurCommits pushes any local murmur commits to the ledger remote.
 // Called during the ledger sync cycle for natural batching (~60s).
 // Non-fatal: failures are logged but don't block the sync cycle.
+// murmurCommitPrefix is the commit-subject marker for every daemon-written
+// murmur commit (see daemon.go's "murmur: %s" / "murmur: delete %s"). The daemon
+// uses it to decide whether an unpushed branch consists exclusively of murmur
+// commits before batching a push.
+const murmurCommitPrefix = "murmur: "
+
+// shouldPushMurmurs decides whether an unpushed commit set is safe for the daemon
+// to batch-push, given the newline-separated commit subjects. Mirrors
+// shouldPushSessionDrafts and enforces the same rule daemon-git.md mandates for
+// every daemon push: `git push` moves the WHOLE branch, and this path runs
+// neither pushLedger's pre-push secret gate nor its LFS reconcile. So pushing
+// when any non-murmur commit is unpushed could ship a commit the CLI deliberately
+// refused (a secret-gate rejection) or a pointer whose LFS blob is not yet
+// uploaded — the GH #810 wedge, but smuggled via the murmur path. Only push when
+// every unpushed commit is a murmur; otherwise defer entirely to the CLI, which
+// has the full gate stack.
+//
+// Returns (blockingSubject, false) when a non-murmur commit is present so the
+// caller can log which one blocked; ("", false) when there is nothing to push.
+func shouldPushMurmurs(logOutput string) (blockingSubject string, ok bool) {
+	trimmed := strings.TrimSpace(logOutput)
+	if trimmed == "" {
+		return "", false
+	}
+	sawMurmur := false
+	for _, subject := range strings.Split(trimmed, "\n") {
+		subject = strings.TrimSpace(subject)
+		if subject == "" {
+			continue
+		}
+		if !strings.HasPrefix(subject, murmurCommitPrefix) {
+			return subject, false
+		}
+		sawMurmur = true
+	}
+	return "", sawMurmur
+}
+
 func (s *SyncScheduler) pushMurmurCommits(ctx context.Context, ledgerPath string) {
 	ctx, span := perf.Start(ctx, "daemon:push_murmurs")
 	defer span.End()
 
-	// check for unpushed murmur commits
-	out, err := s.git.RunGit(ctx, ledgerPath, "log", "--oneline", "origin/main..HEAD", "--", "data/murmurs/")
+	// Subjects of every unpushed commit, one per line. Detection is by subject,
+	// NOT a data/murmurs/ pathspec: a pathspec finds murmur commits but is blind
+	// to a NON-murmur commit sitting unpushed underneath them, which the
+	// whole-branch push would carry along without any gate. shouldPushMurmurs
+	// refuses in that case.
+	out, err := s.git.RunGit(ctx, ledgerPath, "log", "--format=%s", "@{upstream}..HEAD")
 	if err != nil || strings.TrimSpace(out) == "" {
+		return
+	}
+
+	if blocker, ok := shouldPushMurmurs(out); !ok {
+		if blocker != "" {
+			s.logger.Debug("skipping murmur push: a non-murmur commit is unpushed",
+				"path", ledgerPath, "blocking_subject", blocker)
+		}
 		return
 	}
 

--- a/internal/daemon/sync_murmur_push_test.go
+++ b/internal/daemon/sync_murmur_push_test.go
@@ -1,0 +1,71 @@
+package daemon
+
+import "testing"
+
+// shouldPushMurmurs is the murmur-path counterpart to shouldPushSessionDrafts,
+// and the reason it exists is identical: the daemon's batched push runs neither
+// pushLedger's pre-push secret gate nor its LFS reconcile, and `git push` moves
+// the WHOLE branch. So the only thing standing between the daemon and shipping a
+// commit the CLI deliberately refused — or a pointer whose LFS blob is not yet
+// uploaded (the GH #810 wedge, smuggled via the murmur path) — is the rule that
+// every unpushed commit must be a murmur commit.
+//
+// Every ok=false row is a way an ungated commit would otherwise reach the remote.
+func TestShouldPushMurmurs(t *testing.T) {
+	tests := []struct {
+		name        string
+		subjects    string
+		wantOK      bool
+		wantBlocker string
+		why         string
+	}{
+		{
+			name:     "all murmur commits",
+			subjects: "murmur: 2026-08-24 wip\nmurmur: delete abc",
+			wantOK:   true,
+			why:      "the only case where pushing without the gate stack is acceptable",
+		},
+		{
+			name:        "a plan commit is unpushed underneath",
+			subjects:    "murmur: 2026-08-24 wip\nplan: 2026-08-24-some-plan",
+			wantBlocker: "plan: 2026-08-24-some-plan",
+			why: "a deferred plan commit may carry a plan.html pointer; pushing it here " +
+				"without the LFS reconcile is exactly the #810 wedge this guard prevents",
+		},
+		{
+			name:        "an arbitrary CLI commit is unpushed underneath",
+			subjects:    "murmur: 2026-08-24 wip\nsummary: 2026-08-24 something",
+			wantBlocker: "summary: 2026-08-24 something",
+			why:         "it may be a commit the CLI's pre-push secret gate refused",
+		},
+		{
+			name:        "the blocking commit is on top",
+			subjects:    "plan: 2026-08-24-some-plan\nmurmur: 2026-08-24 wip",
+			wantBlocker: "plan: 2026-08-24-some-plan",
+			why:         "order does not matter — any non-murmur commit blocks",
+		},
+		{
+			name:     "nothing to push",
+			subjects: "",
+			wantOK:   false,
+			why:      "empty log: no murmur seen, nothing to do",
+		},
+		{
+			name:     "blank lines are ignored",
+			subjects: "murmur: a\n\n  \nmurmur: b",
+			wantOK:   true,
+			why:      "whitespace-only lines must not be mistaken for a non-murmur commit",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			blocker, ok := shouldPushMurmurs(tc.subjects)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (%s)", ok, tc.wantOK, tc.why)
+			}
+			if blocker != tc.wantBlocker {
+				t.Fatalf("blocker = %q, want %q (%s)", blocker, tc.wantBlocker, tc.why)
+			}
+		})
+	}
+}

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -663,9 +663,11 @@ func WriteSessionMeta(sessionPath string, meta *SessionMeta) error {
 		return err
 	}
 
-	// replace content files with LFS pointer files for GC protection
+	// replace content files with LFS pointer files for GC protection.
+	// AssertUploaded: meta.Files is the persisted manifest of blobs already in
+	// the store (WriteSessionMeta's callers upload before persisting it).
 	if len(meta.Files) > 0 {
-		if _, err := WritePointerFiles(sessionPath, meta.Files); err != nil {
+		if _, err := WritePointerFiles(sessionPath, AssertUploadedManifest(meta.Files)); err != nil {
 			slog.Warn("LFS pointer file write failed", "error", err, "path", sessionPath)
 		}
 	}
@@ -996,8 +998,10 @@ func UpdateMetaSummary(sessionPath, title string) error {
 	// Replace content files with LFS pointer files for GC protection.
 	// Best-effort, matches WriteSessionMeta's prior behavior; pointer
 	// write failures don't invalidate the meta.json update.
+	// AssertUploaded: pointerFiles is a snapshot of the persisted meta manifest,
+	// whose blobs were uploaded before this metadata mutation.
 	if len(pointerFiles) > 0 {
-		if _, err := WritePointerFiles(sessionPath, pointerFiles); err != nil {
+		if _, err := WritePointerFiles(sessionPath, AssertUploadedManifest(pointerFiles)); err != nil {
 			slog.Warn("LFS pointer file write failed", "error", err, "path", sessionPath)
 		}
 	}

--- a/internal/lfs/meta_lfs_safety_test.go
+++ b/internal/lfs/meta_lfs_safety_test.go
@@ -84,7 +84,7 @@ func TestMutateSessionMeta_PointerWritersCannotClobberGitContent(t *testing.T) {
 	// replace summary.json's real bytes (WritePointerFiles already
 	// skips Storage=git, but we want a regression test for it because
 	// the consequences of a future change are silent data loss).
-	if _, err := WritePointerFiles(dir, final.Files); err != nil {
+	if _, err := WritePointerFiles(dir, AssertUploadedManifest(final.Files)); err != nil {
 		t.Fatalf("WritePointerFiles: %v", err)
 	}
 	got, err := os.ReadFile(filepath.Join(dir, "summary.json"))
@@ -115,7 +115,7 @@ func TestWritePointerFiles_SkipsStorageGit(t *testing.T) {
 	files := map[string]FileRef{
 		"report.md": NewGitFileRef(int64(len(userBytes))),
 	}
-	written, err := WritePointerFiles(dir, files)
+	written, err := WritePointerFiles(dir, AssertUploadedManifest(files))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lfs/meta_repair_hydrate_test.go
+++ b/internal/lfs/meta_repair_hydrate_test.go
@@ -84,7 +84,7 @@ func TestHydrateRawToCacheErr_UsesCacheWhenAlreadyHydrated(t *testing.T) {
 
 	// in-place stays a pointer; the real bytes live in the cache
 	rawPath := filepath.Join(sessionDir, "raw.jsonl")
-	require.NoError(t, WritePointerFile(rawPath, FileRef{OID: "sha256:abc", Size: 10}))
+	require.NoError(t, WritePointerFile(rawPath, AssertUploaded(FileRef{OID: "sha256:abc", Size: 10})))
 
 	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
 	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
@@ -116,7 +116,7 @@ func TestResetInlineSummaryEligible_UnhydratablePointerDoesNotReset(t *testing.T
 
 	eligibleMeta(t, sessionDir)
 	require.NoError(t, WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"),
-		FileRef{OID: "sha256:abc", Size: 10}))
+		AssertUploaded(FileRef{OID: "sha256:abc", Size: 10})))
 
 	before, err := os.ReadFile(filepath.Join(sessionDir, "meta.json"))
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestResetInlineSummaryEligible_HydratedPointerDoesReset(t *testing.T) {
 
 	eligibleMeta(t, sessionDir)
 	require.NoError(t, WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"),
-		FileRef{OID: "sha256:abc", Size: 10}))
+		AssertUploaded(FileRef{OID: "sha256:abc", Size: 10})))
 
 	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
 	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
@@ -220,7 +220,7 @@ func TestHydrateRawToCacheErr_FallsBackToOnDiskPointer(t *testing.T) {
 
 	// ...but a valid pointer on disk, carrying the OID
 	require.NoError(t, WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"),
-		FileRef{OID: "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", Size: 4242}))
+		AssertUploaded(FileRef{OID: "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", Size: 4242})))
 
 	// nil client, so this gets as far as needing the network and no further —
 	// what matters is that it is NOT the terminal sentinel.

--- a/internal/lfs/meta_test.go
+++ b/internal/lfs/meta_test.go
@@ -515,11 +515,11 @@ func TestCheckHydrationStatus_WithPointers(t *testing.T) {
 	// write pointer files (not real content)
 	require.NoError(t, WritePointerFile(
 		filepath.Join(sessionDir, "raw.jsonl"),
-		FileRef{OID: "sha256:abc", Size: 100},
+		AssertUploaded(FileRef{OID: "sha256:abc", Size: 100}),
 	))
 	require.NoError(t, WritePointerFile(
 		filepath.Join(sessionDir, "summary.md"),
-		FileRef{OID: "sha256:def", Size: 200},
+		AssertUploaded(FileRef{OID: "sha256:def", Size: 200}),
 	))
 
 	meta := &SessionMeta{
@@ -542,7 +542,7 @@ func TestCheckHydrationStatus_MixedPointerAndContent(t *testing.T) {
 	// one pointer file, one real content file
 	require.NoError(t, WritePointerFile(
 		filepath.Join(sessionDir, "raw.jsonl"),
-		FileRef{OID: "sha256:abc", Size: 100},
+		AssertUploaded(FileRef{OID: "sha256:abc", Size: 100}),
 	))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(sessionDir, "summary.md"),
@@ -573,11 +573,11 @@ func TestCheckHydrationStatusWithCache_AllInCache(t *testing.T) {
 	// pointer files in session dir
 	require.NoError(t, WritePointerFile(
 		filepath.Join(sessionDir, "raw.jsonl"),
-		FileRef{OID: "sha256:abc", Size: 100},
+		AssertUploaded(FileRef{OID: "sha256:abc", Size: 100}),
 	))
 	require.NoError(t, WritePointerFile(
 		filepath.Join(sessionDir, "summary.md"),
-		FileRef{OID: "sha256:def", Size: 200},
+		AssertUploaded(FileRef{OID: "sha256:def", Size: 200}),
 	))
 
 	// real content in cache
@@ -630,7 +630,7 @@ func TestCheckHydrationStatusWithCache_PartialCacheOnly(t *testing.T) {
 	// pointer in session dir, nothing else
 	require.NoError(t, WritePointerFile(
 		filepath.Join(sessionDir, "raw.jsonl"),
-		FileRef{OID: "sha256:abc", Size: 100},
+		AssertUploaded(FileRef{OID: "sha256:abc", Size: 100}),
 	))
 	// only summary in cache, raw.jsonl missing from cache too
 	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "summary.md"), []byte("# Cached summary"), 0644))
@@ -654,7 +654,7 @@ func TestCheckHydrationStatusWithCache_EmptyCache(t *testing.T) {
 
 	require.NoError(t, WritePointerFile(
 		filepath.Join(sessionDir, "raw.jsonl"),
-		FileRef{OID: "sha256:abc", Size: 100},
+		AssertUploaded(FileRef{OID: "sha256:abc", Size: 100}),
 	))
 
 	meta := &SessionMeta{

--- a/internal/lfs/path_validate_test.go
+++ b/internal/lfs/path_validate_test.go
@@ -84,7 +84,7 @@ func TestWritePointerFiles_RejectsPathTraversal(t *testing.T) {
 	files := map[string]FileRef{
 		"../escape.txt": {Storage: StorageLFS, OID: "sha256:abc", Size: 100},
 	}
-	_, err := WritePointerFiles(dir, files)
+	_, err := WritePointerFiles(dir, AssertUploadedManifest(files))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsafe pointer filename")
 }

--- a/internal/lfs/pointer.go
+++ b/internal/lfs/pointer.go
@@ -95,9 +95,15 @@ func NestedPointer(outer FileRef, content []byte) (FileRef, bool) {
 // auto-hydrate these files — hydration is handled by our own download path.
 
 // WritePointerFile writes a standard LFS pointer file at path.
-// Refuses to replace real content that does not match ref.OID — see
+//
+// It takes an UploadedRef, not a bare FileRef: a pointer may only be written for
+// a blob whose upload is proven (see uploaded.go). This makes GH #810 — a
+// pointer minted for content that was never uploaded — a compile error.
+//
+// Refuses to replace real content that does not match the ref OID — see
 // guardPointerOverwrite.
-func WritePointerFile(path string, ref FileRef) error {
+func WritePointerFile(path string, uploaded UploadedRef) error {
+	ref := uploaded.ref
 	if err := guardPointerOverwrite(path, ref); err != nil {
 		return err
 	}
@@ -147,21 +153,21 @@ func guardPointerOverwrite(path string, ref FileRef) error {
 // are skipped — writing a pointer file there would clobber the real content
 // with empty bytes. Legacy entries (no Storage field) are treated as LFS
 // per FileRef.EffectiveStorage().
-func WritePointerFiles(dir string, files map[string]FileRef) ([]string, error) {
+func WritePointerFiles(dir string, files map[string]UploadedRef) ([]string, error) {
 	if len(files) == 0 {
 		return nil, nil
 	}
 
 	var paths []string
-	for name, ref := range files {
-		if !ref.IsLFS() {
+	for name, uploaded := range files {
+		if !uploaded.ref.IsLFS() {
 			continue // Storage=git: real content stays in place
 		}
 		if err := ValidateRelativePath(name); err != nil {
 			return paths, fmt.Errorf("unsafe pointer filename: %w", err)
 		}
 		p := filepath.Join(dir, name)
-		if err := WritePointerFile(p, ref); err != nil {
+		if err := WritePointerFile(p, uploaded); err != nil {
 			return paths, fmt.Errorf("write pointer %s: %w", name, err)
 		}
 		paths = append(paths, p)

--- a/internal/lfs/pointer_test.go
+++ b/internal/lfs/pointer_test.go
@@ -87,7 +87,7 @@ func TestWritePointerFile(t *testing.T) {
 	ref := FileRef{OID: "sha256:abc123def456", Size: 9876}
 	path := filepath.Join(dir, "raw.jsonl")
 
-	err := WritePointerFile(path, ref)
+	err := WritePointerFile(path, AssertUploaded(ref))
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(path)
@@ -102,7 +102,7 @@ func TestWritePointerFiles(t *testing.T) {
 		"summary.md": {OID: "sha256:ccc", Size: 300},
 	}
 
-	paths, err := WritePointerFiles(dir, files)
+	paths, err := WritePointerFiles(dir, AssertUploadedManifest(files))
 	require.NoError(t, err)
 	assert.Len(t, paths, 2)
 
@@ -121,13 +121,13 @@ func TestWritePointerFiles(t *testing.T) {
 }
 
 func TestWritePointerFiles_EmptyMap(t *testing.T) {
-	paths, err := WritePointerFiles(t.TempDir(), map[string]FileRef{})
+	paths, err := WritePointerFiles(t.TempDir(), AssertUploadedManifest(map[string]FileRef{}))
 	assert.NoError(t, err)
 	assert.Nil(t, paths)
 }
 
 func TestWritePointerFiles_NilMap(t *testing.T) {
-	paths, err := WritePointerFiles(t.TempDir(), nil)
+	paths, err := WritePointerFiles(t.TempDir(), AssertUploadedManifest(nil))
 	assert.NoError(t, err)
 	assert.Nil(t, paths)
 }
@@ -153,7 +153,7 @@ func TestWritePointerFiles_SkipsGitStorage(t *testing.T) {
 		"summary.json": NewGitFileRef(int64(len(realJSON))), // Storage=git
 	}
 
-	paths, err := WritePointerFiles(dir, files)
+	paths, err := WritePointerFiles(dir, AssertUploadedManifest(files))
 	require.NoError(t, err)
 	// only the LFS entry should produce a pointer file path
 	assert.Len(t, paths, 1)
@@ -181,7 +181,7 @@ func TestIsPointerFile(t *testing.T) {
 
 	// write a valid pointer file
 	pointerPath := filepath.Join(dir, "raw.jsonl")
-	require.NoError(t, WritePointerFile(pointerPath, FileRef{OID: "sha256:abc", Size: 100}))
+	require.NoError(t, WritePointerFile(pointerPath, AssertUploaded(FileRef{OID: "sha256:abc", Size: 100})))
 
 	// write a real content file (too large to be a pointer)
 	contentPath := filepath.Join(dir, "content.jsonl")
@@ -202,7 +202,7 @@ func TestReadPointerFile(t *testing.T) {
 	ref := FileRef{OID: "sha256:deadbeef1234", Size: 42}
 	path := filepath.Join(dir, "test.jsonl")
 
-	require.NoError(t, WritePointerFile(path, ref))
+	require.NoError(t, WritePointerFile(path, AssertUploaded(ref)))
 
 	got, err := ReadPointerFile(path)
 	require.NoError(t, err)
@@ -307,7 +307,7 @@ func TestWritePointerFile_OverwritesLargeContent(t *testing.T) {
 	// every FileRef as "sha256:"+ComputeOID(content)), and it is what proves the
 	// bytes reached the LFS store before we drop the local copy.
 	ref := FileRef{OID: "sha256:" + ComputeOID(largeContent), Size: int64(len(largeContent))}
-	require.NoError(t, WritePointerFile(path, ref))
+	require.NoError(t, WritePointerFile(path, AssertUploaded(ref)))
 
 	// verify file is now a pointer (small)
 	info, err := os.Stat(path)
@@ -340,7 +340,7 @@ func TestWritePointerFile_RefusesToClobberMismatchedContent(t *testing.T) {
 		content := []byte(`{"type":"header"}` + "\n")
 		require.NoError(t, os.WriteFile(path, content, 0644))
 
-		err := WritePointerFile(path, FileRef{OID: "sha256:deadbeef", Size: int64(len(content))})
+		err := WritePointerFile(path, AssertUploaded(FileRef{OID: "sha256:deadbeef", Size: int64(len(content))}))
 		require.Error(t, err, "must refuse rather than destroy the only local copy")
 		assert.Equal(t, string(content), readBack(t, path), "content must survive untouched")
 	})
@@ -349,10 +349,10 @@ func TestWritePointerFile_RefusesToClobberMismatchedContent(t *testing.T) {
 		// A redaction pass legitimately installs a new OID over the old pointer.
 		// Nothing is lost — the old bytes were never on disk to begin with.
 		path := filepath.Join(dir, "redacted.jsonl")
-		require.NoError(t, WritePointerFile(path, FileRef{OID: "sha256:" + ComputeOID([]byte("v1")), Size: 2}))
+		require.NoError(t, WritePointerFile(path, AssertUploaded(FileRef{OID: "sha256:" + ComputeOID([]byte("v1")), Size: 2})))
 
 		newRef := FileRef{OID: "sha256:" + ComputeOID([]byte("v2")), Size: 2}
-		require.NoError(t, WritePointerFile(path, newRef))
+		require.NoError(t, WritePointerFile(path, AssertUploaded(newRef)))
 
 		oid, _, err := ParsePointer(readBack(t, path))
 		require.NoError(t, err)
@@ -361,7 +361,7 @@ func TestWritePointerFile_RefusesToClobberMismatchedContent(t *testing.T) {
 
 	t.Run("writing into a fresh path always succeeds", func(t *testing.T) {
 		path := filepath.Join(dir, "brand-new.jsonl")
-		require.NoError(t, WritePointerFile(path, FileRef{OID: "sha256:abc123", Size: 7}))
+		require.NoError(t, WritePointerFile(path, AssertUploaded(FileRef{OID: "sha256:abc123", Size: 7})))
 		assert.True(t, IsPointerFile(path))
 	})
 }
@@ -373,7 +373,7 @@ func TestNewFileRef_EndToEnd_RoundTrip(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "raw.jsonl")
-	require.NoError(t, WritePointerFile(path, ref))
+	require.NoError(t, WritePointerFile(path, AssertUploaded(ref)))
 
 	got, err := ReadPointerFile(path)
 	require.NoError(t, err)
@@ -394,7 +394,7 @@ func TestWritePointerFiles_PartialFailure(t *testing.T) {
 		"nonexistent/bad.jsonl": {OID: "sha256:bbb", Size: 200},
 	}
 
-	paths, err := WritePointerFiles(dir, files)
+	paths, err := WritePointerFiles(dir, AssertUploadedManifest(files))
 	// map iteration is random, so we might get the error on either file
 	// at least one file should fail because the subdirectory doesn't exist
 	if err != nil {

--- a/internal/lfs/reconcile.go
+++ b/internal/lfs/reconcile.go
@@ -15,17 +15,26 @@ import (
 
 // ReconcileResult describes what ReconcileUnpushedPointers found and fixed.
 type ReconcileResult struct {
-	ScannedPointers int      // total pointer files found in sessions/
+	ScannedPointers int      // total pointer files found across the scanned trees
 	MissingOnRemote int      // pointers whose LFS OIDs are not in the remote store
 	Replaced        int      // pointers replaced with empty stubs
 	Squashed        bool     // whether unpushed history was squashed
 	ReplacedFiles   []string // relative paths of replaced files
 }
 
-// ReconcileUnpushedPointers scans the working tree under sessions/ for LFS pointer
-// files whose backing blobs are missing from the remote LFS store, replaces them
-// with empty stubs, and squashes all unpushed commits into one so the poisoned
-// pointer blobs no longer appear in the push pack.
+// ReconcileUnpushedPointers scans the working tree under sessions/ AND data/plans/
+// for LFS pointer files whose backing blobs are missing from the remote LFS store,
+// replaces them with empty stubs, and squashes all unpushed commits into one so the
+// poisoned pointer blobs no longer appear in the push pack.
+//
+// data/plans/ is included because a poisoned PLAN pointer wedges the push exactly
+// like a session one — GitLab's pre-receive scans the whole pack — and pushLedger
+// auto-runs this reconcile on a rejected push. Without the plan walk, a plan.html
+// pointer whose blob was never uploaded (the pre-fix GH #810 bug) stalls the ledger
+// with no self-heal, which is precisely how one such ledger sat unpushable for 43
+// commits. Post-fix the plan path never commits an un-uploaded pointer; this walk
+// heals the ones that predate the fix (their bytes are gone, so blanking to unblock
+// is the only recovery) and backstops any future regression.
 //
 // This is the repair mechanism for ledgers whose push is blocked by
 // "GitLab: LFS objects are missing" — regardless of HOW the bad pointer got
@@ -45,10 +54,11 @@ func ReconcileUnpushedPointers(ctx context.Context, ledgerPath, endpointURL stri
 
 	result := &ReconcileResult{}
 
-	// find all pointer files under sessions/
-	sessionsDir := filepath.Join(ledgerPath, "sessions")
-	if _, err := os.Stat(sessionsDir); os.IsNotExist(err) {
-		return result, nil
+	// find all pointer files under the pointer-bearing trees: session artifacts
+	// and captured plans. Either can poison the shared push.
+	roots := []string{
+		filepath.Join(ledgerPath, "sessions"),
+		filepath.Join(ledgerPath, "data", "plans"),
 	}
 
 	type pointerEntry struct {
@@ -57,23 +67,28 @@ func ReconcileUnpushedPointers(ctx context.Context, ledgerPath, endpointURL stri
 	}
 	var pointers []pointerEntry
 
-	err := filepath.Walk(sessionsDir, func(absPath string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() || info.Size() > maxPointerSize {
-			return nil
+	for _, root := range roots {
+		if _, err := os.Stat(root); os.IsNotExist(err) {
+			continue
 		}
-		if !IsPointerFile(absPath) {
+		err := filepath.Walk(root, func(absPath string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() || info.Size() > maxPointerSize {
+				return nil
+			}
+			if !IsPointerFile(absPath) {
+				return nil
+			}
+			ref, parseErr := ReadPointerFile(absPath)
+			if parseErr != nil {
+				return nil
+			}
+			relPath, _ := filepath.Rel(ledgerPath, absPath)
+			pointers = append(pointers, pointerEntry{relPath: relPath, ref: ref})
 			return nil
+		})
+		if err != nil {
+			return result, fmt.Errorf("walk %s: %w", root, err)
 		}
-		ref, parseErr := ReadPointerFile(absPath)
-		if parseErr != nil {
-			return nil
-		}
-		relPath, _ := filepath.Rel(ledgerPath, absPath)
-		pointers = append(pointers, pointerEntry{relPath: relPath, ref: ref})
-		return nil
-	})
-	if err != nil {
-		return result, fmt.Errorf("walk sessions/: %w", err)
 	}
 
 	result.ScannedPointers = len(pointers)

--- a/internal/lfs/reconcile_plan_test.go
+++ b/internal/lfs/reconcile_plan_test.go
@@ -1,0 +1,58 @@
+package lfs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReconcile_WalksPlanPointers pins the GH #810 fix: ReconcileUnpushedPointers
+// must scan data/plans/, not only sessions/.
+//
+// Failure prevented: a poisoned plan.html pointer (blob never uploaded) was
+// invisible to the reconcile that pushLedger auto-runs on a rejected push, so it
+// never got neutralized — which is exactly how one ledger sat unpushable for 43
+// commits. Before the walk was extended, a plan-only pointer counted 0 here.
+//
+// The reconcile can't reach the remote in this fixture (no configured LFS
+// endpoint), so it returns an error at the batch-check step — but ScannedPointers
+// is set by the WALK, before that call, and the walk is what this test pins.
+func TestReconcile_WalksPlanPointers(t *testing.T) {
+	dir := initLedgerRepo(t)
+
+	// one session pointer (sessions/ — always walked)
+	sess := filepath.Join(dir, "sessions", "2026-08-24-s")
+	require.NoError(t, os.MkdirAll(sess, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sess, "raw.jsonl"),
+		[]byte(lfsPointerContent(strings.Repeat("a", 64), 10)), 0o644))
+
+	// one plan pointer (data/plans/ — the newly-walked tree)
+	planDir := filepath.Join(dir, "data", "plans", "2026-08-24-p")
+	require.NoError(t, os.MkdirAll(planDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(planDir, "plan.html"),
+		[]byte(lfsPointerContent(strings.Repeat("b", 64), 20)), 0o644))
+
+	result, _ := ReconcileUnpushedPointers(context.Background(), dir, "", nil)
+	assert.Equal(t, 2, result.ScannedPointers,
+		"reconcile must scan BOTH sessions/ and data/plans/ (a plan pointer was invisible before)")
+}
+
+// TestReconcile_PlanOnlyPointerIsScanned isolates the plan tree: a ledger with a
+// pointer ONLY under data/plans/ must still see it. Guards against a regression
+// that drops the plan root from the walk while keeping sessions/.
+func TestReconcile_PlanOnlyPointerIsScanned(t *testing.T) {
+	dir := initLedgerRepo(t)
+
+	planDir := filepath.Join(dir, "data", "plans", "2026-08-24-only")
+	require.NoError(t, os.MkdirAll(planDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(planDir, "plan.html"),
+		[]byte(lfsPointerContent(strings.Repeat("c", 64), 30)), 0o644))
+
+	result, _ := ReconcileUnpushedPointers(context.Background(), dir, "", nil)
+	assert.Equal(t, 1, result.ScannedPointers, "a plan-only pointer must be scanned")
+}

--- a/internal/lfs/session_upload.go
+++ b/internal/lfs/session_upload.go
@@ -32,6 +32,11 @@ var ContentFiles = pipeline.LedgerContentFiles
 //  3. Call LFS batch API to get upload actions
 //  4. Upload all blobs in parallel
 //  5. Return filename->FileRef map for meta.json
+//
+// The returned manifest is a filename->FileRef map (not UploadedRef) because it
+// flows straight into meta.json merge logic that is FileRef-shaped. Its blobs
+// ARE uploaded on a nil-error return, so callers wrap it in AssertUploadedManifest
+// at the WritePointerFiles boundary — the one audited place upload is asserted.
 func UploadSessionFiles(client *Client, sessionPath string, logger *slog.Logger) (map[string]FileRef, error) {
 	if logger == nil {
 		logger = slog.Default()

--- a/internal/lfs/session_upload_test.go
+++ b/internal/lfs/session_upload_test.go
@@ -626,6 +626,6 @@ func writePointerForContent(t *testing.T, sessionDir, filename string, content [
 	refs := map[string]FileRef{filename: NewFileRef(content)}
 	// write a temporary content file so WritePointerFiles can replace it
 	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, filename), content, 0644))
-	_, err := WritePointerFiles(sessionDir, refs)
+	_, err := WritePointerFiles(sessionDir, AssertUploadedManifest(refs))
 	require.NoError(t, err)
 }

--- a/internal/lfs/uploaded.go
+++ b/internal/lfs/uploaded.go
@@ -1,0 +1,72 @@
+package lfs
+
+import "fmt"
+
+// UploadedRef is evidence that a FileRef's content is present in the LFS store.
+//
+// Its whole reason to exist is a compile-time invariant: WritePointerFile /
+// WritePointerFiles take an UploadedRef, not a bare FileRef, so a caller holding
+// only a hash (NewFileRef's output — sha256 + size, no I/O) CANNOT write a
+// pointer. The only ways to obtain an UploadedRef are:
+//
+//  1. UploadBlob / UploadSessionFiles — actually talked to the Batch API and got
+//     a success response, so the blob is provably in the store; or
+//  2. AssertUploaded / AssertUploadedManifest — the explicitly-named, audited
+//     escape hatch for a ref whose blob a PRIOR run already uploaded (a persisted
+//     meta.json manifest being re-pointerized after a successful push).
+//
+// This closes the GH #810 bug class by construction, for the plan path, the
+// session path, and every future caller: minting a pointer for a blob that was
+// never uploaded is no longer expressible. The field is unexported precisely so
+// no code outside this package can fabricate the proof.
+type UploadedRef struct {
+	ref FileRef
+}
+
+// Ref returns the underlying FileRef (OID + size + storage).
+func (u UploadedRef) Ref() FileRef { return u.ref }
+
+// BareOID returns the underlying ref's hex digest without the "sha256:" prefix.
+func (u UploadedRef) BareOID() string { return u.ref.BareOID() }
+
+// AssertUploaded wraps a FileRef whose blob is ALREADY in the LFS store into the
+// proof type WritePointerFile requires. Use ONLY where a prior successful upload
+// is proven — a persisted meta.json manifest re-pointerized after its push
+// succeeded, or an import of blobs already confirmed present. NEVER call it on a
+// fresh NewFileRef whose content was not uploaded: that is exactly the #810 bug,
+// and the whole point of the type is to make that call stand out in review.
+func AssertUploaded(ref FileRef) UploadedRef { return UploadedRef{ref: ref} }
+
+// AssertUploadedManifest is the bulk form of AssertUploaded for a persisted
+// filename->FileRef manifest (meta.Files). Same contract: every entry's blob
+// MUST already be in the store. Grep for AssertUploaded to audit every site that
+// asserts (rather than proves) upload.
+func AssertUploadedManifest(files map[string]FileRef) map[string]UploadedRef {
+	out := make(map[string]UploadedRef, len(files))
+	for name, ref := range files {
+		out[name] = UploadedRef{ref: ref}
+	}
+	return out
+}
+
+// UploadBlob uploads a single content blob to the LFS store and returns proof of
+// upload. It is the single-object counterpart to UploadSessionFiles, sharing the
+// same upload-then-return-proof core: hash, request an upload action via the
+// Batch API, PUT the bytes, and surface any per-object failure. Only a nil error
+// yields a usable UploadedRef.
+//
+// A blob the server reports as already present (UploadAll skips it) is a success
+// — it is in the store, which is all UploadedRef attests.
+func UploadBlob(client *Client, content []byte) (UploadedRef, error) {
+	ref := NewFileRef(content)
+	resp, err := client.BatchUpload([]BatchObject{{OID: ref.BareOID(), Size: ref.Size}})
+	if err != nil {
+		return UploadedRef{}, fmt.Errorf("LFS batch upload: %w", err)
+	}
+	for _, r := range UploadAll(resp, map[string][]byte{ref.BareOID(): content}, 1) {
+		if r.Error != nil {
+			return UploadedRef{}, fmt.Errorf("LFS upload OID %s: %w", r.OID, r.Error)
+		}
+	}
+	return UploadedRef{ref: ref}, nil
+}

--- a/internal/plan/dehydrate.go
+++ b/internal/plan/dehydrate.go
@@ -1,0 +1,48 @@
+package plan
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// DehydrateHTML replaces a large, already-written plain plan.html with an LFS
+// pointer — but ONLY after uploading its bytes to the store, so a committed
+// pointer never references a blob that isn't there (the GH #810 wedge). Returns
+// true when it pointerized, false when it left plan.html plain.
+//
+// It is deliberately separate from Save. Save is the no-network storage layer
+// and always writes plan.html plain; DehydrateHTML runs in the CLI caller, which
+// owns credential resolution and the LFS client. Because it goes through
+// lfs.UploadBlob → lfs.WritePointerFile (which requires an lfs.UploadedRef), it
+// is structurally impossible for this path to mint a pointer for un-uploaded
+// content.
+//
+// Behavior by case:
+//   - html at or below htmlLFSThreshold: stays plain so a dehydrated clone reads
+//     it directly with no hydration — returns (false, nil).
+//   - client == nil (offline / no ledger remote): stays plain — returns
+//     (false, nil). Larger in git, but retrievable and pushable; never lost.
+//   - upload fails: returns (false, err). The plain plan.html Save wrote is still
+//     on disk, so the caller leaves it plain and defers — content is safe and the
+//     push is not poisoned.
+//   - upload succeeds: overwrites plan.html with a pointer to the now-present
+//     blob. The OID matches the plain bytes on disk, so guardPointerOverwrite
+//     permits the swap — returns (true, nil).
+func DehydrateHTML(dir string, html []byte, client *lfs.Client) (bool, error) {
+	if int64(len(html)) <= htmlLFSThreshold {
+		return false, nil
+	}
+	if client == nil {
+		return false, nil
+	}
+	uploaded, err := lfs.UploadBlob(client, html)
+	if err != nil {
+		return false, fmt.Errorf("upload plan.html blob: %w", err)
+	}
+	if err := lfs.WritePointerFile(filepath.Join(dir, planHTMLFile), uploaded); err != nil {
+		return false, fmt.Errorf("write plan.html LFS pointer: %w", err)
+	}
+	return true, nil
+}

--- a/internal/plan/dehydrate_test.go
+++ b/internal/plan/dehydrate_test.go
@@ -1,0 +1,196 @@
+package plan
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// writePlanHTMLPlain simulates what Save writes: a plain plan.html on disk.
+func writePlanHTMLPlain(t *testing.T, dir string, html []byte) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, planHTMLFile), html, 0o644); err != nil {
+		t.Fatalf("seed plain plan.html: %v", err)
+	}
+}
+
+func assertPlainHTML(t *testing.T, dir string, want []byte) {
+	t.Helper()
+	p := filepath.Join(dir, planHTMLFile)
+	if lfs.IsPointerFile(p) {
+		t.Fatalf("plan.html is an LFS pointer, want plain")
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read plan.html: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("plan.html bytes changed: got %d, want %d", len(got), len(want))
+	}
+}
+
+// fakeLFSUploadServer stands up a minimal Git LFS Batch API server that hands out
+// upload actions and stores PUT'd blobs in memory. Returns a client pointed at it
+// and the OID->bytes store so a test can prove the blob really landed.
+func fakeLFSUploadServer(t *testing.T) (*lfs.Client, *sync.Map) {
+	t.Helper()
+	stored := &sync.Map{}
+	var srv *httptest.Server
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/info/lfs/objects/batch", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Operation string `json:"operation"`
+			Objects   []struct {
+				OID  string `json:"oid"`
+				Size int64  `json:"size"`
+			} `json:"objects"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		type action struct {
+			Href string `json:"href"`
+		}
+		type actions struct {
+			Upload *action `json:"upload,omitempty"`
+		}
+		type obj struct {
+			OID     string   `json:"oid"`
+			Size    int64    `json:"size"`
+			Actions *actions `json:"actions,omitempty"`
+		}
+		resp := struct {
+			Transfer string `json:"transfer"`
+			Objects  []obj  `json:"objects"`
+		}{Transfer: "basic"}
+		for _, o := range req.Objects {
+			resp.Objects = append(resp.Objects, obj{
+				OID:     o.OID,
+				Size:    o.Size,
+				Actions: &actions{Upload: &action{Href: srv.URL + "/store/" + o.OID}},
+			})
+		}
+		w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/store/", func(w http.ResponseWriter, r *http.Request) {
+		oid := strings.TrimPrefix(r.URL.Path, "/store/")
+		body, _ := io.ReadAll(r.Body)
+		stored.Store(oid, body)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return lfs.NewClient(srv.URL, "oauth2", "token"), stored
+}
+
+// TestDehydrateHTML_SmallStaysPlain: a sub-threshold render is never pointerized,
+// so a dehydrated clone reads it directly.
+func TestDehydrateHTML_SmallStaysPlain(t *testing.T) {
+	dir := t.TempDir()
+	html := bytes.Repeat([]byte("x"), 1024)
+	writePlanHTMLPlain(t, dir, html)
+	client, _ := fakeLFSUploadServer(t)
+
+	pointerized, err := DehydrateHTML(dir, html, client)
+	if err != nil {
+		t.Fatalf("DehydrateHTML: %v", err)
+	}
+	if pointerized {
+		t.Fatalf("small render pointerized, want plain")
+	}
+	assertPlainHTML(t, dir, html)
+}
+
+// TestDehydrateHTML_NilClientStaysPlain: offline / no ledger remote leaves a large
+// render plain — bigger in git, but retrievable and pushable, never lost.
+func TestDehydrateHTML_NilClientStaysPlain(t *testing.T) {
+	dir := t.TempDir()
+	html := bytes.Repeat([]byte("PRESERVE "), htmlLFSThreshold/8+2)
+	writePlanHTMLPlain(t, dir, html)
+
+	pointerized, err := DehydrateHTML(dir, html, nil)
+	if err != nil {
+		t.Fatalf("DehydrateHTML: %v", err)
+	}
+	if pointerized {
+		t.Fatalf("nil client pointerized, want plain")
+	}
+	assertPlainHTML(t, dir, html)
+}
+
+// TestDehydrateHTML_UploadFailureLeavesPlain is the load-bearing failure-mode
+// test: when the upload fails, DehydrateHTML must NOT write a pointer. The plain
+// plan.html Save wrote stays on disk (content safe) and no poisoned pointer can
+// reach the remote. Failure prevented: reintroducing GH #810 via a failed upload.
+func TestDehydrateHTML_UploadFailureLeavesPlain(t *testing.T) {
+	dir := t.TempDir()
+	html := bytes.Repeat([]byte("PRESERVE "), htmlLFSThreshold/8+2)
+	writePlanHTMLPlain(t, dir, html)
+
+	// server that rejects the batch request → BatchUpload errors.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	client := lfs.NewClient(srv.URL, "oauth2", "token")
+
+	pointerized, err := DehydrateHTML(dir, html, client)
+	if err == nil {
+		t.Fatalf("DehydrateHTML: want error on upload failure, got nil")
+	}
+	if pointerized {
+		t.Fatalf("pointerized despite upload failure — content would be lost")
+	}
+	assertPlainHTML(t, dir, html) // plain render intact, no dangling pointer
+}
+
+// TestDehydrateHTML_LargeUploadsThenPointerizes proves the whole fix end to end:
+// the blob is actually uploaded to the store AND the on-disk plan.html becomes a
+// pointer to it. Order matters — the pointer's OID must be a blob the server now
+// holds.
+func TestDehydrateHTML_LargeUploadsThenPointerizes(t *testing.T) {
+	dir := t.TempDir()
+	html := bytes.Repeat([]byte("PRESERVE-ME "), htmlLFSThreshold/12+2)
+	writePlanHTMLPlain(t, dir, html)
+	client, stored := fakeLFSUploadServer(t)
+
+	pointerized, err := DehydrateHTML(dir, html, client)
+	if err != nil {
+		t.Fatalf("DehydrateHTML: %v", err)
+	}
+	if !pointerized {
+		t.Fatalf("large render not pointerized")
+	}
+
+	htmlPath := filepath.Join(dir, planHTMLFile)
+	if !lfs.IsPointerFile(htmlPath) {
+		t.Fatalf("plan.html is not a pointer after dehydration")
+	}
+	ref, err := lfs.ReadPointerFile(htmlPath)
+	if err != nil {
+		t.Fatalf("ReadPointerFile: %v", err)
+	}
+	wantOID := "sha256:" + lfs.ComputeOID(html)
+	if ref.OID != wantOID {
+		t.Fatalf("pointer OID = %q, want %q", ref.OID, wantOID)
+	}
+	// the blob the pointer names must actually be in the store.
+	blob, ok := stored.Load(lfs.ComputeOID(html))
+	if !ok {
+		t.Fatalf("blob for %s not uploaded — pointer would be poisoned", wantOID)
+	}
+	if !bytes.Equal(blob.([]byte), html) {
+		t.Fatalf("uploaded blob differs from the render")
+	}
+}

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -13,8 +13,10 @@ package plan
 //	plan.md          # always plain git (Input.Raw)
 //	annotations.json # always plain git (the Result — searchable badge data)
 //	meta.json        # always plain git (topic, slug, authors, timestamps, …)
-//	plan.html        # only if a render was passed in; plain git if small,
-//	                 # LFS pointer (internal/lfs.WritePointerFile) if large.
+//	plan.html        # only if a render was passed in. Save writes it PLAIN;
+//	                 # a large render is dehydrated to an LFS pointer by the CLI
+//	                 # caller (DehydrateHTML) AFTER its blob is uploaded, never
+//	                 # before — see the GH #810 note at the plan.html write below.
 //
 // CLI WRITES files into the ledger working tree (daemon-git split): we never
 // commit inline and never discard uncommitted changes — same as session
@@ -178,10 +180,11 @@ func LoadMeta(planDir string) (Meta, error) {
 
 // Save writes a captured plan into the ledger under data/plans/<dated-slug>/.
 // It writes plan.md (from in.Raw), annotations.json (res), and meta.json as
-// plain git-tracked text. plan.html is written ONLY when html != nil: plain
-// when small, as an LFS pointer when it exceeds htmlLFSThreshold. Save never
-// renders HTML and never commits — it only materializes files in the working
-// tree. Returns the absolute plan directory.
+// plain git-tracked text. plan.html is written ONLY when html != nil, and always
+// as PLAIN bytes — dehydration of a large render to an LFS pointer is the CLI
+// caller's job (DehydrateHTML), post-upload. Save never renders HTML, never
+// uploads, and never commits — it only materializes files in the working tree.
+// Returns the absolute plan directory.
 //
 // Save also appends one lifecycle event to the plan's events.jsonl (see
 // events.go) — additive, dual-write alongside meta.json: meta.json remains the
@@ -333,21 +336,24 @@ func Save(gitRoot string, in Input, res Result, html []byte, meta Meta) (string,
 			return fmt.Errorf("write %s: %w", planMetaFile, err)
 		}
 
-		// plan.html — only when a render was already produced. Size-gated: small
-		// renders stay plain so dehydrated clones read them directly; large ones
-		// become LFS pointers (pure-Go pointer write, never the git-lfs binary).
+		// plan.html — only when a render was already produced. ALWAYS written
+		// plain here. Save is the no-network storage layer: it can hash content
+		// but cannot upload it, and a pointer whose blob was never uploaded is
+		// exactly GH #810 — the render is lost AND the poisoned pointer makes the
+		// remote reject every future push, wedging the whole team's ledger.
+		// Dehydration of a large render to an LFS pointer happens in the CLI
+		// caller (savePlanArtifacts → DehydrateHTML) AFTER a confirmed upload, and
+		// only overwrites this plain file once the blob is provably in the store.
+		// If that step is skipped or the store is unreachable, the plan stays
+		// plain: larger in git, but retrievable and pushable — never lost, never
+		// poisoned. That is the structural property the size-gate-here design
+		// lacked.
 		if html != nil {
-			// Stamp the plan's self-identifying meta tags (see html_meta.go) before
-			// either write path below, so both the plain and LFS-pointer'd copies
-			// carry the same content.
+			// Stamp the plan's self-identifying meta tags (see html_meta.go) so the
+			// stored copy carries them regardless of later dehydration.
 			html = StampHTMLMeta(html, planID, meta.Slug, meta.Topic)
 			htmlPath := filepath.Join(dir, planHTMLFile)
-			if int64(len(html)) > htmlLFSThreshold {
-				ref := lfs.NewFileRef(html)
-				if err := lfs.WritePointerFile(htmlPath, ref); err != nil {
-					return fmt.Errorf("write plan.html LFS pointer: %w", err)
-				}
-			} else if err := os.WriteFile(htmlPath, html, 0o644); err != nil {
+			if err := os.WriteFile(htmlPath, html, 0o644); err != nil {
 				return fmt.Errorf("write %s: %w", planHTMLFile, err)
 			}
 

--- a/internal/plan/store_test.go
+++ b/internal/plan/store_test.go
@@ -139,21 +139,35 @@ func TestSaveListLoad_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestSave_HTMLSizeGating(t *testing.T) {
+// TestSave_AlwaysWritesRetrievablePlainHTML pins the GH #810 invariant: a
+// successful Save leaves plan.html RETRIEVABLE, at EVERY size — including above
+// htmlLFSThreshold, which is exactly where the bug lived.
+//
+// Failure prevented: Save wrote a large render as an LFS pointer WITHOUT
+// uploading the blob, so the content named by the pointer existed nowhere — lost,
+// and the poisoned pointer wedged the ledger push. Save is the no-network layer
+// now, so it writes plain at every size; pointerizing a large render is the CLI
+// caller's job (DehydrateHTML), only AFTER a confirmed upload.
+//
+// The old test asserted the LARGE case produced a pointer with the right OID —
+// which the bug produced too. That is test theater: it passed while the content
+// was being discarded. This asserts the bytes come back.
+func TestSave_AlwaysWritesRetrievablePlainHTML(t *testing.T) {
 	tests := []struct {
-		name        string
-		size        int
-		wantPointer bool
+		name string
+		size int
 	}{
-		{"small html stays plain git", 1024, false},
-		{"large html becomes LFS pointer", htmlLFSThreshold + 1, true},
+		{"small render stays plain", 1024},
+		{"large render crosses the old LFS threshold", htmlLFSThreshold + 1},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ledger := t.TempDir()
 			withLedger(t, ledger)
 
-			html := bytes.Repeat([]byte("a"), tc.size)
+			// distinctive payload so a silently-discarded render can't masquerade
+			// as an empty-but-present file.
+			html := bytes.Repeat([]byte("PRESERVE-ME "), tc.size/12+1)[:tc.size]
 			in := Input{Raw: "# H\n"}
 			meta := Meta{Topic: "Size gate", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
 
@@ -163,35 +177,20 @@ func TestSave_HTMLSizeGating(t *testing.T) {
 			}
 
 			htmlPath := filepath.Join(dir, "plan.html")
-			isPointer := lfs.IsPointerFile(htmlPath)
-			if isPointer != tc.wantPointer {
-				t.Fatalf("plan.html IsPointer = %v, want %v (size=%d)", isPointer, tc.wantPointer, tc.size)
+			if lfs.IsPointerFile(htmlPath) {
+				t.Fatalf("Save wrote plan.html as an LFS pointer (size=%d); it must write plain — "+
+					"pointerizing without an upload is GH #810", tc.size)
+			}
+			got, err := os.ReadFile(htmlPath)
+			if err != nil {
+				t.Fatalf("read plan.html: %v", err)
+			}
+			// StampHTMLMeta may rewrite tag-bearing HTML; this payload has no tags,
+			// so the bytes must round-trip exactly.
+			if !bytes.Equal(got, html) {
+				t.Fatalf("plan.html not retrievable: got %d bytes, want %d", len(got), len(html))
 			}
 
-			if tc.wantPointer {
-				// pointer references the correct OID/size
-				ref, err := lfs.ReadPointerFile(htmlPath)
-				if err != nil {
-					t.Fatalf("ReadPointerFile: %v", err)
-				}
-				if ref.Size != int64(len(html)) {
-					t.Errorf("pointer size = %d, want %d", ref.Size, len(html))
-				}
-				if ref.OID != "sha256:"+lfs.ComputeOID(html) {
-					t.Errorf("pointer OID = %q, want sha256:%s", ref.OID, lfs.ComputeOID(html))
-				}
-			} else {
-				// plain bytes survive verbatim
-				got, err := os.ReadFile(htmlPath)
-				if err != nil {
-					t.Fatalf("read plain html: %v", err)
-				}
-				if !bytes.Equal(got, html) {
-					t.Errorf("plain html bytes differ from input")
-				}
-			}
-
-			// List reflects HasHTML in both cases.
 			plans, err := List("/g")
 			if err != nil || len(plans) != 1 {
 				t.Fatalf("List: %v (n=%d)", err, len(plans))

--- a/internal/recap/fixture_test.go
+++ b/internal/recap/fixture_test.go
@@ -126,7 +126,7 @@ func (f *fx) WritePointerTrace(name string) {
 	dir := filepath.Join(f.Ledger, "sessions", name)
 	require.NoError(f.t, os.MkdirAll(dir, 0o755))
 	ref := lfs.NewFileRef([]byte(`{"fake":"trace content, never hydrated in this test"}`))
-	require.NoError(f.t, lfs.WritePointerFile(filepath.Join(dir, contexttrace.FileName), ref))
+	require.NoError(f.t, lfs.WritePointerFile(filepath.Join(dir, contexttrace.FileName), lfs.AssertUploaded(ref)))
 }
 
 // WriteSummary writes summary.json for session `name`.

--- a/internal/session/classify_pointer_test.go
+++ b/internal/session/classify_pointer_test.go
@@ -23,10 +23,10 @@ import (
 // ox commits for a synced session.
 func writePointerStub(t *testing.T, path string) {
 	t.Helper()
-	require.NoError(t, lfs.WritePointerFile(path, lfs.FileRef{
+	require.NoError(t, lfs.WritePointerFile(path, lfs.AssertUploaded(lfs.FileRef{
 		OID:  "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 		Size: 4242,
-	}))
+	})))
 }
 
 func TestClassifyRawFile(t *testing.T) {


### PR DESCRIPTION
## Summary

**A coworker who runs `ox plan save` on a large plan now keeps that plan.** A rendered `plan.html` over 256 KB — the norm for agent reports that inline imagery — was being **silently discarded**, and the broken artifact it left behind **stopped the whole team's ledger from pushing**. Reported by @vikgup in #810: 3 plans lost as 132-byte dead pointers, and the ledger unable to push for 43 commits.

This PR makes the whole bug **class** unrepresentable — for plans, sessions, and any future caller — rather than patching the one call site.

## What broke

- **`ox plan save` never uploaded the blob.** For a large render it hashed the bytes, wrote a Git-LFS *pointer* to that hash, and reported success — but the content was uploaded nowhere and kept nowhere. The render was gone.
- **The dead pointer wedged the ledger.** Committing a pointer whose object is missing makes the remote's pre-receive hook reject **every** subsequent push (`LFS objects are missing`). One oversized plan blocked the entire team.
- **The self-heal was blind to plans.** The reconciler that clears orphaned pointers on a rejected push only ever walked `sessions/`, so a poisoned `data/plans/` pointer was invisible — which is why the ledger stayed stuck for 43 commits instead of recovering.

The session-recording path had always done this correctly (upload, *then* write the pointer). The plan path was the only caller in the repo that skipped the upload — 20 lines from the code that got it right.

## What this PR ships

- **`lfs.UploadedRef` proof-of-upload type (the structural fix).** `WritePointerFile` / `WritePointerFiles` now take an `UploadedRef`, obtainable only from a real upload (`UploadBlob`, `UploadSessionFiles`) or the audited, grep-able `AssertUploaded` / `AssertUploadedManifest` escape hatch (8 session/import manifest sites, each with a justifying comment). **Minting a pointer for an un-uploaded blob is now a compile error.**
- **Plan path: `Save` always writes `plan.html` PLAIN;** the CLI caller uploads and swaps it to a pointer *before* the commit (`DehydrateHTML`). Offline or upload failure ⇒ it stays plain: larger in git, but **retrievable, pushable, never poisoned.** The worst failure mode is now git bloat, not data loss + a team-wide wedge.
- **Reconciler walk extended to `data/plans/`** — it now finds and neutralizes a poisoned plan pointer, so the auto-reconcile on push heals @vikgup's 3 stuck pointers (their bytes are gone, so blanking to unblock is the only recovery). Keeps the 404-only guard (a transient 401/5xx never blanks a live artifact).
- **Daemon murmur push hardened** — `pushMurmurCommits` now refuses to push when any unpushed commit isn't a `murmur:` commit (the guard the session-draft path already has). Closes a ~60s window where a deferred plan commit could have been shipped past the gate stack.
- **`ox doctor` plan-pointer check** surfaces the previously-invisible wedge; `--fix` runs the reconcile. **`commitPlanToLedger` gained an `IsSafeForGitOps` mid-rebase guard** (a pre-existing index-mutation gap, closed in-place).

```mermaid
flowchart TB
    subgraph BEFORE["Before — data loss + poisoned push"]
        A1[plan.html &gt; 256KB] --> A2[hash only, no upload]
        A2 --> A3[write LFS pointer] --> A4[commit + push]
        A4 --> A5{{"remote: blob missing → REJECT every push\nrender lost, ledger wedged team-wide"}}
    end
    subgraph AFTER["After — upload-proven pointer, plain fallback"]
        B1[plan.html &gt; 256KB] --> B2["Save writes PLAIN"]
        B2 --> B3["upload blob → UploadedRef"]
        B3 -->|ok| B4["swap to pointer, then commit ✓"]
        B3 -->|offline / fails| B5["stays PLAIN, commit\nretrievable · pushable · not poisoned"]
    end
```

## Test Plan

- **Red-first proven:** reintroduced the bug (pointer without upload for the large case) → the `internal/plan` invariant test failed *on the claim step* (large fails, small passes) → restored → green.
- **Full suites green:** `internal/lfs`, `internal/plan`, `internal/daemon/agentwork`, plus the new/changed cmd/ox `Plan` tests. `go build ./...` clean; `make check-no-git-lfs-shell` passes (LFS stays pure-Go); changed/new files are lint-clean.
- **New coverage:** the #810 retrievability invariant; `DehydrateHTML` fault matrix (small / nil-client / upload-failure-leaves-plain / green upload-then-pointer against a fake LFS server); reconcile now walks `data/plans/`; `shouldPushMurmurs` guard table; doctor 404-only classification. A further adversarial coverage-hardening pass (edge cases: re-save transitions, boundary sizes, reconcile blank-path) is in progress and will land as follow-up commits on this branch.
- **Pre-existing, unrelated (not this PR):** `make lint` flags 3 deprecated-field warnings in `agentwork/manager_test.go` (present on `origin/main`, untouched here); `TestDoctorSuppression_DaemonNotRunning` / `TestMurmurJSONImportanceOverridesDefault` flake under parallel load (live-daemon state / global config) but pass in isolation.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (red-first regression + fault matrix + guard tables)
- [ ] CHANGELOG entry — N/A: bug fix to an experimental, off-by-default surface; can add if desired
- [x] Breaking change documented — internal only: `WritePointerFile*` / pointer-writer signatures now take `UploadedRef`; all in-repo callers updated. No user-facing/behavioral break.
- [x] `/security-review` — N/A: no `internal/auth`, `internal/mcp`, `raw_writer`, `prepush_scan`, `internal/upgrade`, or `go.sum` changes; LFS transport stays pure-Go per `lfs-no-git-lfs-binary`.

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a03520-1293-7664-ba71-f255ef40acee

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790196079&installation_model_id=433550&pr_number=815&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F815&signature=d85ba29c676c8fa8e1cdd7d54fb7e35fcdd534c578149c67cf746d59f2dbb200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large plan renders can be stored efficiently while preserving plain HTML when needed.
  * Added health checks for plan files referencing unavailable content, with optional repair support.
* **Bug Fixes**
  * Prevented creation of content pointers unless the underlying files are confirmed uploaded.
  * Improved reconciliation to cover both session and plan content.
  * Prevented unsafe ledger states from being modified during plan commits.
  * Restricted automated murmur pushes to branches containing only murmur commits.
* **Reliability**
  * Improved handling of upload failures, missing content, and incomplete remote checks while preserving recoverable files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->