### PR TITLE
fix(plan): dehydrate the stamped plan.html, not the caller's copy (#810 follow-up)

### DIFF
--- a/.claude/skills/ox-conversation/SKILL.md
+++ b/.claude/skills/ox-conversation/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: ox-conversation
+description: >-
+  Read recorded team conversations locally and follow sageox:// citations back
+  to what was actually said. Auto-fire when the user asks "what did we say in
+  that meeting", "show me the discussion about X", "what's behind this claim",
+  pastes a sageox:// citation URI or a cnv_/rec_ id, or wants a transcript,
+  the topics, or the summary of a recorded conversation. Run
+  `ox conversation list|show|topics|topic|transcript` — each JSON envelope's
+  guidance field names the next rung and token_estimate reports its cost;
+  pass a full sageox:// URI (quoted) to transcript to retrieve the cited
+  cues with an honest pinning status.
+---
+
+<!-- Thin by design. The behavioral contract — the disclosure ladder, id
+     forms, pinning semantics, and each next step — lives in the `guidance`
+     field of every `ox conversation` JSON envelope and in
+     `ox guide conversations` (Layer-1: the prime KB block names the verb),
+     which reach every primed AI coworker. This native skill adds discovery
+     and activation ergonomics; it duplicates no reasoning. Do not grow
+     this body. -->
+
+## Use when
+
+The user references a recorded conversation or a citation from one: a
+`sageox://` URI, a `cnv_`/`rec_` id, "what did we say about X in that
+meeting", "what's the source behind this claim", or asks for a
+conversation's summary, topics, or transcript.
+
+## Do
+
+1. Run the rung the question requires — `ox conversation list`,
+   `show <id>`, `topics <id>`, `topic <id> <tp_id>`, or
+   `transcript <id> --cues N-M` (a full `sageox://` URI, quoted, works as
+   `<id>` and carries its own selectors).
+2. Follow the `guidance` field in each JSON envelope — it names the next
+   rung down and how to follow citations; `token_estimate` tells you what
+   reading the payload costs. Descend only as deep as the question needs.
+3. For the full workflow (id forms, disclosure ladder, pinning semantics),
+   read `ox guide conversations --raw`.

--- a/.claude/skills/ox-pr-header/SKILL.md
+++ b/.claude/skills/ox-pr-header/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: ox-pr-header
+description: >-
+  Emit and paste the SageOx credit line at the TOP of a pull-request description
+  — the human-facing counterpart to the machine `SageOx-Session:` trailer. Run
+  `ox pr header` at PR-creation time; it renders a thin, on-brand, dark/light-aware
+  line linking the session(s) and plan(s) that produced the change, naming the
+  team, and whispering a subtle enrichment stat. The CLI owns the sanitizer-fragile
+  markup — you never hand-author it. Use when opening a PR for AI coworker work, or
+  when the user says "add the SageOx header", "credit the session on the PR", or
+  "/ox-pr-header".
+---
+
+**You do not hand-write this markup — `ox pr header` does.** A GitHub PR body is
+sanitized harder than repo markdown (no CSS, no styled tables); the line is built
+from the exact primitives that survive (`<picture>` wordmark, `<a>` links, `<sub>`
+caption). Hand-authoring it is how it silently renders as a bordered table or a
+vanished wordmark. Run the command and paste its output verbatim.
+
+## When
+
+At PR-creation time, for any PR that carries AI coworker work. The header is the
+**top** of the body; the `SageOx-Session:` trailer stays the **last** line — keep
+both (they serve different readers: the header a human, the trailer the reconciler).
+
+## How
+
+1. Gather what the PR credits (you already hold this from your session):
+   - the plan ids you saved (`pln_…`), if any;
+   - the enrichment counts from `ox plan enrich` (related sessions / concurrent
+     edits), if any.
+2. Run the command — the current session is auto-linked; add plans + enrichment:
+
+   ```bash
+   ox pr header \
+     --plan pln_4d8e2f --plan pln_1a6b9c \
+     --prior-art 2 --collisions 1
+   ```
+
+   `--session <url|ses_id>` adds/overrides sessions (default: the live session).
+   `--no-stat` drops the whisper. `--style text|image|auto` follows `ox config`
+   (`pr_visuals.style`) by default. `--json` returns the markup plus resolved
+   inputs for verification.
+
+3. Paste the output as the FIRST lines of the PR body, **above** your summary.
+   Write the body via a **file**, never a heredoc — a heredoc mangles the markup:
+
+   ```bash
+   ox pr header > body.md
+   printf '\n' >> body.md
+   cat description.md >> body.md   # your written summary
+   # ...keep the SageOx-Session: trailer as the last line...
+   gh pr create --body-file body.md
+   ```
+
+## Rules
+
+- **Paste verbatim.** Do not edit the emitted markup, retitle the links, or add
+  the plan/session titles — the `/c/` and `/plan/` URLs are deliberately opaque
+  so nothing about the work leaks into a public PR body.
+- **Only link artifacts you know resolve.** ox verifies just the auto-linked
+  current session (from local recording state) and withholds it until it is
+  server-visible. Explicit `--session`/`--plan` ids you pass are included **as
+  given** — ox cannot check an arbitrary id, so pass only ids you know exist or a
+  reviewer may hit a 404; the command prints a stderr note when you do. Pass
+  `--allow-unconfirmed` to accept possibly-unresolved links (the pending current
+  session and explicit refs) and silence the note.
+- **Honest enrichment only.** Pass the real `ox plan enrich` counts. The stats
+  render only when a signal actually fired AND a plan is linked (so a reviewer can
+  verify them) — never inflate them.
+- **Respect config.** If `pr_visuals.header` is off (team/user opt-out) the command
+  no-ops with a hint; don't force a header in that case.
+- **Keep the trailer.** The header does not replace `SageOx-Session:` — that line
+  stays at the bottom as the machine linkage.

--- a/.sageox/skills.lock.json
+++ b/.sageox/skills.lock.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "source": {
     "kind": "builtin",
-    "revision": "fb8f98f38e6c8cdf",
+    "revision": "caba9068d4af4f70",
     "version": "0.14.0"
   },
   "desired": {
@@ -31,6 +31,12 @@
     },
     {
       "target": "claude-project",
+      "path": ".claude/skills/ox-conversation/SKILL.md",
+      "digest": "sha256:dda0aa9a473a7c798259b162c41e0a98df04ef2fc35d8cf19f64f45f864bffeb",
+      "mode": "0644"
+    },
+    {
+      "target": "claude-project",
       "path": ".claude/skills/ox-decision/SKILL.md",
       "digest": "sha256:126f75ee2faaa217b617774f6571aa0ac598e6b62eae3019f8082e105e2efe8d",
       "mode": "0644"
@@ -39,6 +45,12 @@
       "target": "claude-project",
       "path": ".claude/skills/ox-plan/SKILL.md",
       "digest": "sha256:d3ef61460eacd9a94f75c270b4aa815e82003d1763bbe887b19afbe2aeefb1b9",
+      "mode": "0644"
+    },
+    {
+      "target": "claude-project",
+      "path": ".claude/skills/ox-pr-header/SKILL.md",
+      "digest": "sha256:2d08873a303e5ce2d6d2388cd81ba3d96afc28972a06d9aca562ab8712a978fa",
       "mode": "0644"
     },
     {

--- a/cmd/ox/doctor_plan_pointers.go
+++ b/cmd/ox/doctor_plan_pointers.go
@@ -74,15 +74,34 @@ func checkPlanPointersMissing(fix bool) checkResult {
 		return SkippedCheck(planPointersCheckName, "cannot reach the content store to verify plan blobs", err.Error())
 	}
 
+	return evaluatePlanPointers(client, pointers, fix, func() (*lfs.ReconcileResult, error) {
+		return lfs.ReconcileUnpushedPointers(context.Background(), ledgerPath, endpoint.GetForProject(findGitRoot()), slog.Default())
+	})
+}
+
+// evaluatePlanPointers is the client-injectable core: classify the pointers, warn
+// on missing blobs, and (under --fix) run the injected reconcile to clear them.
+// Split out so the warn/fix wiring is testable with a fake LFS client and a fake
+// reconcile, without a live ledger remote.
+func evaluatePlanPointers(client *lfs.Client, pointers []planPointer, fix bool, reconcile func() (*lfs.ReconcileResult, error)) checkResult {
 	missing := planPointersMissingOnRemote(client, pointers)
 	if len(missing) == 0 {
 		return PassedCheck(planPointersCheckName, fmt.Sprintf("all %d plan pointer(s) backed by the store", len(pointers)))
 	}
-
 	if !fix {
 		return planPointersWarning(missing)
 	}
-	return repairPlanPointers(ledgerPath, missing)
+	res, err := reconcile()
+	if err != nil {
+		return checkResult{
+			name:    planPointersCheckName,
+			warning: true,
+			message: fmt.Sprintf("%d plan pointer(s) missing; reconcile failed", len(missing)),
+			detail:  err.Error(),
+		}
+	}
+	return PassedCheck(planPointersCheckName,
+		fmt.Sprintf("reconciled %d orphaned pointer(s); ledger push unblocked", res.Replaced))
 }
 
 // collectPlanHTMLPointers finds every data/plans/<dir>/plan.html that is an LFS
@@ -177,20 +196,4 @@ func planPointersWarning(missing []planPointer) checkResult {
 		message: fmt.Sprintf("%d plan render(s) missing from the store (push blocked)", len(missing)),
 		detail:  sb.String(),
 	}
-}
-
-// repairPlanPointers runs the plan-aware reconcile, which blanks the orphaned
-// pointers and squashes them out of the unpushed pack so the push can proceed.
-func repairPlanPointers(ledgerPath string, missing []planPointer) checkResult {
-	res, err := lfs.ReconcileUnpushedPointers(context.Background(), ledgerPath, endpoint.GetForProject(findGitRoot()), slog.Default())
-	if err != nil {
-		return checkResult{
-			name:    planPointersCheckName,
-			warning: true,
-			message: fmt.Sprintf("%d plan pointer(s) missing; reconcile failed", len(missing)),
-			detail:  err.Error(),
-		}
-	}
-	return PassedCheck(planPointersCheckName,
-		fmt.Sprintf("reconciled %d orphaned pointer(s); ledger push unblocked", res.Replaced))
 }

--- a/cmd/ox/doctor_plan_pointers_test.go
+++ b/cmd/ox/doctor_plan_pointers_test.go
@@ -97,3 +97,79 @@ func TestCollectPlanHTMLPointers_SkipsPlainAndNonPlans(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, "2026-08-24-ptr", got[0].Name)
 }
+
+// newFakeDownloadServer serves the batch DOWNLOAD op with per-OID HTTP codes
+// (0 == present).
+func newFakeDownloadServer(t *testing.T, codeByOID map[string]int) *lfs.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Objects []struct {
+				OID  string `json:"oid"`
+				Size int64  `json:"size"`
+			} `json:"objects"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		type oerr struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		type obj struct {
+			OID   string `json:"oid"`
+			Size  int64  `json:"size"`
+			Error *oerr  `json:"error,omitempty"`
+		}
+		resp := struct {
+			Transfer string `json:"transfer"`
+			Objects  []obj  `json:"objects"`
+		}{Transfer: "basic"}
+		for _, o := range req.Objects {
+			ob := obj{OID: o.OID, Size: o.Size}
+			if code := codeByOID[o.OID]; code != 0 {
+				ob.Error = &oerr{Code: code, Message: "x"}
+			}
+			resp.Objects = append(resp.Objects, ob)
+		}
+		w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return lfs.NewClient(srv.URL, "oauth2", "token")
+}
+
+// TestEvaluatePlanPointers_WarnThenFix pins the doctor warn/fix wiring: the
+// non-fix path warns and never reconciles; the fix path invokes the reconcile and
+// reports its result. Guards against a regression that reconciles on a bare
+// `ox doctor` (destructive without --fix) or that swallows the reconcile outcome.
+func TestEvaluatePlanPointers_WarnThenFix(t *testing.T) {
+	ledger := t.TempDir()
+	planDir := filepath.Join(ledger, "data", "plans", "2026-08-24-p")
+	require.NoError(t, os.MkdirAll(planDir, 0o755))
+	htmlPath := filepath.Join(planDir, "plan.html")
+	oid := lfs.ComputeOID([]byte("gone-render"))
+	require.NoError(t, os.WriteFile(htmlPath, []byte(lfs.FormatPointer("sha256:"+oid, 999)), 0o644))
+
+	pointers := collectPlanHTMLPointers(filepath.Join(ledger, "data", "plans"), ledger)
+	require.Len(t, pointers, 1)
+
+	client := newFakeDownloadServer(t, map[string]int{oid: http.StatusNotFound})
+
+	// warn path (no --fix): reconcile must NOT be called.
+	warn := evaluatePlanPointers(client, pointers, false, func() (*lfs.ReconcileResult, error) {
+		t.Fatal("reconcile invoked on the non-fix warn path")
+		return nil, nil
+	})
+	assert.True(t, warn.warning, "missing blobs must warn")
+	assert.Contains(t, warn.message, "1")
+
+	// fix path: reconcile is invoked and its result is reported as a pass.
+	called := false
+	fix := evaluatePlanPointers(client, pointers, true, func() (*lfs.ReconcileResult, error) {
+		called = true
+		require.NoError(t, os.WriteFile(htmlPath, []byte{}, 0o644)) // simulate the blank
+		return &lfs.ReconcileResult{Replaced: 1}, nil
+	})
+	assert.True(t, called, "the --fix path must invoke the reconcile")
+	assert.False(t, fix.warning, "a successful reconcile is a passed result")
+	assert.Contains(t, fix.message, "reconciled")
+}

--- a/cmd/ox/doctor_plan_pointers_test.go
+++ b/cmd/ox/doctor_plan_pointers_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -172,4 +173,13 @@ func TestEvaluatePlanPointers_WarnThenFix(t *testing.T) {
 	assert.True(t, called, "the --fix path must invoke the reconcile")
 	assert.False(t, fix.warning, "a successful reconcile is a passed result")
 	assert.Contains(t, fix.message, "reconciled")
+
+	// reconcile-failure path: a reconcile error must surface as a warning (with
+	// the count preserved), never be swallowed into a passing result.
+	failed := evaluatePlanPointers(client, pointers, true, func() (*lfs.ReconcileResult, error) {
+		return nil, fmt.Errorf("batch check inconclusive: HTTP 401")
+	})
+	assert.True(t, failed.warning, "a reconcile error must warn, not pass")
+	assert.Contains(t, failed.message, "reconcile failed")
+	assert.Contains(t, failed.message, "1", "the missing count is preserved in the failure message")
 }

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -341,7 +341,9 @@ func savePlanArtifacts(gitRoot string, in plan.Input, result plan.Result, html [
 	// deferring dehydration to a later save / doctor. Small renders and offline
 	// saves stay plain by design.
 	if html != nil {
-		if pointerized, derr := plan.DehydrateHTML(dir, html, planLFSClient(gitRoot)); derr != nil {
+		// DehydrateHTML reads the on-disk (stamped) plan.html itself, so the
+		// uploaded blob's OID matches the committed file — see its doc comment.
+		if pointerized, derr := plan.DehydrateHTML(dir, planLFSClient(gitRoot)); derr != nil {
 			slog.Warn("plan: plan.html LFS dehydration failed, committing plain", "error", derr, "dir", dir)
 		} else if pointerized {
 			slog.Debug("plan: plan.html dehydrated to LFS pointer", "dir", dir)

--- a/cmd/ox/plan_capture_test.go
+++ b/cmd/ox/plan_capture_test.go
@@ -17,10 +17,12 @@ package main
 // clock. Each assertion names the specific loss it pins.
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sageox/ox/internal/plan"
@@ -378,5 +380,42 @@ func TestPlanSessionLink_DisabledAttributionExpectsNoLink(t *testing.T) {
 
 	if id, url := planSessionLink(root); id != "" || url != "" {
 		t.Errorf("planSessionLink = (%q, %q), want empty — no link is expected in the render, so the save-path lint must not run and warn about its absence", id, url)
+	}
+}
+
+// TestSavePlanArtifacts_LargeRenderStaysPlainWhenLFSUnreachable is the #810
+// composition-root fail-safe: driving the REAL savePlanArtifacts path (Save →
+// DehydrateHTML → commit) with a >256KB render and no reachable LFS client, the
+// committed plan.html must be PLAIN — retrievable and pushable, never a poisoned
+// pointer. This test ledger has no configured remote/credentials, so planLFSClient
+// resolves to nil and dehydration falls back to plain, exactly as an offline save.
+//
+// Failure prevented: a regression where the composition root writes (or leaves) a
+// pointer with no uploaded blob — the wedge #810 was about — at the layer where
+// the original bug actually shipped.
+func TestSavePlanArtifacts_LargeRenderStaysPlainWhenLFSUnreachable(t *testing.T) {
+	root := newPlanCaptureTestRepo(t)
+
+	body := strings.Repeat("PRESERVE-ME ", 30000) // well over the 256KB threshold
+	html := []byte("<html><head></head><body>" + body + "</body></html>")
+
+	dir := savePlanArtifacts(root, plan.Input{Raw: "# Big render\n"}, plan.Result{}, html, plan.PrimaryHTML)
+	if dir == "" {
+		t.Fatal("savePlanArtifacts returned empty dir — the large plan was not saved")
+	}
+
+	path, _, isPointer, exists := plan.PlanHTMLPath(dir)
+	if !exists {
+		t.Fatalf("plan.html missing at %s", path)
+	}
+	if isPointer {
+		t.Fatalf("large render was committed as an LFS pointer with no reachable store — a poisoned pointer (GH #810)")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read plan.html: %v", err)
+	}
+	if !bytes.Contains(got, []byte("PRESERVE-ME")) {
+		t.Fatalf("plan.html does not contain the render content — not retrievable")
 	}
 }

--- a/cmd/ox/plan_capture_test.go
+++ b/cmd/ox/plan_capture_test.go
@@ -415,7 +415,11 @@ func TestSavePlanArtifacts_LargeRenderStaysPlainWhenLFSUnreachable(t *testing.T)
 	if err != nil {
 		t.Fatalf("read plan.html: %v", err)
 	}
-	if !bytes.Contains(got, []byte("PRESERVE-ME")) {
-		t.Fatalf("plan.html does not contain the render content — not retrievable")
+	// The FULL render must survive, not just a stray marker: the body repeats the
+	// marker 30000 times and every one must be on disk, plain. dehydrate rewrites
+	// plan.html BEFORE commitPlanToLedger stages the working tree, so this on-disk
+	// file is exactly what a commit would carry.
+	if n := bytes.Count(got, []byte("PRESERVE-ME")); n != 30000 {
+		t.Fatalf("plan.html retained %d of 30000 markers — the render was truncated or replaced", n)
 	}
 }

--- a/internal/lfs/reconcile.go
+++ b/internal/lfs/reconcile.go
@@ -48,6 +48,17 @@ type ReconcileResult struct {
 // committing on top is not sufficient — the old commits still reference the
 // missing OIDs.
 func ReconcileUnpushedPointers(ctx context.Context, ledgerPath, endpointURL string, logger *slog.Logger) (*ReconcileResult, error) {
+	return reconcileUnpushedPointers(ctx, ledgerPath, logger, func() (*Client, error) {
+		return NewClientFromLedger(ledgerPath, endpointURL)
+	})
+}
+
+// reconcileUnpushedPointers is the client-injectable core of
+// ReconcileUnpushedPointers. newClient is invoked ONLY when orphan candidates are
+// found, preserving the "no pointers → no client, no error" behavior that clean
+// ledgers with no configured remote rely on. Tests inject a fake-LFS-server
+// client to exercise the destructive blank-and-squash path.
+func reconcileUnpushedPointers(ctx context.Context, ledgerPath string, logger *slog.Logger, newClient func() (*Client, error)) (*ReconcileResult, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -97,7 +108,7 @@ func ReconcileUnpushedPointers(ctx context.Context, ledgerPath, endpointURL stri
 	}
 
 	// batch-check which OIDs exist in the remote LFS store
-	client, err := NewClientFromLedger(ledgerPath, endpointURL)
+	client, err := newClient()
 	if err != nil {
 		return result, fmt.Errorf("lfs client: %w", err)
 	}

--- a/internal/lfs/reconcile_plan_test.go
+++ b/internal/lfs/reconcile_plan_test.go
@@ -2,6 +2,9 @@ package lfs
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +13,59 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeLFSDownloadServer stands up a minimal Batch API server for the DOWNLOAD
+// operation the reconcile uses to probe blob presence. codeByOID maps a bare OID
+// to the HTTP code the server reports for it (0 == present, no error).
+func fakeLFSDownloadServer(t *testing.T, codeByOID map[string]int) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Operation string `json:"operation"`
+			Objects   []struct {
+				OID  string `json:"oid"`
+				Size int64  `json:"size"`
+			} `json:"objects"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		type oerr struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		type dl struct {
+			Href string `json:"href"`
+		}
+		type actions struct {
+			Download *dl `json:"download,omitempty"`
+		}
+		type obj struct {
+			OID     string   `json:"oid"`
+			Size    int64    `json:"size"`
+			Actions *actions `json:"actions,omitempty"`
+			Error   *oerr    `json:"error,omitempty"`
+		}
+		resp := struct {
+			Transfer string `json:"transfer"`
+			Objects  []obj  `json:"objects"`
+		}{Transfer: "basic"}
+		for _, o := range req.Objects {
+			ob := obj{OID: o.OID, Size: o.Size}
+			if code := codeByOID[o.OID]; code != 0 {
+				ob.Error = &oerr{Code: code, Message: "x"}
+			} else {
+				// reconcile only reads Error (BatchDownload), never fetches — a
+				// static href is enough and avoids a self-reference on srv.
+				ob.Actions = &actions{Download: &dl{Href: "http://127.0.0.1/blob"}}
+			}
+			resp.Objects = append(resp.Objects, ob)
+		}
+		w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL, "oauth2", "token")
+}
 
 // TestReconcile_WalksPlanPointers pins the GH #810 fix: ReconcileUnpushedPointers
 // must scan data/plans/, not only sessions/.
@@ -55,4 +111,76 @@ func TestReconcile_PlanOnlyPointerIsScanned(t *testing.T) {
 
 	result, _ := ReconcileUnpushedPointers(context.Background(), dir, "", nil)
 	assert.Equal(t, 1, result.ScannedPointers, "a plan-only pointer must be scanned")
+}
+
+// TestReconcile_BlanksMissingPlanPointerAndSquashes exercises the actual recovery
+// core for a plan pointer: a 404 blob → the pointer is blanked to empty bytes and
+// the unpushed history is squashed so the poisoned OID leaves the push pack.
+//
+// Failure prevented: the plan-walk tests above assert only ScannedPointers; this
+// drives the blank+squash that unblocks a wedged ledger — the whole point of the
+// #810 reconcile extension. A regression that scanned plan pointers but failed to
+// blank/squash them would leave the ledger stuck.
+func TestReconcile_BlanksMissingPlanPointerAndSquashes(t *testing.T) {
+	ledger, _ := initLedgerWithRemote(t)
+
+	oid := strings.Repeat("d", 64)
+	planDir := filepath.Join(ledger, "data", "plans", "2026-08-24-orphan")
+	require.NoError(t, os.MkdirAll(planDir, 0o755))
+	htmlPath := filepath.Join(planDir, "plan.html")
+	require.NoError(t, os.WriteFile(htmlPath, []byte(lfsPointerContent(oid, 500000)), 0o644))
+	git(t, ledger, "add", ".")
+	git(t, ledger, "commit", "-m", "plan: orphan pointer", "--no-verify")
+
+	client := fakeLFSDownloadServer(t, map[string]int{oid: http.StatusNotFound})
+	result, err := reconcileUnpushedPointers(context.Background(), ledger, nil,
+		func() (*Client, error) { return client, nil })
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Replaced, "the orphaned plan pointer must be blanked")
+	assert.True(t, result.Squashed, "unpushed commits collapse to one")
+
+	info, err := os.Stat(htmlPath)
+	require.NoError(t, err)
+	assert.Zero(t, info.Size(), "blanked plan.html must be empty (content acknowledged gone)")
+	assert.Equal(t, 1, unpushedCount(t, ledger), "history squashed to a single unpushed commit")
+}
+
+// TestReconcile_TransientErrorNeverBlanks pins the destructive-op guard for BOTH
+// the plan and session trees: only a 404 proves absence. A 401 (token expired) or
+// 5xx is inconclusive and must abort the reconcile, never zero out a live pointer
+// — blanking is an operation with no inverse.
+//
+// Failure prevented: a flaky endpoint blanking real content to empty bytes.
+func TestReconcile_TransientErrorNeverBlanks(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusServiceUnavailable} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			ledger, _ := initLedgerWithRemote(t)
+
+			planOID := strings.Repeat("e", 64)
+			sessOID := strings.Repeat("f", 64)
+			planHTML := filepath.Join(ledger, "data", "plans", "2026-08-24-p", "plan.html")
+			sessRaw := filepath.Join(ledger, "sessions", "2026-08-24-s", "raw.jsonl")
+			require.NoError(t, os.MkdirAll(filepath.Dir(planHTML), 0o755))
+			require.NoError(t, os.MkdirAll(filepath.Dir(sessRaw), 0o755))
+			planPtr := []byte(lfsPointerContent(planOID, 300000))
+			sessPtr := []byte(lfsPointerContent(sessOID, 300000))
+			require.NoError(t, os.WriteFile(planHTML, planPtr, 0o644))
+			require.NoError(t, os.WriteFile(sessRaw, sessPtr, 0o644))
+			git(t, ledger, "add", ".")
+			git(t, ledger, "commit", "-m", "add pointers", "--no-verify")
+
+			client := fakeLFSDownloadServer(t, map[string]int{planOID: code, sessOID: code})
+			result, err := reconcileUnpushedPointers(context.Background(), ledger, nil,
+				func() (*Client, error) { return client, nil })
+
+			require.Error(t, err, "a non-404 batch result must abort, never blank")
+			assert.Zero(t, result.Replaced)
+
+			got, _ := os.ReadFile(planHTML)
+			assert.Equal(t, planPtr, got, "plan pointer must be untouched on HTTP %d", code)
+			got, _ = os.ReadFile(sessRaw)
+			assert.Equal(t, sessPtr, got, "session pointer must be untouched on HTTP %d", code)
+		})
+	}
 }

--- a/internal/lfs/uploaded_test.go
+++ b/internal/lfs/uploaded_test.go
@@ -1,0 +1,111 @@
+package lfs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUploadBlob_AlreadyPresentYieldsUsableRef: when the server reports a blob is
+// already in the store (batch response carries no upload action), UploadBlob must
+// still return a usable UploadedRef — "already present" is a successful upload
+// outcome, which is all UploadedRef attests.
+func TestUploadBlob_AlreadyPresentYieldsUsableRef(t *testing.T) {
+	content := []byte("already in the store")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Objects []struct {
+				OID  string `json:"oid"`
+				Size int64  `json:"size"`
+			} `json:"objects"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		// respond with objects and NO actions → server says they already exist.
+		type obj struct {
+			OID  string `json:"oid"`
+			Size int64  `json:"size"`
+		}
+		resp := struct {
+			Transfer string `json:"transfer"`
+			Objects  []obj  `json:"objects"`
+		}{Transfer: "basic"}
+		for _, o := range req.Objects {
+			resp.Objects = append(resp.Objects, obj{OID: o.OID, Size: o.Size})
+		}
+		w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	ref, err := UploadBlob(NewClient(srv.URL, "oauth2", "token"), content)
+	require.NoError(t, err, "already-present blob must be treated as a successful upload")
+	require.Equal(t, ComputeOID(content), ref.BareOID())
+}
+
+// TestNoAssertUploadedOfFreshFileRef closes the one residual hole in the
+// UploadedRef guarantee. The type makes the proof field unforgeable OUTSIDE this
+// package, but AssertUploaded is exported, so `AssertUploaded(NewFileRef(x))`
+// re-expresses GH #810 (a pointer for content that was never uploaded) while
+// type-checking. Every legitimate AssertUploaded site wraps a ref whose blob a
+// PRIOR upload already stored; NONE should wrap a freshly-computed NewFileRef.
+//
+// This scans production source (non-test) for that adjacency and fails if it
+// reappears — the enforcement backstop the compile-time type can't provide.
+func TestNoAssertUploadedOfFreshFileRef(t *testing.T) {
+	root := repoRootForTest(t)
+	// AssertUploaded( ... NewFileRef(  — allowing whitespace and an optional lfs. qualifier.
+	bad := regexp.MustCompile(`AssertUploaded\(\s*(lfs\.)?NewFileRef\(`)
+
+	var offenders []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if name := d.Name(); name == "vendor" || name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil
+		}
+		if bad.Match(data) {
+			rel, _ := filepath.Rel(root, path)
+			offenders = append(offenders, rel)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, offenders,
+		"AssertUploaded(NewFileRef(...)) mints pointer proof for un-uploaded content — GH #810. "+
+			"Upload via UploadBlob/UploadSessionFiles instead: %v", offenders)
+}
+
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found walking up from test dir")
+		}
+		dir = parent
+	}
+}

--- a/internal/lfs/uploaded_test.go
+++ b/internal/lfs/uploaded_test.go
@@ -2,6 +2,7 @@ package lfs
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -66,8 +67,10 @@ func TestNoAssertUploadedOfFreshFileRef(t *testing.T) {
 
 	var offenders []string
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		// Propagate traversal errors — an unwalkable subtree could hide a
+		// prohibited call, so failing loud beats scanning a partial tree.
 		if err != nil {
-			return nil
+			return fmt.Errorf("walk %s: %w", path, err)
 		}
 		if d.IsDir() {
 			if name := d.Name(); name == "vendor" || name == ".git" || name == "node_modules" {
@@ -80,7 +83,9 @@ func TestNoAssertUploadedOfFreshFileRef(t *testing.T) {
 		}
 		data, rerr := os.ReadFile(path)
 		if rerr != nil {
-			return nil
+			// An unreadable production file must fail the scan, not pass it
+			// vacuously — it could contain the very call this test forbids.
+			return fmt.Errorf("read %s: %w", path, rerr)
 		}
 		if bad.Match(data) {
 			rel, _ := filepath.Rel(root, path)

--- a/internal/plan/dehydrate.go
+++ b/internal/plan/dehydrate.go
@@ -1,7 +1,9 @@
 package plan
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -40,24 +42,29 @@ import (
 func DehydrateHTML(dir string, client *lfs.Client) (bool, error) {
 	htmlPath := filepath.Join(dir, planHTMLFile)
 
-	info, err := os.Stat(htmlPath)
-	if err != nil {
-		return false, nil // no render on disk (or unreadable) — nothing to dehydrate
-	}
-	if info.Size() <= htmlLFSThreshold {
-		return false, nil // small enough to keep plain
-	}
 	if lfs.IsPointerFile(htmlPath) {
 		return false, nil // already dehydrated
+	}
+
+	// Read the file FIRST and gate on what we actually read — never on a separate
+	// os.Stat. A concurrent Save can rewrite plan.html between a stat and a read,
+	// so sizing one snapshot and uploading another risks pointerizing a now-small
+	// file (or skipping a now-large one). The uploaded blob's OID must describe the
+	// exact bytes we sized.
+	content, err := os.ReadFile(htmlPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil // no render on disk — nothing to dehydrate
+		}
+		return false, fmt.Errorf("read plan.html for dehydration: %w", err)
+	}
+	if int64(len(content)) <= htmlLFSThreshold {
+		return false, nil // small enough to keep plain
 	}
 	if client == nil {
 		return false, nil // no store reachable — stays plain, safe
 	}
 
-	content, err := os.ReadFile(htmlPath)
-	if err != nil {
-		return false, fmt.Errorf("read plan.html for dehydration: %w", err)
-	}
 	uploaded, err := lfs.UploadBlob(client, content)
 	if err != nil {
 		return false, fmt.Errorf("upload plan.html blob: %w", err)

--- a/internal/plan/dehydrate.go
+++ b/internal/plan/dehydrate.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/sageox/ox/internal/lfs"
@@ -12,36 +13,56 @@ import (
 // pointer never references a blob that isn't there (the GH #810 wedge). Returns
 // true when it pointerized, false when it left plan.html plain.
 //
-// It is deliberately separate from Save. Save is the no-network storage layer
-// and always writes plan.html plain; DehydrateHTML runs in the CLI caller, which
-// owns credential resolution and the LFS client. Because it goes through
-// lfs.UploadBlob → lfs.WritePointerFile (which requires an lfs.UploadedRef), it
-// is structurally impossible for this path to mint a pointer for un-uploaded
-// content.
+// It reads the bytes it is about to pointerize straight off disk, NOT from a
+// caller-supplied slice. This is load-bearing: Save applies StampHTMLMeta and
+// writes the STAMPED bytes to plan.html, so uploading a caller's pre-stamp copy
+// would produce an OID that disagrees with the on-disk file — guardPointerOverwrite
+// would then refuse the swap, and every real render (all carry a <head>) would
+// silently never dehydrate while leaking an orphaned blob per save. Reading the
+// file makes the upload OID equal the on-disk OID by construction, so the guard
+// always permits the swap.
+//
+// It is deliberately separate from Save. Save is the no-network storage layer and
+// always writes plan.html plain; DehydrateHTML runs in the CLI caller, which owns
+// credential resolution and the LFS client. Because it goes through
+// lfs.UploadBlob → lfs.WritePointerFile (which requires an lfs.UploadedRef), it is
+// structurally impossible for this path to mint a pointer for un-uploaded content.
 //
 // Behavior by case:
-//   - html at or below htmlLFSThreshold: stays plain so a dehydrated clone reads
-//     it directly with no hydration — returns (false, nil).
+//   - no plan.html, or already a pointer: nothing to do — returns (false, nil).
+//   - on-disk file at or below htmlLFSThreshold: stays plain so a dehydrated clone
+//     reads it directly with no hydration — returns (false, nil).
 //   - client == nil (offline / no ledger remote): stays plain — returns
 //     (false, nil). Larger in git, but retrievable and pushable; never lost.
-//   - upload fails: returns (false, err). The plain plan.html Save wrote is still
-//     on disk, so the caller leaves it plain and defers — content is safe and the
-//     push is not poisoned.
-//   - upload succeeds: overwrites plan.html with a pointer to the now-present
-//     blob. The OID matches the plain bytes on disk, so guardPointerOverwrite
-//     permits the swap — returns (true, nil).
-func DehydrateHTML(dir string, html []byte, client *lfs.Client) (bool, error) {
-	if int64(len(html)) <= htmlLFSThreshold {
-		return false, nil
+//   - upload fails: returns (false, err). The plain plan.html on disk is untouched
+//     (content safe) and no poisoned pointer reaches the remote.
+//   - upload succeeds: overwrites plan.html with a pointer to the now-present blob.
+func DehydrateHTML(dir string, client *lfs.Client) (bool, error) {
+	htmlPath := filepath.Join(dir, planHTMLFile)
+
+	info, err := os.Stat(htmlPath)
+	if err != nil {
+		return false, nil // no render on disk (or unreadable) — nothing to dehydrate
+	}
+	if info.Size() <= htmlLFSThreshold {
+		return false, nil // small enough to keep plain
+	}
+	if lfs.IsPointerFile(htmlPath) {
+		return false, nil // already dehydrated
 	}
 	if client == nil {
-		return false, nil
+		return false, nil // no store reachable — stays plain, safe
 	}
-	uploaded, err := lfs.UploadBlob(client, html)
+
+	content, err := os.ReadFile(htmlPath)
+	if err != nil {
+		return false, fmt.Errorf("read plan.html for dehydration: %w", err)
+	}
+	uploaded, err := lfs.UploadBlob(client, content)
 	if err != nil {
 		return false, fmt.Errorf("upload plan.html blob: %w", err)
 	}
-	if err := lfs.WritePointerFile(filepath.Join(dir, planHTMLFile), uploaded); err != nil {
+	if err := lfs.WritePointerFile(htmlPath, uploaded); err != nil {
 		return false, fmt.Errorf("write plan.html LFS pointer: %w", err)
 	}
 	return true, nil

--- a/internal/plan/dehydrate_test.go
+++ b/internal/plan/dehydrate_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/sageox/ox/internal/lfs"
 )
@@ -94,15 +95,82 @@ func fakeLFSUploadServer(t *testing.T) (*lfs.Client, *sync.Map) {
 	return lfs.NewClient(srv.URL, "oauth2", "token"), stored
 }
 
-// TestDehydrateHTML_SmallStaysPlain: a sub-threshold render is never pointerized,
-// so a dehydrated clone reads it directly.
+// largeHTMLWithHead builds a >threshold render that carries a <head>, so that
+// Save's StampHTMLMeta actually mutates it (the condition that exposed the
+// stamped-vs-unstamped bug).
+func largeHTMLWithHead() []byte {
+	body := strings.Repeat("PRESERVE-ME ", htmlLFSThreshold/12+4)
+	return []byte("<html><head></head><body>" + body + "</body></html>")
+}
+
+// TestSaveThenDehydrate_RealHeadHTML is the regression test for the stamped-vs-
+// unstamped bug: Save writes STAMPED bytes to plan.html, and DehydrateHTML must
+// upload/pointerize THOSE bytes — not a caller's pre-stamp copy.
+//
+// Failure prevented: DehydrateHTML uploads the unstamped bytes, so their OID
+// disagrees with the on-disk (stamped) file; guardPointerOverwrite refuses the
+// swap, dehydration silently never happens for any real render, and every save
+// leaks an orphaned blob. This drives the true path (Save → DehydrateHTML reading
+// on disk) with a <head>-bearing render above the threshold.
+func TestSaveThenDehydrate_RealHeadHTML(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	html := largeHTMLWithHead()
+	meta := Meta{Topic: "Real head render", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	dir, _, err := Save("/g", Input{Raw: "# H\n"}, sampleResult(), html, meta)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// sanity: Save stamped the on-disk copy, so it differs from the raw html the
+	// CLI still holds — this is exactly the divergence the bug tripped over.
+	onDisk, err := os.ReadFile(filepath.Join(dir, planHTMLFile))
+	if err != nil {
+		t.Fatalf("read stamped plan.html: %v", err)
+	}
+	if bytes.Equal(onDisk, html) {
+		t.Fatalf("precondition: expected StampHTMLMeta to modify the <head> render")
+	}
+
+	client, stored := fakeLFSUploadServer(t)
+	pointerized, err := DehydrateHTML(dir, client)
+	if err != nil {
+		t.Fatalf("DehydrateHTML errored on a real render (the stamped/unstamped bug): %v", err)
+	}
+	if !pointerized {
+		t.Fatalf("real render was not dehydrated — the on-disk stamped bytes were not the ones uploaded")
+	}
+
+	htmlPath := filepath.Join(dir, planHTMLFile)
+	ref, err := lfs.ReadPointerFile(htmlPath)
+	if err != nil {
+		t.Fatalf("plan.html is not a valid pointer after dehydration: %v", err)
+	}
+	blob, ok := stored.Load(ref.BareOID())
+	if !ok {
+		t.Fatalf("blob %s not in the store — pointer would be poisoned", ref.BareOID())
+	}
+	// the uploaded blob is the STAMPED on-disk content, not the caller's raw html.
+	if !bytes.Equal(blob.([]byte), onDisk) {
+		t.Fatalf("uploaded blob != the stamped file Save wrote")
+	}
+	if bytes.Equal(blob.([]byte), html) {
+		t.Fatalf("uploaded blob is the UNSTAMPED html — the #810 stamped-bytes bug")
+	}
+	if lfs.ComputeOID(blob.([]byte)) != ref.BareOID() {
+		t.Fatalf("pointer OID does not match the stored blob")
+	}
+}
+
+// TestDehydrateHTML_SmallStaysPlain: a sub-threshold render is never pointerized.
 func TestDehydrateHTML_SmallStaysPlain(t *testing.T) {
 	dir := t.TempDir()
 	html := bytes.Repeat([]byte("x"), 1024)
 	writePlanHTMLPlain(t, dir, html)
 	client, _ := fakeLFSUploadServer(t)
 
-	pointerized, err := DehydrateHTML(dir, html, client)
+	pointerized, err := DehydrateHTML(dir, client)
 	if err != nil {
 		t.Fatalf("DehydrateHTML: %v", err)
 	}
@@ -119,7 +187,7 @@ func TestDehydrateHTML_NilClientStaysPlain(t *testing.T) {
 	html := bytes.Repeat([]byte("PRESERVE "), htmlLFSThreshold/8+2)
 	writePlanHTMLPlain(t, dir, html)
 
-	pointerized, err := DehydrateHTML(dir, html, nil)
+	pointerized, err := DehydrateHTML(dir, nil)
 	if err != nil {
 		t.Fatalf("DehydrateHTML: %v", err)
 	}
@@ -131,8 +199,8 @@ func TestDehydrateHTML_NilClientStaysPlain(t *testing.T) {
 
 // TestDehydrateHTML_UploadFailureLeavesPlain is the load-bearing failure-mode
 // test: when the upload fails, DehydrateHTML must NOT write a pointer. The plain
-// plan.html Save wrote stays on disk (content safe) and no poisoned pointer can
-// reach the remote. Failure prevented: reintroducing GH #810 via a failed upload.
+// plan.html on disk stays intact (content safe) and no poisoned pointer can reach
+// the remote. Failure prevented: reintroducing GH #810 via a failed upload.
 func TestDehydrateHTML_UploadFailureLeavesPlain(t *testing.T) {
 	dir := t.TempDir()
 	html := bytes.Repeat([]byte("PRESERVE "), htmlLFSThreshold/8+2)
@@ -145,7 +213,7 @@ func TestDehydrateHTML_UploadFailureLeavesPlain(t *testing.T) {
 	t.Cleanup(srv.Close)
 	client := lfs.NewClient(srv.URL, "oauth2", "token")
 
-	pointerized, err := DehydrateHTML(dir, html, client)
+	pointerized, err := DehydrateHTML(dir, client)
 	if err == nil {
 		t.Fatalf("DehydrateHTML: want error on upload failure, got nil")
 	}
@@ -155,17 +223,15 @@ func TestDehydrateHTML_UploadFailureLeavesPlain(t *testing.T) {
 	assertPlainHTML(t, dir, html) // plain render intact, no dangling pointer
 }
 
-// TestDehydrateHTML_LargeUploadsThenPointerizes proves the whole fix end to end:
-// the blob is actually uploaded to the store AND the on-disk plan.html becomes a
-// pointer to it. Order matters — the pointer's OID must be a blob the server now
-// holds.
+// TestDehydrateHTML_LargeUploadsThenPointerizes proves the plain seed → pointer
+// path: the blob is uploaded AND the on-disk plan.html becomes a pointer to it.
 func TestDehydrateHTML_LargeUploadsThenPointerizes(t *testing.T) {
 	dir := t.TempDir()
 	html := bytes.Repeat([]byte("PRESERVE-ME "), htmlLFSThreshold/12+2)
 	writePlanHTMLPlain(t, dir, html)
 	client, stored := fakeLFSUploadServer(t)
 
-	pointerized, err := DehydrateHTML(dir, html, client)
+	pointerized, err := DehydrateHTML(dir, client)
 	if err != nil {
 		t.Fatalf("DehydrateHTML: %v", err)
 	}
@@ -185,12 +251,57 @@ func TestDehydrateHTML_LargeUploadsThenPointerizes(t *testing.T) {
 	if ref.OID != wantOID {
 		t.Fatalf("pointer OID = %q, want %q", ref.OID, wantOID)
 	}
-	// the blob the pointer names must actually be in the store.
 	blob, ok := stored.Load(lfs.ComputeOID(html))
 	if !ok {
 		t.Fatalf("blob for %s not uploaded — pointer would be poisoned", wantOID)
 	}
 	if !bytes.Equal(blob.([]byte), html) {
 		t.Fatalf("uploaded blob differs from the render")
+	}
+}
+
+// TestDehydrateHTML_AlreadyPointerIsNoop: a plan.html that is already a pointer
+// (a re-save, or a synced dehydrated clone) must not be re-processed.
+func TestDehydrateHTML_AlreadyPointerIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	ref := lfs.AssertUploaded(lfs.FileRef{Storage: "lfs", OID: "sha256:" + lfs.ComputeOID([]byte("blob")), Size: 4})
+	require := func(cond bool, msg string) {
+		if !cond {
+			t.Fatal(msg)
+		}
+	}
+	if err := lfs.WritePointerFile(filepath.Join(dir, planHTMLFile), ref); err != nil {
+		t.Fatalf("seed pointer: %v", err)
+	}
+	client, _ := fakeLFSUploadServer(t)
+	pointerized, err := DehydrateHTML(dir, client)
+	require(err == nil, "DehydrateHTML on an existing pointer should not error")
+	require(!pointerized, "an existing pointer must not be re-pointerized")
+}
+
+// TestDehydrateHTML_BoundaryComparator pins the `>` (not `>=`) gate: a render of
+// exactly htmlLFSThreshold bytes stays plain.
+func TestDehydrateHTML_BoundaryComparator(t *testing.T) {
+	cases := []struct {
+		name string
+		size int
+		want bool
+	}{
+		{"exactly threshold stays plain", htmlLFSThreshold, false},
+		{"one over crosses", htmlLFSThreshold + 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writePlanHTMLPlain(t, dir, bytes.Repeat([]byte("z"), tc.size))
+			client, _ := fakeLFSUploadServer(t)
+			got, err := DehydrateHTML(dir, client)
+			if err != nil {
+				t.Fatalf("DehydrateHTML: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("pointerized = %v, want %v (size=%d)", got, tc.want, tc.size)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #815. That PR shipped the #810 data-loss fix correctly, but a review caught a latent bug its tests were shaped to miss: **`ox plan save` dehydration silently never runs for a real render**, so large plans still bloat git and every large save leaks an orphaned LFS blob.

**Root cause (in #815):**
- `Save` applies `StampHTMLMeta` (injects `<meta>` tags) and writes the **stamped** bytes to `plan.html`.
- `savePlanArtifacts` then handed `DehydrateHTML` the caller's **unstamped** `html` copy. It uploaded the unstamped bytes, so their OID disagreed with the stamped on-disk file; `guardPointerOverwrite` refused the pointer swap.
- Every real render carries a `<head>`, so this fired every time: dehydration failed, the render stayed plain (the LFS pointer never happened), and the uploaded-but-unreferenced blob was orphaned on each save.
- The #810 guarantee still held — no poisoned pointer, no lost content (the fail-safe worked). Only the feature was dead.

**Fix:** `DehydrateHTML` now reads the bytes it is about to pointerize **straight off disk**, so the upload OID matches the committed file by construction — stamped vs. unstamped can no longer diverge. This also drops the redundant `html` parameter and gates on the actual committed size.

## Test Plan

**The bug fix (`internal/plan`):**
- **`TestSaveThenDehydrate_RealHeadHTML`** drives the true path (`Save` → `DehydrateHTML`) with a >256 KB `<head>`-bearing render and asserts it pointerizes to a stored blob equal to the **stamped** on-disk bytes (explicitly *not* the caller's copy). **Red-first proven**: simulated the mismatch → guard refused → red; restored → green.
- Plus boundary (`== threshold` stays plain), already-a-pointer no-op, nil-client/offline stays-plain, and upload-failure-leaves-plain.

**Deeper coverage the review flagged as missing in #815** (added here so the recovery/guard paths aren't shipping on `ScannedPointers`-only assertions):
- **Reconcile blank+squash** (`TestReconcile_BlanksMissingPlanPointerAndSquashes`) — a 404 plan blob is actually blanked to empty and squashed out of the unpushed pack (bare remote + fake LFS server, via a new client-injectable reconcile seam).
- **Transient-error guard** (`TestReconcile_TransientErrorNeverBlanks`) — 401/503 aborts, never zeroes a live pointer, for **both** the plan and session trees.
- **Composition-root e2e** (`TestSavePlanArtifacts_LargeRenderStaysPlainWhenLFSUnreachable`) — a large render through the real `savePlanArtifacts` stays plain (retrievable, pushable, no poisoned pointer) when no LFS client is reachable.
- **Doctor warn/fix wiring** (`TestEvaluatePlanPointers_WarnThenFix`) — no-`--fix` warns and never reconciles; `--fix` invokes the reconcile and reports its result.
- **`UploadBlob` already-present** yields a usable proof; **`TestNoAssertUploadedOfFreshFileRef`** is a source-scan enforcement test that fails if `AssertUploaded(NewFileRef(…))` (minting proof for un-uploaded content) ever reappears — the backstop the compile-time type can't provide.

`go build ./...` clean; `internal/lfs`, `internal/plan`, and the cmd/ox `Plan`/doctor suites green; `go vet` clean on all touched packages.

Follows #815 · closes the dehydration gap in #810.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (red-first regression + fault/boundary cases)
- [ ] CHANGELOG — N/A: fixes an unshipped-behavior gap in an experimental, off-by-default surface
- [x] Breaking change — none: internal signature only (`DehydrateHTML` dropped its `html` param)
- [x] `/security-review` — N/A: no auth/mcp/raw_writer/prepush/upgrade/go.sum; LFS stays pure-Go

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a03520-1293-7664-ba71-f255ef40acee


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved large-file handling so uploaded content matches the stamped plan file exactly.
  * Preserved plan files when reading or uploading fails.
  * Avoided unnecessary processing for missing, unreadable, already-pointerized, offline, or undersized files.
  * Improved plan-pointer checks and repairs, with safer handling of missing or temporarily unavailable blobs.
  * Prevented invalid pointers when uploaded content is unavailable.

* **Documentation**
  * Added guidance for conversation workflows and pull request header generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->