### PR TITLE
fix(codedb): stop go-git rewriting source .git/config (#819)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,9 @@ check-codedb-guarded-open: ## Ensure codedb opens user repos only via internal/c
 	@# command. All source-repo opens must route through gitopen.GuardedPlainOpen
 	@# or gitopen.WrapReadOnlyConfig, which deny the config write. gitopen.go
 	@# itself and tests are exempt. Fail CLOSED on a scanner error (grep >1).
+	@# The sed strips ONLY the exact guarded form git.Open(gitopen.WrapReadOnlyConfig(
+	@# (per-call, not line-wide) then flags any surviving raw open — so a raw
+	@# git.Open sharing a line with a wrapper reference cannot slip through.
 	@raw=$$(grep -rnE 'git\.(PlainOpen|Open)\(' --include='*.go' internal/codedb); rc=$$?; \
 	if [ $$rc -gt 1 ]; then \
 		echo "ERROR: check-codedb-guarded-open scan failed (grep exit $$rc) — refusing to report success"; \
@@ -275,7 +278,8 @@ check-codedb-guarded-open: ## Ensure codedb opens user repos only via internal/c
 		| grep -v '_test\.go:' \
 		| grep -v 'internal/codedb/gitopen/gitopen\.go:' \
 		| grep -vE ':[0-9]+:[[:space:]]*//' \
-		| grep -v 'gitopen\.WrapReadOnlyConfig'); \
+		| sed 's/git\.Open(gitopen\.WrapReadOnlyConfig(/GUARDED_OPEN(/g' \
+		| grep -E 'git\.(PlainOpen|Open)\('); \
 	if [ -n "$$violations" ]; then \
 		echo "$$violations"; \
 		echo "ERROR: open user repos via internal/codedb/gitopen (GuardedPlainOpen / WrapReadOnlyConfig), not raw go-git — see issue #819."; \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for ox CLI tool
 
-.PHONY: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw
+.PHONY: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw check-codedb-guarded-open
 .PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-timings test-all test-slow test-browser test-integration test-agents test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version check-release-drift beads-setup
 
 # Variables
@@ -259,7 +259,30 @@ check-raw-writer-chokepoint: ## Ensure raw.jsonl is only opened via session.RawW
 		exit 1; \
 	fi
 
-test-preflight: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw ## Pre-PR quality gate: lint + all unit tests + slow tests (lint/test-all/test-slow run concurrently)
+check-codedb-guarded-open: ## Ensure codedb opens user repos only via internal/codedb/gitopen (issue #819)
+	@# codedb indexes the managed SOURCE checkout in place. A raw git.PlainOpen /
+	@# unwrapped git.Open lets go-git rewrite that repo's .git/config (flips
+	@# core.bare, drops extensions.worktreeConfig) and break every work-tree git
+	@# command. All source-repo opens must route through gitopen.GuardedPlainOpen
+	@# or gitopen.WrapReadOnlyConfig, which deny the config write. gitopen.go
+	@# itself and tests are exempt. Fail CLOSED on a scanner error (grep >1).
+	@raw=$$(grep -rnE 'git\.(PlainOpen|Open)\(' --include='*.go' internal/codedb); rc=$$?; \
+	if [ $$rc -gt 1 ]; then \
+		echo "ERROR: check-codedb-guarded-open scan failed (grep exit $$rc) — refusing to report success"; \
+		exit 1; \
+	fi; \
+	violations=$$(printf '%s\n' "$$raw" | grep -v '^$$' \
+		| grep -v '_test\.go:' \
+		| grep -v 'internal/codedb/gitopen/gitopen\.go:' \
+		| grep -vE ':[0-9]+:[[:space:]]*//' \
+		| grep -v 'gitopen\.WrapReadOnlyConfig'); \
+	if [ -n "$$violations" ]; then \
+		echo "$$violations"; \
+		echo "ERROR: open user repos via internal/codedb/gitopen (GuardedPlainOpen / WrapReadOnlyConfig), not raw go-git — see issue #819."; \
+		exit 1; \
+	fi
+
+test-preflight: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw check-codedb-guarded-open ## Pre-PR quality gate: lint + all unit tests + slow tests (lint/test-all/test-slow run concurrently)
 	$(call say,"Running lint, full tests, and slow tests concurrently...")
 	@# lint and the test binaries don't share any output file (test-all writes
 	@# coverage.out; test-slow and lint don't touch it), so running them

--- a/internal/codedb/gitopen/gitopen.go
+++ b/internal/codedb/gitopen/gitopen.go
@@ -2,18 +2,19 @@
 // in a way that can NEVER rewrite that repository's .git/config.
 //
 // Why this exists (issue #819): codedb opens the managed source project repo
-// in place to read objects. go-git v6's config Marshal is lossy — it drops
-// unrecognized [extensions] subsections (notably extensions.worktreeConfig)
-// and rewrites [core], and some go-git versions persist worktree/bare config
-// as a side effect of *opening* a repo. On a linked-worktree checkout that
-// silently flipped core.bare=true on the user's shared main .git/config,
+// in place to read objects. go-git re-marshals config through the single
+// contract Storer.SetConfig, and across go-git v6 alpha snapshots that has
+// flipped core.bare, dropped extensions.worktreeConfig, and (in some snapshots)
+// persisted config as a side effect of *opening* a worktree repo. On a linked
+// worktree that silently flipped core.bare=true on the shared main .git/config,
 // breaking every work-tree git command until it was manually reset.
 //
 // The daemon must never write the managed source repo's .git/config (see
-// .claude/rules/daemon-git.md). We enforce that structurally here rather than
-// trusting any particular go-git version's open path to be read-only: the
-// storer's SetConfig — the single contract through which go-git persists
-// config in every version — is turned into a no-op for these read-only opens.
+// .claude/rules/daemon-git.md). We enforce that structurally rather than
+// trusting any particular alpha's open path to be read-only: SetConfig — the
+// only path through which go-git persists config in every version — is a no-op
+// for these read-only opens. codedb only READS objects here, so denying the
+// write is always safe.
 package gitopen
 
 import (
@@ -53,50 +54,55 @@ func WrapReadOnlyConfig(s *filesystem.Storage) storage.Storer {
 }
 
 // GuardedPlainOpen is a drop-in replacement for git.PlainOpen for user-owned
-// repositories. For a normal checkout (or a linked worktree, resolved to its
-// shared main checkout), it opens with config writes denied so #819 can never
-// recur. For a bare repository (e.g. codedb's own cache clone) it falls back
-// to git.PlainOpen: a bare repo's config legitimately carries core.bare=true
-// and has no worktree/extensions to lose, so it is not part of the #819
-// surface and is not ours to protect.
+// repositories. It opens with config writes denied so #819 can never recur,
+// covering three layouts:
+//   - a normal checkout (.git is a directory),
+//   - a linked worktree (.git is a file with a commondir → the shared main
+//     checkout, resolved by ResolveGitDir),
+//   - a submodule (.git is a file whose self-contained gitdir has no commondir).
+//
+// A bare repository (e.g. codedb's own cache clone) falls back to git.PlainOpen:
+// its config legitimately carries core.bare=true and it has no worktree/
+// extensions to lose, so it is not part of the #819 surface.
 func GuardedPlainOpen(path string) (*git.Repository, error) {
+	// Normal repo, or a linked worktree resolved to its shared main checkout —
+	// either way the resolved root has a real .git directory holding objects.
 	root, _ := ResolveGitDir(path)
-	gitDir := filepath.Join(root, ".git")
-	if fi, err := os.Stat(gitDir); err == nil && fi.IsDir() {
-		dot := osfs.New(gitDir, osfs.WithBoundOS())
-		wt := osfs.New(root, osfs.WithBoundOS())
-		s := filesystem.NewStorage(dotgit.NewRepositoryFilesystem(dot, nil), cache.NewObjectLRUDefault())
-		return git.Open(readOnlyConfigStorer{s}, wt)
+	if fi, err := os.Stat(filepath.Join(root, ".git")); err == nil && fi.IsDir() {
+		return openGuarded(filepath.Join(root, ".git"), root)
 	}
+	// A .git FILE that ResolveGitDir did not remap: a submodule, whose gitdir
+	// (e.g. .git/modules/<name>) is self-contained. Guard it directly rather
+	// than falling through to an unguarded open.
+	if gitDir, ok := submoduleGitDir(path); ok {
+		return openGuarded(gitDir, path)
+	}
+	// Bare repo (path is itself the git dir) or unresolvable layout.
 	return git.PlainOpen(path)
 }
 
+// openGuarded opens the repo whose git directory is dotDir and worktree is
+// wtDir, with config writes denied.
+func openGuarded(dotDir, wtDir string) (*git.Repository, error) {
+	dot := osfs.New(dotDir, osfs.WithBoundOS())
+	wt := osfs.New(wtDir, osfs.WithBoundOS())
+	s := filesystem.NewStorage(dotgit.NewRepositoryFilesystem(dot, nil), cache.NewObjectLRUDefault())
+	return git.Open(readOnlyConfigStorer{s}, wt)
+}
+
 // ResolveGitDir returns the path to open with go-git and whether it is a linked
-// worktree. For linked worktrees (where .git is a file containing "gitdir: ..."),
-// it follows commondir to the main repo's root so go-git can access the shared
-// object store. For normal repos, returns the path unchanged.
+// worktree. For linked worktrees (where .git is a file containing "gitdir: ..."
+// AND the target has a commondir), it follows commondir to the main repo's root
+// so go-git can access the shared object store. For normal repos, submodules, or
+// anything unresolvable, returns the path unchanged.
 func ResolveGitDir(repoPath string) (string, bool) {
-	dotGit := filepath.Join(repoPath, ".git")
-	info, err := os.Lstat(dotGit)
-	if err != nil || info.IsDir() {
-		return repoPath, false // normal repo or no .git
+	worktreeGitDir, ok := gitdirTarget(repoPath)
+	if !ok {
+		return repoPath, false // normal repo, no .git, or unreadable .git file
 	}
 
-	// .git is a file → linked worktree, read "gitdir: <path>"
-	content, err := os.ReadFile(dotGit)
-	if err != nil {
-		return repoPath, false
-	}
-	line := strings.TrimSpace(string(content))
-	if !strings.HasPrefix(line, "gitdir: ") {
-		return repoPath, false
-	}
-	worktreeGitDir := strings.TrimPrefix(line, "gitdir: ")
-	if !filepath.IsAbs(worktreeGitDir) {
-		worktreeGitDir = filepath.Join(repoPath, worktreeGitDir)
-	}
-
-	// read commondir to find the shared .git (e.g., "../.." → main .git)
+	// A linked worktree has a commondir pointing at the shared .git; a submodule
+	// does not (its gitdir is self-contained and is handled by GuardedPlainOpen).
 	commondirFile := filepath.Join(worktreeGitDir, "commondir")
 	commondirBytes, err := os.ReadFile(commondirFile)
 	if err != nil {
@@ -108,6 +114,46 @@ func ResolveGitDir(repoPath string) (string, bool) {
 	}
 
 	// commondir points to the main .git dir; the repo root is its parent
-	mainRepoRoot := filepath.Dir(commondir)
-	return mainRepoRoot, true
+	return filepath.Dir(commondir), true
+}
+
+// submoduleGitDir returns the self-contained gitdir a submodule's ".git" file
+// points at (no commondir), or ("", false) for anything else (linked worktree,
+// normal repo, bare, unreadable).
+func submoduleGitDir(repoPath string) (string, bool) {
+	gitDir, ok := gitdirTarget(repoPath)
+	if !ok {
+		return "", false
+	}
+	if _, err := os.Stat(filepath.Join(gitDir, "commondir")); err == nil {
+		return "", false // linked worktree — handled by ResolveGitDir
+	}
+	if fi, err := os.Stat(gitDir); err != nil || !fi.IsDir() {
+		return "", false
+	}
+	return gitDir, true
+}
+
+// gitdirTarget reads a ".git" FILE ("gitdir: <path>") and returns the absolute
+// target directory. Returns ("", false) when .git is a directory, is missing,
+// is unreadable, or does not contain a gitdir pointer.
+func gitdirTarget(repoPath string) (string, bool) {
+	dotGit := filepath.Join(repoPath, ".git")
+	info, err := os.Lstat(dotGit)
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	content, err := os.ReadFile(dotGit)
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return "", false
+	}
+	target := strings.TrimPrefix(line, "gitdir: ")
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(repoPath, target)
+	}
+	return target, true
 }

--- a/internal/codedb/gitopen/gitopen.go
+++ b/internal/codedb/gitopen/gitopen.go
@@ -1,0 +1,113 @@
+// Package gitopen centralizes opening a user-owned git repository with go-git
+// in a way that can NEVER rewrite that repository's .git/config.
+//
+// Why this exists (issue #819): codedb opens the managed source project repo
+// in place to read objects. go-git v6's config Marshal is lossy — it drops
+// unrecognized [extensions] subsections (notably extensions.worktreeConfig)
+// and rewrites [core], and some go-git versions persist worktree/bare config
+// as a side effect of *opening* a repo. On a linked-worktree checkout that
+// silently flipped core.bare=true on the user's shared main .git/config,
+// breaking every work-tree git command until it was manually reset.
+//
+// The daemon must never write the managed source repo's .git/config (see
+// .claude/rules/daemon-git.md). We enforce that structurally here rather than
+// trusting any particular go-git version's open path to be read-only: the
+// storer's SetConfig — the single contract through which go-git persists
+// config in every version — is turned into a no-op for these read-only opens.
+package gitopen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
+)
+
+// readOnlyConfigStorer embeds a filesystem storer and turns SetConfig into a
+// no-op. codedb opens repos purely to READ objects, so a config write is never
+// needed and denying it is always safe. Returning nil (rather than an error)
+// keeps an open-time SetConfig — which some go-git versions perform when a
+// worktree filesystem is supplied — from aborting the open; the read path does
+// not depend on the write having landed (go-git holds config in memory).
+type readOnlyConfigStorer struct {
+	*filesystem.Storage
+}
+
+// SetConfig deliberately does nothing so go-git can never rewrite the source
+// repo's .git/config (issue #819). Never remove this override.
+func (readOnlyConfigStorer) SetConfig(*config.Config) error { return nil }
+
+// WrapReadOnlyConfig wraps a filesystem storer so its config can never be
+// persisted. Use this whenever go-git opens a user-owned repo for read-only
+// work (e.g. codedb's KeepDescriptors fast path builds its own storer and
+// wraps it before git.Open).
+func WrapReadOnlyConfig(s *filesystem.Storage) storage.Storer {
+	return readOnlyConfigStorer{s}
+}
+
+// GuardedPlainOpen is a drop-in replacement for git.PlainOpen for user-owned
+// repositories. For a normal checkout (or a linked worktree, resolved to its
+// shared main checkout), it opens with config writes denied so #819 can never
+// recur. For a bare repository (e.g. codedb's own cache clone) it falls back
+// to git.PlainOpen: a bare repo's config legitimately carries core.bare=true
+// and has no worktree/extensions to lose, so it is not part of the #819
+// surface and is not ours to protect.
+func GuardedPlainOpen(path string) (*git.Repository, error) {
+	root, _ := ResolveGitDir(path)
+	gitDir := filepath.Join(root, ".git")
+	if fi, err := os.Stat(gitDir); err == nil && fi.IsDir() {
+		dot := osfs.New(gitDir, osfs.WithBoundOS())
+		wt := osfs.New(root, osfs.WithBoundOS())
+		s := filesystem.NewStorage(dotgit.NewRepositoryFilesystem(dot, nil), cache.NewObjectLRUDefault())
+		return git.Open(readOnlyConfigStorer{s}, wt)
+	}
+	return git.PlainOpen(path)
+}
+
+// ResolveGitDir returns the path to open with go-git and whether it is a linked
+// worktree. For linked worktrees (where .git is a file containing "gitdir: ..."),
+// it follows commondir to the main repo's root so go-git can access the shared
+// object store. For normal repos, returns the path unchanged.
+func ResolveGitDir(repoPath string) (string, bool) {
+	dotGit := filepath.Join(repoPath, ".git")
+	info, err := os.Lstat(dotGit)
+	if err != nil || info.IsDir() {
+		return repoPath, false // normal repo or no .git
+	}
+
+	// .git is a file → linked worktree, read "gitdir: <path>"
+	content, err := os.ReadFile(dotGit)
+	if err != nil {
+		return repoPath, false
+	}
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return repoPath, false
+	}
+	worktreeGitDir := strings.TrimPrefix(line, "gitdir: ")
+	if !filepath.IsAbs(worktreeGitDir) {
+		worktreeGitDir = filepath.Join(repoPath, worktreeGitDir)
+	}
+
+	// read commondir to find the shared .git (e.g., "../.." → main .git)
+	commondirFile := filepath.Join(worktreeGitDir, "commondir")
+	commondirBytes, err := os.ReadFile(commondirFile)
+	if err != nil {
+		return repoPath, false
+	}
+	commondir := strings.TrimSpace(string(commondirBytes))
+	if !filepath.IsAbs(commondir) {
+		commondir = filepath.Join(worktreeGitDir, commondir)
+	}
+
+	// commondir points to the main .git dir; the repo root is its parent
+	mainRepoRoot := filepath.Dir(commondir)
+	return mainRepoRoot, true
+}

--- a/internal/codedb/index/gogit.go
+++ b/internal/codedb/index/gogit.go
@@ -24,11 +24,12 @@ import (
 //
 // Both the fast path and the fallback open the source repo through a storer
 // whose config can never be persisted (gitopen.WrapReadOnlyConfig /
-// GuardedPlainOpen). This is load-bearing: go-git v6 does NOT round-trip
-// extensions.worktreeConfig, and some go-git versions rewrite [core]
-// (core.bare / core.worktree) as a side effect of opening a worktree repo.
-// codedb only READS objects here, so denying the config write is always safe
-// and prevents corrupting the user's managed .git/config — see issue #819 and
+// GuardedPlainOpen). This is load-bearing: go-git re-marshals config through
+// Storer.SetConfig, and across go-git v6 alpha snapshots that has flipped
+// core.bare, dropped extensions.worktreeConfig, and (in some snapshots)
+// persisted config as a side effect of opening a worktree repo. codedb only
+// READS objects here, so denying the config write is always safe and prevents
+// corrupting the user's managed .git/config — see issue #819 and
 // internal/codedb/gitopen. TestV6_PlainOpenAcceptsKnownExtensions verifies v6
 // still opens known extensions without erroring.
 func plainOpenTolerant(path string) (*git.Repository, error) {

--- a/internal/codedb/index/gogit.go
+++ b/internal/codedb/index/gogit.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
+
+	"github.com/sageox/ox/internal/codedb/gitopen"
 )
 
 // plainOpenTolerant opens a git repo via go-git with KeepDescriptors enabled for
@@ -17,22 +19,23 @@ import (
 // reads instead of reopening on every git object access — eliminates the dominant
 // I/O overhead when reading thousands of objects from packfiles.
 //
-// Falls back to git.PlainOpen if the custom open fails (e.g., .git is a file not
-// a directory, as in submodule checkouts).
+// Falls back to gitopen.GuardedPlainOpen if the custom open fails (e.g., .git is
+// a file not a directory, as in submodule checkouts).
 //
-// In go-git v5, this required an extensionSafeStorer workaround to strip
-// [extensions] from the in-memory config (objectformat, worktreeconfig, etc.)
-// because v5 rejected repos with any extensions it didn't recognize.
-//
-// go-git v6 handles all known extensions natively, making the workaround
-// unnecessary. TestV6_PlainOpenAcceptsKnownExtensions verifies this.
-// If a future git version adds extensions that v6 doesn't recognize,
-// the workaround can be restored from git history.
+// Both the fast path and the fallback open the source repo through a storer
+// whose config can never be persisted (gitopen.WrapReadOnlyConfig /
+// GuardedPlainOpen). This is load-bearing: go-git v6 does NOT round-trip
+// extensions.worktreeConfig, and some go-git versions rewrite [core]
+// (core.bare / core.worktree) as a side effect of opening a worktree repo.
+// codedb only READS objects here, so denying the config write is always safe
+// and prevents corrupting the user's managed .git/config — see issue #819 and
+// internal/codedb/gitopen. TestV6_PlainOpenAcceptsKnownExtensions verifies v6
+// still opens known extensions without erroring.
 func plainOpenTolerant(path string) (*git.Repository, error) {
 	if repo, err := plainOpenWithKeepDescriptors(path); err == nil {
 		return repo, nil
 	}
-	return git.PlainOpen(path)
+	return gitopen.GuardedPlainOpen(path)
 }
 
 // plainOpenWithKeepDescriptors opens a git repo using filesystem.Options{KeepDescriptors: true}.
@@ -57,7 +60,9 @@ func plainOpenWithKeepDescriptors(path string) (*git.Repository, error) {
 	s := filesystem.NewStorageWithOptions(repositoryFs, cache.NewObjectLRUDefault(), filesystem.Options{
 		KeepDescriptors: true,
 	})
-	return git.Open(s, wt)
+	// Deny config writes: go-git must never rewrite the source repo's
+	// .git/config while codedb reads its objects (issue #819).
+	return git.Open(gitopen.WrapReadOnlyConfig(s), wt)
 }
 
 // plainOpenPool opens n independent Repository handles for the same git directory.

--- a/internal/codedb/index/gogit_readonly_config_test.go
+++ b/internal/codedb/index/gogit_readonly_config_test.go
@@ -17,17 +17,26 @@ import (
 
 	"github.com/sageox/ox/internal/codedb/gitopen"
 	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/sageox/ox/internal/testguard"
 )
 
 // gitRunner returns a helper that runs git in cwd with a deterministic identity.
+// Uses testguard.MinimalEnv (an allowlist), which strips GIT_DIR/GIT_WORK_TREE/
+// GIT_COMMON_DIR so an inherited routing var can't retarget git at a repo
+// outside the temp dir — cmd.Dir alone decides the target.
 func gitRunner(t *testing.T) func(cwd string, args ...string) {
 	t.Helper()
-	env := append(os.Environ(), // safe: git in temp dir, not ox subprocess
+	env := testguard.MinimalEnv([]string{
 		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
-		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai",
+	})
 	return func(cwd string, args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		// Disable commit/tag signing so tests don't depend on the developer's
+		// global git config (SSH/GPG signing key + agent, which MinimalEnv's
+		// clean env intentionally cannot reach).
+		full := append([]string{"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}, args...)
+		cmd := exec.Command("git", full...)
 		cmd.Dir = cwd
 		cmd.Env = env
 		out, err := cmd.CombinedOutput()
@@ -154,17 +163,7 @@ func TestGuardedOpen_LinkedWorktree_PreservesSharedConfig(t *testing.T) {
 	}
 	mainDir, _ := initGitRepo(t, 1)
 
-	gitEnv := append(os.Environ(), // safe: git in temp dir, not ox subprocess
-		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
-		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
-	runGit := func(cwd string, args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = cwd
-		cmd.Env = gitEnv
-		out, err := cmd.CombinedOutput()
-		require.NoError(t, err, "git %v: %s", args, out)
-	}
+	runGit := gitRunner(t)
 
 	wtDir := filepath.Join(t.TempDir(), "wt")
 	runGit(mainDir, "worktree", "add", wtDir)

--- a/internal/codedb/index/gogit_readonly_config_test.go
+++ b/internal/codedb/index/gogit_readonly_config_test.go
@@ -1,0 +1,194 @@
+package index
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sageox/ox/internal/codedb/gitopen"
+)
+
+// Failure prevented: the daemon rewriting a managed source repo's .git/config
+// (flipping core.bare, dropping extensions.worktreeConfig) when codedb opens it
+// to index — which breaks every work-tree git command in the user's checkout
+// until manually reset. See issue #819 and internal/codedb/gitopen.
+
+// bugReportConfigShape rewrites .git/config into the shape from the #819 report:
+// repositoryformatversion=1 (required for extensions), an extensions block with
+// worktreeconfig=true, and a git-crypt filter with quoted values. Returns the
+// snapshot bytes so tests can assert byte-identity afterward.
+func bugReportConfigShape(t *testing.T, dir string) (cfgPath string, snapshot []byte) {
+	t.Helper()
+	cfgPath = filepath.Join(dir, ".git", "config")
+	base, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	augmented := replaceFormatVersion(string(base)+
+		"\n[extensions]\n\tworktreeconfig = true\n"+
+		"[filter \"git-crypt\"]\n\tsmudge = \"git-crypt\" smudge\n\tclean = \"git-crypt\" clean\n", "1")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(augmented), 0o644))
+	snapshot, err = os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	return cfgPath, snapshot
+}
+
+// keepDescriptorsStorer builds the exact storer codedb's fast path uses.
+func keepDescriptorsStorer(dir string) *filesystem.Storage {
+	dot := osfs.New(filepath.Join(dir, ".git"), osfs.WithBoundOS())
+	repositoryFs := dotgit.NewRepositoryFilesystem(dot, nil)
+	return filesystem.NewStorageWithOptions(repositoryFs, cache.NewObjectLRUDefault(), filesystem.Options{
+		KeepDescriptors: true,
+	})
+}
+
+// TestReadOnlyConfigStorer_NeverWritesSourceConfig proves the guard intercepts
+// the exact write contract that corrupts the config, with a negative control
+// showing the unguarded storer DOES corrupt it (so this is not test theater).
+func TestReadOnlyConfigStorer_NeverWritesSourceConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git init")
+	}
+	dir, _ := initGitRepo(t, 1)
+	cfgPath, snapshot := bugReportConfigShape(t, dir)
+	wt := osfs.New(dir, osfs.WithBoundOS())
+
+	// Guarded: SetConfig must be a no-op even when a caller drives the worst
+	// case (flipping core.bare, the field that broke the user's checkout).
+	repo, err := git.Open(gitopen.WrapReadOnlyConfig(keepDescriptorsStorer(dir)), wt)
+	require.NoError(t, err)
+	cfg, err := repo.Storer.Config()
+	require.NoError(t, err)
+	cfg.Core.IsBare = true
+	require.NoError(t, repo.Storer.SetConfig(cfg)) // denied → no-op
+	require.NoError(t, repo.Close())
+
+	after, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(snapshot), string(after),
+		"guarded open must leave .git/config byte-identical (#819)")
+
+	// Negative control: the UNGUARDED storer rewrites the file — this is the
+	// hazard the guard exists to prevent. If go-git ever stopped writing here,
+	// the guard would be unnecessary and this assertion would flag the change.
+	require.NoError(t, os.WriteFile(cfgPath, snapshot, 0o644))
+	repo2, err := git.Open(keepDescriptorsStorer(dir), wt)
+	require.NoError(t, err)
+	cfg2, err := repo2.Storer.Config()
+	require.NoError(t, err)
+	cfg2.Core.IsBare = true
+	require.NoError(t, repo2.Storer.SetConfig(cfg2))
+	require.NoError(t, repo2.Close())
+	corrupted, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, string(snapshot), string(corrupted),
+		"sanity: unguarded go-git SetConfig rewrites .git/config (the #819 hazard)")
+	assert.Contains(t, string(corrupted), "bare = true",
+		"unguarded write flips core.bare — exactly what broke the reporter's checkout")
+}
+
+// TestPlainOpenTolerant_PreservesSourceConfig exercises the production open path
+// end to end (open + blob read + close) and asserts .git/config is untouched.
+// Green on the pinned go-git even pre-fix (its open path is read-only); its job
+// is catching a future go-git bump that reintroduces open-time config writes.
+func TestPlainOpenTolerant_PreservesSourceConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git init")
+	}
+	dir, _ := initGitRepo(t, 1)
+	cfgPath, snapshot := bugReportConfigShape(t, dir)
+
+	repo, err := plainOpenTolerant(dir)
+	require.NoError(t, err)
+	head, err := repo.Head()
+	require.NoError(t, err)
+	commit, err := repo.CommitObject(head.Hash())
+	require.NoError(t, err)
+	_, err = repo.TreeObject(commit.TreeHash) // touch the object store like a real index
+	require.NoError(t, err)
+	require.NoError(t, repo.Close())
+
+	after, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(snapshot), string(after),
+		"plainOpenTolerant must not rewrite .git/config (#819)")
+}
+
+// TestGuardedOpen_LinkedWorktree_PreservesSharedConfig covers the reporter's
+// actual environment: a linked git worktree whose shared main .git/config is
+// the file that got corrupted. Both the resolve-then-open path and a direct
+// GuardedPlainOpen on the worktree dir must leave the shared config AND the
+// per-worktree config.worktree byte-identical.
+func TestGuardedOpen_LinkedWorktree_PreservesSharedConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git worktree operations")
+	}
+	mainDir, _ := initGitRepo(t, 1)
+
+	gitEnv := append(os.Environ(), // safe: git in temp dir, not ox subprocess
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+	runGit := func(cwd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = cwd
+		cmd.Env = gitEnv
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	wtDir := filepath.Join(t.TempDir(), "wt")
+	runGit(mainDir, "worktree", "add", wtDir)
+	// Enable the worktreeConfig extension (requires format version 1), then set
+	// a --worktree value so the per-worktree config.worktree file exists — the
+	// exact shape whose extension the #819 rewrite dropped.
+	runGit(mainDir, "config", "core.repositoryformatversion", "1")
+	runGit(mainDir, "config", "extensions.worktreeConfig", "true")
+	runGit(wtDir, "config", "--worktree", "core.bare", "false")
+
+	mainCfg := filepath.Join(mainDir, ".git", "config")
+	mainSnap, err := os.ReadFile(mainCfg)
+	require.NoError(t, err)
+	wtCfgPath := filepath.Join(mainDir, ".git", "worktrees", filepath.Base(wtDir), "config.worktree")
+	wtSnap, err := os.ReadFile(wtCfgPath)
+	require.NoError(t, err)
+
+	assertUnchanged := func(label string, open func() (*git.Repository, error)) {
+		repo, err := open()
+		require.NoError(t, err, label)
+		// drive a config write; the guard must swallow it
+		if cfg, cerr := repo.Storer.Config(); cerr == nil {
+			cfg.Core.IsBare = true
+			_ = repo.Storer.SetConfig(cfg)
+		}
+		require.NoError(t, repo.Close())
+
+		got, err := os.ReadFile(mainCfg)
+		require.NoError(t, err)
+		assert.Equal(t, string(mainSnap), string(got), "%s: shared .git/config changed", label)
+		gotWt, err := os.ReadFile(wtCfgPath)
+		require.NoError(t, err)
+		assert.Equal(t, string(wtSnap), string(gotWt), "%s: config.worktree changed", label)
+	}
+
+	// (a) codedb's path: resolveGitDir(worktree) → main root → plainOpenTolerant.
+	openPath, isWorktree := resolveGitDir(wtDir)
+	assert.True(t, isWorktree, "wtDir must be detected as a linked worktree")
+	assertUnchanged("resolve+plainOpenTolerant", func() (*git.Repository, error) {
+		return plainOpenTolerant(openPath)
+	})
+	// (b) direct GuardedPlainOpen on the worktree dir.
+	assertUnchanged("GuardedPlainOpen(worktree)", func() (*git.Repository, error) {
+		return gitopen.GuardedPlainOpen(wtDir)
+	})
+}

--- a/internal/codedb/index/gogit_readonly_config_test.go
+++ b/internal/codedb/index/gogit_readonly_config_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +16,24 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sageox/ox/internal/codedb/gitopen"
+	"github.com/sageox/ox/internal/codedb/store"
 )
+
+// gitRunner returns a helper that runs git in cwd with a deterministic identity.
+func gitRunner(t *testing.T) func(cwd string, args ...string) {
+	t.Helper()
+	env := append(os.Environ(), // safe: git in temp dir, not ox subprocess
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+	return func(cwd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = cwd
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+}
 
 // Failure prevented: the daemon rewriting a managed source repo's .git/config
 // (flipping core.bare, dropping extensions.worktreeConfig) when codedb opens it
@@ -91,8 +109,9 @@ func TestReadOnlyConfigStorer_NeverWritesSourceConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, string(snapshot), string(corrupted),
 		"sanity: unguarded go-git SetConfig rewrites .git/config (the #819 hazard)")
-	assert.Contains(t, string(corrupted), "bare = true",
-		"unguarded write flips core.bare — exactly what broke the reporter's checkout")
+	require.Contains(t, string(snapshot), "bare = false", "fixture precondition")
+	assert.NotContains(t, string(corrupted), "bare = false",
+		"unguarded write flipped core.bare away from false — exactly what broke the reporter's checkout")
 }
 
 // TestPlainOpenTolerant_PreservesSourceConfig exercises the production open path
@@ -166,11 +185,12 @@ func TestGuardedOpen_LinkedWorktree_PreservesSharedConfig(t *testing.T) {
 	assertUnchanged := func(label string, open func() (*git.Repository, error)) {
 		repo, err := open()
 		require.NoError(t, err, label)
-		// drive a config write; the guard must swallow it
-		if cfg, cerr := repo.Storer.Config(); cerr == nil {
-			cfg.Core.IsBare = true
-			_ = repo.Storer.SetConfig(cfg)
-		}
+		// drive a config write; the guard must swallow it. require (not if) so a
+		// Config() error can't make this assertion pass vacuously.
+		cfg, cerr := repo.Storer.Config()
+		require.NoError(t, cerr, label)
+		cfg.Core.IsBare = true
+		require.NoError(t, repo.Storer.SetConfig(cfg), label)
 		require.NoError(t, repo.Close())
 
 		got, err := os.ReadFile(mainCfg)
@@ -191,4 +211,98 @@ func TestGuardedOpen_LinkedWorktree_PreservesSharedConfig(t *testing.T) {
 	assertUnchanged("GuardedPlainOpen(worktree)", func() (*git.Repository, error) {
 		return gitopen.GuardedPlainOpen(wtDir)
 	})
+}
+
+// TestIndexLocalRepo_PreservesWorktreeConfig drives the REAL production pipeline
+// (IndexLocalRepo over a linked worktree) and asserts it never rewrites the
+// shared .git/config or config.worktree. On the pinned go-git this open path is
+// read-only, so it is green with and without the guard — it is a sentinel that
+// fails loudly if a future go-git bump reintroduces open-time config writes on
+// the production path (the #819 class). The version-independent proof that the
+// guard itself works is TestReadOnlyConfigStorer_NeverWritesSourceConfig.
+func TestIndexLocalRepo_PreservesWorktreeConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git worktree + indexing")
+	}
+	mainDir, _ := initGitRepo(t, 3)
+	worktreeDir := createLinkedWorktree(t, mainDir, "idx-cfg-branch")
+
+	runGit := gitRunner(t)
+	runGit(mainDir, "config", "core.repositoryformatversion", "1")
+	runGit(mainDir, "config", "extensions.worktreeConfig", "true")
+	runGit(worktreeDir, "config", "--worktree", "core.bare", "false")
+
+	mainCfg := filepath.Join(mainDir, ".git", "config")
+	mainSnap, err := os.ReadFile(mainCfg)
+	require.NoError(t, err)
+	wtCfg := filepath.Join(mainDir, ".git", "worktrees", filepath.Base(worktreeDir), "config.worktree")
+	wtSnap, err := os.ReadFile(wtCfg)
+	require.NoError(t, err)
+
+	dataDir := filepath.Join(t.TempDir(), "codedb")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	s, err := store.Open(dataDir)
+	require.NoError(t, err)
+	defer s.Close()
+
+	require.NoError(t, IndexLocalRepo(context.Background(), s, worktreeDir, IndexOptions{}))
+
+	got, err := os.ReadFile(mainCfg)
+	require.NoError(t, err)
+	assert.Equal(t, string(mainSnap), string(got), "IndexLocalRepo rewrote the shared .git/config")
+	gotWt, err := os.ReadFile(wtCfg)
+	require.NoError(t, err)
+	assert.Equal(t, string(wtSnap), string(gotWt), "IndexLocalRepo rewrote config.worktree")
+}
+
+// TestGuardedOpen_Submodule_PreservesConfig covers the .git-is-a-file submodule
+// layout: its gitdir (.git/modules/<name>) is self-contained (no commondir), so
+// ResolveGitDir does not remap it. Before the fix, GuardedPlainOpen fell through
+// to an unguarded git.PlainOpen for this shape, leaving the submodule's config
+// writable. Found by adversarial review of #819.
+func TestGuardedOpen_Submodule_PreservesConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git submodule operations")
+	}
+	subSrc, _ := initGitRepo(t, 2)
+	mainDir, _ := initGitRepo(t, 1)
+
+	runGit := gitRunner(t)
+	// local-path submodules need protocol.file.allow=always on modern git
+	runGit(mainDir, "-c", "protocol.file.allow=always", "submodule", "add", subSrc, "sub")
+	runGit(mainDir, "-c", "protocol.file.allow=always", "commit", "-m", "add submodule")
+
+	subPath := filepath.Join(mainDir, "sub")
+	require.FileExists(t, filepath.Join(subPath, ".git")) // .git is a FILE for a submodule
+	subCfg := filepath.Join(mainDir, ".git", "modules", "sub", "config")
+	require.FileExists(t, subCfg)
+
+	// give the submodule config the bug shape and snapshot it
+	base, err := os.ReadFile(subCfg)
+	require.NoError(t, err)
+	aug := replaceFormatVersion(string(base)+
+		"\n[filter \"git-crypt\"]\n\tsmudge = \"git-crypt\" smudge\n", "1")
+	require.NoError(t, os.WriteFile(subCfg, []byte(aug), 0o644))
+	snap, err := os.ReadFile(subCfg)
+	require.NoError(t, err)
+
+	// sanity: this is NOT a linked worktree, so it must go through the submodule
+	// guard branch (not ResolveGitDir's remap).
+	_, isWorktree := resolveGitDir(subPath)
+	assert.False(t, isWorktree, "submodule must not be classified as a linked worktree")
+
+	repo, err := gitopen.GuardedPlainOpen(subPath)
+	require.NoError(t, err)
+	cfg, err := repo.Storer.Config()
+	require.NoError(t, err)
+	cfg.Core.IsBare = true
+	require.NoError(t, repo.Storer.SetConfig(cfg)) // denied → no-op
+	require.NoError(t, repo.Close())
+
+	after, err := os.ReadFile(subCfg)
+	require.NoError(t, err)
+	assert.Equal(t, string(snap), string(after),
+		"submodule .git/modules/<name>/config must be byte-identical (#819)")
 }

--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/sageox/ox/internal/codedb/comments"
 	"github.com/sageox/ox/internal/codedb/diffformat"
+	"github.com/sageox/ox/internal/codedb/gitopen"
 	"github.com/sageox/ox/internal/codedb/language"
 	codedbsqlc "github.com/sageox/ox/internal/codedb/sqlc"
 	"github.com/sageox/ox/internal/codedb/store"
@@ -759,44 +760,11 @@ func resolveDefaultBranchGit(repoPath string) (refInfo, error) {
 }
 
 // resolveGitDir returns the path to open with go-git and whether it's a linked
-// worktree. For linked worktrees (where .git is a file containing "gitdir: ..."),
-// it follows the pointer to the main repo's .git directory so go-git can access
-// the shared object store. For normal repos, returns the path unchanged.
+// worktree. Thin alias over gitopen.ResolveGitDir, which is the single source of
+// truth (shared with the store package's guarded blob-repo open). See there for
+// the linked-worktree/commondir resolution.
 func resolveGitDir(repoPath string) (string, bool) {
-	dotGit := filepath.Join(repoPath, ".git")
-	info, err := os.Lstat(dotGit)
-	if err != nil || info.IsDir() {
-		return repoPath, false // normal repo or no .git
-	}
-
-	// .git is a file → linked worktree, read "gitdir: <path>"
-	content, err := os.ReadFile(dotGit)
-	if err != nil {
-		return repoPath, false
-	}
-	line := strings.TrimSpace(string(content))
-	if !strings.HasPrefix(line, "gitdir: ") {
-		return repoPath, false
-	}
-	worktreeGitDir := strings.TrimPrefix(line, "gitdir: ")
-	if !filepath.IsAbs(worktreeGitDir) {
-		worktreeGitDir = filepath.Join(repoPath, worktreeGitDir)
-	}
-
-	// read commondir to find the shared .git (e.g., "../.." → main .git)
-	commondirFile := filepath.Join(worktreeGitDir, "commondir")
-	commondirBytes, err := os.ReadFile(commondirFile)
-	if err != nil {
-		return repoPath, false
-	}
-	commondir := strings.TrimSpace(string(commondirBytes))
-	if !filepath.IsAbs(commondir) {
-		commondir = filepath.Join(worktreeGitDir, commondir)
-	}
-
-	// commondir points to the main .git dir; the repo root is its parent
-	mainRepoRoot := filepath.Dir(commondir)
-	return mainRepoRoot, true
+	return gitopen.ResolveGitDir(repoPath)
 }
 
 // walkNewCommits discovers commits reachable from tip that aren't in knownCommits.

--- a/internal/codedb/store/blob_reader.go
+++ b/internal/codedb/store/blob_reader.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/sageox/ox/internal/codedb/gitopen"
 )
 
 // maxReadBlobBytes caps blob reads at the search read path. Files larger than
@@ -92,7 +94,9 @@ func (s *Store) initBlobRepos() {
 	_ = rows.Close()
 
 	for _, p := range paths {
-		repo, err := git.PlainOpen(p)
+		// GuardedPlainOpen: the repos table holds source-checkout paths too, and
+		// go-git must never rewrite a managed source repo's .git/config (#819).
+		repo, err := gitopen.GuardedPlainOpen(p)
 		if err != nil {
 			slog.Warn("blob reader: open repo failed", "path", p, "err", err)
 			continue

--- a/internal/codedb/store/blob_reader_test.go
+++ b/internal/codedb/store/blob_reader_test.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadBlob_GuardedOpen_ReadsBlobsAndPreservesConfig proves blob_reader opens
+// source checkouts via gitopen.GuardedPlainOpen. Two guarantees:
+//  1. blobs are still readable through the guarded/wrapped storer — the guard
+//     must not break reads;
+//  2. reading a blob from a source checkout never rewrites its .git/config —
+//     the #819 invariant, at the blob_reader call site specifically.
+//
+// Reverting blob_reader.go to a raw git.PlainOpen on a writing go-git version
+// would fail guarantee (2); a guard that broke object reads would fail (1).
+func TestReadBlob_GuardedOpen_ReadsBlobsAndPreservesConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: builds a real git repository")
+	}
+
+	repoDir := t.TempDir()
+	env := append(os.Environ(), // safe: git in temp dir, not ox subprocess
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+	runGit := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+		return strings.TrimSpace(string(out))
+	}
+	runGit("init", "-b", "main")
+	content := "package sample\n\nfunc Sample() {}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "sample.go"), []byte(content), 0o644))
+	runGit("add", "sample.go")
+	runGit("commit", "-m", "init")
+	blobHash := runGit("rev-parse", "HEAD:sample.go")
+
+	// Give the checkout config the #819 shape (a git-crypt filter with quoted
+	// values that a lossy re-marshal would re-quote) and snapshot it.
+	cfgPath := filepath.Join(repoDir, ".git", "config")
+	base, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(string(base)+
+		"[filter \"git-crypt\"]\n\tsmudge = \"git-crypt\" smudge\n"), 0o644))
+	snap, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+
+	s, err := Open(t.TempDir())
+	require.NoError(t, err)
+	defer s.Close()
+	_, err = s.Exec("INSERT INTO repos (name, path) VALUES (?, ?)", "sample", repoDir)
+	require.NoError(t, err)
+
+	got := s.ReadBlob(blobHash)
+	assert.Equal(t, content, string(got),
+		"ReadBlob must return the committed blob content through the guarded open")
+
+	after, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(snap), string(after),
+		"ReadBlob must not rewrite the source repo's .git/config (#819)")
+}

--- a/internal/codedb/store/blob_reader_test.go
+++ b/internal/codedb/store/blob_reader_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sageox/ox/internal/testguard"
 )
 
 // TestReadBlob_GuardedOpen_ReadsBlobsAndPreservesConfig proves blob_reader opens
@@ -26,12 +28,18 @@ func TestReadBlob_GuardedOpen_ReadsBlobsAndPreservesConfig(t *testing.T) {
 	}
 
 	repoDir := t.TempDir()
-	env := append(os.Environ(), // safe: git in temp dir, not ox subprocess
+	// MinimalEnv (allowlist) strips GIT_DIR/GIT_WORK_TREE/GIT_COMMON_DIR so an
+	// inherited routing var can't retarget git outside repoDir.
+	env := testguard.MinimalEnv([]string{
 		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
-		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai",
+	})
 	runGit := func(args ...string) string {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		// Disable signing so the test is independent of the developer's global
+		// git config (MinimalEnv's clean env can't reach the signing agent).
+		full := append([]string{"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}, args...)
+		cmd := exec.Command("git", full...)
 		cmd.Dir = repoDir
 		cmd.Env = env
 		out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Running the ox daemon on a `git worktree` checkout no longer silently breaks your repo. Previously, a few times a day the daemon would rewrite your **main checkout's `.git/config`** with `core.bare = true` — after which every work-tree command (`git status`, `git pull`) failed with `fatal: this operation must be run in a work tree` until you manually ran `git config core.bare false`. The rewrite also dropped `extensions.worktreeConfig`, so even the per-worktree override didn't stick. This PR makes it structurally impossible for the daemon to write your managed source repo's `.git/config` at all.

Fixes #819.

## What broke

codedb indexes your source checkout in place with go-git. For a linked worktree, `resolveGitDir` follows `commondir` to the **shared main checkout** — the one holding `extensions.worktreeConfig`. go-git v6's config `Marshal` is lossy: it drops unrecognized `[extensions]` subsections and re-encodes `[core]`, and it persists config through `Storer.SetConfig` as a side effect of some open/worktree paths. The result on the reporter's machine: `core.bare` flipped to `true`, `extensions.worktreeConfig` dropped, git-crypt filter quotes re-escaped — the unmistakable signature of a go-git config re-encode landing on a file it should never have touched.

```mermaid
flowchart TD
    A[daemon --repo=&lt;slug&gt;<br/>ProjectRoot = source checkout] --> B[codedb reindex on sync loop]
    B --> C[IndexLocalRepo projectRoot]
    C --> D{linked worktree?}
    D -->|yes| E[resolveGitDir → shared MAIN checkout<br/>holds extensions.worktreeConfig]
    D -->|no| F[source root]
    E --> G[go-git opens the repo in place]
    F --> G
    G --> H["go-git Storer.SetConfig re-encodes .git/config<br/>flips core.bare=true, drops extensions.worktreeConfig"]
    H --> I["main checkout broken:<br/>git status / git pull → 'must be run in a work tree'"]
    style H fill:#c0392b,color:#fff
    style I fill:#c0392b,color:#fff
```

The invariant this restores is already documented in `.claude/rules/daemon-git.md`: **the daemon must never write the managed source repo's `.git/config`.** The bug was an indirect violation via go-git.

## What this PR ships

- **New `internal/codedb/gitopen` package** — the single, dependency-free chokepoint for opening a user-owned repo read-only with go-git:
  - `readOnlyConfigStorer{*filesystem.Storage}` turns `SetConfig` into a **no-op**. Every go-git version persists config only through `Storer.SetConfig`, so this closes the hole regardless of which go-git alpha is pinned or which internal path (open-time, `setIsBare`, `setConfigWorktree`, `Init`) tries to write. Returning `nil` (not an error) keeps an open-time write from aborting indexing.
  - `GuardedPlainOpen(path)` — drop-in for `git.PlainOpen` on user repos: guards normal checkouts, linked worktrees (resolved to the shared main checkout), **and submodules** (`.git`-is-a-file with a self-contained gitdir); falls through to plain open only for bare repos (codedb's own cache), which legitimately carry `core.bare=true` and are not the #819 surface.
  - `ResolveGitDir` moved here as the single source of truth (thin alias kept in `index` for existing callers).
- **Wired into every codedb source-repo open** — `gogit.go` KeepDescriptors fast path (`WrapReadOnlyConfig`) + tolerant fallback (`GuardedPlainOpen`), and `store/blob_reader.go` (the live fallback consumer that opens straight from the `repos` table). The `KeepDescriptors` perf path is untouched — only `config` writes are denied.
- **`make check-codedb-guarded-open`** guard, wired into `test-preflight`: fails the build if any codedb file opens a user repo with raw `git.PlainOpen`/unwrapped `git.Open`, so this can't silently regress.

## Why the storer-level no-op (not a filesystem wrapper)

`Storer.SetConfig` is the one contract through which go-git persists config in every version — a ~5-line override intercepts the identical write set as a billy filesystem wrapper, with zero filesystem surface (no hot-path cost, no Chroot footguns) and a safe failure mode.

## Test Plan

- **Red-first proof (no test theater):** neutering the `SetConfig` override to delegate to the real storer turns the guard tests **red** — the shared worktree `.git/config` shows `bare = false` → `bare = true`, the exact reported corruption. Restoring the no-op returns them green. Both runs verified locally.
- **New regression tests** (`internal/codedb/index/gogit_readonly_config_test.go`, `internal/codedb/store/blob_reader_test.go`):
  - `TestReadOnlyConfigStorer_NeverWritesSourceConfig` — the version-independent proof: guarded `SetConfig` is a no-op (config byte-identical), with a **negative control** proving the unguarded storer flips `core.bare = false` away.
  - `TestPlainOpenTolerant_PreservesSourceConfig` / `TestIndexLocalRepo_PreservesWorktreeConfig` — production-path sentinels: the real open path and the full `IndexLocalRepo` pipeline leave `.git/config` (and `config.worktree`) untouched. Read-only on the pinned go-git, so they exist to fail loudly if a future go-git bump reintroduces open-time writes.
  - `TestGuardedOpen_LinkedWorktree_PreservesSharedConfig` — the reporter's actual environment (linked worktree, shared config + `config.worktree`).
  - `TestGuardedOpen_Submodule_PreservesConfig` — submodule layout; **red-first verified** (neutering the submodule branch corrupts `.git/modules/<name>/config`, re-quoting the git-crypt filter).
  - `TestReadBlob_GuardedOpen_ReadsBlobsAndPreservesConfig` — the `blob_reader` call site: blobs stay readable through the guarded storer **and** config is preserved.
- **Adversarial review:** a test-strategy pass hardened this set — closed the submodule fallthrough (a real code gap), added the production-pipeline + blob_reader tests, removed a vacuous-pass conditional, and de-circularized the negative control.
- **Gates:** `go build ./...` · `go vet ./internal/codedb/...` · `golangci-lint` (repo config) 0 issues · `make check-codedb-guarded-open` · codedb `index` + `store` suites green.

## Scope / follow-ups (filed as issues)

- **Prevention only.** Once this lands, no new corruption occurs; anyone already corrupted still uses the one-line `git config core.bare false`. A separate follow-up adds an `ox doctor` auto-repair for the transient broken state.
- **`CodeDBDataDir` fallback** — codedb can root its store inside the source tree when the ledger identity is unresolved (a distinct hygiene bug found while tracing this). Flagged for review because it changes a path location.
- **`gitutil.StripLFSConfig`** fragile parser — noted, not this bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repository inspection and blob reads from modifying Git configuration files.
  * Improved compatibility with linked worktrees, submodules, and other repository layouts.
  * Preserved access to committed content while keeping source repository configuration unchanged.

* **Tests**
  * Added coverage confirming configuration files remain unchanged during indexing and blob reads.
  * Strengthened validation for safe repository-opening behavior across supported Git layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->