### PR TITLE
Commit HTML plans under 1MiB plain, LFS-gate only above

### DIFF
--- a/cmd/ox/doctor_plan_pointers.go
+++ b/cmd/ox/doctor_plan_pointers.go
@@ -180,7 +180,7 @@ func planPointersMissingOnRemote(client *lfs.Client, pointers []planPointer) []p
 func planPointersWarning(missing []planPointer) checkResult {
 	var sb strings.Builder
 	sb.WriteString("These captured plans have a plan.html LFS pointer whose blob is missing from the content store.\n")
-	sb.WriteString("The bytes were never uploaded (a pre-fix `ox plan save` of a render above 256KB), so the render is ")
+	sb.WriteString("The bytes were never uploaded (a pre-fix `ox plan save` of a render above 1MiB), so the render is ")
 	sb.WriteString("unrecoverable — and the missing blob makes the ledger reject every push.\n")
 	shown := min(len(missing), 5)
 	for _, p := range missing[:shown] {

--- a/cmd/ox/plan_capture_test.go
+++ b/cmd/ox/plan_capture_test.go
@@ -385,7 +385,7 @@ func TestPlanSessionLink_DisabledAttributionExpectsNoLink(t *testing.T) {
 
 // TestSavePlanArtifacts_LargeRenderStaysPlainWhenLFSUnreachable is the #810
 // composition-root fail-safe: driving the REAL savePlanArtifacts path (Save →
-// DehydrateHTML → commit) with a >256KB render and no reachable LFS client, the
+// DehydrateHTML → commit) with a >1MiB render and no reachable LFS client, the
 // committed plan.html must be PLAIN — retrievable and pushable, never a poisoned
 // pointer. This test ledger has no configured remote/credentials, so planLFSClient
 // resolves to nil and dehydration falls back to plain, exactly as an offline save.
@@ -396,7 +396,7 @@ func TestPlanSessionLink_DisabledAttributionExpectsNoLink(t *testing.T) {
 func TestSavePlanArtifacts_LargeRenderStaysPlainWhenLFSUnreachable(t *testing.T) {
 	root := newPlanCaptureTestRepo(t)
 
-	body := strings.Repeat("PRESERVE-ME ", 30000) // well over the 256KB threshold
+	body := strings.Repeat("PRESERVE-ME ", 100000) // ~1.2MiB, well over the 1MiB threshold
 	html := []byte("<html><head></head><body>" + body + "</body></html>")
 
 	dir := savePlanArtifacts(root, plan.Input{Raw: "# Big render\n"}, plan.Result{}, html, plan.PrimaryHTML)
@@ -416,10 +416,10 @@ func TestSavePlanArtifacts_LargeRenderStaysPlainWhenLFSUnreachable(t *testing.T)
 		t.Fatalf("read plan.html: %v", err)
 	}
 	// The FULL render must survive, not just a stray marker: the body repeats the
-	// marker 30000 times and every one must be on disk, plain. dehydrate rewrites
+	// marker 100000 times and every one must be on disk, plain. dehydrate rewrites
 	// plan.html BEFORE commitPlanToLedger stages the working tree, so this on-disk
 	// file is exactly what a commit would carry.
-	if n := bytes.Count(got, []byte("PRESERVE-ME")); n != 30000 {
-		t.Fatalf("plan.html retained %d of 30000 markers — the render was truncated or replaced", n)
+	if n := bytes.Count(got, []byte("PRESERVE-ME")); n != 100000 {
+		t.Fatalf("plan.html retained %d of 100000 markers — the render was truncated or replaced", n)
 	}
 }

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -495,7 +495,7 @@ func CloneWithSparseCheckout(path, remoteURL string) error {
 // data/plans is deliberately unwindowed. Plans are durable artifacts every
 // local read path needs (`ox plan list/view/render/backfill-titles`), and they
 // are tiny: plan.md + annotations.json + events.jsonl, with the only large
-// member (plan.html) LFS-gated above 256 KB. Omitting it made plans
+// member (plan.html) LFS-gated above 1 MiB. Omitting it made plans
 // effectively WRITE-ONLY — `ox plan save` wrote and pushed a plan directory,
 // then the sync scheduler's ~60s ConfigureSparseCheckout refresh deleted it
 // from the working tree again, leaving ledgers with dozens of plans on

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -48,10 +48,14 @@ const (
 	planHTMLFile    = "plan.html"
 
 	// htmlLFSThreshold is the size above which a passed-in plan.html is stored
-	// as an LFS pointer rather than committed plain. ~256KB: base64 imagery and
-	// large rendered plans cross this; a normal text-only render stays well
-	// under it and is kept plain so a dehydrated clone reads it directly.
-	htmlLFSThreshold = 256 * 1024
+	// as an LFS pointer rather than committed plain. 1MiB: a plan is a decision
+	// record read far more often than it is written, and reading it should never
+	// require network — so word-heavy and diagram-heavy HTML plans (up to 1MiB,
+	// which covers essentially every authored plan including inline SVG/Mermaid
+	// and modest base64 imagery) are kept plain so a dehydrated clone reads them
+	// directly. Only genuinely large renders past 1MiB cross to LFS to keep the
+	// git tree from bloating.
+	htmlLFSThreshold = 1024 * 1024
 )
 
 // PlanStatus is the plan's own lifecycle, independent of the producing


### PR DESCRIPTION
## Summary

A saved plan is a decision record read far more often than it is written — and reading one should never require a network round-trip. Before this change, any plan render over **256 KiB** was pushed to LFS, so a fresh dehydrated clone had to hydrate over the network just to read a moderately word-heavy or diagram-heavy HTML plan. This raises the plain-in-git threshold to **1 MiB**, so essentially every authored plan (inline SVG/Mermaid, modest base64 imagery) commits directly into git and reads with zero network. Only genuinely large renders past 1 MiB still cross to LFS to keep the git tree from bloating.

There is no rejection cap and never was — `htmlLFSThreshold` only ever chose *where* `plan.html` is stored, never whether it is accepted. This PR tunes that storage boundary; it does not add, remove, or relax any limit on plan acceptance.

```mermaid
flowchart LR
    A[ox plan save<br/>plan.html] --> B{size ≤ threshold?}
    B -->|yes| C[commit plain in git<br/>dehydrated clone reads directly, no network]
    B -->|no| D[upload blob to LFS<br/>git holds pointer, hydrate on demand]

    subgraph before [before]
      T1[threshold = 256 KiB]
    end
    subgraph after [after]
      T2[threshold = 1 MiB]
    end
```

**What changed**

- **`internal/plan/store.go`** — `htmlLFSThreshold` `256 * 1024` → `1024 * 1024`, with the rationale comment rewritten to explain the read-often / no-network tradeoff.
- **`internal/ledger/ledger.go`** — sparse-checkout comment updated to "LFS-gated above 1 MiB".
- **`cmd/ox/doctor_plan_pointers.go`** — user-facing doctor warning now reads "a render above 1MiB".
- **`cmd/ox/plan_capture_test.go`** — bumped the offline-fail-safe test render from ~360 KiB to ~1.2 MiB (100k markers) so it still exercises the over-threshold path and asserts the full render survives plain (never a poisoned pointer).

The boundary tests in `internal/plan/dehydrate_test.go` ("exactly threshold stays plain", "one over crosses") and `store_test.go` compute their sizes from the `htmlLFSThreshold` constant symbolically, so they track the new value automatically.

**Not breaking:** existing plans are untouched. The only behavior delta is that a *new* plan in the 256 KiB–1 MiB band now commits plain instead of as an LFS pointer. Tradeoff accepted: such a plan lives plain in every dehydrated clone (git-history weight) in exchange for network-free reads — the right call for a decision-record doc.

## Test Plan

- `go build ./...` — clean.
- `go test ./internal/plan/ ./internal/ledger/` — pass (symbolic boundary tests track the new threshold).
- `go test ./cmd/ox/ -run 'TestSavePlanArtifacts_LargeRenderStaysPlainWhenLFSUnreachable|PlanPointers' -v` — pass; the fail-safe test now drives a 1.2 MiB render and confirms all 100000 markers survive plain on disk.
- `gofmt -l` on all four changed files — clean.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — updated the existing over-threshold fail-safe test to exceed 1 MiB; symbolic boundary tests auto-track the constant.
- [x] CHANGELOG entry added (if user-facing) — N/A: internal storage-location tuning, no CLI/flag surface change.
- [x] Breaking change documented — N/A: existing plans untouched; only new 256 KiB–1 MiB plans change storage location.
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: touches none of `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, or `go.sum`.

</details>

Co-authored-by: SageOx <ox@sageox.ai>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790214984&installation_model_id=433550&pr_number=821&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F821&signature=50d12d88d5cabe78e97ed4472a4d5e0b35737c3f6b490f039cf11cf9c1c9791d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Larger plan renders up to 1 MiB now remain available as standard Git files.
  * Renders exceeding 1 MiB continue to use large-file handling, improving reliability for large plans.
  * Updated diagnostics and documentation to reflect the revised size threshold.
  * Expanded validation to confirm that large rendered plans retain all content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->