### PR TITLE
fix(ledger): close the commit-time conflict race (PR #811 follow-up)

### DIFF
--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -1023,20 +1023,20 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 				conflicted, ledgerPath, conflicted, conflicted, conflicted, conflicted))
 	}
 
-	// commit via RunGit: it owns the commit.gpgsign=false override plus the
-	// GIT_TERMINAL_PROMPT=0 / cmd.Dir safeguards, so the auto-commit can't
-	// drift from the managed-git execution contract.
-	out, err := gitutil.RunGit(context.Background(), ledgerPath,
-		"commit", "-m", "ox doctor: auto-commit ledger changes")
+	// Commit the validated index as an immutable tree snapshot so a concurrent
+	// daemon autostash-pop can't stage an unchecked blob between the pre-check
+	// above and the commit (PR #811 validation↔commit TOCTOU). It carries the same
+	// managed-git hardening (gpgsign off, non-interactive, cmd.Dir), runs its own
+	// snapshot scan, and refuses mid-rebase.
+	committed, err := commitLedgerSnapshot(context.Background(), ledgerPath, "ox doctor: auto-commit ledger changes")
 	if err != nil {
-		// "nothing to commit" is fine (race with session auto-stage). RunGit
-		// folds git's output into the error, so check there.
-		if strings.Contains(out, "nothing to commit") || strings.Contains(err.Error(), "nothing to commit") {
-			return PassedCheck("Ledger clean workdir", "clean (already committed)")
-		}
 		return FailedCheck("Ledger clean workdir",
 			"commit failed",
 			fmt.Sprintf("git commit error: %s", strings.TrimSpace(err.Error())))
+	}
+	if !committed {
+		// nothing to commit (race with session auto-stage) is fine.
+		return PassedCheck("Ledger clean workdir", "clean (already committed)")
 	}
 
 	// Commit landed, but flag a partial repair: the inline override saved this

--- a/cmd/ox/ledger_commit_snapshot.go
+++ b/cmd/ox/ledger_commit_snapshot.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sageox/ox/internal/gitutil"
+)
+
+// commitLedgerSnapshot commits the ledger index as an IMMUTABLE, pre-validated
+// tree, closing the validation↔commit TOCTOU that a plain `git add` + validate +
+// `git commit` pair leaves open (PR #811 review, Greptile P1; builds on #749).
+//
+// The old shape validated the index, then ran a separate no-pathspec `git commit`
+// that RE-READ the whole index at commit time. A concurrent daemon
+// `pull --rebase --autostash` can stage an unchecked blob (a stash-pop conflict's
+// markers) into that index in the window between the check and the commit; the
+// commit then persists it.
+//
+// This commits exactly the tree it validated:
+//
+//  1. `git write-tree` snapshots the current index into an immutable tree OID.
+//     write-tree itself FAILS on unmerged (UU/UD) entries, so a live conflict
+//     fails closed here.
+//  2. only the blobs this commit changes vs its parent are scanned for staged
+//     conflict-marker content (an unchanged blob was vetted when first committed;
+//     scanning the whole tree would cost O(repo) and risk flagging historical
+//     content).
+//  3. `git commit-tree` commits that exact tree, and `git update-ref` advances the
+//     branch with a compare-and-swap on the old tip — a concurrent writer that
+//     staged into the index afterward is neither swept into THIS commit nor able
+//     to silently clobber the ref.
+//
+// This is what `git commit` does internally (write-tree → commit-tree →
+// update-ref); the only difference is the validation inserted in the middle and
+// the immutability of the committed tree. Hooks are already bypassed on these
+// paths (`--no-verify` previously), so committing via plumbing loses nothing.
+//
+// Returns committed=false with nil error when there is nothing to commit (the
+// snapshot tree equals the parent's tree) — matching the old "nothing to commit"
+// idempotency the callers rely on.
+func commitLedgerSnapshot(ctx context.Context, ledgerPath, message string) (committed bool, err error) {
+	// Never mutate the ledger mid-rebase: moving the branch ref under a rebase
+	// consumes the replay step (see .claude/rules/cache-only-design.md).
+	if err := gitutil.IsSafeForGitOps(ledgerPath); err != nil {
+		return false, fmt.Errorf("unsafe to commit ledger: %w", err)
+	}
+
+	tree, parent, err := snapshotLedgerIndexTree(ctx, ledgerPath)
+	if err != nil {
+		return false, err
+	}
+
+	// nothing to commit: the snapshot is identical to the parent's tree.
+	if parent != "" {
+		if parentTree, terr := ledgerTreeOfCommit(ctx, ledgerPath, parent); terr == nil && parentTree == tree {
+			return false, nil
+		}
+	}
+
+	if bad, serr := firstConflictMarkerInTree(ctx, ledgerPath, parent, tree); serr != nil {
+		return false, serr
+	} else if bad != "" {
+		return false, fmt.Errorf("refusing to commit %s: contains an unresolved conflict "+
+			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", bad)
+	}
+
+	if err := commitTreeToBranch(ctx, ledgerPath, tree, parent, message); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// snapshotLedgerIndexTree writes the current index to an immutable tree and
+// returns that tree OID plus the current branch tip (parent), which is "" on an
+// unborn branch. `git write-tree` errors on unmerged index entries, so a live
+// conflict is surfaced as an error here (fail closed).
+func snapshotLedgerIndexTree(ctx context.Context, ledgerPath string) (tree, parent string, err error) {
+	tb, err := ledgerGit(ctx, ledgerPath, "write-tree")
+	if err != nil {
+		return "", "", fmt.Errorf("snapshot ledger index (unresolved conflict in index?): %w", err)
+	}
+	tree = strings.TrimSpace(string(tb))
+	if tree == "" {
+		return "", "", fmt.Errorf("git write-tree returned an empty tree")
+	}
+	// --verify --quiet HEAD exits nonzero (=> err) on an unborn branch; parent
+	// stays "" for the first-commit case.
+	if pb, perr := ledgerGit(ctx, ledgerPath, "rev-parse", "--verify", "--quiet", "HEAD"); perr == nil {
+		parent = strings.TrimSpace(string(pb))
+	}
+	return tree, parent, nil
+}
+
+// ledgerTreeOfCommit resolves a commit-ish to its tree OID.
+func ledgerTreeOfCommit(ctx context.Context, ledgerPath, commit string) (string, error) {
+	b, err := ledgerGit(ctx, ledgerPath, "rev-parse", "--verify", commit+"^{tree}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// firstConflictMarkerInTree returns the first path in `tree` (among the blobs it
+// changes vs `parent`) whose committed content carries a git conflict marker, or
+// "" if none. On an unborn branch (parent == "") every blob is new, so the whole
+// tree is scanned.
+func firstConflictMarkerInTree(ctx context.Context, ledgerPath, parent, tree string) (string, error) {
+	if parent == "" {
+		raw, err := ledgerGit(ctx, ledgerPath, "ls-tree", "-r", "-z", tree)
+		if err != nil {
+			return "", fmt.Errorf("git ls-tree: %w", err)
+		}
+		return firstMarkerInLsTree(ctx, ledgerPath, raw)
+	}
+	// no rename/copy detection (no -M/-C) => every record is meta + one path.
+	raw, err := ledgerGit(ctx, ledgerPath, "diff-tree", "-r", "-z", parent, tree)
+	if err != nil {
+		return "", fmt.Errorf("git diff-tree: %w", err)
+	}
+	return firstMarkerInDiffTree(ctx, ledgerPath, raw)
+}
+
+// firstMarkerInDiffTree parses `git diff-tree -r -z` raw output. Each entry is a
+// metadata token ":<srcmode> <dstmode> <srcsha> <dstsha> <status>" followed by a
+// path token. Deletions (status D) have no blob to inspect.
+func firstMarkerInDiffTree(ctx context.Context, ledgerPath string, raw []byte) (string, error) {
+	toks := splitNULBytes(raw)
+	for i := 0; i+1 < len(toks); i += 2 {
+		fields := strings.Fields(strings.TrimPrefix(toks[i], ":"))
+		path := toks[i+1]
+		if len(fields) < 4 {
+			continue
+		}
+		dstSHA := fields[3]
+		status := ""
+		if len(fields) >= 5 {
+			status = fields[4]
+		}
+		if strings.HasPrefix(status, "D") || isAllZero(dstSHA) {
+			continue // deleted from the tree — no blob to inspect
+		}
+		if marker, err := blobHasMarker(ctx, ledgerPath, dstSHA, path); err != nil {
+			return "", err
+		} else if marker {
+			return path, nil
+		}
+	}
+	return "", nil
+}
+
+// firstMarkerInLsTree parses `git ls-tree -r -z` output ("<mode> <type> <sha>\t<path>").
+func firstMarkerInLsTree(ctx context.Context, ledgerPath string, raw []byte) (string, error) {
+	for _, rec := range splitNULBytes(raw) {
+		tab := strings.IndexByte(rec, '\t')
+		if tab < 0 {
+			continue
+		}
+		fields := strings.Fields(rec[:tab])
+		path := rec[tab+1:]
+		if len(fields) < 3 || fields[1] != "blob" {
+			continue
+		}
+		if marker, err := blobHasMarker(ctx, ledgerPath, fields[2], path); err != nil {
+			return "", err
+		} else if marker {
+			return path, nil
+		}
+	}
+	return "", nil
+}
+
+// blobHasMarker reads a blob by OID and reports whether it carries a conflict
+// marker. An unreadable blob is an error (fail closed) — an inaccessible blob is
+// not proof it is safe.
+func blobHasMarker(ctx context.Context, ledgerPath, oid, path string) (bool, error) {
+	blob, err := ledgerGit(ctx, ledgerPath, "cat-file", "blob", oid)
+	if err != nil {
+		return false, fmt.Errorf("inspect staged blob %s: %w", path, err)
+	}
+	return gitutil.HasConflictMarkersBytes(blob), nil
+}
+
+// commitTreeToBranch commits an already-validated tree and advances the current
+// branch ref with a compare-and-swap on its old value, so a concurrent commit
+// fails this update rather than being silently overwritten.
+func commitTreeToBranch(ctx context.Context, ledgerPath, tree, parent, message string) error {
+	args := []string{"commit-tree", tree, "-m", message}
+	if parent != "" {
+		args = append(args, "-p", parent)
+	}
+	cb, err := ledgerGit(ctx, ledgerPath, args...)
+	if err != nil {
+		return fmt.Errorf("git commit-tree: %w", err)
+	}
+	commit := strings.TrimSpace(string(cb))
+	if commit == "" {
+		return fmt.Errorf("git commit-tree returned an empty commit")
+	}
+
+	refBytes, err := ledgerGit(ctx, ledgerPath, "symbolic-ref", "HEAD")
+	if err != nil {
+		return fmt.Errorf("resolve HEAD ref: %w", err)
+	}
+	branchRef := strings.TrimSpace(string(refBytes))
+
+	upd := []string{"update-ref", "-m", "ox: " + message, branchRef, commit}
+	if parent != "" {
+		upd = append(upd, parent) // CAS: only advance if the tip is still `parent`
+	}
+	if _, err := ledgerGit(ctx, ledgerPath, upd...); err != nil {
+		return fmt.Errorf("advance %s (concurrent ledger commit?): %w", branchRef, err)
+	}
+	return nil
+}
+
+// ledgerGit runs a git plumbing command against the ledger with the same
+// non-interactive / locale-pinned hardening as gitutil.RunGit, but returns CLEAN
+// stdout bytes (RunGit merges stderr, which would corrupt an OID or a binary
+// blob). commit.gpgsign=false is mirrored for parity; the plumbing here does not
+// sign, so it is a harmless no-op.
+func ledgerGit(ctx context.Context, ledgerPath string, args ...string) ([]byte, error) {
+	full := []string{"-C", ledgerPath, "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}
+	full = append(full, args...)
+
+	cmd := exec.CommandContext(ctx, "git", full...)
+	cmd.Dir = ledgerPath
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C", "LANG=C")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		sub := "git"
+		if len(args) > 0 {
+			sub = args[0]
+		}
+		return nil, fmt.Errorf("git %s: %w: %s", sub, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// splitNULBytes splits NUL-delimited git output into records, dropping the
+// trailing empty element.
+func splitNULBytes(b []byte) []string {
+	s := strings.TrimRight(string(b), "\x00")
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\x00")
+}
+
+// isAllZero reports whether a git OID is the all-zeros null OID (a deletion's
+// destination).
+func isAllZero(oid string) bool {
+	return oid != "" && strings.Trim(oid, "0") == ""
+}

--- a/cmd/ox/ledger_commit_snapshot_test.go
+++ b/cmd/ox/ledger_commit_snapshot_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newLedgerTestRepo makes a real git repo with a base commit and repo-local
+// identity, so the production commit plumbing (ledgerGit, which reads repo/global
+// config rather than the test's scrubbed env) has an author/committer.
+func newLedgerTestRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	mustRunGit(t, repo, "config", "user.name", "Test")
+	mustRunGit(t, repo, "config", "user.email", "test@example.com")
+	mustRunGit(t, repo, "config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "base.txt"), []byte("base\n"), 0644))
+	mustRunGit(t, repo, "add", "base.txt")
+	mustRunGit(t, repo, "commit", "-m", "base")
+	return repo
+}
+
+const conflictBlob = "{\n<<<<<<< ours\n  \"n\": 1,\n=======\n  \"n\": 2,\n>>>>>>> theirs\n}\n"
+
+// TestCommitLedgerSnapshot_IgnoresBlobStagedAfterSnapshot is the load-bearing
+// regression for the PR #811 validation↔commit TOCTOU (Greptile P1). It
+// reproduces the exact interleaving proven there: a second writer stages a
+// conflict-marker blob AFTER the index is snapshotted but before the commit. The
+// immutable-tree commit must persist only the snapshot, never that later blob.
+//
+// Failure prevented: a concurrent daemon `pull --rebase --autostash` stages
+// markers between validate and commit, and the old whole-index `git commit`
+// re-reads the index at commit time and bakes them into the ledger.
+func TestCommitLedgerSnapshot_IgnoresBlobStagedAfterSnapshot(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+	ctx := context.Background()
+
+	// our own clean change, staged
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "ours.txt"), []byte("clean\n"), 0644))
+	mustRunGit(t, repo, "add", "ours.txt")
+
+	// snapshot the index — this is the validation point
+	tree, parent, err := snapshotLedgerIndexTree(ctx, repo)
+	require.NoError(t, err)
+
+	// SECOND WRITER stages a conflict-marker blob AFTER the snapshot
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "intruder.txt"), []byte(conflictBlob), 0644))
+	mustRunGit(t, repo, "add", "intruder.txt")
+
+	// commit the SNAPSHOT tree
+	require.NoError(t, commitTreeToBranch(ctx, repo, tree, parent, "session: X"))
+
+	// HEAD carries our clean change, NOT the after-snapshot intruder
+	head, err := runIsolatedGit(t, repo, "ls-tree", "-r", "--name-only", "HEAD")
+	require.NoError(t, err)
+	assert.Contains(t, head, "ours.txt")
+	assert.NotContains(t, head, "intruder.txt",
+		"a blob staged after the snapshot must not be swept into the commit")
+
+	// the intruder is not lost — it remains staged for its own future commit
+	staged, err := runIsolatedGit(t, repo, "diff", "--cached", "--name-only")
+	require.NoError(t, err)
+	assert.Contains(t, staged, "intruder.txt",
+		"the second writer's staged blob must survive, not be swallowed")
+}
+
+// TestCommitLedgerSnapshot_RefusesMarkerAlreadyStaged proves the snapshot scan
+// catches staged marker content (the non-racy case): a resolved-but-marker blob
+// already in the index is refused, and nothing is committed.
+func TestCommitLedgerSnapshot_RefusesMarkerAlreadyStaged(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+	ctx := context.Background()
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "meta.json"), []byte(conflictBlob), 0644))
+	mustRunGit(t, repo, "add", "meta.json")
+
+	committed, err := commitLedgerSnapshot(ctx, repo, "session: X")
+	require.Error(t, err)
+	assert.False(t, committed)
+	assert.Contains(t, err.Error(), "unresolved conflict")
+
+	log, gerr := runIsolatedGit(t, repo, "log", "--oneline")
+	require.NoError(t, gerr)
+	assert.Equal(t, 1, countLines(log), "no commit should have been created")
+}
+
+// TestCommitLedgerSnapshot_RefusesUnmergedIndex proves an unmerged (UU) index —
+// a live conflict — is refused: `git write-tree` cannot snapshot unmerged entries,
+// so the snapshot itself fails closed.
+func TestCommitLedgerSnapshot_RefusesUnmergedIndex(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+	ctx := context.Background()
+
+	mustRunGit(t, repo, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "base.txt"), []byte("feature\n"), 0644))
+	mustRunGit(t, repo, "commit", "-am", "feature change")
+	mustRunGit(t, repo, "checkout", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "base.txt"), []byte("mainline\n"), 0644))
+	mustRunGit(t, repo, "commit", "-am", "main change")
+
+	_, merr := runIsolatedGit(t, repo, "merge", "feature")
+	require.Error(t, merr, "merge must conflict to produce the UU wedge")
+
+	committed, err := commitLedgerSnapshot(ctx, repo, "session: X")
+	require.Error(t, err)
+	assert.False(t, committed)
+}
+
+// TestCommitLedgerSnapshot_NothingToCommit proves idempotency: a clean index
+// identical to HEAD reports committed=false with no error and no new commit.
+func TestCommitLedgerSnapshot_NothingToCommit(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+
+	committed, err := commitLedgerSnapshot(context.Background(), repo, "session: X")
+	require.NoError(t, err)
+	assert.False(t, committed)
+
+	log, _ := runIsolatedGit(t, repo, "log", "--oneline")
+	assert.Equal(t, 1, countLines(log))
+}
+
+// TestCommitLedgerSnapshot_CommitsCleanIndex proves the happy path: a clean
+// staged change is committed with the given subject and advances the branch.
+func TestCommitLedgerSnapshot_CommitsCleanIndex(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "new.txt"), []byte("hi\n"), 0644))
+	mustRunGit(t, repo, "add", "new.txt")
+
+	committed, err := commitLedgerSnapshot(context.Background(), repo, "session: abc")
+	require.NoError(t, err)
+	assert.True(t, committed)
+
+	subj, _ := runIsolatedGit(t, repo, "log", "-1", "--format=%s")
+	assert.Equal(t, "session: abc", subj)
+	files, _ := runIsolatedGit(t, repo, "ls-tree", "-r", "--name-only", "HEAD")
+	assert.Contains(t, files, "new.txt")
+}
+
+// TestCommitLedgerSnapshot_CleanRenameCommits proves a clean staged rename is not
+// false-flagged as a conflict (diff-tree emits delete+add, both clean).
+func TestCommitLedgerSnapshot_CleanRenameCommits(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+
+	mustRunGit(t, repo, "mv", "base.txt", "renamed.txt")
+
+	committed, err := commitLedgerSnapshot(context.Background(), repo, "rename")
+	require.NoError(t, err, "a clean rename must not be flagged as a conflict")
+	assert.True(t, committed)
+
+	files, _ := runIsolatedGit(t, repo, "ls-tree", "-r", "--name-only", "HEAD")
+	assert.Contains(t, files, "renamed.txt")
+	assert.NotContains(t, files, "base.txt")
+}
+
+// TestCommitTreeToBranch_RefusesWhenBranchAdvanced proves the compare-and-swap:
+// if the branch tip moves between the snapshot and the ref update (another writer
+// committed), the update fails rather than clobbering their commit.
+func TestCommitTreeToBranch_RefusesWhenBranchAdvanced(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+	ctx := context.Background()
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "ours.txt"), []byte("ours\n"), 0644))
+	mustRunGit(t, repo, "add", "ours.txt")
+	tree, parent, err := snapshotLedgerIndexTree(ctx, repo)
+	require.NoError(t, err)
+
+	// a concurrent writer advances the branch tip away from `parent`
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "other.txt"), []byte("other\n"), 0644))
+	mustRunGit(t, repo, "add", "other.txt")
+	mustRunGit(t, repo, "commit", "-m", "concurrent")
+
+	err = commitTreeToBranch(ctx, repo, tree, parent, "ours")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "concurrent")
+}
+
+func countLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	n := 1
+	for _, r := range s {
+		if r == '\n' {
+			n++
+		}
+	}
+	return n
+}

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -313,29 +313,20 @@ func commitAndPushLedger(ledgerPath, sessionName string) error {
 		return fmt.Errorf("git add failed: %s: %w", string(output), err)
 	}
 
-	// Refuse to commit if anything now staged — not just the files this call
-	// intended to add — still carries an unresolved conflict. `git commit`
-	// below has no pathspec, so it commits the WHOLE index. A concurrent
-	// daemon `pull --rebase --autostash` can leave a stash-pop conflict with
-	// no MERGE_HEAD-style marker to detect it by, and `git add` does not
-	// refuse a conflicted path on its own — it stages the markers as if
-	// resolved. See #749.
-	if conflicted, err := firstUnstageableFileInIndex(ledgerPath); err != nil {
-		return fmt.Errorf("checking for unresolved conflicts: %w", err)
-	} else if conflicted != "" {
-		return fmt.Errorf("refusing to commit %s: contains an unresolved conflict "+
-			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", conflicted)
+	// Commit the index as an immutable, pre-validated tree snapshot. The old
+	// shape (validate the index, then a no-pathspec `git commit` that re-reads the
+	// WHOLE index at commit time) left a window where a concurrent daemon
+	// `pull --rebase --autostash` could stage an unchecked conflict blob between
+	// the check and the commit. commitLedgerSnapshot writes the index to an
+	// immutable tree, scans that snapshot, and commits exactly it — so a blob
+	// staged after the snapshot is neither vetted-away nor swept in. See #749 and
+	// the PR #811 review (validation↔commit TOCTOU).
+	committed, err := commitLedgerSnapshot(context.Background(), ledgerPath, fmt.Sprintf("session: %s", sessionName))
+	if err != nil {
+		return fmt.Errorf("committing ledger: %w", err)
 	}
-
-	// commit
-	commitMsg := fmt.Sprintf("session: %s", sessionName)
-	commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "--no-verify", "-m", commitMsg)
-	if output, err := commitCmd.CombinedOutput(); err != nil {
-		// check if nothing to commit
-		if strings.Contains(string(output), "nothing to commit") {
-			return nil
-		}
-		return fmt.Errorf("%s: %w", wrapCommitError(string(output), err), err)
+	if !committed {
+		return nil // nothing to commit
 	}
 
 	// push with pull --rebase retry (up to 3 attempts)
@@ -368,23 +359,15 @@ func commitPointerRewriteAndPush(ledgerPath, sessionName string, pointerPaths []
 		return fmt.Errorf("git add failed: %s: %w", string(output), err)
 	}
 
-	// See the identical guard in commitAndPushLedger above (#749).
-	if conflicted, err := firstUnstageableFileInIndex(ledgerPath); err != nil {
-		return fmt.Errorf("checking for unresolved conflicts: %w", err)
-	} else if conflicted != "" {
-		return fmt.Errorf("refusing to commit %s: contains an unresolved conflict "+
-			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", conflicted)
+	// Same immutable-snapshot commit as commitAndPushLedger (see #749 and the
+	// PR #811 validation↔commit TOCTOU note). Distinct subject so it doesn't
+	// shadow the canonical "session: <name>" commit in git log.
+	committed, err := commitLedgerSnapshot(context.Background(), ledgerPath, fmt.Sprintf("lfs: pointerize %s", sessionName))
+	if err != nil {
+		return fmt.Errorf("committing ledger: %w", err)
 	}
-
-	// commit under a distinct subject so it doesn't shadow the canonical
-	// "session: <name>" commit in git log
-	commitMsg := fmt.Sprintf("lfs: pointerize %s", sessionName)
-	commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "--no-verify", "-m", commitMsg)
-	if output, err := commitCmd.CombinedOutput(); err != nil {
-		if strings.Contains(string(output), "nothing to commit") {
-			return nil
-		}
-		return fmt.Errorf("%s: %w", wrapCommitError(string(output), err), err)
+	if !committed {
+		return nil // nothing to commit
 	}
 
 	// push with pull --rebase retry. If the remote has independently modified


### PR DESCRIPTION
Protects the team **Ledger** from a class of silent corruption: a concurrent daemon sync can no longer sweep unresolved git conflict markers into a session commit. This closes the last open concern from PR #811's review (Greptile's verified P1) — the fix that shipped in #811 stopped the common `#749` case, but left a narrow validation↔commit race the guard couldn't cover.

## What broke

The ledger commit path was `git add` → validate the index (`firstUnstageableFileInIndex`) → `git commit` (no pathspec). But `git commit` is a **separate process that re-reads the whole index at commit time**. In the window between the check and the commit, the daemon's `pull --rebase --autostash` (the exact concurrency `#749` is about) can stage a stash-pop conflict's marker blob into the index — and the commit then persists it into the Ledger. Greptile reproduced this with a real-git interleaving; the committed file contained `<<<<<<< ours`.

```mermaid
sequenceDiagram
  participant CLI as CLI (session stop)
  participant IDX as git index
  participant D as daemon (autostash-pop)
  Note over CLI,D: BEFORE — validate and commit are two processes
  CLI->>IDX: git add --sparse (clean)
  CLI->>IDX: validate → clean ✓
  D-->>IDX: stage marker blob (autostash-pop conflict)
  CLI->>IDX: git commit (re-reads index) ❌ markers persisted
  Note over CLI,D: AFTER — commit exactly the validated snapshot
  CLI->>IDX: git write-tree → immutable tree T
  CLI->>CLI: scan T (changed blobs) → clean ✓
  D-->>IDX: stage marker blob (ignored — not in T)
  CLI->>CLI: git commit-tree T → update-ref (CAS) ✓ only T lands
```

## What this ships

`commitLedgerSnapshot` (`cmd/ox/ledger_commit_snapshot.go`) — commits the index as an **immutable, pre-validated tree**, which is exactly what `git commit` does internally (`write-tree` → `commit-tree` → `update-ref`), with validation inserted in the middle:

- **`git write-tree`** snapshots the index to an immutable tree OID — and *fails closed* on unmerged (`UU`/`UD`) entries, so a live conflict can't be committed.
- **Scan only the blobs this commit changes** vs its parent for staged marker content (an unchanged blob was vetted when first committed; scanning the whole tree would cost O(repo) and risk flagging historical content).
- **`git commit-tree`** commits that exact tree; **`git update-ref` with a compare-and-swap** on the old tip means a concurrent writer that staged afterward is neither swept in nor able to clobber the ref.
- Refuses mid-rebase (`gitutil.IsSafeForGitOps`) per the ledger index-mutation rule; carries the managed-git hardening (gpgsign off, non-interactive, locale-pinned).

Wired into all three ledger commit sites: `commitAndPushLedger`, `commitPointerRewriteAndPush` (session-stop), and doctor's `fixLedgerDirtyWorkdir` (which keeps its rich pre-check message as a fast early-reject). **No daemon changes** — the fix makes the CLI's own commit atomic, so it needs no cross-process lock cooperation.

## Test Plan

`cmd/ox/ledger_commit_snapshot_test.go` (real-git integration):

- **Race (load-bearing):** `TestCommitLedgerSnapshot_IgnoresBlobStagedAfterSnapshot` reproduces Greptile's interleaving — a marker blob staged *after* the snapshot is not in the commit, and is not lost (stays staged for its own commit). **Proven red-first:** sabotaging the snapshot (re-reading the live index at commit time = the old behavior) commits the intruder and the test fails on exactly that assertion.
- Refuses a marker already staged; refuses an unmerged (`UU`) index; idempotent nothing-to-commit; commits a clean index; a clean staged rename is not false-flagged; the compare-and-swap refuses when the branch advanced concurrently.
- `go vet` clean; `gofmt` clean; existing session/doctor/`firstUnstageableFileInIndex` tests still green.
- Note: `TestDoctorSuppression_DaemonNotRunning` flakes under the full parallel run (daemon env state); it passes in isolation on this branch **and** on clean `origin/main` — unrelated to this change.

## Scope note

This touches the ledger commit path — a daemon-CLI-split / required-review area. The change is deliberately self-contained to the CLI commit sites and preserves every existing invariant (LFS pointer commits, mid-rebase refusal, cache-only design). Opened as **draft** for review.

Closes the PR #811 review's outstanding P1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790220126&installation_model_id=433550&pr_number=822&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F822&signature=07dd5998eae2afe68661e2584b5b58c81f71d595b6949e898b85f99ffd92ba90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ledger commits now use a consistent snapshot, preventing later staged changes from being included unexpectedly.
  * Added safeguards against unresolved conflicts and files containing conflict markers.
  * Concurrent no-op commits now complete successfully while genuine errors remain visible.
  * Branch updates are protected from overwriting concurrent changes.

* **Tests**
  * Added coverage for clean commits, renames, no-op operations, conflict handling, snapshot isolation, and concurrent branch updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->