### PR TITLE
fix(decision): length-robust enrich retrieval + honesty signals (#823)

### DIFF
--- a/cmd/ox/decision.go
+++ b/cmd/ox/decision.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/decision"
 	"github.com/spf13/cobra"
 )
@@ -46,7 +47,9 @@ Input modes (precedence order):
   --file <dr.md>        an existing DR (adds drift + ref verification)
   stdin                 a draft to verify before presenting
 
-Output is JSON by default (the agent path). Use --text for a human summary.`,
+Output is JSON by default (the agent path). Use --text for a human summary.
+If any configured source cannot be read, enrich emits a degraded result and
+exits non-zero so callers cannot mistake partial retrieval for a verified miss.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		topic, _ := cmd.Flags().GetString("topic")
 		file, _ := cmd.Flags().GetString("file")
@@ -69,11 +72,19 @@ Output is JSON by default (the agent path). Use --text for a human summary.`,
 		result := decision.Enrich(context.Background(), in, gitRoot, decision.WithExplain(explain))
 
 		if text {
-			return writeDecisionHuman(cmd, result)
+			err = writeDecisionHuman(cmd, result)
+		} else {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			err = enc.Encode(result)
 		}
-		enc := json.NewEncoder(cmd.OutOrStdout())
-		enc.SetIndent("", "  ")
-		return enc.Encode(result)
+		if err != nil {
+			return err
+		}
+		if result.Signals.Degraded {
+			return cli.ErrSilent
+		}
+		return nil
 	},
 }
 

--- a/cmd/ox/decision.go
+++ b/cmd/ox/decision.go
@@ -47,7 +47,7 @@ Input modes (precedence order):
   --file <dr.md>        an existing DR (adds drift + ref verification)
   stdin                 a draft to verify before presenting
 
-Output is JSON by default (the agent path). Use --text for a human summary.
+Output is JSON by default (the AI coworker path). Use --text for a human summary.
 If any configured source cannot be read, enrich emits a degraded result and
 exits non-zero so callers cannot mistake partial retrieval for a verified miss.`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ox/decision.go
+++ b/cmd/ox/decision.go
@@ -123,7 +123,7 @@ func writeDecisionHuman(cmd *cobra.Command, r decision.Result) error {
 		}
 	}
 	if len(r.Dropped) > 0 {
-		fmt.Fprintln(out, "\nDropped (below relevance floor):")
+		fmt.Fprintln(out, "\nDropped candidates:")
 		for _, d := range r.Dropped {
 			label := d.Ref
 			if label == "" {
@@ -149,7 +149,7 @@ func init() {
 	decisionEnrichCmd.Flags().String("topic", "", "consult mode: the DR subject, before drafting")
 	decisionEnrichCmd.Flags().String("file", "", "an existing DR file to enrich (adds drift + ref checks)")
 	decisionEnrichCmd.Flags().Bool("text", false, "human summary instead of JSON")
-	decisionEnrichCmd.Flags().Bool("explain", false, "also list candidates dropped below the relevance floor")
+	decisionEnrichCmd.Flags().Bool("explain", false, "also list candidates omitted by result caps or the relevance floor")
 
 	decisionCmd.AddCommand(decisionEnrichCmd)
 	decisionCmd.GroupID = "dev"

--- a/cmd/ox/decision.go
+++ b/cmd/ox/decision.go
@@ -51,6 +51,7 @@ Output is JSON by default (the agent path). Use --text for a human summary.`,
 		topic, _ := cmd.Flags().GetString("topic")
 		file, _ := cmd.Flags().GetString("file")
 		text, _ := cmd.Flags().GetBool("text")
+		explain, _ := cmd.Flags().GetBool("explain")
 
 		in, err := decision.ResolveInput(topic, file, cmd.InOrStdin())
 		if err != nil {
@@ -65,7 +66,7 @@ Output is JSON by default (the agent path). Use --text for a human summary.`,
 		// gitRoot is best-effort: detectors are fail-open, so an empty root
 		// simply yields fewer signals rather than an error.
 		gitRoot := findGitRoot()
-		result := decision.Enrich(context.Background(), in, gitRoot)
+		result := decision.Enrich(context.Background(), in, gitRoot, decision.WithExplain(explain))
 
 		if text {
 			return writeDecisionHuman(cmd, result)
@@ -93,6 +94,9 @@ func writeDecisionHuman(cmd *cobra.Command, r decision.Result) error {
 	}
 	fmt.Fprintf(out, "Signals:  related=%d sessions=%d murmurs=%d diagnostics=%d unresolved_refs=%d\n",
 		r.Signals.Related, r.Signals.PriorSessions, r.Signals.Murmurs, r.Signals.Diagnostics, r.Signals.UnresolvedRefs)
+	if r.Signals.Degraded {
+		fmt.Fprintln(out, "          degraded=true (a source could not be read — absence is NOT verified)")
+	}
 
 	if len(r.Annotations) > 0 {
 		fmt.Fprintln(out, "\nAnnotations:")
@@ -118,6 +122,16 @@ func writeDecisionHuman(cmd *cobra.Command, r decision.Result) error {
 			fmt.Fprintf(out, "  - [%s] %s%s%s\n", c.Kind, c.Title, who, when)
 		}
 	}
+	if len(r.Dropped) > 0 {
+		fmt.Fprintln(out, "\nDropped (below relevance floor):")
+		for _, d := range r.Dropped {
+			label := d.Ref
+			if label == "" {
+				label = d.RefPath
+			}
+			fmt.Fprintf(out, "  - %s — %s (%.3f)\n", label, d.Title, d.Score)
+		}
+	}
 	if r.Guidance != "" {
 		fmt.Fprintf(out, "\nGuidance: %s\n", r.Guidance)
 	}
@@ -135,6 +149,7 @@ func init() {
 	decisionEnrichCmd.Flags().String("topic", "", "consult mode: the DR subject, before drafting")
 	decisionEnrichCmd.Flags().String("file", "", "an existing DR file to enrich (adds drift + ref checks)")
 	decisionEnrichCmd.Flags().Bool("text", false, "human summary instead of JSON")
+	decisionEnrichCmd.Flags().Bool("explain", false, "also list candidates dropped below the relevance floor")
 
 	decisionCmd.AddCommand(decisionEnrichCmd)
 	decisionCmd.GroupID = "dev"

--- a/cmd/ox/decision_test.go
+++ b/cmd/ox/decision_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/decision"
 )
 
@@ -36,7 +37,7 @@ func newDecisionTestRepo(t *testing.T, withCorpus bool) string {
 	return root
 }
 
-func runDecisionEnrich(t *testing.T, args ...string) string {
+func runDecisionEnrichResult(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	cmd := decisionEnrichCmd
 	var out bytes.Buffer
@@ -54,10 +55,17 @@ func runDecisionEnrich(t *testing.T, args ...string) string {
 			t.Fatal(err)
 		}
 	}
-	if err := cmd.RunE(cmd, nil); err != nil {
+	err := cmd.RunE(cmd, nil)
+	return out.String(), err
+}
+
+func runDecisionEnrich(t *testing.T, args ...string) string {
+	t.Helper()
+	out, err := runDecisionEnrichResult(t, args...)
+	if err != nil {
 		t.Fatalf("enrich RunE: %v", err)
 	}
-	return out.String()
+	return out
 }
 
 func TestDecisionEnrichCmd_TopicJSON(t *testing.T) {
@@ -169,6 +177,24 @@ func TestDecisionEnrichCmd_Text(t *testing.T) {
 	}
 	if !strings.Contains(out, "Signals:") || !strings.Contains(out, "Guidance:") {
 		t.Errorf("summary sections missing:\n%s", out)
+	}
+}
+
+func TestDecisionEnrichCmd_DegradedResultExitsNonZero(t *testing.T) {
+	root := newDecisionTestRepo(t, false)
+	writeADRFile(t, root, "docs/adr/deployment-strategy.md",
+		"# Deployment Strategy\n\nProse without enough metadata to catalog this decision.\n")
+
+	out, err := runDecisionEnrichResult(t, "topic", "deployment strategy")
+	if !cli.IsSilent(err) {
+		t.Fatalf("degraded retrieval must return a silent non-zero error, got %v", err)
+	}
+	var res decision.Result
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("degraded output must remain valid JSON: %v\n%s", err, out)
+	}
+	if !res.Signals.Degraded {
+		t.Fatalf("malformed decision source must be marked degraded: %s", out)
 	}
 }
 

--- a/cmd/ox/decision_test.go
+++ b/cmd/ox/decision_test.go
@@ -47,6 +47,7 @@ func runDecisionEnrich(t *testing.T, args ...string) string {
 		_ = cmd.Flags().Set("topic", "")
 		_ = cmd.Flags().Set("file", "")
 		_ = cmd.Flags().Set("text", "false")
+		_ = cmd.Flags().Set("explain", "false")
 	})
 	for i := 0; i+1 < len(args); i += 2 {
 		if err := cmd.Flags().Set(args[i], args[i+1]); err != nil {
@@ -78,6 +79,84 @@ func TestDecisionEnrichCmd_TopicJSON(t *testing.T) {
 	}
 	if res.Guidance == "" {
 		t.Error("guidance empty")
+	}
+}
+
+// writeADRFile drops a single Decision Record into a repo's docs/adr corpus.
+func writeADRFile(t *testing.T, root, rel, body string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDecisionEnrichCmd_FindsRelatedADRForLongTopic is the #823 proof at the real
+// command surface: a long, real-world topic that contradicts an existing ADR must
+// surface that ADR as a related decision through `ox decision enrich`. This is the
+// silent failure the reporter hit — a full plan/issue body found nothing because
+// the old scorer diluted relevance with query length. See also
+// tests/acceptance/features/decision-records/consult-before-drafting.feature.
+func TestDecisionEnrichCmd_FindsRelatedADRForLongTopic(t *testing.T) {
+	root := newDecisionTestRepo(t, false) // git repo + chdir, no default corpus
+	writeADRFile(t, root, "docs/adr/ADR-002-feature-flags.md",
+		"# ADR-002: Feature flags are added only at explicit user request\n\n"+
+			"**Status**: Accepted\n**Date**: 2026-02-01\n\n"+
+			"## Context\n\nWe add a feature flag only when a coworker asks for one by "+
+			"name — never speculatively for staged rollouts or kill switches.\n")
+
+	longTopic := "we want to gate the new todo digest emailer behind a feature flag " +
+		"so we can stage the rollout by percentage and keep a kill switch in case the " +
+		"new sender misbehaves in production, adding two flag-shaped environment variables"
+
+	out := runDecisionEnrich(t, "topic", longTopic)
+	var res decision.Result
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	found := false
+	for _, a := range res.Annotations {
+		if a.Type == decision.BadgeRelatedDecision && a.Ref == "ADR-002" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("#823: long topic did not surface the contradicting ADR-002 at the command surface: %s", out)
+	}
+	if res.Signals.Degraded {
+		t.Errorf("a readable corpus must not report degraded: %s", out)
+	}
+}
+
+// TestDecisionEnrichCmd_ExplainSurfacesDropped proves --explain exposes sub-floor
+// candidates in the JSON so a caller can tell "nothing relevant" from "found and
+// dropped" (#823 ask 4).
+func TestDecisionEnrichCmd_ExplainSurfacesDropped(t *testing.T) {
+	root := newDecisionTestRepo(t, false)
+	writeADRFile(t, root, "docs/adr/ADR-070-widget.md",
+		"# ADR-070: Widget Rendering Pipeline\n\n**Status**: Accepted\n**Date**: 2026-02-02\n\n"+
+			"## Context\n\nThe kubernetes cluster hosts the renderer.\n")
+
+	// "kubernetes" hits only the excerpt → scores below the floor → dropped.
+	off := runDecisionEnrich(t, "topic", "kubernetes")
+	var offRes decision.Result
+	if err := json.Unmarshal([]byte(off), &offRes); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, off)
+	}
+	if len(offRes.Dropped) != 0 {
+		t.Errorf("dropped must be empty without --explain: %+v", offRes.Dropped)
+	}
+
+	on := runDecisionEnrich(t, "topic", "kubernetes", "explain", "true")
+	var onRes decision.Result
+	if err := json.Unmarshal([]byte(on), &onRes); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, on)
+	}
+	if len(onRes.Dropped) == 0 || onRes.Dropped[0].Ref != "ADR-070" {
+		t.Errorf("--explain should surface ADR-070 as a dropped candidate: %s", on)
 	}
 }
 

--- a/docs/reference/decision/enrich.mdx
+++ b/docs/reference/decision/enrich.mdx
@@ -21,7 +21,7 @@ Input modes (precedence order):
   --file <dr.md>        an existing DR (adds drift + ref verification)
   stdin                 a draft to verify before presenting
 
-Output is JSON by default (the agent path). Use --text for a human summary.
+Output is JSON by default (the AI coworker path). Use --text for a human summary.
 If any configured source cannot be read, enrich emits a degraded result and
 exits non-zero so callers cannot mistake partial retrieval for a verified miss.
 

--- a/docs/reference/decision/enrich.mdx
+++ b/docs/reference/decision/enrich.mdx
@@ -30,6 +30,7 @@ ox decision enrich [flags]
 ### Options
 
 ```
+      --explain        also list candidates omitted by result caps or the relevance floor
       --file string    an existing DR file to enrich (adds drift + ref checks)
   -h, --help           help for enrich
       --text           human summary instead of JSON
@@ -50,4 +51,3 @@ ox decision enrich [flags]
 ### SEE ALSO
 
 * [ox decision](/decision)	 - Work with Decision Records (ADRs, DDRs) — enrich with team context
-

--- a/docs/reference/decision/enrich.mdx
+++ b/docs/reference/decision/enrich.mdx
@@ -22,6 +22,8 @@ Input modes (precedence order):
   stdin                 a draft to verify before presenting
 
 Output is JSON by default (the agent path). Use --text for a human summary.
+If any configured source cannot be read, enrich emits a degraded result and
+exits non-zero so callers cannot mistake partial retrieval for a verified miss.
 
 ```
 ox decision enrich [flags]

--- a/internal/config/decision.go
+++ b/internal/config/decision.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 // DecisionConfig holds the `decision.*` settings namespace for `ox decision`.
@@ -72,6 +74,9 @@ func ValidateDecisionConfig(c *DecisionConfig) error {
 		}
 		if p == ".." || strings.HasPrefix(p, "../") || strings.Contains(p, "/../") {
 			return fmt.Errorf("decision.paths[%d]: %q may not traverse above the repo root", i, p)
+		}
+		if !doublestar.ValidatePattern(filepath.ToSlash(p)) {
+			return fmt.Errorf("decision.paths[%d]: %q is not a valid glob pattern", i, p)
 		}
 	}
 	return nil

--- a/internal/config/decision_test.go
+++ b/internal/config/decision_test.go
@@ -19,6 +19,7 @@ func TestValidateDecisionConfig(t *testing.T) {
 		{"parent traversal", &DecisionConfig{Paths: []string{"../other/adr"}}, "traverse"},
 		{"embedded traversal", &DecisionConfig{Paths: []string{"docs/../../adr"}}, "traverse"},
 		{"bare dotdot", &DecisionConfig{Paths: []string{".."}}, "traverse"},
+		{"malformed glob", &DecisionConfig{Paths: []string{"docs/adr/["}}, "valid glob"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/daemon/agentwork/manager_test.go
+++ b/internal/daemon/agentwork/manager_test.go
@@ -17,18 +17,15 @@ import (
 // --- helpers ---
 
 func enabledConfigWith(maxConcurrent, maxPerHour int) *config.AgentWorkerConfig {
-	t := true
 	return &config.AgentWorkerConfig{
-		Enabled:               &t,
-		AgentType:             "claude",
+		Agent:                 "claude",
 		MaxConcurrent:         &maxConcurrent,
 		MaxInvocationsPerHour: &maxPerHour,
 	}
 }
 
 func disabledConfig() *config.AgentWorkerConfig {
-	f := false
-	return &config.AgentWorkerConfig{Enabled: &f}
+	return &config.AgentWorkerConfig{Agent: "none"}
 }
 
 // mockHandler implements WorkHandler for testing.

--- a/internal/daemon/sync_di_test.go
+++ b/internal/daemon/sync_di_test.go
@@ -94,7 +94,8 @@ func TestDI_PushMurmurCommitsUsesInjectedGitRunner(t *testing.T) {
 
 	assert.Equal(t, int64(1), mock.calls.Load(), "should call injected git runner for murmur commit check")
 	assert.Contains(t, mock.lastArgs, "log", "should pass log subcommand")
-	assert.Contains(t, mock.lastArgs, "data/murmurs/", "should filter to murmur path")
+	assert.Contains(t, mock.lastArgs, "@{upstream}..HEAD", "should inspect every unpushed commit")
+	assert.NotContains(t, mock.lastArgs, "data/murmurs/", "a path filter could hide unsafe non-murmur commits")
 }
 
 func TestDI_BackwardCompatibility(t *testing.T) {

--- a/internal/daemon/sync_di_test.go
+++ b/internal/daemon/sync_di_test.go
@@ -95,7 +95,7 @@ func TestDI_PushMurmurCommitsUsesInjectedGitRunner(t *testing.T) {
 	assert.Equal(t, int64(1), mock.calls.Load(), "should call injected git runner for murmur commit check")
 	assert.Contains(t, mock.lastArgs, "log", "should pass log subcommand")
 	assert.Contains(t, mock.lastArgs, "@{upstream}..HEAD", "should inspect every unpushed commit")
-	assert.NotContains(t, mock.lastArgs, "data/murmurs/", "a path filter could hide unsafe non-murmur commits")
+	assert.NotContains(t, mock.lastArgs, "--", "a pathspec separator could hide unsafe non-murmur commits")
 }
 
 func TestDI_BackwardCompatibility(t *testing.T) {

--- a/internal/decision/decision_test.go
+++ b/internal/decision/decision_test.go
@@ -777,6 +777,15 @@ func TestGuidanceBranches(t *testing.T) {
 			t.Errorf("degraded run must warn the source was unreadable: %q", g)
 		}
 	})
+	t.Run("degraded warning accompanies related history", func(t *testing.T) {
+		g := buildGuidance(Input{Topic: "x"}, SignalSummary{Related: 1, PriorSessions: 2, Degraded: true}, conv, nil, nil)
+		if !strings.Contains(g, "team history") || !strings.Contains(g, "DEGRADED") {
+			t.Errorf("degraded rich result must include both history and incompleteness guidance: %q", g)
+		}
+		if strings.Contains(g, "verifiable claim") {
+			t.Errorf("degraded rich result must not present any absence as verified: %q", g)
+		}
+	})
 	// the credit cap is a standing rule in every branch
 	g := buildGuidance(Input{Topic: "x"}, SignalSummary{}, conv, nil, nil)
 	if !strings.Contains(g, "max 2 per DR") {

--- a/internal/decision/decision_test.go
+++ b/internal/decision/decision_test.go
@@ -286,7 +286,7 @@ func TestScoreCorpus(t *testing.T) {
 	}
 
 	t.Run("exact id short-circuits", func(t *testing.T) {
-		for _, q := range []string{"ADR-001", "adr 1", "001"} {
+		for _, q := range []string{"ADR-001", "adr 1", "001", "ADR-001 with appended rationale"} {
 			got := scoreCorpus(corpus, q)
 			if len(got) == 0 || got[0].rec.ID != "ADR-001" || got[0].score != 1.0 {
 				t.Errorf("query %q: %+v", q, got)
@@ -358,6 +358,56 @@ func TestScoreCorpus_MonotonicInQueryLength(t *testing.T) {
 	}
 	if sProse < minDRScore {
 		t.Errorf("#823: record fell below the floor %.2f on ordinary prose input: %.3f", minDRScore, sProse)
+	}
+}
+
+// TestRelatedDetector_MonotonicAcrossCompetingRecords guards the second half of
+// the monotonicity contract: appended terms may add stronger-scoring records,
+// but the bounded output must retain the shorter prefix query's seed match and
+// report that additional candidates were omitted.
+func TestRelatedDetector_MonotonicAcrossCompetingRecords(t *testing.T) {
+	corpus := []Record{{ID: "ADR-002", Title: "Unix Domain Socket IPC"}}
+	for i, title := range []string{
+		"Session Adapter Context",
+		"Plan Integration Lifecycle",
+		"Security Adapter Distribution",
+		"Context Session Lifecycle",
+		"Integration Security Plan",
+		"Adapter Lifecycle Context",
+	} {
+		corpus = append(corpus, Record{ID: fmt.Sprintf("ADR-%03d", i+3), Title: title})
+	}
+
+	detector := relatedDetector{}
+	containsTarget := func(topic string) (found bool, related, overflow int) {
+		anns, err := detector.Detect(context.Background(), &Env{Corpus: corpus}, Input{Topic: topic})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, ann := range anns {
+			if ann.Ref == "ADR-002" {
+				found = true
+			}
+			if ann.Type == BadgeRelatedDecision {
+				related++
+			}
+			if ann.Rule == RuleRelatedOverflow {
+				overflow++
+			}
+		}
+		return found, related, overflow
+	}
+
+	if found, _, _ := containsTarget("socket"); !found {
+		t.Fatal("short query must surface ADR-002")
+	}
+	long := "socket session adapter context plan integration lifecycle security distribution"
+	if found, related, overflow := containsTarget(long); !found {
+		t.Fatalf("adding competing terms evicted ADR-002 from %d related matches", related)
+	} else if related != relatedCap {
+		t.Fatalf("related results must stay capped at %d, got %d", relatedCap, related)
+	} else if overflow != 1 {
+		t.Fatalf("bounded results must report overflow once, got %d", overflow)
 	}
 }
 
@@ -500,6 +550,9 @@ func TestEnrich_OnRealTempCorpus(t *testing.T) {
 	}
 	if !res.Signals.Material {
 		t.Error("material should be true with a related decision")
+	}
+	if res.Signals.Degraded {
+		t.Error("ordinary README/notes files must not degrade an otherwise readable corpus")
 	}
 	if res.Guidance == "" || !strings.Contains(res.Guidance, "ox code search") {
 		t.Errorf("guidance: %q", res.Guidance)
@@ -740,6 +793,60 @@ func TestEnrich_DegradedOnSourceError(t *testing.T) {
 	}
 }
 
+// TestMurmursRetriever_ReportsCorruptSource proves the production retriever,
+// not only a synthetic test double, returns an error for corrupt local data so
+// runRetriever can mark enrichment degraded.
+func TestMurmursRetriever_ReportsCorruptSource(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now().UTC()
+	dir := filepath.Join(root, "data", "murmurs", now.Format("2006-01-02"), now.Format("15"))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	valid := fmt.Sprintf(`{"id":"valid","timestamp":%q,"topic":"authentication","content":"authentication authentication authentication authentication"}`, now.Format(time.RFC3339))
+	if err := os.WriteFile(filepath.Join(dir, "a-valid.json"), []byte(valid), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "z-broken.json"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	items, errored := runRetriever(context.Background(), murmursRetriever{}, &Env{LedgerPath: root}, Input{Topic: "authentication"})
+	if !errored {
+		t.Fatal("corrupt production murmur source must report an error")
+	}
+	if len(items) != 1 || items[0].Ref != "valid" {
+		t.Fatalf("valid partial hits must survive a corrupt sibling: %+v", items)
+	}
+}
+
+func TestSessionsRetriever_IgnoresCorruptMurmurSibling(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "sessions", "current-session")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, "summary.md"), []byte("authentication authentication authentication authentication authentication"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	murmurDir := filepath.Join(root, "data", "murmurs", now.Format("2006-01-02"), now.Format("15"))
+	if err := os.MkdirAll(murmurDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(murmurDir, "broken.json"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	items, err := sessionsRetriever{}.Retrieve(context.Background(), &Env{LedgerPath: root}, Input{Topic: "authentication"})
+	if err != nil {
+		t.Fatalf("durable retriever must not inherit murmur source errors: %v", err)
+	}
+	if len(items) != 1 || items[0].Kind != "session" {
+		t.Fatalf("valid durable hit lost because a sibling murmur was corrupt: %+v", items)
+	}
+}
+
 // TestEnrich_CorpusPresentButUnparsed: a decision dir full of markdown that does
 // not parse as records is present-but-unreadable, NOT "no decisions". Enrich
 // must flag it (diagnostic + degraded) instead of silently returning empty.
@@ -750,8 +857,8 @@ func TestEnrich_CorpusPresentButUnparsed(t *testing.T) {
 	swapRegistry(t, nil, nil)
 	root := t.TempDir()
 	writeCorpus(t, root, map[string]string{
-		"docs/adr/thoughts.md": "# Some Title\n\nProse with no status, no date, no number.\n",
-		"docs/adr/more.md":     "# Another Thought\n\nAlso not a record.\n",
+		"docs/adr/ADR-thoughts.md": "# Some Title\n\nProse with no status, no date, no number.\n",
+		"docs/adr/DDR-more.md":     "# Another Thought\n\nAlso not a record.\n",
 	})
 	res := Enrich(context.Background(), Input{Topic: "some title"}, root)
 	if !res.Signals.Degraded {
@@ -768,6 +875,109 @@ func TestEnrich_CorpusPresentButUnparsed(t *testing.T) {
 	}
 	if strings.Contains(res.Guidance, "verifiable claim") {
 		t.Errorf("must not assert verified absence for an unreadable corpus: %q", res.Guidance)
+	}
+}
+
+// TestEnrich_CorpusPartiallyUnparsed prevents a valid neighboring DR from
+// masking a markdown file retrieval could not catalog. A query about the hidden
+// file must not be reported as a verified absence merely because another record
+// in the same directory parsed successfully.
+func TestEnrich_CorpusPartiallyUnparsed(t *testing.T) {
+	swapRegistry(t, nil, nil)
+	root := t.TempDir()
+	writeCorpus(t, root, map[string]string{
+		"docs/adr/ADR-001-visible.md": "# ADR-001: Visible Decision\n\n**Status**: Accepted\n",
+		"docs/adr/ADR-hidden.md":      "# Hidden Authentication Decision\n\nProse without DR metadata.\n",
+	})
+
+	res := Enrich(context.Background(), Input{Topic: "hidden authentication"}, root)
+	if !res.Signals.Degraded {
+		t.Fatal("a partially uncataloged corpus must mark the result degraded")
+	}
+	if res.Signals.Diagnostics != 1 {
+		t.Fatalf("want one unreadable-corpus diagnostic, got %+v", res.Annotations)
+	}
+	if strings.Contains(res.Guidance, "verifiable claim") {
+		t.Errorf("partial corpus visibility must not produce a verified-absence claim: %q", res.Guidance)
+	}
+}
+
+func TestEnrich_CorpusPartiallyUnreadable(t *testing.T) {
+	swapRegistry(t, nil, nil)
+	root := t.TempDir()
+	writeCorpus(t, root, map[string]string{
+		"docs/adr/ADR-001-visible.md": "# ADR-001: Visible Decision\n\n**Status**: Accepted\n",
+	})
+	broken := filepath.Join(root, "docs/adr/ADR-002-broken.md")
+	if err := os.Symlink(filepath.Join(root, "missing-target"), broken); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Enrich(context.Background(), Input{Topic: "authentication"}, root)
+	if !res.Signals.Degraded {
+		t.Fatal("an unreadable DR beside a valid record must mark retrieval degraded")
+	}
+	if res.Signals.Diagnostics != 1 {
+		t.Fatalf("want one unreadable-corpus diagnostic, got %+v", res.Annotations)
+	}
+}
+
+// TestEnrich_InvalidDecisionConfigDegraded pins the production buildEnv path:
+// invalid configured paths are a source failure, not an empty readable corpus.
+func TestEnrich_InvalidDecisionConfigDegraded(t *testing.T) {
+	swapRegistry(t, nil, nil)
+	root := t.TempDir()
+	configDir := filepath.Join(root, ".sageox")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configBody := "config_version: \"2\"\ndecision:\n  paths:\n    - ../outside\n"
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Enrich(context.Background(), Input{Topic: "authentication"}, root)
+	if !res.Signals.Degraded {
+		t.Fatal("an invalid decision.paths source must mark the result degraded")
+	}
+	if strings.Contains(res.Guidance, "verifiable claim") {
+		t.Errorf("invalid decision config must not produce a verified-absence claim: %q", res.Guidance)
+	}
+}
+
+func TestEnrich_MalformedGlobDegraded(t *testing.T) {
+	swapRegistry(t, nil, nil)
+	root := t.TempDir()
+	configDir := filepath.Join(root, ".sageox")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configBody := "config_version: \"2\"\ndecision:\n  paths:\n    - docs/adr/[\n"
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Enrich(context.Background(), Input{Topic: "authentication"}, root)
+	if !res.Signals.Degraded {
+		t.Fatal("a malformed configured glob must mark retrieval degraded")
+	}
+}
+
+func TestEnrich_MissingConfiguredDirectoryDegraded(t *testing.T) {
+	swapRegistry(t, nil, nil)
+	root := t.TempDir()
+	configDir := filepath.Join(root, ".sageox")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configBody := "config_version: \"2\"\ndecision:\n  paths:\n    - docs/decisions\n"
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := Enrich(context.Background(), Input{Topic: "authentication"}, root)
+	if !res.Signals.Degraded {
+		t.Fatal("a missing explicit decision directory must mark retrieval degraded")
 	}
 }
 
@@ -796,5 +1006,23 @@ func TestEnrich_ExplainSurfacesDroppedCandidates(t *testing.T) {
 	}
 	if on.Dropped[0].Ref != "ADR-070" || on.Dropped[0].Score >= minDRScore {
 		t.Errorf("dropped candidate wrong (want ADR-070 below %.2f): %+v", minDRScore, on.Dropped[0])
+	}
+}
+
+func TestEnrich_ExplainSurfacesCapOmissions(t *testing.T) {
+	swapRegistry(t, nil, nil)
+	root := t.TempDir()
+	files := make(map[string]string)
+	for i := 1; i <= relatedCap+1; i++ {
+		files[fmt.Sprintf("docs/adr/ADR-%03d-socket.md", i)] = fmt.Sprintf("# ADR-%03d: Socket Transport %d\n\n**Status**: Accepted\n", i, i)
+	}
+	writeCorpus(t, root, files)
+
+	res := Enrich(context.Background(), Input{Topic: "socket"}, root, WithExplain(true))
+	if len(res.Dropped) != 1 {
+		t.Fatalf("want the one cap-omitted candidate explained, got %+v", res.Dropped)
+	}
+	if !strings.Contains(res.Dropped[0].Reason, "annotation cap") {
+		t.Fatalf("cap omission reason missing: %+v", res.Dropped[0])
 	}
 }

--- a/internal/decision/decision_test.go
+++ b/internal/decision/decision_test.go
@@ -2,6 +2,7 @@ package decision
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -303,14 +304,61 @@ func TestScoreCorpus(t *testing.T) {
 		}
 	})
 
-	t.Run("low coverage excluded", func(t *testing.T) {
+	t.Run("weak excerpt-only match scores below the floor", func(t *testing.T) {
+		// ADR-002 matches only in the excerpt ("socket"), so it must rank below
+		// minDRScore — excluded by the floor, NOT zeroed by query length. The
+		// distinction matters: a strong TITLE match must survive a long query
+		// (see TestScoreCorpus_MonotonicInQueryLength), a weak excerpt one need not.
 		got := scoreCorpus(corpus, "socket quantum blockchain kubernetes")
 		for _, s := range got {
-			if s.score > 0 && s.rec.ID == "ADR-002" {
-				t.Errorf("1/4 coverage should be excluded: %+v", s)
+			if s.rec.ID == "ADR-002" && s.score >= minDRScore {
+				t.Errorf("excerpt-only match should score below floor %.2f: %+v", minDRScore, s)
 			}
 		}
 	})
+}
+
+// TestScoreCorpus_MonotonicInQueryLength is the #823 regression: adding words to
+// a query must NEVER drop a record that a shorter subset query matched. The old
+// coverage=matched/len(terms) scorer zeroed a strong title match as ordinary
+// prose lengthened, so a real plan/issue body found less than a two-word probe.
+// Failure prevented: an agent passing a full plan silently loses the ADR that
+// its two-word title would have surfaced.
+func TestScoreCorpus_MonotonicInQueryLength(t *testing.T) {
+	corpus := []Record{{
+		ID: "ADR-002", Number: 2, Date: "2026-01-01",
+		Title:   "Feature flags are added only at explicit user request",
+		Excerpt: "gate rollout kill switch staged percentage",
+	}}
+
+	scoreOf := func(q string) float64 {
+		for _, s := range scoreCorpus(corpus, q) {
+			if s.rec.ID == "ADR-002" {
+				return s.score
+			}
+		}
+		return 0 // dropped entirely
+	}
+
+	// Same subject, growing query. Each is a superset of the record's own words
+	// plus increasing off-topic prose — the normal case, not an edge case.
+	short := "feature flags"
+	title := "feature flags are added only at explicit user request"
+	prose := "we want to gate the new todo digest emailer behind a feature flag " +
+		"so we can stage the rollout by percentage and keep a kill switch in " +
+		"case the new sender misbehaves in production"
+
+	sShort, sTitle, sProse := scoreOf(short), scoreOf(title), scoreOf(prose)
+
+	if sTitle < sShort {
+		t.Errorf("exact-title query scored below its two-word subset: title=%.3f short=%.3f", sTitle, sShort)
+	}
+	if sProse < sShort {
+		t.Errorf("#823: longer prose query dropped the record below the short query: short=%.3f prose=%.3f", sShort, sProse)
+	}
+	if sProse < minDRScore {
+		t.Errorf("#823: record fell below the floor %.2f on ordinary prose input: %.3f", minDRScore, sProse)
+	}
 }
 
 func TestResolveInput(t *testing.T) {
@@ -368,8 +416,24 @@ Guided by SageOx.
 }
 
 // panicDetector / stubDetector exercise the fail-open orchestrator. The
-// registry is global and additive, so these tests tolerate the built-in
-// detectors running alongside.
+// swapRegistry replaces the global detector/retriever registry for one test and
+// restores it on cleanup. The registry is package-global and additive, so a test
+// that leaves a fault-injection detector registered would silently degrade every
+// later test's Enrich — masking whether the degraded/annotation logic under test
+// actually fired. Isolating the registry keeps each test proving its own cause.
+func swapRegistry(t *testing.T, ds []Detector, rs []Retriever) {
+	t.Helper()
+	registryMu.Lock()
+	savedD, savedR := detectors, retrievers
+	detectors, retrievers = ds, rs
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		detectors, retrievers = savedD, savedR
+		registryMu.Unlock()
+	})
+}
+
 type panicDetector struct{}
 
 func (panicDetector) Name() string { return "test-panic" }
@@ -385,8 +449,7 @@ func (stubDetector) Detect(context.Context, *Env, Input) ([]Annotation, error) {
 }
 
 func TestEnrich_FailOpenAndSchema(t *testing.T) {
-	RegisterDetector(panicDetector{})
-	RegisterDetector(stubDetector{})
+	swapRegistry(t, []Detector{panicDetector{}, stubDetector{}}, nil)
 
 	res := Enrich(context.Background(), Input{Topic: "anything at all"}, "")
 	if res.SchemaVersion != SchemaVersion {
@@ -400,6 +463,11 @@ func TestEnrich_FailOpenAndSchema(t *testing.T) {
 	}
 	if !found {
 		t.Error("stub detector output lost — panic in sibling detector aborted the run")
+	}
+	// a panicking detector is a failed source: the run must be marked degraded
+	// so its emptiness is never read as a verified absence (#823).
+	if !res.Signals.Degraded {
+		t.Error("a panicking detector must mark the result degraded")
 	}
 }
 
@@ -612,9 +680,121 @@ func TestGuidanceBranches(t *testing.T) {
 			t.Errorf("rich/update guidance incomplete: %q", g)
 		}
 	})
+	t.Run("degraded suppresses the verified-absence claim", func(t *testing.T) {
+		// #823: a swallowed source error must NOT be reported as a checked
+		// absence. The verifiable-claim wording is reserved for a genuine,
+		// fully-read empty result.
+		g := buildGuidance(Input{Topic: "x"}, SignalSummary{Degraded: true}, conv, nil, nil)
+		if strings.Contains(g, "verifiable claim") {
+			t.Errorf("degraded run must not present absence as verified: %q", g)
+		}
+		if !strings.Contains(g, "DEGRADED") {
+			t.Errorf("degraded run must warn the source was unreadable: %q", g)
+		}
+	})
 	// the credit cap is a standing rule in every branch
 	g := buildGuidance(Input{Topic: "x"}, SignalSummary{}, conv, nil, nil)
 	if !strings.Contains(g, "max 2 per DR") {
 		t.Errorf("credit cap missing: %q", g)
+	}
+}
+
+// --- #823: honesty (error-vs-empty) and --explain ---
+
+// errDetector always errors — exercises the degraded-source path end to end.
+type errDetector struct{}
+
+func (errDetector) Name() string { return "test-err" }
+func (errDetector) Detect(context.Context, *Env, Input) ([]Annotation, error) {
+	return nil, fmt.Errorf("simulated source failure")
+}
+
+// TestEnrich_DegradedOnSourceError: a retrieval source that errors must mark the
+// Result degraded and flip guidance away from asserting a verified absence.
+// Failure prevented (#823): a swallowed index/lookup error is otherwise reported
+// as "no prior decision found — a verifiable claim", so an agent drafts a
+// duplicate/contradicting DR with false confidence. The clean-registry arm
+// proves the flip is caused by the error, not by ambient pollution.
+func TestEnrich_DegradedOnSourceError(t *testing.T) {
+	in := Input{Topic: "gate rollout behind a flag"}
+
+	swapRegistry(t, nil, nil) // no sources at all
+	clean := Enrich(context.Background(), in, "")
+	if clean.Signals.Degraded {
+		t.Fatal("an all-clean run (no sources, no corpus) must NOT be degraded")
+	}
+	if !strings.Contains(clean.Guidance, "verifiable claim") {
+		t.Errorf("a genuinely-empty run should still state absence as verifiable: %q", clean.Guidance)
+	}
+
+	swapRegistry(t, []Detector{errDetector{}}, nil) // exactly one erroring source
+	res := Enrich(context.Background(), in, "")
+	if !res.Signals.Degraded {
+		t.Fatal("a source error must set Signals.Degraded")
+	}
+	if strings.Contains(res.Guidance, "verifiable claim") {
+		t.Errorf("degraded result must not present absence as verified: %q", res.Guidance)
+	}
+	if !strings.Contains(res.Guidance, "DEGRADED") {
+		t.Errorf("degraded result must warn: %q", res.Guidance)
+	}
+}
+
+// TestEnrich_CorpusPresentButUnparsed: a decision dir full of markdown that does
+// not parse as records is present-but-unreadable, NOT "no decisions". Enrich
+// must flag it (diagnostic + degraded) instead of silently returning empty.
+// Failure prevented (#823): a user's docs/adr whose files miss a number and a
+// Status/Date line yields related=0 that reads as a verified absence.
+// Empty registry: degraded here can ONLY come from the corpus, not a source error.
+func TestEnrich_CorpusPresentButUnparsed(t *testing.T) {
+	swapRegistry(t, nil, nil)
+	root := t.TempDir()
+	writeCorpus(t, root, map[string]string{
+		"docs/adr/thoughts.md": "# Some Title\n\nProse with no status, no date, no number.\n",
+		"docs/adr/more.md":     "# Another Thought\n\nAlso not a record.\n",
+	})
+	res := Enrich(context.Background(), Input{Topic: "some title"}, root)
+	if !res.Signals.Degraded {
+		t.Error("present-but-unparsed corpus must mark the result degraded")
+	}
+	found := false
+	for _, a := range res.Annotations {
+		if a.Rule == RuleUnreadableCorpus {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("unreadable-corpus diagnostic missing: %+v", res.Annotations)
+	}
+	if strings.Contains(res.Guidance, "verifiable claim") {
+		t.Errorf("must not assert verified absence for an unreadable corpus: %q", res.Guidance)
+	}
+}
+
+// TestEnrich_ExplainSurfacesDroppedCandidates: --explain must list records that
+// matched but fell below the floor, so a caller can tell "nothing relevant" from
+// "found and dropped". Failure prevented (#823 ask 4): a silent floor hides
+// near-misses, so a user cannot distinguish a true gap from a discarded match.
+func TestEnrich_ExplainSurfacesDroppedCandidates(t *testing.T) {
+	swapRegistry(t, nil, nil)
+	root := t.TempDir()
+	writeCorpus(t, root, map[string]string{
+		// "kubernetes" appears only in the Context excerpt, never the title —
+		// an excerpt-only match scores below minDRScore under the saturating scorer.
+		"docs/adr/ADR-070-widget.md": "# ADR-070: Widget Rendering Pipeline\n\n**Status**: Accepted\n**Date**: 2026-02-02\n\n## Context\n\nThe kubernetes cluster hosts the renderer.\n",
+	})
+	topic := "kubernetes"
+
+	off := Enrich(context.Background(), Input{Topic: topic}, root)
+	if len(off.Dropped) != 0 {
+		t.Errorf("dropped must be empty without --explain: %+v", off.Dropped)
+	}
+
+	on := Enrich(context.Background(), Input{Topic: topic}, root, WithExplain(true))
+	if len(on.Dropped) == 0 {
+		t.Fatalf("--explain should surface the sub-floor candidate: %+v", on)
+	}
+	if on.Dropped[0].Ref != "ADR-070" || on.Dropped[0].Score >= minDRScore {
+		t.Errorf("dropped candidate wrong (want ADR-070 below %.2f): %+v", minDRScore, on.Dropped[0])
 	}
 }

--- a/internal/decision/decision_test.go
+++ b/internal/decision/decision_test.go
@@ -63,7 +63,7 @@ func defaultCorpusFiles() map[string]string {
 		"docs/adr/002-daemon-architecture.md":   "# Daemon Architecture\n\n**Status**: Accepted\n**Date**: 2025-11-01\n\n## Context\n\nDaemon owns pulls.\n",
 		"docs/adr/ADR-002-unix-socket.md":       "# ADR-002: Unix Socket IPC\n\n**Status**: Accepted\n**Date**: 2025-12-01\n\n## Context\n\nIPC over unix sockets.\n",
 		"docs/adr/README.md":                    "# Index\n\n| ADR | Title |\n",
-		"docs/adr/notes.md":                     "just some markdown with no decision shape\n",
+		"docs/adr/notes.md":                     "# Notes\n\nJust some markdown with no decision shape.\n",
 	}
 }
 
@@ -310,10 +310,17 @@ func TestScoreCorpus(t *testing.T) {
 		// distinction matters: a strong TITLE match must survive a long query
 		// (see TestScoreCorpus_MonotonicInQueryLength), a weak excerpt one need not.
 		got := scoreCorpus(corpus, "socket quantum blockchain kubernetes")
+		found := false
 		for _, s := range got {
-			if s.rec.ID == "ADR-002" && s.score >= minDRScore {
-				t.Errorf("excerpt-only match should score below floor %.2f: %+v", minDRScore, s)
+			if s.rec.ID == "ADR-002" {
+				found = true
+				if s.score >= minDRScore {
+					t.Errorf("excerpt-only match should score below floor %.2f: %+v", minDRScore, s)
+				}
 			}
+		}
+		if !found {
+			t.Fatalf("ADR-002 must remain a scored below-floor candidate: %+v", got)
 		}
 	})
 }
@@ -547,6 +554,9 @@ func TestEnrich_OnRealTempCorpus(t *testing.T) {
 	}
 	if related.Relation != RelationCandidate && related.Relation != VariantSupersedeCandidate {
 		t.Errorf("relation: %q", related.Relation)
+	}
+	if res.Signals.Degraded {
+		t.Errorf("known support markdown must not degrade a readable corpus: %+v", res.Annotations)
 	}
 	if !res.Signals.Material {
 		t.Error("material should be true with a related decision")
@@ -878,6 +888,23 @@ func TestEnrich_CorpusPresentButUnparsed(t *testing.T) {
 	}
 }
 
+func TestEnrich_DescriptiveMalformedRecordDegraded(t *testing.T) {
+	swapRegistry(t, nil, nil)
+	root := t.TempDir()
+	writeCorpus(t, root, map[string]string{
+		"docs/adr/ADR-001-visible.md":     "# ADR-001: Visible Decision\n\n**Status**: Accepted\n",
+		"docs/adr/deployment-strategy.md": "# Deployment Strategy\n\nProse without DR metadata.\n",
+	})
+
+	res := Enrich(context.Background(), Input{Topic: "deployment strategy"}, root)
+	if !res.Signals.Degraded {
+		t.Fatal("a titled, unparseable markdown file in the decision corpus must mark retrieval degraded")
+	}
+	if strings.Contains(res.Guidance, "verifiable claim") {
+		t.Errorf("malformed decision must prevent verified-absence guidance: %q", res.Guidance)
+	}
+}
+
 // TestEnrich_CorpusPartiallyUnparsed prevents a valid neighboring DR from
 // masking a markdown file retrieval could not catalog. A query about the hidden
 // file must not be reported as a verified absence merely because another record
@@ -1024,5 +1051,21 @@ func TestEnrich_ExplainSurfacesCapOmissions(t *testing.T) {
 	}
 	if !strings.Contains(res.Dropped[0].Reason, "annotation cap") {
 		t.Fatalf("cap omission reason missing: %+v", res.Dropped[0])
+	}
+}
+
+func TestDroppedCandidates_ExcludesInputRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "docs", "adr", "ADR-070-widget.md")
+	env := &Env{Corpus: []Record{{
+		ID:      "ADR-070",
+		Path:    path,
+		RelPath: "docs/adr/ADR-070-widget.md",
+		Title:   "Widget Rendering Pipeline",
+		Excerpt: "The kubernetes cluster hosts the renderer.",
+	}}}
+
+	got := droppedCandidates(env, Input{Path: path, Topic: "kubernetes"})
+	if len(got) != 0 {
+		t.Fatalf("the input DR must never be reported as a dropped related candidate: %+v", got)
 	}
 }

--- a/internal/decision/decision_test.go
+++ b/internal/decision/decision_test.go
@@ -154,6 +154,28 @@ func TestParseContent_Variants(t *testing.T) {
 	}
 }
 
+func TestLikelyDecisionRecord(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		body string
+		want bool
+	}{
+		{name: "descriptive malformed decision", path: "deployment-strategy.md", body: "# Deployment Strategy\n", want: true},
+		{name: "README support file", path: "README.md", body: "# ADR-000: Decision Index\n", want: false},
+		{name: "notes support file", path: "notes.md", body: "# Notes\n", want: false},
+		{name: "template support file", path: "TEMPLATE.md", body: "# ADR-000: Title\n", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := likelyDecisionRecord(tc.path, tc.body); got != tc.want {
+				t.Fatalf("likelyDecisionRecord(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadCorpus(t *testing.T) {
 	root := t.TempDir()
 	writeCorpus(t, root, defaultCorpusFiles())

--- a/internal/decision/detectors.go
+++ b/internal/decision/detectors.go
@@ -44,7 +44,7 @@ func (relatedDetector) Detect(_ context.Context, env *Env, in Input) ([]Annotati
 	}
 	var out []Annotation
 	for _, s := range scoreCorpus(env.Corpus, terms) {
-		if s.score < minBundleScore || len(out) >= relatedCap {
+		if s.score < minDRScore || len(out) >= relatedCap {
 			break
 		}
 		if in.Path != "" && samePath(in.Path, s.rec.Path) {
@@ -100,7 +100,7 @@ func (relatedRetriever) Retrieve(_ context.Context, env *Env, in Input) ([]Conte
 	}
 	var out []ContextItem
 	for _, s := range scoreCorpus(env.Corpus, terms) {
-		if s.score < minBundleScore || len(out) >= bundleCap {
+		if s.score < minDRScore || len(out) >= bundleCap {
 			break
 		}
 		if in.Path != "" && samePath(in.Path, s.rec.Path) {

--- a/internal/decision/detectors.go
+++ b/internal/decision/detectors.go
@@ -26,8 +26,8 @@ const (
 	// bundleCap / minScore mirror the plan context-bundle conventions.
 	bundleCap      = 12
 	minBundleScore = 0.55
-	// relatedCap bounds related-decision annotations so a broad topic doesn't
-	// bury the numbering/diagnostic signal.
+	// relatedCap bounds related-decision annotations so a broad topic does not
+	// bury numbering and diagnostics. Overflow is reported explicitly.
 	relatedCap = 5
 )
 
@@ -42,13 +42,17 @@ func (relatedDetector) Detect(_ context.Context, env *Env, in Input) ([]Annotati
 	if terms == "" || len(env.Corpus) == 0 {
 		return nil, nil
 	}
-	var out []Annotation
-	for _, s := range scoreCorpus(env.Corpus, terms) {
-		if s.score < minDRScore || len(out) >= relatedCap {
-			break
-		}
+	var matches []scored
+	for _, s := range relevantCorpus(env.Corpus, terms) {
 		if in.Path != "" && samePath(in.Path, s.rec.Path) {
 			continue // the file being enriched is not "related" to itself
+		}
+		matches = append(matches, s)
+	}
+	var out []Annotation
+	for _, s := range matches {
+		if len(out) >= relatedCap {
+			break
 		}
 		ann := Annotation{
 			Kind:     BadgeDeterministic,
@@ -66,6 +70,14 @@ func (relatedDetector) Detect(_ context.Context, env *Env, in Input) ([]Annotati
 			ann.Anchor = s.rec.DSections[0].ID
 		}
 		out = append(out, ann)
+	}
+	if omitted := len(matches) - min(len(matches), relatedCap); omitted > 0 {
+		out = append(out, Annotation{
+			Kind: BadgeDeterministic,
+			Type: BadgeDiagnostic,
+			Rule: RuleRelatedOverflow,
+			Why:  fmt.Sprintf("%d additional related decision candidate(s) cleared the relevance floor but were omitted from this bounded result; narrow the topic or use `ox decision enrich --explain` / `ox code search --decisions` to inspect them", omitted),
+		})
 	}
 	return out, nil
 }
@@ -99,8 +111,8 @@ func (relatedRetriever) Retrieve(_ context.Context, env *Env, in Input) ([]Conte
 		return nil, nil
 	}
 	var out []ContextItem
-	for _, s := range scoreCorpus(env.Corpus, terms) {
-		if s.score < minDRScore || len(out) >= bundleCap {
+	for _, s := range relevantCorpus(env.Corpus, terms) {
+		if len(out) >= bundleCap {
 			break
 		}
 		if in.Path != "" && samePath(in.Path, s.rec.Path) {

--- a/internal/decision/enrich.go
+++ b/internal/decision/enrich.go
@@ -54,8 +54,8 @@ func snapshotRegistry() ([]Detector, []Retriever) {
 // defaults. Options are applied to the resolved Env after buildEnv.
 type EnrichOption func(*Env)
 
-// WithExplain toggles Result.Dropped population (sub-floor candidates). Off by
-// default so the agent path stays lean.
+// WithExplain toggles Result.Dropped population (cap-omitted and sub-floor
+// candidates). Off by default so the agent path stays lean.
 func WithExplain(on bool) EnrichOption {
 	return func(e *Env) { e.Explain = on }
 }
@@ -72,15 +72,15 @@ func Enrich(ctx context.Context, in Input, gitRoot string, opts ...EnrichOption)
 	}
 	ds, rs := snapshotRegistry()
 
-	degraded := env.CorpusUnparsed > 0
+	degraded := env.CorpusUnparsed > 0 || env.SourceUnavailable
 
 	var annotations []Annotation
-	// A decision dir exists but nothing in it parsed as a record — surface the
-	// format problem as a visible diagnostic, not a silent empty result.
+	// A decision dir contains markdown that did not make it into the catalog —
+	// surface the gap as a visible diagnostic, not a silent partial result.
 	if env.CorpusUnparsed > 0 {
 		annotations = append(annotations, Annotation{
 			Kind: BadgeDeterministic, Type: BadgeDiagnostic, Rule: RuleUnreadableCorpus,
-			Why: fmt.Sprintf("%d markdown file(s) in this repo's decision dir did not parse as Decision Records — a DR needs a number in its filename/H1, or a title plus a Status/Date line. Fix the format; retrieval cannot see these files, so treat 'no prior decision' as UNVERIFIED here", env.CorpusUnparsed),
+			Why: fmt.Sprintf("%d markdown file(s) in this repo's decision dir could not be cataloged (unreadable or not shaped as Decision Records) — a DR needs a number in its filename/H1, or a title plus a Status/Date line. Fix the files; retrieval cannot see them, so treat 'no prior decision' as UNVERIFIED here", env.CorpusUnparsed),
 		})
 	}
 	for _, d := range ds {
@@ -144,20 +144,29 @@ func buildEnv(gitRoot string) *Env {
 		return env
 	}
 	var cfg *config.DecisionConfig
-	if pc, _ := config.LoadProjectConfig(gitRoot); pc != nil {
+	pc, cfgErr := config.LoadProjectConfig(gitRoot)
+	if cfgErr != nil {
+		slog.Warn("decision: project config unavailable", "error", cfgErr)
+		env.SourceUnavailable = true
+	} else if pc != nil {
 		cfg = pc.Decision
-	}
-	env.Corpus = LoadCorpus(gitRoot, cfg)
-	// Corpus honesty: if a decision dir exists and holds markdown but NOTHING
-	// parsed as a record, the corpus is present-but-unreadable — a distinct
-	// state from "no corpus", and one an absence claim must not paper over.
-	if len(env.Corpus) == 0 {
-		if files := listFiles(gitRoot, resolvePaths(gitRoot, cfg)); len(files) > 0 {
-			env.CorpusUnparsed = len(files)
+		if err := config.ValidateDecisionConfig(cfg); err != nil {
+			slog.Warn("decision: invalid decision config", "error", err)
+			env.SourceUnavailable = true
 		}
+	}
+	loaded := loadCorpus(gitRoot, cfg)
+	env.Corpus = loaded.records
+	env.CorpusUnparsed = loaded.unparsed
+	if loaded.err != nil {
+		slog.Warn("decision: corpus source unavailable", "error", loaded.err)
+		env.SourceUnavailable = true
 	}
 	if pctx, err := config.LoadProjectContext(gitRoot); err == nil && pctx != nil {
 		env.LedgerPath = pctx.DefaultLedgerPath()
+	} else if err != nil {
+		slog.Warn("decision: project context unavailable", "error", err)
+		env.SourceUnavailable = true
 	}
 	return env
 }
@@ -191,7 +200,7 @@ func runRetriever(ctx context.Context, r Retriever, env *Env, in Input) (out []C
 	items, err := r.Retrieve(ctx, env, in)
 	if err != nil {
 		slog.Warn("decision retriever failed", "retriever", r.Name(), "error", err)
-		return nil, true
+		return items, true
 	}
 	return items, false
 }

--- a/internal/decision/enrich.go
+++ b/internal/decision/enrich.go
@@ -2,6 +2,7 @@ package decision
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sort"
 	"strconv"
@@ -49,20 +50,49 @@ func snapshotRegistry() ([]Detector, []Retriever) {
 	return ds, rs
 }
 
+// EnrichOption tunes a single Enrich call without changing the fail-open
+// defaults. Options are applied to the resolved Env after buildEnv.
+type EnrichOption func(*Env)
+
+// WithExplain toggles Result.Dropped population (sub-floor candidates). Off by
+// default so the agent path stays lean.
+func WithExplain(on bool) EnrichOption {
+	return func(e *Env) { e.Explain = on }
+}
+
 // Enrich runs every registered detector and retriever, FAIL-OPEN: a panic or
-// error in any one is logged and skipped, never aborting the others. Zero LLM
-// or network calls — everything reads local data resolved once into Env.
-func Enrich(ctx context.Context, in Input, gitRoot string) Result {
+// error in any one is logged and skipped, never aborting the others. A source
+// that errors marks the Result DEGRADED so guidance never reports a swallowed
+// failure as a verified absence (#823). Zero LLM or network calls — everything
+// reads local data resolved once into Env.
+func Enrich(ctx context.Context, in Input, gitRoot string, opts ...EnrichOption) Result {
 	env := buildEnv(gitRoot)
+	for _, o := range opts {
+		o(env)
+	}
 	ds, rs := snapshotRegistry()
 
+	degraded := env.CorpusUnparsed > 0
+
 	var annotations []Annotation
+	// A decision dir exists but nothing in it parsed as a record — surface the
+	// format problem as a visible diagnostic, not a silent empty result.
+	if env.CorpusUnparsed > 0 {
+		annotations = append(annotations, Annotation{
+			Kind: BadgeDeterministic, Type: BadgeDiagnostic, Rule: RuleUnreadableCorpus,
+			Why: fmt.Sprintf("%d markdown file(s) in this repo's decision dir did not parse as Decision Records — a DR needs a number in its filename/H1, or a title plus a Status/Date line. Fix the format; retrieval cannot see these files, so treat 'no prior decision' as UNVERIFIED here", env.CorpusUnparsed),
+		})
+	}
 	for _, d := range ds {
-		annotations = append(annotations, runDetector(ctx, d, env, in)...)
+		anns, errored := runDetector(ctx, d, env, in)
+		annotations = append(annotations, anns...)
+		degraded = degraded || errored
 	}
 	var items []ContextItem
 	for _, r := range rs {
-		items = append(items, runRetriever(ctx, r, env, in)...)
+		its, errored := runRetriever(ctx, r, env, in)
+		items = append(items, its...)
+		degraded = degraded || errored
 	}
 
 	sort.SliceStable(items, func(i, j int) bool {
@@ -76,6 +106,7 @@ func Enrich(ctx context.Context, in Input, gitRoot string) Result {
 	}
 
 	sum := summarize(annotations, items)
+	sum.Degraded = degraded
 	info := decisionInfo(in, env)
 	var cfg *config.DecisionConfig
 	if pc, _ := config.LoadProjectConfig(gitRoot); pc != nil {
@@ -90,7 +121,7 @@ func Enrich(ctx context.Context, in Input, gitRoot string) Result {
 		info.SuggestedID = normalizeRefToken(prefix, strconv.Itoa(conv.NextNumber))
 	}
 
-	return Result{
+	res := Result{
 		SchemaVersion: SchemaVersion,
 		Decision:      info,
 		Conventions:   conv,
@@ -99,6 +130,10 @@ func Enrich(ctx context.Context, in Input, gitRoot string) Result {
 		Signals:       sum,
 		Guidance:      buildGuidance(in, sum, conv, annotations, items),
 	}
+	if env.Explain {
+		res.Dropped = droppedCandidates(env, in)
+	}
+	return res
 }
 
 // buildEnv resolves the shared read-only environment once per Enrich call.
@@ -113,40 +148,52 @@ func buildEnv(gitRoot string) *Env {
 		cfg = pc.Decision
 	}
 	env.Corpus = LoadCorpus(gitRoot, cfg)
+	// Corpus honesty: if a decision dir exists and holds markdown but NOTHING
+	// parsed as a record, the corpus is present-but-unreadable — a distinct
+	// state from "no corpus", and one an absence claim must not paper over.
+	if len(env.Corpus) == 0 {
+		if files := listFiles(gitRoot, resolvePaths(gitRoot, cfg)); len(files) > 0 {
+			env.CorpusUnparsed = len(files)
+		}
+	}
 	if pctx, err := config.LoadProjectContext(gitRoot); err == nil && pctx != nil {
 		env.LedgerPath = pctx.DefaultLedgerPath()
 	}
 	return env
 }
 
-func runDetector(ctx context.Context, d Detector, env *Env, in Input) (out []Annotation) {
+// runDetector isolates one detector: a panic or error is logged and swallowed
+// so siblings still run, but it also reports errored=true so Enrich can mark
+// the whole Result degraded — a swallowed failure must never masquerade as a
+// verified "nothing found" (#823).
+func runDetector(ctx context.Context, d Detector, env *Env, in Input) (out []Annotation, errored bool) {
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Warn("decision detector panicked", "detector", d.Name(), "recover", r)
-			out = nil
+			out, errored = nil, true
 		}
 	}()
 	anns, err := d.Detect(ctx, env, in)
 	if err != nil {
 		slog.Warn("decision detector failed", "detector", d.Name(), "error", err)
-		return nil
+		return nil, true
 	}
-	return anns
+	return anns, false
 }
 
-func runRetriever(ctx context.Context, r Retriever, env *Env, in Input) (out []ContextItem) {
+func runRetriever(ctx context.Context, r Retriever, env *Env, in Input) (out []ContextItem, errored bool) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			slog.Warn("decision retriever panicked", "retriever", r.Name(), "recover", rec)
-			out = nil
+			out, errored = nil, true
 		}
 	}()
 	items, err := r.Retrieve(ctx, env, in)
 	if err != nil {
 		slog.Warn("decision retriever failed", "retriever", r.Name(), "error", err)
-		return nil
+		return nil, true
 	}
-	return items
+	return items, false
 }
 
 func summarize(annotations []Annotation, items []ContextItem) SignalSummary {

--- a/internal/decision/guidance.go
+++ b/internal/decision/guidance.go
@@ -28,6 +28,11 @@ func buildGuidance(in Input, sum SignalSummary, conv Conventions, annotations []
 		b.WriteString("This DR has drifted: cited files changed after its date. If the decision still stands, add a dated amendment noting the new context; if not, amend or supersede per the corpus convention — your call. ")
 	case sum.Related > 0 || sum.PriorSessions > 0:
 		fmt.Fprintf(&b, "This topic has team history: %d related decision(s), %d prior session(s)/plan(s). Read the related DRs via ref_path and reconcile explicitly — state whether this aligns with, amends, or supersedes them; that judgment is yours, ox only surfaces candidates. Merge items that point at the same underlying fact into one citation rather than citing it three times; if a surfaced candidate turns out not to apply, say so and why instead of dropping it silently — a reviewer can't tell considered-and-rejected from missed. ", sum.Related, sum.PriorSessions)
+	case sum.Degraded:
+		// A source could not be read, so an empty result is NOT a checked
+		// absence. Never tell the agent to assert "no prior decision" as fact
+		// when retrieval was blind (#823).
+		b.WriteString("Retrieval was DEGRADED — a decision source could not be read (an unreadable corpus, or a lookup that errored), so this empty result is NOT a verified 'no prior decision'. Do not assert absence as fact. Investigate first: check the decision dir parses (a DR needs a number in filename/H1, or title + Status/Date), run `ox doctor`, and try `ox code search`. Only draft from first principles once you have confirmed there is genuinely nothing to reconcile. ")
 	case !isUpdate:
 		b.WriteString("No related decisions, sessions, or plans matched this topic. Draft from first principles and say so — 'no prior team decision found' is itself a verifiable claim. Do not invent citations; a gap admitted beats a citation invented. ")
 	}

--- a/internal/decision/guidance.go
+++ b/internal/decision/guidance.go
@@ -28,13 +28,14 @@ func buildGuidance(in Input, sum SignalSummary, conv Conventions, annotations []
 		b.WriteString("This DR has drifted: cited files changed after its date. If the decision still stands, add a dated amendment noting the new context; if not, amend or supersede per the corpus convention — your call. ")
 	case sum.Related > 0 || sum.PriorSessions > 0:
 		fmt.Fprintf(&b, "This topic has team history: %d related decision(s), %d prior session(s)/plan(s). Read the related DRs via ref_path and reconcile explicitly — state whether this aligns with, amends, or supersedes them; that judgment is yours, ox only surfaces candidates. Merge items that point at the same underlying fact into one citation rather than citing it three times; if a surfaced candidate turns out not to apply, say so and why instead of dropping it silently — a reviewer can't tell considered-and-rejected from missed. ", sum.Related, sum.PriorSessions)
-	case sum.Degraded:
-		// A source could not be read, so an empty result is NOT a checked
-		// absence. Never tell the agent to assert "no prior decision" as fact
-		// when retrieval was blind (#823).
-		b.WriteString("Retrieval was DEGRADED — a decision source could not be read (an unreadable corpus, or a lookup that errored), so this empty result is NOT a verified 'no prior decision'. Do not assert absence as fact. Investigate first: check the decision dir parses (a DR needs a number in filename/H1, or title + Status/Date), run `ox doctor`, and try `ox code search`. Only draft from first principles once you have confirmed there is genuinely nothing to reconcile. ")
-	case !isUpdate:
+	case !isUpdate && !sum.Degraded:
 		b.WriteString("No related decisions, sessions, or plans matched this topic. Draft from first principles and say so — 'no prior team decision found' is itself a verifiable claim. Do not invent citations; a gap admitted beats a citation invented. ")
+	}
+	if sum.Degraded {
+		// A source could not be read, so even surfaced matches are not exhaustive
+		// and an empty result is not a checked absence. Never tell the AI coworker
+		// to assert "no prior decision" as fact when retrieval was blind (#823).
+		b.WriteString("Retrieval was DEGRADED — a decision source could not be read (an unreadable corpus, or a lookup that errored), so the surfaced context may be incomplete and any apparent absence is NOT a verified 'no prior decision'. Do not assert absence as fact. Investigate first: check the decision dir parses (a DR needs a number in filename/H1, or title + Status/Date), run `ox doctor`, and try `ox code search`. Only draft from first principles once you have confirmed there is genuinely nothing to reconcile. ")
 	}
 
 	// Conventions.

--- a/internal/decision/retrievers.go
+++ b/internal/decision/retrievers.go
@@ -29,11 +29,13 @@ func (sessionsRetriever) Retrieve(_ context.Context, env *Env, in Input) ([]Cont
 		return nil, nil
 	}
 	results, err := ledgersearch.Search(ledgersearch.Options{
-		LedgerPath: env.LedgerPath,
-		Query:      terms,
-		Limit:      5,
+		LedgerPath:  env.LedgerPath,
+		Query:       terms,
+		Limit:       5,
+		StrictRead:  true,
+		SkipMurmurs: true,
 	})
-	if err != nil || len(results) == 0 {
+	if len(results) == 0 && err == nil {
 		return nil, nil
 	}
 
@@ -65,6 +67,9 @@ func (sessionsRetriever) Retrieve(_ context.Context, env *Env, in Input) ([]Cont
 		}
 		out = append(out, item)
 	}
+	if err != nil {
+		return out, fmt.Errorf("search prior sessions: %w", err)
+	}
 	return out, nil
 }
 
@@ -93,8 +98,8 @@ func (murmursRetriever) Retrieve(_ context.Context, env *Env, in Input) ([]Conte
 	if len(terms) == 0 || env.LedgerPath == "" {
 		return nil, nil
 	}
-	murmurs, err := ledger.ReadMurmursInWindow(env.LedgerPath, 24)
-	if err != nil || len(murmurs) == 0 {
+	murmurs, err := ledger.ReadMurmursInWindowStrict(env.LedgerPath, 24)
+	if len(murmurs) == 0 && err == nil {
 		return nil, nil
 	}
 
@@ -127,6 +132,9 @@ func (murmursRetriever) Retrieve(_ context.Context, env *Env, in Input) ([]Conte
 		if len(out) >= 3 {
 			break
 		}
+	}
+	if err != nil {
+		return out, fmt.Errorf("read recent decision murmurs: %w", err)
 	}
 	return out, nil
 }

--- a/internal/decision/search.go
+++ b/internal/decision/search.go
@@ -23,13 +23,16 @@ type RelevantDR struct {
 	Score   float64
 }
 
-// Relevant walks this repo's DR corpus fresh and returns the records most
-// relevant to query. Zero LLM/network; fail-open (empty on any miss). Exported
-// for internal/plan so `ox plan enrich` surfaces the decisions a plan builds
-// on — subtly, as context items the render turns into inline markers.
-func Relevant(gitRoot, query string, limit int) []RelevantDR {
+// Relevant walks this repo's DR corpus fresh and returns a bounded page of
+// above-floor records plus the number omitted. Ranking gives priority to the
+// earliest query prefix that provides enough evidence to clear the relevance
+// floor, then uses stable record metadata. Appending detail can therefore add
+// matches without reordering or evicting matches found by the shorter prefix
+// query. Zero LLM/network; fail-open on any miss.
+// Exported for internal/plan so both enrich commands share the same retrieval.
+func Relevant(gitRoot, query string, limit int) ([]RelevantDR, int) {
 	if gitRoot == "" || strings.TrimSpace(query) == "" || limit <= 0 {
-		return nil
+		return nil, 0
 	}
 	var cfg *config.DecisionConfig
 	if pc, err := config.LoadProjectConfig(gitRoot); err == nil && pc != nil {
@@ -37,11 +40,12 @@ func Relevant(gitRoot, query string, limit int) []RelevantDR {
 	}
 	corpus := LoadCorpus(gitRoot, cfg)
 	if len(corpus) == 0 {
-		return nil
+		return nil, 0
 	}
 	var out []RelevantDR
-	for _, s := range scoreCorpus(corpus, query) {
-		if s.score < minDRScore || len(out) >= limit {
+	matches := relevantCorpus(corpus, query)
+	for _, s := range matches {
+		if len(out) >= limit {
 			break
 		}
 		out = append(out, RelevantDR{
@@ -53,7 +57,7 @@ func Relevant(gitRoot, query string, limit int) []RelevantDR {
 			Score:   s.score,
 		})
 	}
-	return out
+	return out, len(matches) - len(out)
 }
 
 // minDRScore is the relevance floor for the DR-corpus scorer (Relevant,
@@ -77,16 +81,98 @@ type scored struct {
 	score float64
 }
 
-// droppedCandidates lists records that matched the query but scored below
-// minDRScore — the near-misses the floor discarded. Surfaced under --explain so
-// a caller can tell "no record was relevant" from "records were found and
-// dropped" (#823). Bounded so a broad query can't flood the output.
+// relevantCorpus filters to the relevance floor and orders matches so a
+// prefix query's bounded results survive when more descriptive words are
+// appended. A candidate ranks by the first query position where its cumulative
+// field evidence clears the floor; a record that needs appended evidence must
+// therefore follow every record that the original prefix already qualified.
+func relevantCorpus(corpus []Record, query string) []scored {
+	terms := tokenize(query)
+	if len(terms) == 0 {
+		return nil
+	}
+	var out []scored
+	for _, s := range scoreCorpus(corpus, query) {
+		if s.score >= minDRScore {
+			out = append(out, s)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		iPos, iWeight := qualificationRank(terms, out[i].rec, query)
+		jPos, jWeight := qualificationRank(terms, out[j].rec, query)
+		if iPos != jPos {
+			return iPos < jPos
+		}
+		if iWeight != jWeight {
+			return iWeight > jWeight
+		}
+		if out[i].rec.Date != out[j].rec.Date {
+			return out[i].rec.Date > out[j].rec.Date
+		}
+		return out[i].rec.ID < out[j].rec.ID
+	})
+	return out
+}
+
+func qualificationRank(terms []string, rec Record, query string) (int, int) {
+	if queryContainsRecordID(query, rec.ID) {
+		return -1, 3
+	}
+	title, mid, excerpt := recordFields(rec)
+	seen := make(map[string]struct{}, len(terms))
+	var cumulative float64
+	for i, term := range terms {
+		if _, duplicate := seen[term]; duplicate {
+			continue
+		}
+		seen[term] = struct{}{}
+		weight := 0
+		switch {
+		case strings.Contains(title, term):
+			weight = 3
+		case strings.Contains(mid, term):
+			weight = 2
+		case strings.Contains(excerpt, term):
+			weight = 1
+		}
+		cumulative += float64(weight)
+		if cumulative/(cumulative+fieldScoreK) >= minDRScore {
+			return i, weight
+		}
+	}
+	return len(terms), 0
+}
+
+// droppedCandidates lists records omitted by the related-annotation cap, then
+// records that matched below minDRScore. Surfaced under --explain so a caller
+// can distinguish a true miss from a bounded or thresholded result (#823).
+// The explanation itself is bounded so a broad query cannot flood output.
 func droppedCandidates(env *Env, in Input) []DroppedCandidate {
 	terms := in.Terms()
 	if strings.TrimSpace(terms) == "" || len(env.Corpus) == 0 {
 		return nil
 	}
 	var out []DroppedCandidate
+	related := 0
+	for _, s := range relevantCorpus(env.Corpus, terms) {
+		if in.Path != "" && samePath(in.Path, s.rec.Path) {
+			continue
+		}
+		related++
+		if related <= relatedCap {
+			continue
+		}
+		out = append(out, DroppedCandidate{
+			Ref:     s.rec.ID,
+			RefPath: s.rec.RelPath,
+			Title:   s.rec.Title,
+			Score:   s.score,
+			Reason:  fmt.Sprintf("cleared the relevance floor but ranked below the %d-item related-decision annotation cap", relatedCap),
+		})
+		if len(out) >= 10 {
+			return out
+		}
+	}
 	for _, s := range scoreCorpus(env.Corpus, terms) {
 		if s.score >= minDRScore {
 			continue // surfaced already, not dropped
@@ -120,7 +206,7 @@ func scoreCorpus(corpus []Record, query string) []scored {
 
 	var out []scored
 	for _, rec := range corpus {
-		if rec.ID != "" && rec.ID == normalizeLooseID(qUpper) {
+		if rec.ID != "" && (rec.ID == normalizeLooseID(qUpper) || queryContainsRecordID(query, rec.ID)) {
 			out = append(out, scored{rec: rec, score: 1.0})
 			continue
 		}
@@ -142,6 +228,21 @@ func scoreCorpus(corpus []Record, query string) []scored {
 	return out
 }
 
+func queryContainsRecordID(query, recordID string) bool {
+	if recordID == "" {
+		return false
+	}
+	if normalizeLooseID(strings.ToUpper(strings.TrimSpace(query))) == recordID {
+		return true
+	}
+	for _, match := range refTokenRe.FindAllStringSubmatch(query, -1) {
+		if normalizeRefToken(match[1], match[2]) == recordID {
+			return true
+		}
+	}
+	return false
+}
+
 // fieldScore ranks a record by how much distinctive signal the query lands on
 // its structured fields — NOT by what fraction of the query matched. The query
 // is often a whole plan or issue body, so the old coverage=matched/len(terms)
@@ -155,14 +256,7 @@ func scoreCorpus(corpus []Record, query string) []scored {
 // query can never score a record below a shorter subset query. That is exactly
 // the invariant #823 needs, and TestScoreCorpus_MonotonicInQueryLength guards it.
 func fieldScore(terms []string, rec Record) float64 {
-	title := strings.ToLower(rec.Title)
-	var anchors strings.Builder
-	for _, d := range rec.DSections {
-		anchors.WriteString(strings.ToLower(d.Heading))
-		anchors.WriteByte(' ')
-	}
-	mid := anchors.String() + strings.ToLower(rec.Status) + " " + strings.ToLower(strings.Join(rec.Deciders, " "))
-	excerpt := strings.ToLower(rec.Excerpt)
+	title, mid, excerpt := recordFields(rec)
 
 	seen := make(map[string]struct{}, len(terms))
 	matched := 0
@@ -190,6 +284,18 @@ func fieldScore(terms []string, rec Record) float64 {
 	return mw / (mw + fieldScoreK)
 }
 
+func recordFields(rec Record) (title, mid, excerpt string) {
+	title = strings.ToLower(rec.Title)
+	var anchors strings.Builder
+	for _, d := range rec.DSections {
+		anchors.WriteString(strings.ToLower(d.Heading))
+		anchors.WriteByte(' ')
+	}
+	mid = anchors.String() + strings.ToLower(rec.Status) + " " + strings.ToLower(strings.Join(rec.Deciders, " "))
+	excerpt = strings.ToLower(rec.Excerpt)
+	return title, mid, excerpt
+}
+
 // tokenize mirrors the ledgersearch tokenizer: lowercase alphanumeric terms,
 // punctuation stripped, stopword-light (short tokens dropped).
 func tokenize(q string) []string {
@@ -202,7 +308,8 @@ func tokenize(q string) []string {
 			return
 		}
 		switch t {
-		case "the", "and", "for", "with", "this", "that", "into", "over", "our":
+		case "the", "and", "for", "with", "this", "that", "into", "over", "our",
+			"about", "accepted", "decision", "need", "proposal", "record", "want":
 			return
 		}
 		out = append(out, t)

--- a/internal/decision/search.go
+++ b/internal/decision/search.go
@@ -174,6 +174,9 @@ func droppedCandidates(env *Env, in Input) []DroppedCandidate {
 		}
 	}
 	for _, s := range scoreCorpus(env.Corpus, terms) {
+		if in.Path != "" && samePath(in.Path, s.rec.Path) {
+			continue
+		}
 		if s.score >= minDRScore {
 			continue // surfaced already, not dropped
 		}

--- a/internal/decision/search.go
+++ b/internal/decision/search.go
@@ -1,6 +1,7 @@
 package decision
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -40,7 +41,7 @@ func Relevant(gitRoot, query string, limit int) []RelevantDR {
 	}
 	var out []RelevantDR
 	for _, s := range scoreCorpus(corpus, query) {
-		if s.score < minBundleScore || len(out) >= limit {
+		if s.score < minDRScore || len(out) >= limit {
 			break
 		}
 		out = append(out, RelevantDR{
@@ -55,10 +56,53 @@ func Relevant(gitRoot, query string, limit int) []RelevantDR {
 	return out
 }
 
+// minDRScore is the relevance floor for the DR-corpus scorer (Relevant,
+// relatedDetector, relatedRetriever). It is deliberately SEPARATE from
+// minBundleScore, which gates the ledgersearch/sessions path on a different
+// score scale ([0.5,1.0]). Under the saturating fieldScore (see below), a match
+// on a single title term scores ~0.43 and a two-term title match ~0.60, while a
+// lone excerpt hit scores ~0.20 — so 0.30 admits real title/anchor matches and
+// rejects excerpt-only noise. Errs toward recall by design (#823): callers can
+// see what the floor dropped via `--explain`.
+const minDRScore = 0.30
+
+// fieldScoreK is the saturation constant in fieldScore's mw/(mw+K). Larger K
+// makes scores rise more slowly with matched signal; K=4 keeps a single title
+// term below a two-term title match while both clear minDRScore.
+const fieldScoreK = 4.0
+
 // scored pairs a corpus record with its lexical relevance to the input terms.
 type scored struct {
 	rec   Record
 	score float64
+}
+
+// droppedCandidates lists records that matched the query but scored below
+// minDRScore — the near-misses the floor discarded. Surfaced under --explain so
+// a caller can tell "no record was relevant" from "records were found and
+// dropped" (#823). Bounded so a broad query can't flood the output.
+func droppedCandidates(env *Env, in Input) []DroppedCandidate {
+	terms := in.Terms()
+	if strings.TrimSpace(terms) == "" || len(env.Corpus) == 0 {
+		return nil
+	}
+	var out []DroppedCandidate
+	for _, s := range scoreCorpus(env.Corpus, terms) {
+		if s.score >= minDRScore {
+			continue // surfaced already, not dropped
+		}
+		out = append(out, DroppedCandidate{
+			Ref:     s.rec.ID,
+			RefPath: s.rec.RelPath,
+			Title:   s.rec.Title,
+			Score:   s.score,
+			Reason:  fmt.Sprintf("scored %.3f, below the relevance floor %.2f", s.score, minDRScore),
+		})
+		if len(out) >= 10 {
+			break
+		}
+	}
+	return out
 }
 
 // scoreCorpus ranks corpus records against query terms with the house lexical
@@ -98,6 +142,18 @@ func scoreCorpus(corpus []Record, query string) []scored {
 	return out
 }
 
+// fieldScore ranks a record by how much distinctive signal the query lands on
+// its structured fields — NOT by what fraction of the query matched. The query
+// is often a whole plan or issue body, so the old coverage=matched/len(terms)
+// let every off-topic word dilute a real match until the record vanished
+// (#823). Instead we sum field-weighted hits over the DISTINCT query terms
+// (title 3, anchors/status/deciders 2, excerpt 1 — best field per term) and
+// saturate: score = mw/(mw+fieldScoreK), always in [0,1).
+//
+// This is monotonic in the query: adding a term can only add a match (raising
+// mw) or match nothing (leaving mw unchanged), never remove one — so a longer
+// query can never score a record below a shorter subset query. That is exactly
+// the invariant #823 needs, and TestScoreCorpus_MonotonicInQueryLength guards it.
 func fieldScore(terms []string, rec Record) float64 {
 	title := strings.ToLower(rec.Title)
 	var anchors strings.Builder
@@ -108,44 +164,30 @@ func fieldScore(terms []string, rec Record) float64 {
 	mid := anchors.String() + strings.ToLower(rec.Status) + " " + strings.ToLower(strings.Join(rec.Deciders, " "))
 	excerpt := strings.ToLower(rec.Excerpt)
 
+	seen := make(map[string]struct{}, len(terms))
 	matched := 0
-	var raw float64
+	var mw float64
 	for _, t := range terms {
-		hit := false
-		if strings.Contains(title, t) {
-			raw += 3
-			hit = true
+		if _, dup := seen[t]; dup {
+			continue // a repeated term is one signal, not many
 		}
-		if strings.Contains(mid, t) {
-			raw += 2
-			hit = true
-		}
-		if strings.Contains(excerpt, t) {
-			raw += 1
-			hit = true
-		}
-		if hit {
+		seen[t] = struct{}{}
+		switch { // credit the strongest field the term appears in, once
+		case strings.Contains(title, t):
+			mw += 3
+			matched++
+		case strings.Contains(mid, t):
+			mw += 2
+			matched++
+		case strings.Contains(excerpt, t):
+			mw += 1
 			matched++
 		}
 	}
 	if matched == 0 {
 		return 0
 	}
-	// coverage-dominant score: fraction of terms matched, with the weighted
-	// hits as a small tiebreaker. Requiring most terms keeps AND semantics
-	// without zeroing near-misses on long titles.
-	coverage := float64(matched) / float64(len(terms))
-	if coverage < 0.5 {
-		return 0
-	}
-	return coverage*0.85 + minF(raw/float64(6*len(terms)), 1.0)*0.15
-}
-
-func minF(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
+	return mw / (mw + fieldScoreK)
 }
 
 // tokenize mirrors the ledgersearch tokenizer: lowercase alphanumeric terms,

--- a/internal/decision/sources.go
+++ b/internal/decision/sources.go
@@ -207,20 +207,34 @@ func hasGlobMeta(pattern string) bool {
 var (
 	likelyDecisionNameRe    = regexp.MustCompile(`(?i)^(?:adr|ddr)(?:[-_]|\.md$)|^\d{1,4}[-_]`)
 	decisionSectionIntentRe = regexp.MustCompile(`(?im)^##\s+decision\b`)
+	decisionSupportFiles    = map[string]struct{}{
+		"contributing.md": {},
+		"guide.md":        {},
+		"index.md":        {},
+		"notes.md":        {},
+		"process.md":      {},
+		"template.md":     {},
+	}
 )
 
 // likelyDecisionRecord distinguishes malformed DRs from intentional Markdown
-// neighbors such as notes.md and TEMPLATE.md. Strong intent signals are a DR-
-// shaped filename/H1, explicit DR frontmatter, or a Decision section.
+// neighbors such as notes.md and TEMPLATE.md. Known support filenames are
+// excluded; other Markdown with a title is conservatively treated as a broken
+// DR so a descriptive filename cannot turn an unparseable decision into a
+// falsely verified absence.
 func likelyDecisionRecord(path, content string) bool {
 	base := filepath.Base(path)
 	if likelyDecisionNameRe.MatchString(base) || headIDRe.MatchString(firstH1Line(content)) {
 		return true
 	}
+	if _, excluded := decisionSupportFiles[strings.ToLower(base)]; excluded {
+		return false
+	}
 	lower := strings.ToLower(content)
 	return strings.Contains(lower, "\ntype: adr") ||
 		strings.Contains(lower, "\ntype: ddr") ||
-		decisionSectionIntentRe.MatchString(content)
+		decisionSectionIntentRe.MatchString(content) ||
+		firstH1Line(content) != ""
 }
 
 // PathMatcher returns a predicate reporting whether a repo-relative path lies

--- a/internal/decision/sources.go
+++ b/internal/decision/sources.go
@@ -1,9 +1,12 @@
 package decision
 
 import (
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -63,21 +66,47 @@ func CorpusDetected(gitRoot string) bool {
 // already exists in codedb (`ox code search` reaches these same files).
 // Fail-open throughout: unreadable files are skipped with a debug log.
 func LoadCorpus(gitRoot string, cfg *config.DecisionConfig) []Record {
+	return loadCorpus(gitRoot, cfg).records
+}
+
+type corpusLoadResult struct {
+	records  []Record
+	unparsed int
+	err      error
+}
+
+// loadCorpus is the honesty-sensitive loader used by Enrich. LoadCorpus keeps
+// its historical fail-open API for passive callers, while this variant reports
+// configured-source discovery failures, unreadable files, and markdown that is
+// clearly intended to be a DR but is too malformed to catalog. Ordinary notes,
+// templates, and README files are normal exclusions, not source failures.
+func loadCorpus(gitRoot string, cfg *config.DecisionConfig) corpusLoadResult {
 	paths := resolvePaths(gitRoot, cfg)
 	if len(paths) == 0 {
-		return nil
+		return corpusLoadResult{}
 	}
 
+	discovery := discoverFiles(gitRoot, paths, cfg != nil && !cfg.IsEmpty())
 	var records []Record
-	for _, file := range listFiles(gitRoot, paths) {
+	var loadErrs []error
+	if discovery.err != nil {
+		loadErrs = append(loadErrs, discovery.err)
+	}
+	unparsed := 0
+	for _, file := range discovery.files {
 		data, err := os.ReadFile(file)
 		if err != nil {
 			slog.Debug("decision: unreadable file skipped", "path", file, "error", err)
+			loadErrs = append(loadErrs, fmt.Errorf("read %s: %w", file, err))
+			unparsed++
 			continue
 		}
 		rec := ParseContent(file, string(data))
 		if !rec.IsRecord() {
-			continue // plain markdown, not DR-shaped
+			if likelyDecisionRecord(file, string(data)) {
+				unparsed++
+			}
+			continue
 		}
 		if fi, err := os.Stat(file); err == nil {
 			rec.Mtime = fi.ModTime().Unix()
@@ -96,14 +125,27 @@ func LoadCorpus(gitRoot string, cfg *config.DecisionConfig) []Record {
 		}
 		return records[i].RelPath < records[j].RelPath
 	})
-	return records
+	return corpusLoadResult{records: records, unparsed: unparsed, err: errors.Join(loadErrs...)}
 }
 
 // listFiles expands dirs (recursive *.md) and doublestar globs into a deduped
 // file list. README.md is excluded everywhere — corpus index tables, not DRs.
 func listFiles(gitRoot string, patterns []string) []string {
+	return discoverFiles(gitRoot, patterns, false).files
+}
+
+type fileDiscovery struct {
+	files []string
+	err   error
+}
+
+// discoverFiles is listFiles plus source-status reporting. When configured is
+// true, a literal path was explicitly promised by decision.paths, so a missing
+// or inaccessible path is an unavailable source rather than an empty corpus.
+func discoverFiles(gitRoot string, patterns []string, configured bool) fileDiscovery {
 	seen := make(map[string]struct{})
 	var out []string
+	var discoveryErrs []error
 	add := func(p string) {
 		if !strings.EqualFold(filepath.Ext(p), ".md") {
 			return
@@ -120,26 +162,65 @@ func listFiles(gitRoot string, patterns []string) []string {
 
 	for _, pat := range patterns {
 		full := filepath.Join(gitRoot, pat)
-		if fi, err := os.Stat(full); err == nil && fi.IsDir() {
-			_ = filepath.WalkDir(full, func(p string, d os.DirEntry, err error) error {
-				if err != nil || d.IsDir() {
-					return nil // fail-open per entry
+		fi, statErr := os.Stat(full)
+		if statErr == nil && fi.IsDir() {
+			walkErr := filepath.WalkDir(full, func(p string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() {
+					return nil
 				}
 				add(p)
 				return nil
 			})
+			if walkErr != nil {
+				discoveryErrs = append(discoveryErrs, fmt.Errorf("walk decision path %q: %w", pat, walkErr))
+			}
+			continue
+		}
+		if statErr == nil {
+			add(full)
+			continue
+		}
+		if configured && !hasGlobMeta(pat) {
+			discoveryErrs = append(discoveryErrs, fmt.Errorf("access configured decision path %q: %w", pat, statErr))
 			continue
 		}
 		matches, err := doublestar.Glob(os.DirFS(gitRoot), pat)
 		if err != nil {
 			slog.Debug("decision: bad glob", "pattern", pat, "error", err)
+			discoveryErrs = append(discoveryErrs, fmt.Errorf("expand decision path %q: %w", pat, err))
 			continue
 		}
 		for _, m := range matches {
 			add(filepath.Join(gitRoot, m))
 		}
 	}
-	return out
+	return fileDiscovery{files: out, err: errors.Join(discoveryErrs...)}
+}
+
+func hasGlobMeta(pattern string) bool {
+	return strings.ContainsAny(pattern, `*?[{`)
+}
+
+var (
+	likelyDecisionNameRe    = regexp.MustCompile(`(?i)^(?:adr|ddr)(?:[-_]|\.md$)|^\d{1,4}[-_]`)
+	decisionSectionIntentRe = regexp.MustCompile(`(?im)^##\s+decision\b`)
+)
+
+// likelyDecisionRecord distinguishes malformed DRs from intentional Markdown
+// neighbors such as notes.md and TEMPLATE.md. Strong intent signals are a DR-
+// shaped filename/H1, explicit DR frontmatter, or a Decision section.
+func likelyDecisionRecord(path, content string) bool {
+	base := filepath.Base(path)
+	if likelyDecisionNameRe.MatchString(base) || headIDRe.MatchString(firstH1Line(content)) {
+		return true
+	}
+	lower := strings.ToLower(content)
+	return strings.Contains(lower, "\ntype: adr") ||
+		strings.Contains(lower, "\ntype: ddr") ||
+		decisionSectionIntentRe.MatchString(content)
 }
 
 // PathMatcher returns a predicate reporting whether a repo-relative path lies

--- a/internal/decision/sources.go
+++ b/internal/decision/sources.go
@@ -213,6 +213,7 @@ var (
 		"index.md":        {},
 		"notes.md":        {},
 		"process.md":      {},
+		"readme.md":       {},
 		"template.md":     {},
 	}
 )
@@ -224,11 +225,11 @@ var (
 // falsely verified absence.
 func likelyDecisionRecord(path, content string) bool {
 	base := filepath.Base(path)
-	if likelyDecisionNameRe.MatchString(base) || headIDRe.MatchString(firstH1Line(content)) {
-		return true
-	}
 	if _, excluded := decisionSupportFiles[strings.ToLower(base)]; excluded {
 		return false
+	}
+	if likelyDecisionNameRe.MatchString(base) || headIDRe.MatchString(firstH1Line(content)) {
+		return true
 	}
 	lower := strings.ToLower(content)
 	return strings.Contains(lower, "\ntype: adr") ||

--- a/internal/decision/types.go
+++ b/internal/decision/types.go
@@ -57,6 +57,9 @@ const (
 	RuleDanglingRef           = "dangling-ref"
 	RuleSupersededNoSuccessor = "superseded-no-successor"
 	RuleSageoxCreditOverflow  = "sageox-credit-overflow"
+	// RuleUnreadableCorpus: a decision dir exists and holds markdown, but none
+	// of it parsed as a Decision Record — a format problem, not an absence.
+	RuleUnreadableCorpus = "unreadable-corpus"
 
 	// RelationCandidate is the ONLY relation ox asserts (marker doctrine):
 	// related/conflicting/superseding is the agent's judgment.
@@ -135,6 +138,22 @@ type SignalSummary struct {
 	Diagnostics    int  `json:"diagnostics"`
 	UnresolvedRefs int  `json:"unresolved_refs"`
 	Material       bool `json:"material"`
+	// Degraded is true when a retrieval source could not be read (a detector or
+	// retriever errored, or a decision dir exists but nothing in it parsed as a
+	// record). A degraded run is NOT a verified "no prior decision" — guidance
+	// must never present its emptiness as a checked absence (#823).
+	Degraded bool `json:"degraded,omitempty"`
+}
+
+// DroppedCandidate is a record that matched the query but scored below the
+// relevance floor. Surfaced only under --explain so a caller can tell "nothing
+// was relevant" apart from "records were found and dropped by the floor" (#823).
+type DroppedCandidate struct {
+	Ref     string  `json:"ref,omitempty"`
+	RefPath string  `json:"ref_path,omitempty"`
+	Title   string  `json:"title,omitempty"`
+	Score   float64 `json:"score"`
+	Reason  string  `json:"reason"`
 }
 
 // Result is the `ox decision enrich` JSON payload.
@@ -146,6 +165,8 @@ type Result struct {
 	Context       []ContextItem `json:"context"`
 	Signals       SignalSummary `json:"signals"`
 	Guidance      string        `json:"guidance"`
+	// Dropped lists sub-floor candidates; populated only under --explain.
+	Dropped []DroppedCandidate `json:"dropped,omitempty"`
 }
 
 // Env is the shared, read-only environment Enrich resolves ONCE and hands to
@@ -158,6 +179,13 @@ type Env struct {
 	// LedgerPath is the local ledger checkout (sessions, murmurs). Empty when
 	// no ledger is provisioned.
 	LedgerPath string
+	// CorpusUnparsed counts markdown files found in a decision dir that did NOT
+	// parse as records — nonzero means the corpus is present but unreadable, a
+	// distinct state from "no corpus" (#823).
+	CorpusUnparsed int
+	// Explain, when set, makes Enrich populate Result.Dropped with sub-floor
+	// candidates so a caller can see what the relevance floor discarded.
+	Explain bool
 }
 
 // Detector produces deterministic annotations. Fail-open: return (nil, nil)

--- a/internal/decision/types.go
+++ b/internal/decision/types.go
@@ -57,8 +57,11 @@ const (
 	RuleDanglingRef           = "dangling-ref"
 	RuleSupersededNoSuccessor = "superseded-no-successor"
 	RuleSageoxCreditOverflow  = "sageox-credit-overflow"
-	// RuleUnreadableCorpus: a decision dir exists and holds markdown, but none
-	// of it parsed as a Decision Record — a format problem, not an absence.
+	// RuleRelatedOverflow reports bounded related-decision results with more
+	// above-floor candidates available through --explain/code search.
+	RuleRelatedOverflow = "related-decision-overflow"
+	// RuleUnreadableCorpus: one or more intended DR files could not be read or
+	// parsed — a source gap, not evidence that no prior decision exists.
 	RuleUnreadableCorpus = "unreadable-corpus"
 
 	// RelationCandidate is the ONLY relation ox asserts (marker doctrine):
@@ -145,9 +148,9 @@ type SignalSummary struct {
 	Degraded bool `json:"degraded,omitempty"`
 }
 
-// DroppedCandidate is a record that matched the query but scored below the
-// relevance floor. Surfaced only under --explain so a caller can tell "nothing
-// was relevant" apart from "records were found and dropped by the floor" (#823).
+// DroppedCandidate is a record omitted by a result cap or the relevance floor.
+// Surfaced only under --explain so callers can distinguish a true miss from a
+// bounded or thresholded result (#823).
 type DroppedCandidate struct {
 	Ref     string  `json:"ref,omitempty"`
 	RefPath string  `json:"ref_path,omitempty"`
@@ -165,7 +168,7 @@ type Result struct {
 	Context       []ContextItem `json:"context"`
 	Signals       SignalSummary `json:"signals"`
 	Guidance      string        `json:"guidance"`
-	// Dropped lists sub-floor candidates; populated only under --explain.
+	// Dropped lists cap-omitted and sub-floor candidates under --explain.
 	Dropped []DroppedCandidate `json:"dropped,omitempty"`
 }
 
@@ -179,12 +182,16 @@ type Env struct {
 	// LedgerPath is the local ledger checkout (sessions, murmurs). Empty when
 	// no ledger is provisioned.
 	LedgerPath string
-	// CorpusUnparsed counts markdown files found in a decision dir that did NOT
-	// parse as records — nonzero means the corpus is present but unreadable, a
-	// distinct state from "no corpus" (#823).
+	// CorpusUnparsed counts unreadable files and files with strong DR intent that
+	// did not make it into the catalog. Ordinary notes/templates are excluded
+	// without degrading the corpus.
 	CorpusUnparsed int
-	// Explain, when set, makes Enrich populate Result.Dropped with sub-floor
-	// candidates so a caller can see what the relevance floor discarded.
+	// SourceUnavailable records a project/config source that could not be loaded.
+	// Enrich remains fail-open, but its result must not describe the resulting
+	// absence as verified.
+	SourceUnavailable bool
+	// Explain, when set, makes Enrich populate Result.Dropped with cap-omitted
+	// and sub-floor candidates.
 	Explain bool
 }
 

--- a/internal/ledger/murmur.go
+++ b/internal/ledger/murmur.go
@@ -2,6 +2,7 @@ package ledger
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -155,12 +156,25 @@ func FindMurmur(baseDir, murmurID string) (string, error) {
 // baseDir is the root of the ledger or team context checkout.
 // windowHours is clamped to MaxMurmurWindowHours (24h) — older murmurs are always ignored.
 func ReadMurmursInWindow(baseDir string, windowHours int) ([]MurmurFile, error) {
+	return readMurmursInWindow(baseDir, windowHours, false)
+}
+
+// ReadMurmursInWindowStrict is the honesty-sensitive variant used when an
+// unavailable cache must be distinguishable from a genuinely empty window.
+// Missing hourly directories remain normal; unexpected read or JSON errors are
+// returned instead of silently converted to no murmurs.
+func ReadMurmursInWindowStrict(baseDir string, windowHours int) ([]MurmurFile, error) {
+	return readMurmursInWindow(baseDir, windowHours, true)
+}
+
+func readMurmursInWindow(baseDir string, windowHours int, strict bool) ([]MurmurFile, error) {
 	if windowHours > MaxMurmurWindowHours {
 		windowHours = MaxMurmurWindowHours
 	}
 	now := time.Now().UTC()
 	cutoff := now.Add(-time.Duration(windowHours) * time.Hour)
 	var murmurs []MurmurFile
+	var readErrs []error
 
 	for i := 0; i < windowHours; i++ {
 		t := now.Add(-time.Duration(i) * time.Hour)
@@ -168,7 +182,11 @@ func ReadMurmursInWindow(baseDir string, windowHours int) ([]MurmurFile, error) 
 
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			// missing or unreadable directories are not fatal
+			if strict && !errors.Is(err, os.ErrNotExist) {
+				readErrs = append(readErrs, fmt.Errorf("read murmur directory %s: %w", dir, err))
+			}
+			// Missing hourly directories are normal in both modes; unreadable
+			// directories remain fail-open in the default mode.
 			continue
 		}
 
@@ -179,11 +197,17 @@ func ReadMurmursInWindow(baseDir string, windowHours int) ([]MurmurFile, error) 
 
 			data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
 			if err != nil {
+				if strict && !errors.Is(err, os.ErrNotExist) {
+					readErrs = append(readErrs, fmt.Errorf("read murmur %s: %w", entry.Name(), err))
+				}
 				continue
 			}
 
 			var m MurmurFile
 			if err := json.Unmarshal(data, &m); err != nil {
+				if strict {
+					readErrs = append(readErrs, fmt.Errorf("parse murmur %s: %w", entry.Name(), err))
+				}
 				continue // skip invalid JSON
 			}
 
@@ -195,5 +219,5 @@ func ReadMurmursInWindow(baseDir string, windowHours int) ([]MurmurFile, error) 
 		}
 	}
 
-	return murmurs, nil
+	return murmurs, errors.Join(readErrs...)
 }

--- a/internal/ledger/murmur_io_test.go
+++ b/internal/ledger/murmur_io_test.go
@@ -354,3 +354,29 @@ func TestWriteMurmur_MultipleInSameHour(t *testing.T) {
 		t.Errorf("expected 3 murmurs, got %d", len(murmurs))
 	}
 }
+
+func TestReadMurmursInWindowStrict_ReportsCorruptFile(t *testing.T) {
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+	dir := filepath.Join(baseDir, MurmurDateHourDir(now))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteMurmur(baseDir, MurmurFile{ID: "a-valid", Timestamp: now, Content: "valid"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "z-broken.json"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ReadMurmursInWindow(baseDir, 1); err != nil {
+		t.Fatalf("default read must remain fail-open: %v", err)
+	}
+	murmurs, err := ReadMurmursInWindowStrict(baseDir, 1)
+	if err == nil {
+		t.Fatal("strict read must report corrupt source data")
+	}
+	if len(murmurs) != 1 || murmurs[0].ID != "a-valid" {
+		t.Fatalf("strict read must preserve valid partial murmurs: %+v", murmurs)
+	}
+}

--- a/internal/ledgersearch/ledgersearch.go
+++ b/internal/ledgersearch/ledgersearch.go
@@ -246,6 +246,7 @@ func scanSessions(ledgerPath string, terms []string, now time.Time, strict bool)
 
 	cutoff := now.Add(-MaxSessionAge)
 	var results []Result
+	var scanErrs []error
 
 	for _, e := range entries {
 		if !e.IsDir() {
@@ -268,7 +269,7 @@ func scanSessions(ledgerPath string, terms []string, now time.Time, strict bool)
 			data, rerr := os.ReadFile(path)
 			if rerr != nil {
 				if strict && !errors.Is(rerr, fs.ErrNotExist) {
-					return results, rerr
+					scanErrs = append(scanErrs, fmt.Errorf("read %s: %w", path, rerr))
 				}
 				continue
 			}
@@ -288,7 +289,7 @@ func scanSessions(ledgerPath string, terms []string, now time.Time, strict bool)
 			break // one hit per session
 		}
 	}
-	return results, nil
+	return results, errors.Join(scanErrs...)
 }
 
 // scanMurmurs walks data/murmurs/YYYY-MM-DD/HH/*.json scoring content matches.
@@ -303,6 +304,7 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time, strict bool) 
 
 	cutoff := now.Add(-MaxMurmurAge)
 	var results []Result
+	var scanErrs []error
 
 	dayEntries, err := os.ReadDir(murmursDir)
 	if err != nil {
@@ -323,7 +325,7 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time, strict bool) 
 		hourEntries, readErr := os.ReadDir(dayPath)
 		if readErr != nil {
 			if strict && !errors.Is(readErr, fs.ErrNotExist) {
-				return results, readErr
+				scanErrs = append(scanErrs, fmt.Errorf("read murmur day %s: %w", dayPath, readErr))
 			}
 			continue
 		}
@@ -335,7 +337,7 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time, strict bool) 
 			files, readErr := os.ReadDir(hourPath)
 			if readErr != nil {
 				if strict && !errors.Is(readErr, fs.ErrNotExist) {
-					return results, readErr
+					scanErrs = append(scanErrs, fmt.Errorf("read murmur hour %s: %w", hourPath, readErr))
 				}
 				continue
 			}
@@ -347,7 +349,7 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time, strict bool) 
 				data, rerr := os.ReadFile(path)
 				if rerr != nil {
 					if strict && !errors.Is(rerr, fs.ErrNotExist) {
-						return results, rerr
+						scanErrs = append(scanErrs, fmt.Errorf("read %s: %w", path, rerr))
 					}
 					continue
 				}
@@ -359,7 +361,7 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time, strict bool) 
 				}
 				if jerr := json.Unmarshal(data, &m); jerr != nil {
 					if strict {
-						return results, fmt.Errorf("parse %s: %w", path, jerr)
+						scanErrs = append(scanErrs, fmt.Errorf("parse %s: %w", path, jerr))
 					}
 					continue
 				}
@@ -383,7 +385,7 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time, strict bool) 
 			}
 		}
 	}
-	return results, nil
+	return results, errors.Join(scanErrs...)
 }
 
 // scanPlans walks data/plans/<YYYY-MM-DD-slug>/ and scores plan.md hits. This
@@ -405,6 +407,7 @@ func scanPlans(ledgerPath string, terms []string, now time.Time, strict bool) ([
 
 	cutoff := now.Add(-MaxPlanAge)
 	var results []Result
+	var scanErrs []error
 
 	for _, e := range entries {
 		if !e.IsDir() {
@@ -427,7 +430,7 @@ func scanPlans(ledgerPath string, terms []string, now time.Time, strict bool) ([
 		data, rerr := os.ReadFile(path)
 		if rerr != nil {
 			if strict && !errors.Is(rerr, fs.ErrNotExist) {
-				return results, rerr
+				scanErrs = append(scanErrs, fmt.Errorf("read %s: %w", path, rerr))
 			}
 			continue
 		}
@@ -445,7 +448,7 @@ func scanPlans(ledgerPath string, terms []string, now time.Time, strict bool) ([
 			CreatedAt:  ts.Format(time.RFC3339),
 		})
 	}
-	return results, nil
+	return results, errors.Join(scanErrs...)
 }
 
 // scanPlanFeedback walks data/plans/<dated-slug>/feedback/round-*.json and
@@ -467,6 +470,7 @@ func scanPlanFeedback(ledgerPath string, terms []string, now time.Time, strict b
 
 	cutoff := now.Add(-MaxPlanAge)
 	var results []Result
+	var scanErrs []error
 
 	for _, e := range entries {
 		if !e.IsDir() {
@@ -481,7 +485,7 @@ func scanPlanFeedback(ledgerPath string, terms []string, now time.Time, strict b
 		rounds, rerr := os.ReadDir(fbDir)
 		if rerr != nil {
 			if strict && !errors.Is(rerr, fs.ErrNotExist) {
-				return results, rerr
+				scanErrs = append(scanErrs, fmt.Errorf("read feedback dir %s: %w", fbDir, rerr))
 			}
 			continue
 		}
@@ -493,7 +497,7 @@ func scanPlanFeedback(ledgerPath string, terms []string, now time.Time, strict b
 			data, ferr := os.ReadFile(path)
 			if ferr != nil {
 				if strict && !errors.Is(ferr, fs.ErrNotExist) {
-					return results, ferr
+					scanErrs = append(scanErrs, fmt.Errorf("read %s: %w", path, ferr))
 				}
 				continue
 			}
@@ -510,7 +514,7 @@ func scanPlanFeedback(ledgerPath string, terms []string, now time.Time, strict b
 			}
 			if jerr := json.Unmarshal(data, &round); jerr != nil {
 				if strict {
-					return results, fmt.Errorf("parse %s: %w", path, jerr)
+					scanErrs = append(scanErrs, fmt.Errorf("parse %s: %w", path, jerr))
 				}
 				continue
 			}
@@ -547,7 +551,7 @@ func scanPlanFeedback(ledgerPath string, terms []string, now time.Time, strict b
 			})
 		}
 	}
-	return results, nil
+	return results, errors.Join(scanErrs...)
 }
 
 // planTimestamp resolves a plan's created_at, preferring meta.json's explicit

--- a/internal/ledgersearch/ledgersearch.go
+++ b/internal/ledgersearch/ledgersearch.go
@@ -15,15 +15,20 @@
 //     invocation and add cache-staleness logic for marginal gain at current
 //     sizes. Revisit if session count grows or queries get more complex.
 //
-// All callers MUST go through Search — the package guarantees:
+// All callers MUST go through Search — the package guarantees by default:
 //   - Zero network calls.
 //   - Fail-open: any read error or empty cache returns empty results, nil err.
 //   - Bounded scan: respects MaxSessionAge and result limit.
+//
+// Callers that must distinguish an unavailable source from an empty one set
+// Options.StrictRead. That mode reports unexpected filesystem/JSON errors while
+// still treating genuinely missing optional cache directories as empty.
 package ledgersearch
 
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -97,11 +102,18 @@ type Options struct {
 	Limit int
 	// Now is injectable for tests. Zero value uses time.Now().
 	Now time.Time
+	// StrictRead reports unexpected read/parse failures instead of silently
+	// treating them as an empty cache. Missing optional cache paths remain clean.
+	StrictRead bool
+	// SkipMurmurs excludes ephemeral murmur documents. Durable-history callers
+	// use this when murmurs are owned by a separate retriever/status signal.
+	SkipMurmurs bool
 }
 
 // Search scans the local ledger for query matches. Pure-local, no network.
-// Returns ([], nil) on any read error — this is intentional fail-open behavior
-// per the ox-m01h spec (hooks must never error out on missing cache).
+// By default it returns ([], nil) on read errors — intentional fail-open
+// behavior per the ox-m01h spec (hooks must never fail on missing cache).
+// Options.StrictRead instead reports unexpected read/parse failures.
 func Search(opts Options) ([]Result, error) {
 	query := strings.TrimSpace(opts.Query)
 	if query == "" {
@@ -124,6 +136,9 @@ func Search(opts Options) ([]Result, error) {
 			return nil, nil
 		}
 		slog.Debug("ledgersearch: ledger path stat failed", "path", opts.LedgerPath, "err", err)
+		if opts.StrictRead {
+			return nil, fmt.Errorf("stat ledger path: %w", err)
+		}
 		return nil, nil
 	}
 
@@ -133,10 +148,25 @@ func Search(opts Options) ([]Result, error) {
 	}
 
 	var results []Result
-	results = append(results, scanSessions(opts.LedgerPath, terms, now)...)
-	results = append(results, scanMurmurs(opts.LedgerPath, terms, now)...)
-	results = append(results, scanPlans(opts.LedgerPath, terms, now)...)
-	results = append(results, scanPlanFeedback(opts.LedgerPath, terms, now)...)
+	var searchErrs []error
+	for _, scan := range []struct {
+		name string
+		fn   func(string, []string, time.Time, bool) ([]Result, error)
+	}{
+		{name: "sessions", fn: scanSessions},
+		{name: "murmurs", fn: scanMurmurs},
+		{name: "plans", fn: scanPlans},
+		{name: "plan feedback", fn: scanPlanFeedback},
+	} {
+		if opts.SkipMurmurs && scan.name == "murmurs" {
+			continue
+		}
+		found, err := scan.fn(opts.LedgerPath, terms, now, opts.StrictRead)
+		results = append(results, found...)
+		if err != nil {
+			searchErrs = append(searchErrs, fmt.Errorf("scan %s: %w", scan.name, err))
+		}
+	}
 
 	// sort by score desc, ties broken by recency desc
 	sort.SliceStable(results, func(i, j int) bool {
@@ -149,7 +179,7 @@ func Search(opts Options) ([]Result, error) {
 	if len(results) > opts.Limit {
 		results = results[:opts.Limit]
 	}
-	return results, nil
+	return results, errors.Join(searchErrs...)
 }
 
 // tokenize splits a query into lowercase terms. Strips punctuation so
@@ -204,11 +234,14 @@ func isDraftSession(sessionPath string) bool {
 // scanSessions walks sessions/<session-name>/ and scores summary/meta hits.
 // Reads only summary.md and meta.json — skips raw.jsonl (large, low signal,
 // often dehydrated to LFS pointer files).
-func scanSessions(ledgerPath string, terms []string, now time.Time) []Result {
+func scanSessions(ledgerPath string, terms []string, now time.Time, strict bool) ([]Result, error) {
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	entries, err := os.ReadDir(sessionsDir)
 	if err != nil {
-		return nil
+		if strict && !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		return nil, nil
 	}
 
 	cutoff := now.Add(-MaxSessionAge)
@@ -234,6 +267,9 @@ func scanSessions(ledgerPath string, terms []string, now time.Time) []Result {
 			path := filepath.Join(sessionPath, candidate)
 			data, rerr := os.ReadFile(path)
 			if rerr != nil {
+				if strict && !errors.Is(rerr, fs.ErrNotExist) {
+					return results, rerr
+				}
 				continue
 			}
 			score, snippet := scoreContent(string(data), terms)
@@ -252,14 +288,17 @@ func scanSessions(ledgerPath string, terms []string, now time.Time) []Result {
 			break // one hit per session
 		}
 	}
-	return results
+	return results, nil
 }
 
 // scanMurmurs walks data/murmurs/YYYY-MM-DD/HH/*.json scoring content matches.
-func scanMurmurs(ledgerPath string, terms []string, now time.Time) []Result {
+func scanMurmurs(ledgerPath string, terms []string, now time.Time, strict bool) ([]Result, error) {
 	murmursDir := filepath.Join(ledgerPath, "data", "murmurs")
 	if _, err := os.Stat(murmursDir); err != nil {
-		return nil
+		if strict && !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		return nil, nil
 	}
 
 	cutoff := now.Add(-MaxMurmurAge)
@@ -267,7 +306,10 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time) []Result {
 
 	dayEntries, err := os.ReadDir(murmursDir)
 	if err != nil {
-		return nil
+		if strict && !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		return nil, nil
 	}
 	for _, day := range dayEntries {
 		if !day.IsDir() {
@@ -278,13 +320,25 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time) []Result {
 			continue
 		}
 		dayPath := filepath.Join(murmursDir, day.Name())
-		hourEntries, _ := os.ReadDir(dayPath)
+		hourEntries, readErr := os.ReadDir(dayPath)
+		if readErr != nil {
+			if strict && !errors.Is(readErr, fs.ErrNotExist) {
+				return results, readErr
+			}
+			continue
+		}
 		for _, hour := range hourEntries {
 			if !hour.IsDir() {
 				continue
 			}
 			hourPath := filepath.Join(dayPath, hour.Name())
-			files, _ := os.ReadDir(hourPath)
+			files, readErr := os.ReadDir(hourPath)
+			if readErr != nil {
+				if strict && !errors.Is(readErr, fs.ErrNotExist) {
+					return results, readErr
+				}
+				continue
+			}
 			for _, f := range files {
 				if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
 					continue
@@ -292,6 +346,9 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time) []Result {
 				path := filepath.Join(hourPath, f.Name())
 				data, rerr := os.ReadFile(path)
 				if rerr != nil {
+					if strict && !errors.Is(rerr, fs.ErrNotExist) {
+						return results, rerr
+					}
 					continue
 				}
 				var m struct {
@@ -301,6 +358,9 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time) []Result {
 					Content   string    `json:"content"`
 				}
 				if jerr := json.Unmarshal(data, &m); jerr != nil {
+					if strict {
+						return results, fmt.Errorf("parse %s: %w", path, jerr)
+					}
 					continue
 				}
 				if !m.Timestamp.IsZero() && m.Timestamp.Before(cutoff) {
@@ -323,7 +383,7 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time) []Result {
 			}
 		}
 	}
-	return results
+	return results, nil
 }
 
 // scanPlans walks data/plans/<YYYY-MM-DD-slug>/ and scores plan.md hits. This
@@ -332,12 +392,15 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time) []Result {
 // filter, same Result shape — but reads the canonical plan.md (always plain
 // git, never an LFS pointer) and pulls created_at from meta.json when present.
 // Fail-open: a missing data/plans/ dir yields no results, never an error.
-func scanPlans(ledgerPath string, terms []string, now time.Time) []Result {
+func scanPlans(ledgerPath string, terms []string, now time.Time, strict bool) ([]Result, error) {
 	plansDir := filepath.Join(ledgerPath, "data", "plans")
 	entries, err := os.ReadDir(plansDir)
 	if err != nil {
 		// missing dir (no plans saved yet) or unreadable — fail open.
-		return nil
+		if strict && !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		return nil, nil
 	}
 
 	cutoff := now.Add(-MaxPlanAge)
@@ -363,6 +426,9 @@ func scanPlans(ledgerPath string, terms []string, now time.Time) []Result {
 		path := filepath.Join(planPath, "plan.md")
 		data, rerr := os.ReadFile(path)
 		if rerr != nil {
+			if strict && !errors.Is(rerr, fs.ErrNotExist) {
+				return results, rerr
+			}
 			continue
 		}
 		score, snippet := scoreContent(string(data), terms)
@@ -379,7 +445,7 @@ func scanPlans(ledgerPath string, terms []string, now time.Time) []Result {
 			CreatedAt:  ts.Format(time.RFC3339),
 		})
 	}
-	return results
+	return results, nil
 }
 
 // scanPlanFeedback walks data/plans/<dated-slug>/feedback/round-*.json and
@@ -389,11 +455,14 @@ func scanPlans(ledgerPath string, terms []string, now time.Time) []Result {
 // One doc per round: reviewer, per-item status/section/label, and the notes.
 // Fail-open like every scanner here: unreadable dirs and malformed rounds are
 // skipped, never an error.
-func scanPlanFeedback(ledgerPath string, terms []string, now time.Time) []Result {
+func scanPlanFeedback(ledgerPath string, terms []string, now time.Time, strict bool) ([]Result, error) {
 	plansDir := filepath.Join(ledgerPath, "data", "plans")
 	entries, err := os.ReadDir(plansDir)
 	if err != nil {
-		return nil
+		if strict && !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		return nil, nil
 	}
 
 	cutoff := now.Add(-MaxPlanAge)
@@ -411,6 +480,9 @@ func scanPlanFeedback(ledgerPath string, terms []string, now time.Time) []Result
 		fbDir := filepath.Join(planPath, "feedback")
 		rounds, rerr := os.ReadDir(fbDir)
 		if rerr != nil {
+			if strict && !errors.Is(rerr, fs.ErrNotExist) {
+				return results, rerr
+			}
 			continue
 		}
 		for _, r := range rounds {
@@ -420,6 +492,9 @@ func scanPlanFeedback(ledgerPath string, terms []string, now time.Time) []Result
 			path := filepath.Join(fbDir, r.Name())
 			data, ferr := os.ReadFile(path)
 			if ferr != nil {
+				if strict && !errors.Is(ferr, fs.ErrNotExist) {
+					return results, ferr
+				}
 				continue
 			}
 			var round struct {
@@ -434,6 +509,9 @@ func scanPlanFeedback(ledgerPath string, terms []string, now time.Time) []Result
 				} `json:"items"`
 			}
 			if jerr := json.Unmarshal(data, &round); jerr != nil {
+				if strict {
+					return results, fmt.Errorf("parse %s: %w", path, jerr)
+				}
 				continue
 			}
 			var b strings.Builder
@@ -469,7 +547,7 @@ func scanPlanFeedback(ledgerPath string, terms []string, now time.Time) []Result
 			})
 		}
 	}
-	return results
+	return results, nil
 }
 
 // planTimestamp resolves a plan's created_at, preferring meta.json's explicit

--- a/internal/ledgersearch/ledgersearch_test.go
+++ b/internal/ledgersearch/ledgersearch_test.go
@@ -77,6 +77,111 @@ func TestSearch_StrictReadReportsCorruptMurmur(t *testing.T) {
 	}
 }
 
+func TestStrictScannersContinueAfterEntryFailure(t *testing.T) {
+	t.Parallel()
+	now := ledgerSearchTestNow
+	tests := []struct {
+		name         string
+		wantSourceID string
+		setup        func(*testing.T, string)
+		scan         func(string) ([]Result, error)
+	}{
+		{
+			name:         "sessions",
+			wantSourceID: "2026-05-22T10-15-ryan-OxVALID",
+			setup: func(t *testing.T, root string) {
+				broken := filepath.Join(root, "sessions", "2026-05-21T10-15-ryan-OxBROKEN", "summary.md")
+				if err := os.MkdirAll(broken, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				writeSession(t, root, "2026-05-22T10-15-ryan-OxVALID", "oauth oauth oauth")
+			},
+			scan: func(root string) ([]Result, error) {
+				return scanSessions(root, tokenize("oauth"), now, true)
+			},
+		},
+		{
+			name:         "murmurs",
+			wantSourceID: "z-valid",
+			setup: func(t *testing.T, root string) {
+				hourDir := filepath.Join(root, "data", "murmurs", now.Format("2006-01-02"), now.Format("15"))
+				if err := os.MkdirAll(hourDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(hourDir, "a-broken.json"), []byte("{"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				writeMurmur(t, root, now, "z-valid", "auth", "oauth oauth oauth")
+			},
+			scan: func(root string) ([]Result, error) {
+				return scanMurmurs(root, tokenize("oauth"), now, true)
+			},
+		},
+		{
+			name:         "plans",
+			wantSourceID: "2026-05-22-z-valid",
+			setup: func(t *testing.T, root string) {
+				broken := filepath.Join(root, "data", "plans", "2026-05-21-a-broken", "plan.md")
+				if err := os.MkdirAll(broken, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				writePlan(t, root, "2026-05-22-z-valid", now, "auth", "ryan", "oauth oauth oauth")
+			},
+			scan: func(root string) ([]Result, error) {
+				return scanPlans(root, tokenize("oauth"), now, true)
+			},
+		},
+		{
+			name:         "plan feedback",
+			wantSourceID: "2026-05-22-auth-plan",
+			setup: func(t *testing.T, root string) {
+				fbDir := filepath.Join(root, "data", "plans", "2026-05-22-auth-plan", "feedback")
+				if err := os.MkdirAll(fbDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(fbDir, "round-a-broken.json"), []byte("{"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				round, err := json.Marshal(map[string]any{
+					"reviewer":   "sam",
+					"created_at": now,
+					"items": []map[string]string{{
+						"note": "oauth oauth oauth",
+					}},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(fbDir, "round-z-valid.json"), round, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			scan: func(root string) ([]Result, error) {
+				return scanPlanFeedback(root, tokenize("oauth"), now, true)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			tc.setup(t, root)
+			results, err := tc.scan(root)
+			if err == nil {
+				t.Fatal("strict scan must report the corrupt entry")
+			}
+			found := false
+			for _, result := range results {
+				found = found || result.SourceID == tc.wantSourceID
+			}
+			if !found {
+				t.Fatalf("strict scan lost a valid sibling after the corrupt entry: %+v (err=%v)", results, err)
+			}
+		})
+	}
+}
+
 func TestSearch_SessionMatch(t *testing.T) {
 	t.Parallel()
 	dir := makeLedger(t)

--- a/internal/ledgersearch/ledgersearch_test.go
+++ b/internal/ledgersearch/ledgersearch_test.go
@@ -49,6 +49,34 @@ func TestSearch_EmptyQuery(t *testing.T) {
 	}
 }
 
+func TestSearch_StrictReadReportsCorruptMurmur(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := ledgerSearchTestNow
+	murmurDir := filepath.Join(dir, "data", "murmurs", now.Format("2006-01-02"), now.Format("15"))
+	if err := os.MkdirAll(murmurDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(murmurDir, "broken.json"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSession(t, dir, "2026-05-20T10-15-ryan-OxABCD", "oauth oauth oauth oauth oauth")
+
+	if _, err := Search(Options{LedgerPath: dir, Query: "anything", Now: now}); err != nil {
+		t.Fatalf("default search must remain fail-open: %v", err)
+	}
+	results, err := Search(Options{LedgerPath: dir, Query: "oauth", Now: now, StrictRead: true})
+	if err == nil {
+		t.Fatal("strict search must report corrupt source data")
+	}
+	if len(results) != 1 || results[0].DocType != "session" {
+		t.Fatalf("strict search must preserve valid partial hits: %+v", results)
+	}
+	if _, err := Search(Options{LedgerPath: dir, Query: "oauth", Now: now, StrictRead: true, SkipMurmurs: true}); err != nil {
+		t.Fatalf("durable-only search must ignore a corrupt murmur owned by another retriever: %v", err)
+	}
+}
+
 func TestSearch_SessionMatch(t *testing.T) {
 	t.Parallel()
 	dir := makeLedger(t)

--- a/internal/plan/decision_bundle.go
+++ b/internal/plan/decision_bundle.go
@@ -6,6 +6,8 @@ import (
 	"github.com/sageox/ox/internal/decision"
 )
 
+const planDecisionCap = 5
+
 // decisionRetriever ties plans back to the repo's own Decision Records: DRs
 // relevant to the plan surface as "adr" context items, which the render turns
 // into subtle inline OX markers on their prose tokens ("ADR-021") — context,
@@ -24,8 +26,9 @@ func (decisionRetriever) Retrieve(_ context.Context, in Input, gitRoot string) (
 	if query == "" || gitRoot == "" {
 		return nil, nil
 	}
+	matches, omitted := decision.Relevant(gitRoot, query, planDecisionCap)
 	var items []ContextItem
-	for _, dr := range decision.Relevant(gitRoot, query, 4) {
+	for _, dr := range matches {
 		title := dr.Title
 		if dr.ID != "" {
 			title = dr.ID + " — " + dr.Title
@@ -38,6 +41,9 @@ func (decisionRetriever) Retrieve(_ context.Context, in Input, gitRoot string) (
 			Score:   dr.Score,
 			When:    dr.Date,
 		})
+	}
+	if omitted > 0 && len(items) > 0 {
+		items[0].Omitted = omitted
 	}
 	return items, nil
 }

--- a/internal/plan/decision_parity_test.go
+++ b/internal/plan/decision_parity_test.go
@@ -72,54 +72,72 @@ func TestDecisionPlanParity_SameCorpusSameADR(t *testing.T) {
 // preserve an earlier seed match under a bounded result set. The plan bundle
 // also reports how many above-floor candidates its cap omitted.
 func TestDecisionPlanParity_CompetingRecordsCannotEvictMatch(t *testing.T) {
-	root := t.TempDir()
-	writeDR(t, root, "docs/adr/ADR-002-socket.md",
-		"# ADR-002: Unix Domain Socket IPC\n\n**Status**: Accepted\n**Date**: 2026-01-01\n")
-	for i, title := range []string{
-		"Session Adapter Context",
-		"Plan Integration Lifecycle",
-		"Security Adapter Distribution",
-		"Context Session Lifecycle",
-		"Integration Security Plan",
-		"Adapter Lifecycle Context",
-	} {
-		writeDR(t, root, filepath.Join("docs/adr", fmt.Sprintf("ADR-%03d-distractor.md", i+3)),
-			fmt.Sprintf("# ADR-%03d: %s\n\n**Status**: Accepted\n**Date**: 2026-01-01\n", i+3, title))
+	tests := []struct {
+		name  string
+		topic string
+	}{
+		{
+			name:  "competing terms",
+			topic: "socket session adapter context plan integration lifecycle security distribution",
+		},
+		{
+			name: "ordinary prose extension",
+			topic: "socket session adapter context plan integration lifecycle security distribution " +
+				"implementation ownership compatibility rollout migration observability",
+		},
 	}
 
-	topic := "socket session adapter context plan integration lifecycle security distribution"
-	dres := decision.Enrich(context.Background(), decision.Input{Topic: topic}, root)
-	decisionFound := false
-	for _, ann := range dres.Annotations {
-		decisionFound = decisionFound || ann.Ref == "ADR-002"
-	}
-	if !decisionFound {
-		t.Fatalf("decision enrich evicted ADR-002: %+v", dres.Annotations)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeDR(t, root, "docs/adr/ADR-002-socket.md",
+				"# ADR-002: Unix Domain Socket IPC\n\n**Status**: Accepted\n**Date**: 2026-01-01\n")
+			for i, title := range []string{
+				"Session Adapter Context",
+				"Plan Integration Lifecycle",
+				"Security Adapter Distribution",
+				"Context Session Lifecycle",
+				"Integration Security Plan",
+				"Adapter Lifecycle Context",
+			} {
+				writeDR(t, root, filepath.Join("docs/adr", fmt.Sprintf("ADR-%03d-distractor.md", i+3)),
+					fmt.Sprintf("# ADR-%03d: %s\n\n**Status**: Accepted\n**Date**: 2026-01-01\n", i+3, title))
+			}
 
-	in, err := ResolveInput(topic, nil, "", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pres := Enrich(context.Background(), in, root)
-	planFound := false
-	for _, item := range pres.Context {
-		planFound = planFound || (item.Kind == "adr" && strings.Contains(item.Ref, "ADR-002"))
-	}
-	if !planFound {
-		t.Fatalf("plan enrich evicted ADR-002: %+v", pres.Context)
-	}
-	adrCount, omitted := 0, 0
-	for _, item := range pres.Context {
-		if item.Kind == "adr" {
-			adrCount++
-			omitted += item.Omitted
-		}
-	}
-	if adrCount != planDecisionCap {
-		t.Fatalf("plan DR context must stay capped at %d, got %d", planDecisionCap, adrCount)
-	}
-	if omitted != 2 {
-		t.Fatalf("plan DR context must report two omitted candidates, got %d", omitted)
+			dres := decision.Enrich(context.Background(), decision.Input{Topic: tc.topic}, root)
+			decisionFound := false
+			for _, ann := range dres.Annotations {
+				decisionFound = decisionFound || ann.Ref == "ADR-002"
+			}
+			if !decisionFound {
+				t.Fatalf("decision enrich evicted ADR-002: %+v", dres.Annotations)
+			}
+
+			in, err := ResolveInput(tc.topic, nil, "", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pres := Enrich(context.Background(), in, root)
+			planFound := false
+			for _, item := range pres.Context {
+				planFound = planFound || (item.Kind == "adr" && strings.Contains(item.Ref, "ADR-002"))
+			}
+			if !planFound {
+				t.Fatalf("plan enrich evicted ADR-002: %+v", pres.Context)
+			}
+			adrCount, omitted := 0, 0
+			for _, item := range pres.Context {
+				if item.Kind == "adr" {
+					adrCount++
+					omitted += item.Omitted
+				}
+			}
+			if adrCount != planDecisionCap {
+				t.Fatalf("plan DR context must stay capped at %d, got %d", planDecisionCap, adrCount)
+			}
+			if omitted != 2 {
+				t.Fatalf("plan DR context must report two omitted candidates, got %d", omitted)
+			}
+		})
 	}
 }

--- a/internal/plan/decision_parity_test.go
+++ b/internal/plan/decision_parity_test.go
@@ -2,6 +2,8 @@ package plan
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -63,5 +65,61 @@ func TestDecisionPlanParity_SameCorpusSameADR(t *testing.T) {
 	}
 	if !planFound {
 		t.Errorf("plan enrich did not surface ADR-002 for the same topic: context=%+v", pres.Context)
+	}
+}
+
+// TestDecisionPlanParity_CompetingRecordsCannotEvictMatch proves both commands
+// preserve an earlier seed match under a bounded result set. The plan bundle
+// also reports how many above-floor candidates its cap omitted.
+func TestDecisionPlanParity_CompetingRecordsCannotEvictMatch(t *testing.T) {
+	root := t.TempDir()
+	writeDR(t, root, "docs/adr/ADR-002-socket.md",
+		"# ADR-002: Unix Domain Socket IPC\n\n**Status**: Accepted\n**Date**: 2026-01-01\n")
+	for i, title := range []string{
+		"Session Adapter Context",
+		"Plan Integration Lifecycle",
+		"Security Adapter Distribution",
+		"Context Session Lifecycle",
+		"Integration Security Plan",
+		"Adapter Lifecycle Context",
+	} {
+		writeDR(t, root, filepath.Join("docs/adr", fmt.Sprintf("ADR-%03d-distractor.md", i+3)),
+			fmt.Sprintf("# ADR-%03d: %s\n\n**Status**: Accepted\n**Date**: 2026-01-01\n", i+3, title))
+	}
+
+	topic := "socket session adapter context plan integration lifecycle security distribution"
+	dres := decision.Enrich(context.Background(), decision.Input{Topic: topic}, root)
+	decisionFound := false
+	for _, ann := range dres.Annotations {
+		decisionFound = decisionFound || ann.Ref == "ADR-002"
+	}
+	if !decisionFound {
+		t.Fatalf("decision enrich evicted ADR-002: %+v", dres.Annotations)
+	}
+
+	in, err := ResolveInput(topic, nil, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pres := Enrich(context.Background(), in, root)
+	planFound := false
+	for _, item := range pres.Context {
+		planFound = planFound || (item.Kind == "adr" && strings.Contains(item.Ref, "ADR-002"))
+	}
+	if !planFound {
+		t.Fatalf("plan enrich evicted ADR-002: %+v", pres.Context)
+	}
+	adrCount, omitted := 0, 0
+	for _, item := range pres.Context {
+		if item.Kind == "adr" {
+			adrCount++
+			omitted += item.Omitted
+		}
+	}
+	if adrCount != planDecisionCap {
+		t.Fatalf("plan DR context must stay capped at %d, got %d", planDecisionCap, adrCount)
+	}
+	if omitted != 2 {
+		t.Fatalf("plan DR context must report two omitted candidates, got %d", omitted)
 	}
 }

--- a/internal/plan/decision_parity_test.go
+++ b/internal/plan/decision_parity_test.go
@@ -1,0 +1,67 @@
+package plan
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/decision"
+)
+
+// TestDecisionPlanParity_SameCorpusSameADR is the cross-command proof for #823:
+// `ox plan enrich` and `ox decision enrich` must surface the SAME repo Decision
+// Record for the same input over the same corpus. They share one loader and one
+// scorer; before the fix they diverged because `plan enrich` distilled the query
+// while `decision enrich` scored the raw topic — so a real (long) plan/issue
+// body found the ADR through one command and nothing through the other.
+//
+// Failure prevented: an agent that consults `decision enrich` before drafting a
+// DR is told "no prior decision" for a topic that `plan enrich` clearly ties to
+// an existing ADR — the two halves of the same promise disagree.
+//
+// The input is deliberately long-form prose (the regime that broke), not a
+// two-word probe.
+func TestDecisionPlanParity_SameCorpusSameADR(t *testing.T) {
+	root := t.TempDir()
+	writeDR(t, root, "docs/adr/ADR-002-feature-flags.md",
+		"# ADR-002: Feature flags are added only at explicit user request\n\n"+
+			"**Status**: Accepted\n**Date**: 2026-02-01\n\n"+
+			"## Context\n\nFlags accrete and never get removed; each one is a branch in "+
+			"every code path forever. We add a feature flag only when a coworker asks "+
+			"for one by name, never speculatively for staged rollouts or kill switches.\n")
+
+	// A normal, long way to describe the work — the case the two-word probe hides.
+	topic := "we want to gate the new todo digest emailer behind a feature flag so " +
+		"we can stage the rollout by percentage and keep a kill switch in case the " +
+		"new sender misbehaves in production, wiring two flag-shaped environment " +
+		"variables into the deployment for the rollout knob and the rollback knob"
+
+	// --- decision enrich side: the repo ADR must appear as a related decision ---
+	dres := decision.Enrich(context.Background(), decision.Input{Topic: topic}, root)
+	decisionFound := false
+	for _, a := range dres.Annotations {
+		if a.Type == decision.BadgeRelatedDecision && a.Ref == "ADR-002" {
+			decisionFound = true
+		}
+	}
+	if !decisionFound {
+		t.Errorf("decision enrich did not surface ADR-002 for a long real-world topic: annotations=%+v signals=%+v",
+			dres.Annotations, dres.Signals)
+	}
+
+	// --- plan enrich side: the same repo ADR must appear as an adr context item ---
+	in, err := ResolveInput(topic, nil, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pres := Enrich(context.Background(), in, root)
+	planFound := false
+	for _, c := range pres.Context {
+		if c.Kind == "adr" && strings.Contains(c.Ref, "ADR-002") {
+			planFound = true
+		}
+	}
+	if !planFound {
+		t.Errorf("plan enrich did not surface ADR-002 for the same topic: context=%+v", pres.Context)
+	}
+}

--- a/internal/plan/types.go
+++ b/internal/plan/types.go
@@ -93,6 +93,9 @@ type ContextItem struct {
 	Score   float64 `json:"score"`
 	Author  string  `json:"author,omitempty"`
 	When    string  `json:"when,omitempty"`
+	// Omitted reports additional same-source matches hidden by a local cap. It
+	// keeps the bundle bounded without making a broad query look exhaustive.
+	Omitted int `json:"omitted,omitempty"`
 }
 
 // DiagramKind is a suggested diagram form for a plan section. The values are the

--- a/tests/acceptance/features/decision-records/consult-before-drafting.feature
+++ b/tests/acceptance/features/decision-records/consult-before-drafting.feature
@@ -1,0 +1,56 @@
+Feature: Consulting Decision Records Before Drafting
+  Before Avery drafts or edits a Decision Record — or picks up an issue that a
+  past decision already settled — ox surfaces the records relevant to her work,
+  so a decision does not get made twice and a new record does not quietly
+  contradict one the team already accepted. ox walks the repo's Decision Records
+  fresh and scores them locally, at zero LLM and zero network cost. The promise
+  that matters: when Avery describes her work the way she actually would — a
+  paragraph, an issue body, a whole plan — the record that governs it is found,
+  not only when she already types its title.
+
+  See also: plan-enrichment/enrich-while-drafting.feature
+  See also: code-intelligence/insights.feature
+
+  Rule: A relevant record is found even for long, real-world input
+
+    Scenario: Avery describes her work in a full paragraph and the governing record is found
+      Given the team has a Decision Record that governs feature flags
+      When Avery consults ox with a paragraph describing a feature-flag rollout
+      Then ox surfaces that record as a related decision
+      And it is surfaced whether her description is two words or two hundred
+
+    Scenario: A longer description never finds less than a shorter one
+      Given a Decision Record that a short query surfaces
+      When Avery adds more words describing the same work
+      Then ox still surfaces that record
+      And its relevance does not fall away as her description grows
+
+  Rule: Consulting a topic returns what drafting a plan on it returns
+
+    Scenario: Both entry points agree over the same records
+      Given a repo with a Decision Record about feature flags
+      When Avery consults that topic before drafting a record
+      And Sam enriches a plan on the same topic
+      Then both are shown the same governing record
+
+  Rule: An unreadable corpus is reported, never treated as a verified absence
+
+    Scenario: A decision folder whose files are not records is flagged, not silently empty
+      Given a decision folder that holds markdown that does not parse as records
+      When Avery consults a topic
+      Then ox tells her the corpus could not be read and why
+      And ox does not tell her that "no prior decision exists" as a verified fact
+
+    Scenario: A genuinely empty corpus still lets Avery state absence as verified
+      Given a repo with no Decision Records at all and every source readable
+      When Avery consults a topic
+      Then ox reports that nothing matched
+      And Avery may state "no prior team decision found" as a verifiable claim
+
+  Rule: Near-misses can be surfaced on request
+
+    Scenario: Avery asks to see what the relevance floor discarded
+      Given records that match a topic only weakly
+      When Avery consults the topic and asks ox to explain
+      Then ox lists the candidates it dropped below the relevance floor with their scores
+      And she can tell "nothing was relevant" apart from "records were found and dropped"


### PR DESCRIPTION
AI coworkers now find the Decision Record that governs their work even when they describe it the way they actually would — a full paragraph, an issue body, a whole plan — not only when they already type the record's own title. Before this, retrieval silently returned nothing on real-world input, and `ox decision enrich` presented that emptiness as a **verified fact** ("no prior team decision found is a verifiable claim"), so an AI coworker would confidently draft a record that duplicates or contradicts one the team already accepted. Reported by the community in #823 with a precise, reproducible diagnosis.

Closes #823.

## What broke

All three symptoms trace to **local, deterministic** retrieval in `internal/decision` (zero LLM, zero network — no server involved). The scorer graded each record by *what fraction of the query matched it*, so every off-topic word in a real description diluted a genuine match until the record fell off.

- **Relevance decayed with query length.** `fieldScore` used `coverage = matched / len(terms)` with a hard drop below 0.5 coverage. A two-word probe scored a record **0.925**; the same subject as ordinary prose scored **0.000**. Real input is always long, so the record was found only when the agent already knew it existed.
- **`ox decision enrich` and `ox plan enrich` disagreed** over the same corpus — they share one loader and one scorer, but `plan enrich` distilled the query to keywords first while `decision enrich` scored the raw topic, so the two halves of the same promise returned different records.
- **An unreadable corpus looked identical to "nothing found."** A `docs/adr/` folder whose files don't parse as records, or a source that errored, produced `related: 0` — and guidance told the agent to assert that absence as verified.

```mermaid
flowchart LR
    Q["Query: a full plan /\nissue body (long)"] --> T[tokenize]
    subgraph before["Before — coverage by query length"]
        T --> C["coverage = matched / len(terms)"]
        C --> D{"coverage < 0.5\nor below floor?"}
        D -->|"yes (long input dilutes)"| X["dropped → related: 0"]
        X --> V["guidance: 'no prior decision'\nis a verifiable claim"]
    end
    subgraph after["After — saturating, length-independent"]
        T --> M["mw = Σ field-weight of\nDISTINCT matched terms"]
        M --> S["score = mw / (mw + K)\nmonotonic in the query"]
        S --> K{"≥ floor?"}
        K -->|yes| R["surfaced as related decision"]
        K -->|no| E["--explain lists it as\na dropped candidate"]
    end
    V -.->|"honesty fix"| H["source errored / corpus unreadable\n→ Signals.Degraded → guidance:\nabsence is NOT verified"]
```

## What this PR ships

- **Length-robust, monotonic scorer** (`internal/decision/search.go`). Score is now `mw / (mw + K)` over the **distinct** matched terms (title ×3, anchors/status/deciders ×2, excerpt ×1) — independent of query length. Adding words can only add matches, never remove one, so a longer description can never score a record below a shorter subset of it. Recalibrated the DR-corpus floor to `minDRScore = 0.30`, **decoupled** from the ledgersearch/sessions floor (which lives on a different score scale).
- **Command parity.** With one length-robust scorer over the shared corpus, `decision enrich` and `plan enrich` surface the same repo records for the same input; a cross-command test now pins them together.
- **Error-vs-empty honesty** (`enrich.go`, `guidance.go`, `types.go`). A detector/retriever that errors — or a decision dir that exists but parses to zero records — sets `Signals.Degraded` and a visible `unreadable-corpus` diagnostic. Degraded runs get new guidance that **refuses to present emptiness as a verified absence** and points to `ox doctor` / `ox code search`. A genuinely-empty, fully-read corpus still lets the agent state absence as verifiable.
- **`--explain`** on `ox decision enrich`. Lists candidates dropped below the relevance floor (with scores + reason) so a caller can tell "nothing was relevant" from "records were found and dropped."
- **Real test harness** — the gap that let this ship. The one prior scorer test asserted the bug as intended ("low coverage excluded"); it's been reframed to test the floor honestly. Added: a **monotonicity** guard, a **cross-command parity** guard over a long real-world input, **error-vs-empty** and **corpus-unreadable** guards (with an isolated registry so each test proves its own cause — no pollution), and a `--explain` guard. Plus a customer-facing capability in `tests/acceptance/features/decision-records/`.

## Scope note

`docs/adr/` retrieval is deliberately local (fast, offline, deterministic). This PR keeps it local. Whether relevance ranking should later move behind a cloud API is a separate product call, not needed to fix #823. The reporter's `ox code search` bleve error is a **different, local** index that enrich never opens; the honesty fix here makes enrich stop *masquerading* a swallowed failure as a checked absence regardless of source.

## Test plan

Every behavioral fix was proven **red-first** (neuter the fix → watch the guard fail → restore → green):

- **Scorer / length decay** — `TestScoreCorpus_MonotonicInQueryLength`: red showed `short=0.925 prose=0.000`; green after the saturating score.
- **Parity** — `TestDecisionPlanParity_SameCorpusSameADR`: neutering the scorer back to coverage-drop made **both** commands drop the ADR (`context=[]`); restored → both surface it.
- **Honesty** — `TestEnrich_DegradedOnSourceError` (clean arm proves the flip is caused by the error, not ambient state), `TestEnrich_CorpusPresentButUnparsed`, guidance `degraded` branch.
- **`--explain`** — `TestEnrich_ExplainSurfacesDroppedCandidates` + command-surface `TestDecisionEnrichCmd_ExplainSurfacesDropped`.
- **Command surface** — `TestDecisionEnrichCmd_FindsRelatedADRForLongTopic` drives the real `ox decision enrich` over a temp repo and asserts the contradicting ADR surfaces.

```
go test ./internal/decision/... ./internal/plan/... ./cmd/ox/ -run 'Decision|ScoreCorpus|Enrich|Parity|Guidance'
# ok internal/decision · ok internal/plan · ok cmd/ox
```

`go vet`, `gofmt -l`, and `golangci-lint` are clean on every changed file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790248301&installation_model_id=433550&pr_number=824&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F824&signature=0fce234c5670c4be4f198562f55602306bb1acee9bf39170b6effe1216642b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--explain` option showing near-match decision records, scores, reasons, and omitted candidates.
  * Improved related decision detection for long-form topics and embedded references.
  * Plan enrichment now reports results omitted by local limits.
* **Bug Fixes**
  * Unreadable or incomplete decision sources now preserve available results and provide clear degraded-status diagnostics.
  * Invalid decision-path glob patterns are detected during validation.
  * Degraded enrichment exits with a non-zero status.
* **Tests**
  * Expanded coverage for scoring, retrieval failures, and decision/plan consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->