### PR TITLE
release: ox v0.14.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.14.0"
+      "version": "0.14.1"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/banner_coverage_test.go
+++ b/cmd/ox/banner_coverage_test.go
@@ -13,27 +13,27 @@ func TestTimeSinceError(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		when time.Time
-		want string
+		name   string
+		offset time.Duration
+		want   string
 	}{
-		{"just now (sub-minute)", time.Now().Add(-10 * time.Second), "just now"},
-		{"exactly now", time.Now(), "just now"},
-		{"1 minute ago", time.Now().Add(-90 * time.Second), "1 minute"},
-		{"2 minutes ago", time.Now().Add(-2 * time.Minute), "2 minutes"},
-		{"59 minutes ago", time.Now().Add(-59 * time.Minute), "59 minutes"},
-		{"1 hour ago", time.Now().Add(-90 * time.Minute), "1 hour"},
-		{"2 hours ago", time.Now().Add(-2 * time.Hour), "2 hours"},
-		{"23 hours ago", time.Now().Add(-23 * time.Hour), "23 hours"},
-		{"1 day ago", time.Now().Add(-25 * time.Hour), "1 day"},
-		{"2 days ago", time.Now().Add(-48 * time.Hour), "2 days"},
-		{"7 days ago", time.Now().Add(-7 * 24 * time.Hour), "7 days"},
+		{"just now (sub-minute)", -10 * time.Second, "just now"},
+		{"exactly now", 0, "just now"},
+		{"1 minute ago", -90 * time.Second, "1 minute"},
+		{"2 minutes ago", -2 * time.Minute, "2 minutes"},
+		{"59 minutes ago", -59 * time.Minute, "59 minutes"},
+		{"1 hour ago", -90 * time.Minute, "1 hour"},
+		{"2 hours ago", -2 * time.Hour, "2 hours"},
+		{"23 hours ago", -23 * time.Hour, "23 hours"},
+		{"1 day ago", -25 * time.Hour, "1 day"},
+		{"2 days ago", -48 * time.Hour, "2 days"},
+		{"7 days ago", -7 * 24 * time.Hour, "7 days"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := timeSinceError(tt.when)
+			got := timeSinceError(time.Now().Add(tt.offset))
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/cmd/ox/distill_github_twin_test.go
+++ b/cmd/ox/distill_github_twin_test.go
@@ -183,7 +183,7 @@ func setupFactsTwinRepos(t *testing.T) (bareURL, nodeAPath, nodeBPath string) {
 
 	// Create bare repo.
 	barePath := filepath.Join(base, "team-context.git")
-	runTwinGit(t, "", "init", "--bare", barePath)
+	runTwinGit(t, "", "init", "--bare", "--initial-branch=main", barePath)
 
 	// Clone A and seed directory structure.
 	nodeAPath = filepath.Join(base, "node-a")

--- a/cmd/ox/distill_history_since.go
+++ b/cmd/ox/distill_history_since.go
@@ -70,7 +70,12 @@ func registerDistillHistorySinceFlags(cmd *cobra.Command, flags *distillHistoryS
 // text is intentionally not accepted — see the comment at the format
 // validation branch below for the rationale.
 func runDistillHistorySince(cmd *cobra.Command, args []string) error {
-	flags := distillHistorySinceFlagSet
+	flags := distillHistorySinceFlags{}
+	flags.Layer, _ = cmd.Flags().GetString("layer")
+	flags.Team, _ = cmd.Flags().GetString("team")
+	flags.AllTeams, _ = cmd.Flags().GetBool("all-teams")
+	flags.Format, _ = cmd.Flags().GetString("format")
+	flags.Limit, _ = cmd.Flags().GetInt("limit")
 	start := time.Now()
 	elapsed := func() int64 { return time.Since(start).Milliseconds() }
 

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -687,6 +687,10 @@ func (p *doctorProgress) clear() {
 }
 
 func runDoctorChecks(parent context.Context, opts doctorOptions) []checkCategory {
+	return runDoctorChecksWithState(parent, opts, detectDoctorState())
+}
+
+func runDoctorChecksWithState(parent context.Context, opts doctorOptions, state doctorState) []checkCategory {
 	var categories []checkCategory
 	if parent == nil {
 		parent = context.Background()
@@ -702,9 +706,6 @@ func runDoctorChecks(parent context.Context, opts doctorOptions) []checkCategory
 	progress := newDoctorProgress(opts.verbose)
 	progress.ctx = ctx
 	defer progress.clear()
-
-	// detect environment state early for conditional suppression
-	state := detectDoctorState()
 
 	// Category 0: Authentication (FIRST - most important)
 	// SageOx requires authentication to function

--- a/cmd/ox/doctor_auth_coverage_test.go
+++ b/cmd/ox/doctor_auth_coverage_test.go
@@ -11,47 +11,47 @@ func TestFormatCredentialExpiry(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		expiresAt  time.Time
+		expiresIn  time.Duration
 		wantPrefix string // use prefix match to handle timing drift
 	}{
 		{
 			name:       "expired",
-			expiresAt:  time.Now().Add(-1 * time.Hour),
+			expiresIn:  -1 * time.Hour,
 			wantPrefix: "expired",
 		},
 		{
 			name:       "just expired",
-			expiresAt:  time.Now().Add(-1 * time.Second),
+			expiresIn:  -1 * time.Second,
 			wantPrefix: "expired",
 		},
 		{
 			name:       "minutes remaining",
-			expiresAt:  time.Now().Add(30*time.Minute + 30*time.Second),
+			expiresIn:  30*time.Minute + 30*time.Second,
 			wantPrefix: "30m",
 		},
 		{
 			name:       "hours remaining",
-			expiresAt:  time.Now().Add(5*time.Hour + 30*time.Minute),
+			expiresIn:  5*time.Hour + 30*time.Minute,
 			wantPrefix: "5h",
 		},
 		{
 			name:       "days remaining",
-			expiresAt:  time.Now().Add(3*24*time.Hour + time.Hour),
+			expiresIn:  3*24*time.Hour + time.Hour,
 			wantPrefix: "3d",
 		},
 		{
 			name:       "boundary just over 1 hour",
-			expiresAt:  time.Now().Add(61*time.Minute + 30*time.Second),
+			expiresIn:  61*time.Minute + 30*time.Second,
 			wantPrefix: "1h",
 		},
 		{
 			name:       "boundary just over 1 day",
-			expiresAt:  time.Now().Add(25*time.Hour + 30*time.Second),
+			expiresIn:  25*time.Hour + 30*time.Second,
 			wantPrefix: "1d",
 		},
 		{
 			name:       "under 1 minute",
-			expiresAt:  time.Now().Add(30 * time.Second),
+			expiresIn:  30 * time.Second,
 			wantPrefix: "0m",
 		},
 	}
@@ -59,7 +59,7 @@ func TestFormatCredentialExpiry(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := formatCredentialExpiry(tt.expiresAt)
+			got := formatCredentialExpiry(time.Now().Add(tt.expiresIn))
 			if !strings.HasPrefix(got, tt.wantPrefix) {
 				t.Errorf("formatCredentialExpiry() = %q, want prefix %q", got, tt.wantPrefix)
 			}
@@ -73,19 +73,19 @@ func TestFormatCredentialExpiry_ReturnFormat(t *testing.T) {
 	// verify the format is always a suffix of d/h/m or the word "expired"
 	tests := []struct {
 		name       string
-		expiresAt  time.Time
+		expiresIn  time.Duration
 		wantSuffix string
 	}{
-		{name: "expired has no suffix", expiresAt: time.Now().Add(-1 * time.Hour), wantSuffix: ""},
-		{name: "days end with d", expiresAt: time.Now().Add(48 * time.Hour), wantSuffix: "d"},
-		{name: "hours end with h", expiresAt: time.Now().Add(3 * time.Hour), wantSuffix: "h"},
-		{name: "minutes end with m", expiresAt: time.Now().Add(15 * time.Minute), wantSuffix: "m"},
+		{name: "expired has no suffix", expiresIn: -1 * time.Hour, wantSuffix: ""},
+		{name: "days end with d", expiresIn: 48 * time.Hour, wantSuffix: "d"},
+		{name: "hours end with h", expiresIn: 3 * time.Hour, wantSuffix: "h"},
+		{name: "minutes end with m", expiresIn: 15 * time.Minute, wantSuffix: "m"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := formatCredentialExpiry(tt.expiresAt)
+			got := formatCredentialExpiry(time.Now().Add(tt.expiresIn))
 			if tt.wantSuffix == "" {
 				if got != "expired" {
 					t.Errorf("expected 'expired', got %q", got)

--- a/cmd/ox/doctor_test.go
+++ b/cmd/ox/doctor_test.go
@@ -19,6 +19,7 @@ import (
 // never depend on full doctor state.
 var (
 	cachedCategories     []checkCategory
+	cachedDoctorState    doctorState
 	cachedCategoriesOnce sync.Once
 )
 
@@ -28,7 +29,8 @@ func getCachedDoctorChecks(t *testing.T) []checkCategory {
 		t.Skip("short: full doctor pipeline shells out to git/auth — see .claude/rules/testing.md")
 	}
 	cachedCategoriesOnce.Do(func() {
-		cachedCategories = runDoctorChecks(context.Background(), doctorOptions{fix: false})
+		cachedDoctorState = detectDoctorState()
+		cachedCategories = runDoctorChecksWithState(context.Background(), doctorOptions{fix: false}, cachedDoctorState)
 	})
 	return cachedCategories
 }
@@ -116,7 +118,7 @@ func TestDoctorSuppression_DaemonNotRunning(t *testing.T) {
 
 	// when daemon is not running, we should see a single grouped skip
 	// rather than multiple individual warnings
-	if !isDaemonRunningInTest() {
+	if !cachedDoctorState.isDaemonRunning {
 		// should have exactly one check (the grouped skip)
 		assert.Equal(t, 1, len(daemonCat.checks), "should have single grouped daemon check when daemon not running")
 
@@ -148,7 +150,7 @@ func TestDoctorSuppression_NotLoggedIn(t *testing.T) {
 
 	// when not logged in, we should see a single grouped skip
 	// rather than multiple individual warnings
-	if !isAuthenticatedInTest() {
+	if !cachedDoctorState.isAuthenticated {
 		// should have exactly one check (the grouped skip)
 		assert.Equal(t, 1, len(serviceCat.checks), "should have single grouped service check when not logged in")
 
@@ -188,20 +190,8 @@ func TestDoctorSuppression_GitRepoPaths(t *testing.T) {
 	require.NotNil(t, repoPathsCheck, "git repo paths check should be present")
 
 	// when not logged in, the check should be skipped
-	if !isAuthenticatedInTest() {
+	if !cachedDoctorState.isAuthenticated {
 		assert.True(t, repoPathsCheck.skipped, "git repo paths should be skipped when not logged in")
 		assert.Contains(t, repoPathsCheck.message, "requires login", "message should indicate requires login")
 	}
-}
-
-// isDaemonRunningInTest checks if daemon is running in test environment
-func isDaemonRunningInTest() bool {
-	state := detectDoctorState()
-	return state.isDaemonRunning
-}
-
-// isAuthenticatedInTest checks if authenticated in test environment
-func isAuthenticatedInTest() bool {
-	state := detectDoctorState()
-	return state.isAuthenticated
 }

--- a/cmd/ox/flag_rewrites.go
+++ b/cmd/ox/flag_rewrites.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 // flagAlias is the wire shape we read out of default_catalog.json's `tokens`
@@ -65,9 +67,14 @@ func applyCatalogTokenRewrites(args []string, aliases map[string]string) []strin
 	if len(aliases) == 0 {
 		return args
 	}
+	target, _, _ := rootCmd.Find(args)
 	out := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		a := args[i]
+		if commandAcceptsLongFlag(target, a) {
+			out = append(out, a)
+			continue
+		}
 
 		// joined form: arg literally equals a catalog pattern.
 		if target, ok := aliases[a]; ok {
@@ -90,4 +97,17 @@ func applyCatalogTokenRewrites(args []string, aliases map[string]string) []strin
 		out = append(out, a)
 	}
 	return out
+}
+
+// commandAcceptsLongFlag reports whether arg names a flag owned by the target
+// command. Catalog rewrites are fallbacks for unknown flags; applying one to a
+// command that intentionally defines the same spelling changes valid behavior
+// (for example, `distill history since --format=json` became global `--json`
+// while the command silently kept its default content format).
+func commandAcceptsLongFlag(cmd *cobra.Command, arg string) bool {
+	if cmd == nil || !strings.HasPrefix(arg, "--") {
+		return false
+	}
+	name := strings.TrimPrefix(strings.SplitN(arg, "=", 2)[0], "--")
+	return name != "" && cmd.Flags().Lookup(name) != nil
 }

--- a/cmd/ox/flag_rewrites_test.go
+++ b/cmd/ox/flag_rewrites_test.go
@@ -63,6 +63,18 @@ func TestApplyCatalogTokenRewrites(t *testing.T) {
 			want:    []string{"session", "list", "--json=false"},
 		},
 		{
+			name:    "joined form preserves command-owned flag",
+			in:      []string{"distill", "history", "since", "24h", "--format=json"},
+			aliases: formatAliases,
+			want:    []string{"distill", "history", "since", "24h", "--format=json"},
+		},
+		{
+			name:    "split form preserves command-owned flag",
+			in:      []string{"distill", "history", "since", "24h", "--format", "json"},
+			aliases: formatAliases,
+			want:    []string{"distill", "history", "since", "24h", "--format", "json"},
+		},
+		{
 			name:    "unknown value passes through (cobra/friction handles)",
 			in:      []string{"session", "list", "--format=yaml"},
 			aliases: formatAliases,

--- a/cmd/ox/incremental_e2e_test.go
+++ b/cmd/ox/incremental_e2e_test.go
@@ -48,7 +48,7 @@ func TestIncrementalE2E_SingleAgent(t *testing.T) {
 	claudeSessionID := "test-e2e-session-001"
 
 	// create Claude Code source JSONL in the expected location
-	sourceFile := createClaudeSourceFile(t, env)
+	sourceFile := createClaudeSourceFileNamed(t, env, claudeSessionID+".jsonl")
 
 	// write session marker (simulates what ox agent prime does)
 	writeE2ESessionMarker(t, env, agentID, claudeSessionID)
@@ -57,7 +57,7 @@ func TestIncrementalE2E_SingleAgent(t *testing.T) {
 	createE2EAgentInstance(t, env.workspace, agentID)
 
 	// write initial user entry BEFORE session start (should be filtered out)
-	writeClaudeEntry(t, sourceFile, claudeUserEntry(time.Now().Add(-1*time.Minute).UTC().Format(time.RFC3339Nano), "Hello, fix the bug"))
+	writeClaudeEntry(t, sourceFile, claudeUserEntry(time.Now().Add(-1*time.Minute).UTC().Format(time.RFC3339Nano), "Agent "+agentID+": hello, fix the bug"))
 
 	// --- session start ---
 	out := runOx(t, oxBin, env, agentID, "session", "start")
@@ -220,11 +220,17 @@ func TestIncrementalE2E_CtrlC_AntiEntropy(t *testing.T) {
 	claudeSessionID := "test-ctrlc-session-001"
 
 	// create Claude Code source JSONL
-	sourceFile := createClaudeSourceFile(t, env)
+	sourceFile := createClaudeSourceFileNamed(t, env, claudeSessionID+".jsonl")
 
 	// write session marker and agent instance
 	writeE2ESessionMarker(t, env, agentID, claudeSessionID)
 	createE2EAgentInstance(t, env.workspace, agentID)
+
+	// Give adapter discovery an agent-specific pre-session entry. Session start
+	// routes Claude files by agent ID before hooks can supply the native session
+	// ID; the old empty fixture left recording attached to no source file.
+	writeClaudeEntry(t, sourceFile, claudeUserEntry(
+		time.Now().Add(-1*time.Minute).UTC().Format(time.RFC3339Nano), "Agent "+agentID+": start"))
 
 	// --- session start ---
 	out := runOx(t, oxBin, env, agentID, "session", "start")
@@ -243,7 +249,8 @@ func TestIncrementalE2E_CtrlC_AntiEntropy(t *testing.T) {
 	runOxHook(t, oxBin, env, agentID, "PostToolUse", claudeSessionID)
 
 	writeClaudeEntry(t, sourceFile, claudeUserEntry(
-		now.Add(2*time.Second).UTC().Format(time.RFC3339Nano), "Now fix the validation"))
+		now.Add(2*time.Second).UTC().Format(time.RFC3339Nano),
+		"Now fix validation so malformed configuration is rejected clearly, and add regression coverage for every failure path."))
 	writeClaudeEntry(t, sourceFile, claudeAssistantEntry(
 		now.Add(4*time.Second).UTC().Format(time.RFC3339Nano),
 		"Fixing validation logic.", "Edit", `{"file_path":"/src/validate.go"}`))

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,14 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-08-25
+
+Decision context holds up in real plans, visual plans stay readable and recoverable, and routine Git workflows are safer.
+
 ### New
 
 - **`ox kb query` — search files across knowledge bubbles** — one question, ranked file hits grouped per bubble: `ox kb query '#engineering' '#platform' "how do we batch relay spans"`. Honest per-bubble outcomes (no matches vs. never indexed vs. failed), `--mode`/`-k`/`--path` controls, and `--json` with AI coworker guidance. Requires KB file search enabled server-side.
 
 ### Improved
 
-- **`ox upgrade` now updates direct installs in place** — if you installed ox with the quick-install script, `ox upgrade` downloads and swaps in the new version for you (verified before it is applied) instead of just printing instructions. Homebrew and `go install` installs upgrade as before.
-- **You hear about new versions even without the background service running** — `ox status` checks for a newer ox on its own and offers to upgrade on the spot.
+- **Decision Records stay findable in real work** — `ox decision enrich` and `ox plan enrich` now find governing decisions from full issue bodies and plans, not only short title-like searches. `ox decision enrich --explain` shows near-matches and results omitted by context limits.
+- **Direct installs can update themselves** — `ox upgrade` now verifies and applies quick-install updates in place, while `ox status` checks for new versions even when the background service is not running. Homebrew and `go install` workflows continue to work as before.
+- **Visual plans are easier to open and harder to lose** — most plans now remain directly readable in Git, while large plans save safely and `ox doctor` can detect and repair missing content.
+- **AI coworker context stays focused** — SageOx attribution now appears only when shared context meaningfully influenced the work.
+
+### Fixed
+
+- **Decision lookups no longer claim certainty when a source is unavailable** — degraded runs preserve valid results, warn clearly, and exit non-zero instead of presenting an incomplete search as a verified absence.
+- **`ox distill history since --format=json` now returns structured output as requested** — command-specific format choices no longer silently fall back to content output.
+- **Code indexing no longer breaks linked worktrees** — code search leaves repository Git configuration untouched.
+- **Ledger updates are safer during concurrent work** — unresolved conflicts are rejected, unrelated changes are not swept into the same update, and interrupted work remains recoverable.
 
 ## [0.14.0] - 2026-08-20
 

--- a/cmd/ox/status_test.go
+++ b/cmd/ox/status_test.go
@@ -654,7 +654,6 @@ func TestFormatGitRepoStatus(t *testing.T) {
 				Exists:           true,
 				UncommittedCount: 0,
 				HasLastSync:      true,
-				LastSync:         time.Now().Add(-30 * time.Second),
 			},
 			"synced (just now)", "success",
 		},
@@ -673,7 +672,11 @@ func TestFormatGitRepoStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			text, semantic := status.FormatGitRepoStatus(tt.status)
+			input := tt.status
+			if input.HasLastSync {
+				input.LastSync = time.Now().Add(-30 * time.Second)
+			}
+			text, semantic := status.FormatGitRepoStatus(input)
 			assert.Contains(t, text, tt.wantText)
 			assert.Equal(t, tt.wantSemantic, semantic)
 		})
@@ -683,27 +686,26 @@ func TestFormatGitRepoStatus(t *testing.T) {
 func TestFormatTimeAgo(t *testing.T) {
 	t.Parallel()
 
-	now := time.Now()
 	tests := []struct {
-		name string
-		t    time.Time
-		want string
+		name   string
+		offset time.Duration
+		want   string
 	}{
-		{"just now", now.Add(-5 * time.Second), "just now"},
-		{"1 minute ago", now.Add(-1 * time.Minute), "1 minute ago"},
-		{"multiple minutes", now.Add(-15 * time.Minute), "15 minutes ago"},
-		{"1 hour ago", now.Add(-1 * time.Hour), "1 hour ago"},
-		{"multiple hours", now.Add(-5 * time.Hour), "5 hours ago"},
-		{"1 day ago", now.Add(-25 * time.Hour), "1 day ago"},
-		{"multiple days", now.Add(-72 * time.Hour), "3 days ago"},
-		{"1 week ago", now.Add(-8 * 24 * time.Hour), "1 week ago"},
-		{"multiple weeks", now.Add(-21 * 24 * time.Hour), "3 weeks ago"},
+		{"just now", -5 * time.Second, "just now"},
+		{"1 minute ago", -1 * time.Minute, "1 minute ago"},
+		{"multiple minutes", -15 * time.Minute, "15 minutes ago"},
+		{"1 hour ago", -1 * time.Hour, "1 hour ago"},
+		{"multiple hours", -5 * time.Hour, "5 hours ago"},
+		{"1 day ago", -25 * time.Hour, "1 day ago"},
+		{"multiple days", -72 * time.Hour, "3 days ago"},
+		{"1 week ago", -8 * 24 * time.Hour, "1 week ago"},
+		{"multiple weeks", -21 * 24 * time.Hour, "3 weeks ago"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := status.FormatTimeAgo(tt.t)
+			got := status.FormatTimeAgo(time.Now().Add(tt.offset))
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,5 +13,5 @@
     "type": "git",
     "url": "https://github.com/sageox/ox.git"
   },
-  "version": "0.14.0"
+  "version": "0.14.1"
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.14.0"
+	Version   = "0.14.1"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )

--- a/tests/agents/smoke_test.go
+++ b/tests/agents/smoke_test.go
@@ -61,6 +61,15 @@ type agentCase struct {
 
 var cases = []agentCase{
 	{
+		adapter: "codex",
+		bin:     "codex",
+		args: func(prompt, _ string) []string {
+			return []string{"exec", "--skip-git-repo-check", "--sandbox", "read-only", "--color", "never", prompt}
+		},
+		isolatesSessions: false, // writes to ~/.codex/sessions
+		verified:         "codex exec --help, 0.147.0: `exec` for non-interactive mode with an explicit read-only sandbox",
+	},
+	{
 		adapter: "pi",
 		bin:     "pi", // see the collision warning on bin
 		args: func(prompt, sessionDir string) []string {
@@ -258,7 +267,10 @@ func summarize(entries []map[string]any) string {
 
 func newGitRepo(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, args := range [][]string{
 		{"init", "-q"},
 		// never touch the developer's real git identity
@@ -272,6 +284,9 @@ func newGitRepo(t *testing.T) string {
 		}
 	}
 	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# Test repo\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".sageox"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return dir


### PR DESCRIPTION
## What broke

- `ox distill history since --format=json` was rewritten to the global `--json` alias before Cobra parsed the command, so valid command-specific output silently fell back to content mode.
- Several release-gate tests captured wall-clock or daemon state before parallel tests resumed, making results depend on host activity and queue time.
- The in-repo real-agent gate did not cover Codex, leaving its transcript round-trip unverified.

## What this PR ships

- **Release metadata:** bumps the CLI, Claude plugin manifests, and docs package to `0.14.1`.
- **Release notes:** documents decision-context reliability, knowledge-bubble search, safer upgrades and ledger updates, visual-plan recovery, linked-worktree indexing, and structured distill output.
- **Correct format handling:** preserves flags owned by the selected command before applying catalog aliases.
- **Reliable release gates:** snapshots doctor state consistently, creates time-relative fixtures only when parallel subtests execute, initializes Git fixtures with an explicit branch, and makes incremental-session fixtures discoverable.
- **Real Codex coverage:** drives authenticated `codex exec` in a read-only sandbox and verifies ox can recover the resulting user and assistant entries.

## Failure-mode fix

```mermaid
flowchart LR
    A[CLI arguments] --> B{Target command owns flag?}
    B -->|yes| C[Preserve original flag]
    B -->|no| D[Apply catalog alias]
    C --> E[Cobra parses intended command format]
    D --> E
```

## Test Plan

- [x] `make format`
- [x] `make verify-version`
- [x] `make lint`
- [x] `make test` — 19,865 tests, 1,337 skips
- [x] `make test-all` — 20,216 tests, 28 skips
- [x] `make test-slow` — 20,452 tests, 104 skips
- [x] `make test-agents` — live Codex transcript round-trip passed
- [x] `make build && ./bin/ox version` — `ox 0.14.1`, commit `16f4d5cb`

The legacy `make test-integration` target redirects to the private `sageox/ox-test-harness`; its current CLI compatibility failures are tracked in `ox-0cop` and do not affect the passing repository-native Codex gate.

SageOx-Session: https://sageox.ai/c/ses_01a0398d-f6a5-7b7d-858a-fb080970c16c

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790271784&installation_model_id=433550&pr_number=825&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F825&signature=02fb8ad5b495131cba09a65a55a3ef9e1fbefe7a26da87ef6b7e680077d94477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge-bubble file search and broader decision enrichment.
  * Improved visual plans with clearer presentation and recovery options.
  * Added focused AI coworker attribution.
  * Added safer direct-install upgrades and status checks.
  * Added verified Codex agent support.

* **Bug Fixes**
  * Improved decision lookups, JSON formatting, linked-worktree indexing, and concurrent ledger updates.
  * Preserved valid command options during catalog processing.

* **Release**
  * Updated the product to version 0.14.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->