### PR TITLE
fix(codedb): self-heal torn-bolt cache instead of crash-looping ox index

### DIFF
--- a/cmd/ox/index.go
+++ b/cmd/ox/index.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sageox/ox/internal/codedb"
 	"github.com/sageox/ox/internal/codedb/index"
+	"github.com/sageox/ox/internal/codedb/store"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
 	gh "github.com/sageox/ox/internal/github"
@@ -99,6 +100,33 @@ func indexCodeInProcess(cmd *cobra.Command, args []string, full bool) error {
 	db, err := codedb.Open(dataDir)
 	if err != nil {
 		return fmt.Errorf("open codedb: %w", err)
+	}
+
+	// codedb.Open self-heals a corrupt cache transparently: it nukes and
+	// recreates a structurally broken bleve sub-index and writes a
+	// .needs_reindex marker mid-open. The daemon acts on that marker on its
+	// next pass, but a one-shot in-process `ox index` has no next pass — if we
+	// index incrementally now, the emptied sub-index stays empty, because the
+	// commits are already in SQLite and incremental indexing skips them (silent
+	// empty code search, worse than a hard error). So when a marker is present
+	// (from this open or a prior run), escalate to a full rebuild in this same
+	// invocation. Wiping dataDir also clears the markers, so it cannot loop.
+	if !full && len(store.NeedsReindexMarkers(dataDir)) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"codedb self-heal detected (corrupt cache recovered); rebuilding from scratch...\n")
+		if closeErr := db.Close(); closeErr != nil {
+			slog.Warn("close codedb before self-heal rebuild failed", "error", closeErr)
+		}
+		if err := os.RemoveAll(dataDir); err != nil {
+			return fmt.Errorf("wipe self-healed codedb for full reindex: %w", err)
+		}
+		if err := os.MkdirAll(dataDir, 0o755); err != nil {
+			return fmt.Errorf("recreate codedb dir after self-heal: %w", err)
+		}
+		db, err = codedb.Open(dataDir)
+		if err != nil {
+			return fmt.Errorf("reopen codedb after self-heal rebuild: %w", err)
+		}
 	}
 	defer db.Close()
 

--- a/cmd/ox/index_selfheal_test.go
+++ b/cmd/ox/index_selfheal_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIndexInProcess_AfterSelfHeal_RepopulatesCode is the command-altitude
+// regression for the init-container crash-loop's silent-data-loss twin: when
+// codedb.Open self-heals a corrupt bleve sub-index (emptying it and writing a
+// .needs_reindex marker mid-open), a one-shot in-process `ox index` must
+// escalate to a full rebuild. Otherwise incremental indexing skips the commits
+// already recorded in SQLite and code search stays permanently empty — with no
+// error to signal it.
+//
+// Failure prevented: `ox index` "succeeding" against a mid-write-corrupted
+// cache while leaving code search empty (worse than the crash-loop, because it
+// is invisible). Drives the real command path, not a store helper in isolation.
+func TestIndexInProcess_AfterSelfHeal_RepopulatesCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git + real code indexing")
+	}
+
+	repoDir := newIndexTestRepo(t)
+	t.Chdir(repoDir)
+
+	// Resolve the cache dir exactly as indexCodeInProcess does (findGitRoot
+	// returns the symlink-resolved toplevel on macOS, so recomputing from the
+	// raw temp path could point at a different directory).
+	gitRoot := findGitRoot()
+	require.NotEmpty(t, gitRoot, "git root must resolve")
+	dataDir := resolveCodeDBDir(gitRoot)
+	require.Truef(t, strings.HasPrefix(dataDir, gitRoot),
+		"test must use a repo-local cache (%s), refusing to touch a shared cache", dataDir)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	// 1. Baseline: build the cache and prove code search has content.
+	require.NoError(t, indexCodeInProcess(cmd, nil, false), "baseline index")
+	require.Greater(t, codeIndexDocCount(t, dataDir), uint64(0),
+		"baseline code index must have documents")
+
+	// 2. Simulate a kill-9 mid-write: tear the code sub-index bolt so bbolt
+	// cannot open it at all — the exact unopenable-bolt class from the incident.
+	boltPath := filepath.Join(dataDir, "bleve", "code", "store", "root.bolt")
+	require.FileExists(t, boltPath)
+	require.NoError(t, os.WriteFile(boltPath, []byte("corrupted"), 0o600))
+
+	// 3. Re-run incrementally. Open self-heals the code sub-index (empty +
+	// marker); the in-process path must notice the marker and rebuild fully.
+	require.NoError(t, indexCodeInProcess(cmd, nil, false), "reindex after corruption")
+
+	// 4. Code search must be repopulated, and the marker cleared by the wipe.
+	require.Greater(t, codeIndexDocCount(t, dataDir), uint64(0),
+		"code index must be repopulated after self-heal, not left silently empty")
+	require.Empty(t, store.NeedsReindexMarkers(dataDir),
+		"full rebuild must clear the self-heal marker")
+}
+
+// codeIndexDocCount opens the store at dataDir and returns the code sub-index
+// document count — the observable proxy for "code search returns results".
+func codeIndexDocCount(t *testing.T, dataDir string) uint64 {
+	t.Helper()
+	s, err := store.Open(dataDir)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+	n, err := s.CodeIndex.DocCount()
+	require.NoError(t, err)
+	return n
+}
+
+// newIndexTestRepo creates a throwaway git repo with one indexable Go file.
+func newIndexTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		c := exec.Command(args[0], args[1:]...)
+		c.Dir = dir
+		out, err := c.CombinedOutput()
+		require.NoErrorf(t, err, "%v: %s", args, out)
+	}
+	run("git", "init")
+	run("git", "config", "user.name", "Test User")
+	run("git", "config", "user.email", "test@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package main\n\nfunc ZebrafishMarker() string { return \"hello\" }\n"), 0o644))
+	run("git", "add", "main.go")
+	run("git", "commit", "-m", "initial commit")
+	return dir
+}

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -936,35 +936,51 @@ func isBleveIndexCorrupt(boltPath string) bool {
 // false corruption verdict.
 var bleveExclusiveProbeTimeout = 2 * time.Second
 
-// boltCorruptOnExclusiveOpen disambiguates the two states that both surface as
-// a bbolt-open failure the read-only peek (isBleveIndexCorrupt) cannot classify:
+// boltCorruptOnExclusiveOpen disambiguates the states that surface as a
+// bbolt-open failure the read-only peek (isBleveIndexCorrupt) cannot classify:
 // a bolt torn so badly bbolt rejects it (kill-9 mid-write) versus a bolt held
-// under another writer's exclusive flock. It attempts a bounded EXCLUSIVE open:
+// under another writer's exclusive flock versus a transient/environmental
+// failure. It attempts a bounded EXCLUSIVE open and returns true (self-heal)
+// ONLY on proven on-disk structural corruption:
 //
-//   - bbolt.ErrTimeout: a live writer holds the exclusive lock. Return false —
-//     the caller keeps the safe lock-contention behavior and never nukes an
-//     index that is actively being written.
-//   - any other open error: the flock was taken without contention, so no live
-//     writer holds it, yet bbolt still rejects the file — proven structural
-//     corruption. Return true so the caller self-heals.
-//   - opened cleanly: the bolt itself is fine (whatever failed in bleve.Open is
-//     not a torn bolt). Close and return false — do not destroy it.
+//   - ErrInvalid / ErrVersionMismatch / ErrChecksum: bbolt opened the file and
+//     took the exclusive flock, then failed validating the meta pages. The
+//     file itself is structurally broken — proven corruption. Return true.
+//   - ErrTimeout: a live writer holds the exclusive lock. Return false — never
+//     nuke an index that is actively being written.
+//   - any OTHER error (permission denied, I/O error, mmap/ENOMEM resource
+//     exhaustion): these occur BEFORE meta validation and are transient or
+//     environmental, NOT corruption. Return false — nuking a possibly-healthy
+//     index on a permission blip would be destructive data loss.
+//   - opened cleanly: the bolt is fine. Close and return false.
 //
-// A nuke only ever follows an ACQUIRED flock plus a rejected file, so a
-// genuinely live-locked index is never destroyed — the same "never nuke without
+// A nuke only ever follows a *validation* failure (ErrInvalid/version/checksum)
+// on a flock we took ourselves, so neither a live-locked index nor a
+// transiently-unreadable one is ever destroyed — the same "never nuke without
 // proof" guarantee isBleveIndexCorrupt provides, extended to the
 // unopenable-bolt class the read-only peek structurally cannot reach.
 func boltCorruptOnExclusiveOpen(boltPath string) bool {
 	db, err := bbolt.Open(boltPath, 0600, &bbolt.Options{Timeout: bleveExclusiveProbeTimeout})
-	if err != nil {
-		if errors.Is(err, bbolterrors.ErrTimeout) {
-			return false
-		}
-		slog.Error("bleve bolt is unopenable and unlocked; treating as corruption",
+	if err == nil {
+		_ = db.Close()
+		return false
+	}
+	// Proven on-disk corruption: bbolt validated the meta pages and rejected
+	// them. These are the only failures that justify a destructive discard.
+	if errors.Is(err, bbolterrors.ErrInvalid) ||
+		errors.Is(err, bbolterrors.ErrVersionMismatch) ||
+		errors.Is(err, bbolterrors.ErrChecksum) {
+		slog.Error("bleve bolt failed structural validation; treating as corruption",
 			"path", boltPath, "err", err)
 		return true
 	}
-	_ = db.Close()
+	// ErrTimeout is a live writer; anything else (permission/I/O/resource) is
+	// transient or environmental. Neither proves corruption — preserve the
+	// index and let the caller fall through to the safe lock-contention path.
+	if !errors.Is(err, bbolterrors.ErrTimeout) {
+		slog.Warn("bleve bolt open failed without proving corruption; preserving index",
+			"path", boltPath, "err", err)
+	}
 	return false
 }
 

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -20,6 +20,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	codedbsqlc "github.com/sageox/ox/internal/codedb/sqlc"
 	"go.etcd.io/bbolt"
+	bbolterrors "go.etcd.io/bbolt/errors"
 	_ "modernc.org/sqlite"
 )
 
@@ -713,6 +714,16 @@ func openOrCreateBleveIndex(root, path, name string) (bleve.Index, error) {
 		if isBleveIndexCorrupt(boltPath) {
 			return selfHealBleveSubIndex(root, path, name, err)
 		}
+		// isBleveIndexCorrupt only proves the corruption it can SEE through a
+		// read-only peek. A bolt torn so badly bbolt cannot open it at all (a
+		// kill-9 mid-write, "invalid database") reads identically to a live
+		// exclusive lock here — both made bleve.Open fail and both defeat the
+		// read-only peek. Disambiguate with a bounded exclusive open so the
+		// unopenable-corrupt case self-heals instead of crash-looping, while a
+		// genuinely locked index is still left untouched.
+		if boltCorruptOnExclusiveOpen(boltPath) {
+			return selfHealBleveSubIndex(root, path, name, err)
+		}
 		return nil, fmt.Errorf("bleve index appears to be in use (lock contention): %w", err)
 	} else if !os.IsNotExist(statErr) && !errors.Is(statErr, syscall.ENOTDIR) {
 		// permission/IO errors are transient — nuking would cause data loss
@@ -916,6 +927,45 @@ func isBleveIndexCorrupt(boltPath string) bool {
 		return nil
 	})
 	return corrupt
+}
+
+// bleveExclusiveProbeTimeout bounds how long boltCorruptOnExclusiveOpen waits
+// to take bbolt's exclusive flock before conceding a live writer holds it.
+// Overridable in tests. A timeout only ever biases toward the safe "assume
+// locked, do not nuke" verdict, so shrinking it in tests cannot manufacture a
+// false corruption verdict.
+var bleveExclusiveProbeTimeout = 2 * time.Second
+
+// boltCorruptOnExclusiveOpen disambiguates the two states that both surface as
+// a bbolt-open failure the read-only peek (isBleveIndexCorrupt) cannot classify:
+// a bolt torn so badly bbolt rejects it (kill-9 mid-write) versus a bolt held
+// under another writer's exclusive flock. It attempts a bounded EXCLUSIVE open:
+//
+//   - bbolt.ErrTimeout: a live writer holds the exclusive lock. Return false —
+//     the caller keeps the safe lock-contention behavior and never nukes an
+//     index that is actively being written.
+//   - any other open error: the flock was taken without contention, so no live
+//     writer holds it, yet bbolt still rejects the file — proven structural
+//     corruption. Return true so the caller self-heals.
+//   - opened cleanly: the bolt itself is fine (whatever failed in bleve.Open is
+//     not a torn bolt). Close and return false — do not destroy it.
+//
+// A nuke only ever follows an ACQUIRED flock plus a rejected file, so a
+// genuinely live-locked index is never destroyed — the same "never nuke without
+// proof" guarantee isBleveIndexCorrupt provides, extended to the
+// unopenable-bolt class the read-only peek structurally cannot reach.
+func boltCorruptOnExclusiveOpen(boltPath string) bool {
+	db, err := bbolt.Open(boltPath, 0600, &bbolt.Options{Timeout: bleveExclusiveProbeTimeout})
+	if err != nil {
+		if errors.Is(err, bbolterrors.ErrTimeout) {
+			return false
+		}
+		slog.Error("bleve bolt is unopenable and unlocked; treating as corruption",
+			"path", boltPath, "err", err)
+		return true
+	}
+	_ = db.Close()
+	return false
 }
 
 // zapFilesInDir returns a set of *.zap filenames in dir for fast lookup.

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -591,49 +591,81 @@ func TestBoltCorruptOnExclusiveOpen_DistinguishesCorruptionFromLiveLock(t *testi
 	bleveExclusiveProbeTimeout = 200 * time.Millisecond
 	t.Cleanup(func() { bleveExclusiveProbeTimeout = restore })
 
-	t.Run("torn bolt, no live writer -> corrupt", func(t *testing.T) {
-		boltPath := filepath.Join(t.TempDir(), "root.bolt")
-		require.NoError(t, os.WriteFile(boltPath, []byte("corrupted"), 0o600))
-		require.True(t, boltCorruptOnExclusiveOpen(boltPath),
-			"an unopenable bolt with no writer holding it is proven corruption")
-	})
-
-	t.Run("valid bolt, no live writer -> not corrupt", func(t *testing.T) {
+	// newValidBolt creates a healthy, closed bolt file and returns its path.
+	newValidBolt := func(t *testing.T) string {
+		t.Helper()
 		boltPath := filepath.Join(t.TempDir(), "root.bolt")
 		db, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: 2 * time.Second})
 		require.NoError(t, err)
 		require.NoError(t, db.Close())
-		require.False(t, boltCorruptOnExclusiveOpen(boltPath),
-			"a healthy, openable bolt must never be treated as corruption")
-	})
+		return boltPath
+	}
 
-	t.Run("live writer holds exclusive lock -> not corrupt", func(t *testing.T) {
-		boltPath := filepath.Join(t.TempDir(), "root.bolt")
-		holder, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: 2 * time.Second})
-		require.NoError(t, err, "open holder")
-		defer func() { _ = holder.Close() }()
-		// holder keeps bbolt's exclusive flock open; the probe must time out and
-		// conclude "live writer", never "corrupt" — so a live index stays safe.
-		require.False(t, boltCorruptOnExclusiveOpen(boltPath),
-			"a live exclusive lock must read as contention, not corruption")
-	})
+	tests := []struct {
+		name  string
+		skip  func(t *testing.T)
+		setup func(t *testing.T) string
+		// wantCorrupt is the verdict: true = proven corruption (self-heal),
+		// false = preserve the index (live lock or environmental error).
+		wantCorrupt bool
+	}{
+		{
+			name: "torn bolt, no live writer -> corrupt",
+			setup: func(t *testing.T) string {
+				boltPath := filepath.Join(t.TempDir(), "root.bolt")
+				require.NoError(t, os.WriteFile(boltPath, []byte("corrupted"), 0o600))
+				return boltPath
+			},
+			wantCorrupt: true,
+		},
+		{
+			name:        "valid bolt, no live writer -> preserve",
+			setup:       newValidBolt,
+			wantCorrupt: false,
+		},
+		{
+			name: "live writer holds exclusive lock -> preserve",
+			setup: func(t *testing.T) string {
+				boltPath := filepath.Join(t.TempDir(), "root.bolt")
+				holder, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: 2 * time.Second})
+				require.NoError(t, err, "open holder")
+				// Keep bbolt's exclusive flock held for the duration of the
+				// probe so it must time out and read as "live writer".
+				t.Cleanup(func() { _ = holder.Close() })
+				return boltPath
+			},
+			wantCorrupt: false,
+		},
+		{
+			name: "unreadable bolt (permission) -> preserve",
+			skip: func(t *testing.T) {
+				if os.Geteuid() == 0 {
+					t.Skip("root bypasses file permissions")
+				}
+			},
+			setup: func(t *testing.T) string {
+				boltPath := newValidBolt(t)
+				// A permission failure fires BEFORE bbolt validates the meta
+				// pages — environmental, not corruption. Nuking a healthy index
+				// over a permission blip would be destructive data loss.
+				require.NoError(t, os.Chmod(boltPath, 0o000))
+				t.Cleanup(func() { _ = os.Chmod(boltPath, 0o600) })
+				return boltPath
+			},
+			wantCorrupt: false,
+		},
+	}
 
-	t.Run("unreadable bolt (permission) -> not corrupt, preserved", func(t *testing.T) {
-		if os.Geteuid() == 0 {
-			t.Skip("root bypasses file permissions")
-		}
-		boltPath := filepath.Join(t.TempDir(), "root.bolt")
-		db, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: 2 * time.Second})
-		require.NoError(t, err)
-		require.NoError(t, db.Close())
-		// A permission failure fires BEFORE bbolt validates the meta pages — it
-		// is environmental, not corruption. Nuking a healthy index over a
-		// permission blip would be destructive data loss.
-		require.NoError(t, os.Chmod(boltPath, 0o000))
-		t.Cleanup(func() { _ = os.Chmod(boltPath, 0o600) })
-		require.False(t, boltCorruptOnExclusiveOpen(boltPath),
-			"a permission error must be preserved (not proven corruption)")
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skip != nil {
+				tc.skip(t)
+			}
+			boltPath := tc.setup(t)
+			require.Equalf(t, tc.wantCorrupt, boltCorruptOnExclusiveOpen(boltPath),
+				"boltCorruptOnExclusiveOpen verdict wrong for %q", tc.name)
+		})
+	}
 }
 
 // TestOpenOrCreateBleveIndex_UnopenableBolt_SelfHeals is the regression for the

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -617,6 +617,23 @@ func TestBoltCorruptOnExclusiveOpen_DistinguishesCorruptionFromLiveLock(t *testi
 		require.False(t, boltCorruptOnExclusiveOpen(boltPath),
 			"a live exclusive lock must read as contention, not corruption")
 	})
+
+	t.Run("unreadable bolt (permission) -> not corrupt, preserved", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses file permissions")
+		}
+		boltPath := filepath.Join(t.TempDir(), "root.bolt")
+		db, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: 2 * time.Second})
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+		// A permission failure fires BEFORE bbolt validates the meta pages — it
+		// is environmental, not corruption. Nuking a healthy index over a
+		// permission blip would be destructive data loss.
+		require.NoError(t, os.Chmod(boltPath, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(boltPath, 0o600) })
+		require.False(t, boltCorruptOnExclusiveOpen(boltPath),
+			"a permission error must be preserved (not proven corruption)")
+	})
 }
 
 // TestOpenOrCreateBleveIndex_UnopenableBolt_SelfHeals is the regression for the

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -566,16 +566,73 @@ func TestForeignKeysEnabled(t *testing.T) {
 	}
 }
 
-// TestOpenOrCreateBleveIndex_LockedIndexNotNuked verifies that openOrCreateBleveIndex
-// does NOT delete an existing bleve index when an open error occurs and root.bolt is present.
-// Regression test: previously, any non-ENOENT error caused os.RemoveAll, which would
-// destroy an index being actively written by another goroutine.
+// TestBoltCorruptOnExclusiveOpen_DistinguishesCorruptionFromLiveLock is the
+// honest replacement for a former test (TestOpenOrCreateBleveIndex_LockedIndexNotNuked)
+// that wrote garbage to root.bolt and then asserted the index was NOT recovered.
+// That test used corrupt bytes as a stand-in for a live lock — the two states
+// were indistinguishable at the surface error — and so it hard-coded the
+// crash-loop-on-corruption as the contract. The real guarantee is that the
+// discriminator self-heals ONLY when it can prove no live writer holds the
+// index, so this drives that decision point directly against all three real
+// on-disk states.
 //
-// bleve opens bbolt without a timeout, so true lock-timeout cannot be triggered in-process.
-// Instead the test creates a real index at indexPath (so root.bolt has valid bbolt structure),
-// then corrupts root.bolt to produce an immediate open error — the same code path that fires
-// when another goroutine holds the bbolt exclusive lock.
-func TestOpenOrCreateBleveIndex_LockedIndexNotNuked(t *testing.T) {
+// Failure prevented: destroying a codedb sub-index another process is actively
+// writing (false-corrupt), and its inverse — crash-looping forever on a torn
+// bolt because it was mistaken for a live lock (false-lock, the 458-restart
+// incident).
+func TestBoltCorruptOnExclusiveOpen_DistinguishesCorruptionFromLiveLock(t *testing.T) {
+	// Not parallel: this test overrides the package-level probe timeout. Go
+	// runs non-parallel tests to completion before parallel ones resume, so
+	// the override cannot race a concurrent openOrCreateBleveIndex.
+	if testing.Short() {
+		t.Skip("short: bbolt flock + open operations")
+	}
+	restore := bleveExclusiveProbeTimeout
+	bleveExclusiveProbeTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { bleveExclusiveProbeTimeout = restore })
+
+	t.Run("torn bolt, no live writer -> corrupt", func(t *testing.T) {
+		boltPath := filepath.Join(t.TempDir(), "root.bolt")
+		require.NoError(t, os.WriteFile(boltPath, []byte("corrupted"), 0o600))
+		require.True(t, boltCorruptOnExclusiveOpen(boltPath),
+			"an unopenable bolt with no writer holding it is proven corruption")
+	})
+
+	t.Run("valid bolt, no live writer -> not corrupt", func(t *testing.T) {
+		boltPath := filepath.Join(t.TempDir(), "root.bolt")
+		db, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: 2 * time.Second})
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+		require.False(t, boltCorruptOnExclusiveOpen(boltPath),
+			"a healthy, openable bolt must never be treated as corruption")
+	})
+
+	t.Run("live writer holds exclusive lock -> not corrupt", func(t *testing.T) {
+		boltPath := filepath.Join(t.TempDir(), "root.bolt")
+		holder, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: 2 * time.Second})
+		require.NoError(t, err, "open holder")
+		defer func() { _ = holder.Close() }()
+		// holder keeps bbolt's exclusive flock open; the probe must time out and
+		// conclude "live writer", never "corrupt" — so a live index stays safe.
+		require.False(t, boltCorruptOnExclusiveOpen(boltPath),
+			"a live exclusive lock must read as contention, not corruption")
+	})
+}
+
+// TestOpenOrCreateBleveIndex_UnopenableBolt_SelfHeals is the regression for the
+// init-container crash-loop (observed: 458 identical restarts). A root.bolt
+// torn so badly bbolt cannot open it at all — the kill-9 mid-write signature —
+// must be recovered, not looped on. The read-only corruption peek
+// (isBleveIndexCorrupt) cannot classify an unopenable bolt, so before this fix
+// the sub-index fell to the "lock contention" error and every retry failed
+// identically. Now a bounded EXCLUSIVE open proves no live writer holds the
+// index and the file is unusable, so the sub-index self-heals: nuked +
+// recreated empty + a .needs_reindex marker for the next full rebuild.
+//
+// Failure prevented: `ox index` erroring identically on every run against a
+// mid-write-corrupted cache — a permanent container crash-loop that only an
+// external `rm` of the cache could break.
+func TestOpenOrCreateBleveIndex_UnopenableBolt_SelfHeals(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("short: Bleve + bbolt operations")
@@ -584,28 +641,37 @@ func TestOpenOrCreateBleveIndex_LockedIndexNotNuked(t *testing.T) {
 	tmp := t.TempDir()
 	indexPath := filepath.Join(tmp, "test-index")
 
-	// create a real bleve index at indexPath so root.bolt exists with valid bbolt structure
-	first, err := openOrCreateBleveIndex(tmp, indexPath, "test")
-	if err != nil {
-		t.Fatalf("create index: %v", err)
-	}
-	_ = first.Close()
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err, "create index")
+	require.NoError(t, first.Close())
 
 	boltPath := filepath.Join(indexPath, "store", "root.bolt")
 
-	// corrupt root.bolt — causes bbolt to return an immediate error (invalid magic bytes)
-	// rather than waiting indefinitely for a lock, exercising the same "bolt exists → don't nuke"
-	// code path that fires during real lock contention
-	require.NoError(t, os.WriteFile(boltPath, []byte("corrupted"), 0600))
+	// Torn/half-written bolt: bytes present but no valid meta page, so bbolt
+	// rejects the file outright. This is the unopenable-bolt class the
+	// read-only peek cannot classify — distinct from an empty/truncated
+	// _mapping (which peeks successfully) and from a live exclusive lock.
+	require.NoError(t, os.WriteFile(boltPath, []byte("corrupted"), 0o600))
 
-	// openOrCreateBleveIndex must fail (corrupt bolt) but must NOT delete the index directory
-	_, openErr := openOrCreateBleveIndex(tmp, indexPath, "test")
-	require.Error(t, openErr, "expected error opening corrupt index")
+	idx, healErr := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, healErr, "unopenable bolt must self-heal, not crash-loop")
+	require.NotNil(t, idx)
+	// Release the fresh index's exclusive lock before inspecting the file.
+	require.NoError(t, idx.Close())
 
-	// bolt file must survive — index was not nuked
-	if _, statErr := os.Stat(boltPath); statErr != nil {
-		t.Errorf("root.bolt was deleted: openOrCreateBleveIndex nuked on open error: %v", statErr)
-	}
+	// The recovered bolt must open cleanly — proof the torn file was replaced,
+	// not left in place for the next run to trip over again.
+	reopened, reopenErr := bbolt.Open(boltPath, 0o600, &bbolt.Options{
+		ReadOnly: true,
+		Timeout:  2 * time.Second,
+	})
+	require.NoError(t, reopenErr, "recovered bolt must open cleanly")
+	require.NoError(t, reopened.Close())
+
+	// Marker written so the next daemon/in-process pass forces a full rebuild
+	// and repopulates the emptied sub-index.
+	require.True(t, HasNeedsReindexMarker(tmp, "code"),
+		"self-heal must write a .needs_reindex marker for repopulation")
 }
 
 // emptyMappingForLatestSnapshot opens root.bolt and overwrites the latest


### PR DESCRIPTION
## Why this matters

A developer, CI job, or container running `ox index` against a codedb cache that a **killed process left mid-write** now **recovers automatically** — instead of failing with the same error on every retry (a permanent crash-loop) or, worse, "succeeding" while silently building an **empty** code index. Code search keeps working after an interrupted index without anyone having to `rm` the cache by hand.

## What broke

`ox index`'s codedb cache is a bleve full-text index backed by a bbolt file (`root.bolt`). The store already self-heals several corruption signatures, but only ones it can prove through a **read-only** peek of the bolt.

A bolt torn so badly bbolt cannot open it at all — the classic kill-9 mid-write signature (`invalid database`) — defeats that read-only peek. The code then fell through to a hard error labelled *"bleve index appears to be in use (lock contention)"* and returned it. The torn bytes are still there on the next run, so it fails **identically forever**. In a restart-on-failure container this is an unbounded crash-loop; the only escape was an external script deleting the cache.

Two failure classes, one surface error:

```mermaid
flowchart TD
    A["bleve.Open fails, root.bolt present"] --> B{"read-only peek<br/>proves corruption?"}
    B -- yes --> H["self-heal: nuke + recreate + marker"]
    B -- "no (bolt won't open at all)" --> C{"NEW: bounded<br/>exclusive open"}
    C -- "ErrTimeout (live writer holds flock)" --> L["preserve — never nuke a live index"]
    C -- "acquired flock but bbolt rejects file" --> H
    C -- "opened cleanly" --> L
    B -. "old behavior" .-> X["hard 'lock contention' error<br/>→ identical failure every run<br/>→ crash-loop"]
```

A second, quieter bug: even where the store *did* self-heal (emptying a sub-index and writing a `.needs_reindex` marker), a one-shot in-process `ox index` ignored the marker and indexed **incrementally** — skipping commits already in SQLite — leaving the emptied index permanently empty with no error.

## What this PR ships

- **Corrupt-vs-locked discriminator** (`internal/codedb/store/store.go`) — when the read-only peek can't classify a bolt, attempt a **bounded exclusive** open. Acquiring the flock but having bbolt reject the file proves no live writer holds it **and** the file is unusable → self-heal. `ErrTimeout` proves a live writer → preserve. A nuke only ever follows an *acquired* lock, so a genuinely live-locked index is still never destroyed — the existing "never nuke without proof" guarantee, extended to the unopenable-bolt class.
- **In-process honors self-heal markers** (`cmd/ox/index.go`) — a one-shot `ox index` with no daemon "next pass" now escalates to a full rebuild when a `.needs_reindex` marker is present (including one written mid-open by the self-heal itself), repopulating the emptied sub-index instead of settling on empty.
- **Killed a test that certified the bug** — the former `TestOpenOrCreateBleveIndex_LockedIndexNotNuked` wrote garbage to `root.bolt` and asserted it was *not* recovered, using corrupt bytes as a stand-in for a live lock. It hard-coded the crash-loop as correct. Replaced with a test that uses a **real held exclusive flock**, so "don't nuke a live index" is tested honestly.

## Test Plan

Every behavioral change was proven red-first (broke the fix, watched the claim step fail, restored, watched it pass):

- **`TestOpenOrCreateBleveIndex_UnopenableBolt_SelfHeals`** — torn bolt → self-heals + writes marker. RED before the discriminator with the incident's verbatim error (`lock contention: invalid database`).
- **`TestIndexInProcess_AfterSelfHeal_RepopulatesCode`** — drives the real command path: build cache → tear the code bolt → re-run `ox index` incrementally → code index must be repopulated and the marker cleared. RED before the marker fix (`DocCount 0`).
- **`TestBoltCorruptOnExclusiveOpen_DistinguishesCorruptionFromLiveLock`** — three real on-disk states: torn→heal, valid→keep, and a **real held exclusive lock→keep**.

Gates: `go vet` clean, `gofmt` clean, store + cmd/ox suites green.

## Scope notes

- **De-scoped:** widening the "truncated-but-present `.zap` segment" detector. Reliably detecting a truncated (not missing) segment requires per-segment coupling the existing code deliberately abandoned because it "broke silently across bleve versions." Shipping a version-fragile heuristic there is worse than the residual. This PR fixes the **torn-bolt** class (the dominant kill-9 signature); a truncated-`.zap`-with-healthy-bolt remains a documented residual.
- An external workaround exists in a private deployment repository; removing it once this ships is tracked privately. No customer-facing behavior changes beyond the recovery described above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790277517&installation_model_id=433550&pr_number=826&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F826&signature=dcfe8c5f68eb9094f3cdba66cc0aae31b2f1607b44c83d3ed4cf6f707e856803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery from corrupted local code indexes by automatically rebuilding affected data.
  - Preserved active or inaccessible indexes during lock contention and permission-related failures.
  - Ensured recovered indexes are fully repopulated instead of remaining incomplete.

- **Tests**
  - Added coverage for corrupted, healthy, locked, and permission-restricted index files.
  - Added an integration test verifying code documents return after automatic recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->