### PR TITLE
fix(session): stop phantom session buildup + auto-reclaim stale sessions

### DIFF
--- a/.claude/commands/ox-conversation.md
+++ b/.claude/commands/ox-conversation.md
@@ -1,0 +1,14 @@
+<!-- ox-hash: 6bdc2bd3da8e ver: 0.14.1 -->
+<!-- Keep this file thin. Behavioral guidance (disclosure ladder, id forms,
+     pinning, errors) belongs in the ox CLI JSON output (guidance field) and
+     `ox guide conversations`, not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
+Read recorded team conversations locally: list, summaries, distillation topics, and transcript slices.
+
+## Steps
+
+Run `ox conversation $ARGUMENTS` (or `ox conversation list` if no arguments
+are given), then present the results. Follow the JSON `guidance` field to
+descend the disclosure ladder (`show` → `topics` → `topic` → `transcript`);
+a full `sageox://` citation URI (quoted) works as an id and retrieves the
+cited transcript slice. Full workflow: `ox guide conversations`.

--- a/.claude/rules/ox.md
+++ b/.claude/rules/ox.md
@@ -1,52 +1,68 @@
 ---
 description: SageOx behavioral guidance for AI coworkers
 ---
-<!-- agentx-hash: 674acb043d1a ver: 0.6.2 -->
-# SageOx Rules
+<!-- agentx-hash: 0869654d5e14 ver: 0.14.1 -->
+# SageOx — You're Part of a Team
 
-This project uses [SageOx](https://sageox.ai) for team context and session recording.
+This project uses SageOx for team coordination. You are an AI coworker —
+your teammates (human and AI) can see your work, and you can see theirs.
 
-## Priming
+## Session Start
 
-Run `ox agent prime` at session start, after compaction, or after context clear.
-This loads team context, session recording, and coworker agents.
+Run `ox agent prime` before any other action. This loads:
+- Team conventions, architectural decisions, and norms
+- Prior session history from teammates
+- Your agent identity (needed for all ox commands)
 
-## Commands
+Re-run after context compaction or clear.
 
-| Intent | Command |
-|--------|---------|
-| Team context (meetings, decisions, conventions) | `ox agent team-ctx [slug]` |
-| Search code (symbols, git history, diffs) | `ox code search "<query>"` |
-| Code hotspots, open PRs, contention risk | `ox code insights` |
-| Sync status and project state | `ox status` |
-| Diagnose and fix issues | `ox doctor` |
-| Search team discussions and sessions | `ox query "<question>"` |
-| List prior coding sessions | `ox session list` |
-| View a session recording | `ox session view <name> --text` |
-| List teams | `ox teams` |
-| Load expert coworker agent | `ox coworker load <name>` |
+## Being a Good Teammate
 
-## Session Recording
+### Share What You're Working On
+When starting significant work or making architectural decisions:
 
-Sessions auto-record when `ox agent prime` runs. Discussions may be shared with teammates.
-Use `/ox-session-stop` to end recording.
+    ox murmur --topic=wip "what you're building, which files"
 
-## Murmuring
+Murmurs are lightweight, ephemeral coordination signals. Your teammates'
+murmurs appear as whispers in your context — read them to avoid conflicts.
 
-Publish WIP to teammates so they stay in sync:
+### Learn from Your Team
+Before diving into unfamiliar code or making design decisions:
 
-```bash
-ox murmur --topic=wip "what you're building, which files you're modifying"
-```
+    ox query "your question"              # search discussions + sessions
+    ox code search "<symbol or pattern>"  # search code + git history
+    ox code insights                      # hotspots, contention, open PRs
 
-Murmur at the start of significant work and after architectural decisions.
+### Use Team Expertise
+Your team has expert coworker agents for deep domain knowledge:
 
-## Attribution
+    ox coworker load <name>
 
-When SageOx guidance influences your approach:
+### Credit Your Sources
+When SageOx guidance shapes your approach:
 
 Attribution is **conditional**: attribute to SageOx only when SageOx-delivered team context measurably changed what you did. If it did not, add nothing — no note, no footer, and report the score as `none`. Fabricating attribution is worse than omitting it.
 
+- In responses: "SageOx found [name]'s session on [topic]..."
 - Commit footer: `Co-Authored-By: SageOx <ox@sageox.ai>`
-- PR body (last line): `Co-Authored-By: [SageOx](https://github.com/SageOx)`
-- In responses: "Based on SageOx domain guidance, I'll..."
+- PR body: `Co-Authored-By: [SageOx](https://github.com/SageOx)`
+- PR body last line (while a session is recording): the `SageOx-Session:` link
+  from prime output — copy it exactly, never construct or guess it; stop adding
+  it after the session is stopped or aborted.
+
+### Record Your Session
+Sessions auto-record after priming. Use `/ox-session-stop` to end.
+Your session becomes part of the project ledger — teammates learn from it.
+
+## Quick Reference
+
+| When you need... | Run |
+|------------------|-----|
+| Team context at session start | `ox agent prime` |
+| Team decisions & conventions | `ox agent team-ctx` |
+| Prior work on this topic | `ox query "<question>"` |
+| Code symbols & git history | `ox code search "<query>"` |
+| Change risk & hotspots | `ox code insights` |
+| To signal teammates | `ox murmur --topic=wip "..."` |
+| Domain expertise | `ox coworker load <name>` |
+| Health check | `ox status` / `ox doctor` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,3 +285,15 @@ bd close <id>         # Complete work
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
+
+<!-- ox:prime:pi:start -->
+## SageOx Team Context
+
+This project uses [SageOx](https://sageox.ai) for team context. Run the following command at the start of every session to load team knowledge:
+
+```bash
+ox agent prime
+```
+
+This provides architectural decisions, coding conventions, and session history from your team.
+<!-- ox:prime:pi:end -->

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -716,10 +716,13 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 				// parent session not found; fall back to own session
 				state, _ = session.LoadRecordingStateForAgent(projectRoot, agentID)
 			}
-			if state != nil && state.LifecycleRegistrationState == "pending" {
+			if state != nil && (state.LifecycleRegistrationState == "pending" || state.LifecycleRegistrationState == "deferred") {
 				// Prime is the first reliable post-start interaction for many
 				// short-lived CLI invocations. Retrying here makes an expired or
 				// offline start recover without ever blocking the local recorder.
+				// "deferred" means start-time registration was withheld until a
+				// user turn existed; a re-prime after compaction/clear is exactly
+				// when that turn has since landed, so registration fires here too.
 				notifySessionStartedAsync(projectRoot, state)
 			}
 			output.Session.SessionURL, output.Session.PRDirective = sessionLinkOutputs(projCfg, state, attribution.Session)

--- a/cmd/ox/doctor_session_draft.go
+++ b/cmd/ox/doctor_session_draft.go
@@ -3,13 +3,9 @@ package main
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
-	"sort"
-	"time"
 
 	"github.com/sageox/ox/internal/config"
-	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
 )
 
@@ -24,15 +20,10 @@ func init() {
 	})
 }
 
-// orphanedDraftAge is how long a draft must have gone without a refresh before
-// it is considered abandoned.
-//
-// Comfortably longer than the refresh cadence (10 turns) takes in practice, so
-// a slow but live session — a user thinking, or an agent on a long tool call —
-// is never mistaken for a dead one. The cost of waiting is a stale "in
-// progress" page; the cost of being wrong is deleting a live session's
-// placeholder, so the asymmetry says wait.
-const orphanedDraftAge = 24 * time.Hour
+// orphanedDraftAge is the abandonment threshold; the canonical value and
+// rationale live on session.OrphanedDraftAge, shared with the daemon's periodic
+// retraction so both agree on what "orphaned" means.
+const orphanedDraftAge = session.OrphanedDraftAge
 
 // checkSessionDraftOrphan finds draft placeholders in the ledger whose
 // recording no longer exists anywhere.
@@ -108,81 +99,24 @@ func checkSessionDraftOrphan(fix bool) checkResult {
 	return PassedCheck(name, fmt.Sprintf("retracted %d orphaned draft(s)", removed))
 }
 
-// findOrphanedDrafts returns the names of ledger drafts that have no live or
-// recoverable recording behind them, oldest first.
-//
-// Three conditions must ALL hold, and each one is deliberately conservative —
-// a false positive here deletes a live session's placeholder:
-//
-//  1. The ledger directory is a draft (never a finalized session).
-//  2. Its updated_at is older than orphanedDraftAge. This is the whole reason
-//     drafts refresh their counters: without a heartbeat there is no way to
-//     tell a live session from a dead one.
-//  3. No recording state exists for it in any cache location, and no cached
-//     transcript is waiting to be uploaded. If either exists, the session is
-//     alive or recoverable and the upload-retry check owns it, not this one.
+// findOrphanedDrafts resolves this project's local cache dirs and delegates to
+// session.FindOrphanedDrafts (the shared source of truth). Thin wrapper: the
+// detection logic lives in internal/session so the daemon shares it verbatim.
 func findOrphanedDrafts(projectRoot, ledgerPath string) ([]string, error) {
-	sessionsDir := filepath.Join(ledgerPath, "sessions")
-	entries, err := os.ReadDir(sessionsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read ledger sessions: %w", err)
-	}
-
-	cacheDirs := []string{filepath.Join(ledgerPath, ".sageox", "cache", "sessions")}
-	if contextPath := session.GetContextPath(getRepoIDOrDefault(projectRoot)); contextPath != "" {
-		cacheDirs = append(cacheDirs, filepath.Join(contextPath, "sessions"))
-	}
-
-	type candidate struct {
-		name      string
-		updatedAt time.Time
-	}
-	var found []candidate
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		meta, metaErr := lfs.ReadSessionMeta(filepath.Join(sessionsDir, name))
-		// Fail safe: an unreadable meta.json is not a draft we are willing to
-		// delete. Some other check owns diagnosing it.
-		if metaErr != nil || !meta.IsDraft() {
-			continue
-		}
-		// No updated_at means we cannot age it. Refuse rather than guess —
-		// deleting a placeholder for a session that might be live is worse
-		// than leaving a stale page.
-		if meta.UpdatedAt == nil || time.Since(*meta.UpdatedAt) < orphanedDraftAge {
-			continue
-		}
-		if hasLocalSessionData(cacheDirs, name) {
-			continue
-		}
-		found = append(found, candidate{name: name, updatedAt: *meta.UpdatedAt})
-	}
-
-	sort.Slice(found, func(i, j int) bool { return found[i].updatedAt.Before(found[j].updatedAt) })
-	names := make([]string, 0, len(found))
-	for _, c := range found {
-		names = append(names, c.name)
-	}
-	return names, nil
+	return session.FindOrphanedDrafts(ledgerPath, draftCacheDirs(projectRoot, ledgerPath))
 }
 
-// hasLocalSessionData reports whether any cache location still holds this
-// session, either as an active recording or as a transcript awaiting upload.
-func hasLocalSessionData(cacheDirs []string, sessionName string) bool {
-	for _, dir := range cacheDirs {
-		sessionDir := filepath.Join(dir, sessionName)
-		for _, marker := range []string{".recording.json", "raw.jsonl"} {
-			if _, err := os.Stat(filepath.Join(sessionDir, marker)); err == nil {
-				return true
-			}
-		}
+// draftCacheDirs returns the local cache session directories a draft's recording
+// could live in: the ledger cache and this process's XDG cache.
+func draftCacheDirs(projectRoot, ledgerPath string) []string {
+	dirs := []string{filepath.Join(ledgerPath, ".sageox", "cache", "sessions")}
+	if contextPath := session.GetContextPath(getRepoIDOrDefault(projectRoot)); contextPath != "" {
+		dirs = append(dirs, filepath.Join(contextPath, "sessions"))
 	}
-	return false
+	return dirs
+}
+
+// hasLocalSessionData delegates to the shared detector.
+func hasLocalSessionData(cacheDirs []string, sessionName string) bool {
+	return session.DraftHasLocalSessionData(cacheDirs, sessionName)
 }

--- a/cmd/ox/session_draft_publish.go
+++ b/cmd/ox/session_draft_publish.go
@@ -53,6 +53,16 @@ func maybePublishSessionDraft(ctx *HookContext) {
 		return
 	}
 
+	// Register the /c/ link now that a real turn exists. Start-time registration
+	// is deferred (see notifySessionStartedAsync) so no-user-turn phantoms never
+	// reach the server; the Stop hook is the first reliable signal that a real
+	// turn landed. Fires at most once — only from the "deferred" state, so a
+	// failed attempt drops to "pending" and is left to the prime retry rather
+	// than re-attempted every turn.
+	if state.LifecycleRegistrationState == "deferred" {
+		notifySessionStartedAsync(ctx.ProjectRoot, state)
+	}
+
 	// Cheapest possible early-out before touching config: below the publish
 	// threshold nothing can happen regardless of how the feature is configured.
 	// DraftPublishTurn is a constant, so this costs one comparison.
@@ -149,6 +159,16 @@ func resolveDraftLedgerPath(projectRoot, sessionPath string) string {
 // `ox doctor --fix` on an ahead branch.
 func publishDraftPlaceholder(projectRoot, ledgerPath, sessionName string, state *session.RecordingState) bool {
 	if sessionName == "" || state.SessionID == "" {
+		return false
+	}
+
+	// Never git-commit a placeholder for a session with no user turn. TurnCount
+	// gates the turn count; this gates on a real coworker prompt actually
+	// existing in the transcript. A header-only recording is a phantom, and a
+	// committed draft for one is exactly the ledger/dashboard noise this guards
+	// against — the /c/ link would resolve to a session that never happened.
+	if !session.HasUserTurn(filepath.Join(state.SessionPath, "raw.jsonl")) {
+		slog.Debug("draft: skipped, no user turn", "session", sessionName)
 		return false
 	}
 

--- a/cmd/ox/session_draft_reaper_test.go
+++ b/cmd/ox/session_draft_reaper_test.go
@@ -63,7 +63,7 @@ func draftReaperFixture(t *testing.T) (projectRoot, ledgerPath string) {
 }
 
 // agedDraft writes a draft whose updated_at is `age` in the past.
-// Ages are passed explicitly and far from the 24h threshold rather than nudged
+// Ages are passed explicitly and far from the 72h threshold rather than nudged
 // by a few seconds, so a slow CI machine can never flip a boundary.
 func agedDraft(t *testing.T, ledgerPath, sessionName string, age time.Duration) string {
 	t.Helper()
@@ -93,7 +93,7 @@ func TestFindOrphanedDrafts_OnlyReapsTrulyAbandoned(t *testing.T) {
 		{
 			name: "stale draft with no local data anywhere",
 			setup: func(t *testing.T, _, ledgerPath, name string) {
-				agedDraft(t, ledgerPath, name, 72*time.Hour)
+				agedDraft(t, ledgerPath, name, 120*time.Hour)
 			},
 			wantOrphan: true,
 			why:        "nothing else will ever reclaim this",
@@ -108,7 +108,7 @@ func TestFindOrphanedDrafts_OnlyReapsTrulyAbandoned(t *testing.T) {
 		{
 			name: "stale draft whose recording is still in the ledger cache",
 			setup: func(t *testing.T, _, ledgerPath, name string) {
-				agedDraft(t, ledgerPath, name, 72*time.Hour)
+				agedDraft(t, ledgerPath, name, 120*time.Hour)
 				cache := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", name)
 				require.NoError(t, os.MkdirAll(cache, 0755))
 				require.NoError(t, os.WriteFile(filepath.Join(cache, "raw.jsonl"),
@@ -119,7 +119,7 @@ func TestFindOrphanedDrafts_OnlyReapsTrulyAbandoned(t *testing.T) {
 		{
 			name: "stale draft with an active recording marker in the cache",
 			setup: func(t *testing.T, _, ledgerPath, name string) {
-				agedDraft(t, ledgerPath, name, 72*time.Hour)
+				agedDraft(t, ledgerPath, name, 120*time.Hour)
 				cache := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", name)
 				require.NoError(t, os.MkdirAll(cache, 0755))
 				require.NoError(t, os.WriteFile(filepath.Join(cache, ".recording.json"),
@@ -130,7 +130,7 @@ func TestFindOrphanedDrafts_OnlyReapsTrulyAbandoned(t *testing.T) {
 		{
 			name: "stale draft whose recording is in the XDG cache",
 			setup: func(t *testing.T, projectRoot, ledgerPath, name string) {
-				agedDraft(t, ledgerPath, name, 72*time.Hour)
+				agedDraft(t, ledgerPath, name, 120*time.Hour)
 				makeXDGCacheSession(t, projectRoot, name)
 			},
 			why: "the XDG cache is a real session location and must be searched too",
@@ -142,7 +142,7 @@ func TestFindOrphanedDrafts_OnlyReapsTrulyAbandoned(t *testing.T) {
 				require.NoError(t, os.MkdirAll(dir, 0755))
 				require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
 					Version: "1.0", SessionName: name, SessionID: draftTestSessionID,
-					CreatedAt: time.Now().Add(-72 * time.Hour), Draft: true,
+					CreatedAt: time.Now().Add(-120 * time.Hour), Draft: true,
 					Files: map[string]lfs.FileRef{},
 				}))
 			},
@@ -190,7 +190,7 @@ func TestFindOrphanedDrafts_OrdersOldestFirst(t *testing.T) {
 	setTestCfg(t)
 	projectRoot, ledgerPath := draftReaperFixture(t)
 
-	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxNewer", 30*time.Hour)
+	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxNewer", 96*time.Hour)
 	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxOldst", 200*time.Hour)
 	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxMiddl", 100*time.Hour)
 
@@ -223,7 +223,7 @@ func TestCheckSessionDraftOrphan_ReportsWithoutMutating(t *testing.T) {
 	projectRoot, ledgerPath := setupLedgerProject(t)
 	t.Chdir(projectRoot)
 
-	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxRept", 72*time.Hour)
+	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxRept", 120*time.Hour)
 	before := treeHash(t, ledgerPath)
 
 	res := checkSessionDraftOrphan(false)
@@ -269,7 +269,7 @@ func TestCheckSessionDraftOrphan_FixRemovesFromRemote(t *testing.T) {
 	f.publish(t, orphan, 2)
 	f.publish(t, live, 2)
 	// Age only the orphan. The live draft keeps its fresh updated_at.
-	agedDraft(t, f.ledgerPath, orphan, 72*time.Hour)
+	agedDraft(t, f.ledgerPath, orphan, 120*time.Hour)
 	runGit(t, f.ledgerPath, "add", "--sparse", "--", "sessions/"+orphan+"/meta.json")
 	runGit(t, f.ledgerPath, "commit", "--no-verify", "-m", "session-draft: age "+orphan)
 	f.push(t)

--- a/cmd/ox/session_notify.go
+++ b/cmd/ox/session_notify.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"time"
 
 	"github.com/sageox/ox/internal/api"
@@ -31,6 +32,20 @@ func notifySessionStartedAsync(projectRoot string, state *session.RecordingState
 	}
 	attr := loadResolvedAttribution()
 	if attr.Session == "" {
+		return
+	}
+
+	// Don't register a session the coworker never actually used. At recording
+	// start (and on subagent primes) there is no user turn yet — registering
+	// then is what tells the server "a session started" for the ~majority of
+	// recordings that stay header-only, inflating the team's session count with
+	// sessions that never happened. Defer: mark the state so the prime retry and
+	// the per-turn draft path re-fire this exactly once a real turn exists.
+	if !session.HasUserTurn(filepath.Join(state.SessionPath, "raw.jsonl")) {
+		state.LifecycleRegistrationState = "deferred"
+		if saveErr := session.SaveRecordingState(projectRoot, state); saveErr != nil {
+			slog.Debug("session registration deferred save failed", "session_id", state.SessionID, "error", saveErr)
+		}
 		return
 	}
 	err := runSessionSignal("started", func(client *api.RepoClient, repoID string) error {

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -249,13 +249,23 @@ func (h *SessionFinalizeHandler) Type() string { return sessionFinalizeType }
 //   - ledgerPath/sessions/ — git-tracked sessions (after finalization/upload)
 //   - XDG cache paths — legacy and alternate cache locations
 func (h *SessionFinalizeHandler) Cleanup(ledgerPath string) {
-	// clean primary ledger cache (where StartRecording writes sessions)
+	// clean primary ledger cache (where StartRecording writes sessions).
+	// Ghost cleanup handles marker'd dead-PID stubs; the orphan sweep reclaims
+	// marker-less header-only phantoms (the accumulation source). The orphan
+	// sweep is safe here because this is the LOCAL CACHE dir — never run it on
+	// the git-tracked ledger dir below, where a draft placeholder is meta.json-
+	// only and would classify as a phantom.
 	ledgerCacheSessionsDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions")
 	if ghostResult := session.CleanupGhostSessionsInDir(ledgerCacheSessionsDir); ghostResult.Removed > 0 {
 		h.logger.Info("ghost cleanup (ledger cache): removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
 	}
+	if orphanResult := session.CleanupOrphanedStubsInDir(ledgerCacheSessionsDir); orphanResult.Removed > 0 {
+		h.logger.Info("orphan cleanup (ledger cache): removed phantom stubs", "count", orphanResult.Removed, "sessions", orphanResult.Names)
+	}
 
-	// clean git-tracked ledger sessions (uploaded/finalized sessions)
+	// clean git-tracked ledger sessions (uploaded/finalized sessions). GHOST
+	// cleanup only — never the marker-independent orphan sweep: a draft
+	// placeholder here is meta.json-only and the sweep must not touch it.
 	ledgerSessionsDir := filepath.Join(ledgerPath, "sessions")
 	if ghostResult := session.CleanupGhostSessionsInDir(ledgerSessionsDir); ghostResult.Removed > 0 {
 		h.logger.Info("ghost cleanup (ledger): removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
@@ -268,11 +278,17 @@ func (h *SessionFinalizeHandler) Cleanup(ledgerPath string) {
 		if ghostResult := session.CleanupGhostSessionsInDir(cacheSessionsDir); ghostResult.Removed > 0 {
 			h.logger.Info("ghost cleanup (cache): removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
 		}
+		if orphanResult := session.CleanupOrphanedStubsInDir(cacheSessionsDir); orphanResult.Removed > 0 {
+			h.logger.Info("orphan cleanup (cache): removed phantom stubs", "count", orphanResult.Removed, "sessions", orphanResult.Names)
+		}
 
 		for _, altDir := range paths.AlternateSessionCacheDirs(repoID) {
 			altSessionsDir := filepath.Join(altDir, "sessions")
 			if ghostResult := session.CleanupGhostSessionsInDir(altSessionsDir); ghostResult.Removed > 0 {
 				h.logger.Info("ghost cleanup (alternate cache): removed abandoned recordings", "dir", altDir, "count", ghostResult.Removed, "sessions", ghostResult.Names)
+			}
+			if orphanResult := session.CleanupOrphanedStubsInDir(altSessionsDir); orphanResult.Removed > 0 {
+				h.logger.Info("orphan cleanup (alternate cache): removed phantom stubs", "dir", altDir, "count", orphanResult.Removed, "sessions", orphanResult.Names)
 			}
 		}
 	}

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1797,6 +1797,16 @@ func (s *SyncScheduler) retractOrphanedDrafts(ctx context.Context, ledgerPath st
 			continue
 		}
 		rel := filepath.ToSlash(filepath.Join("sessions", name))
+
+		// Only retract drafts that are ALREADY on the remote. If a draft's publish
+		// commit is still local/unpushed, stacking a retraction on top of it would
+		// make pushSessionDraftCommits ship BOTH — manufacturing a publish the
+		// daemon never should. An unpushed draft belongs to the publish flow, not
+		// this reaper. Unknown/unresolvable upstream fails safe to skip.
+		if !s.draftPublishedOnRemote(ctx, ledgerPath, rel) {
+			continue
+		}
+
 		if _, err := s.git.RunGit(ctx, ledgerPath, "rm", "-r", "--force", "--ignore-unmatch", "--", rel); err != nil {
 			s.logger.Warn("retract orphaned draft: git rm failed", "session", name, "error", err)
 			continue
@@ -1804,21 +1814,50 @@ func (s *SyncScheduler) retractOrphanedDrafts(ctx context.Context, ledgerPath st
 		// Remove any untracked leftovers git rm --ignore-unmatch left behind.
 		_ = os.RemoveAll(filepath.Join(ledgerPath, "sessions", name))
 
-		// Only commit if the rm actually staged a tracked deletion; a draft
-		// written-but-never-committed stages nothing and needs no commit.
-		staged, _ := s.git.RunGit(ctx, ledgerPath, "diff", "--cached", "--name-only", "--", rel)
-		if strings.TrimSpace(staged) == "" {
+		// A published draft's meta.json is tracked, so git rm must have staged a
+		// deletion. If the diff errors or shows nothing staged, we cannot safely
+		// commit — restore the index + worktree from HEAD so a dangling staged
+		// deletion can't be swept into an unrelated commit, and the next scan
+		// rediscovers the orphan to retry.
+		staged, diffErr := s.git.RunGit(ctx, ledgerPath, "diff", "--cached", "--name-only", "--", rel)
+		if diffErr != nil || strings.TrimSpace(staged) == "" {
+			s.restoreDraftForRetry(ctx, ledgerPath, rel, name, diffErr)
 			continue
 		}
 		if _, err := s.git.RunGit(ctx, ledgerPath, "commit", "--no-verify",
 			"-m", sessionDraftCommitPrefix+"retract "+name, "--", rel); err != nil {
-			s.logger.Warn("retract orphaned draft: git commit failed", "session", name, "error", err)
+			// Commit failed: the deletion is staged and the dir is gone, which
+			// would orphan the candidate. Restore so the next scan retries.
+			s.restoreDraftForRetry(ctx, ledgerPath, rel, name, err)
 			continue
 		}
 		removed++
 	}
 	if removed > 0 {
 		s.logger.Info("retracted orphaned session drafts", "path", ledgerPath, "count", removed)
+	}
+}
+
+// draftPublishedOnRemote reports whether the draft at rel exists in the ledger's
+// upstream tree — i.e. it has actually been published to the remote. Fails safe
+// to false (skip retraction) when the upstream cannot be resolved, so the daemon
+// never stacks a retraction on a draft the remote has not seen.
+func (s *SyncScheduler) draftPublishedOnRemote(ctx context.Context, ledgerPath, rel string) bool {
+	_, err := s.git.RunGit(ctx, ledgerPath, "cat-file", "-e", "@{upstream}:"+rel+"/meta.json")
+	return err == nil
+}
+
+// restoreDraftForRetry undoes a partial retraction — unstages the deletion and
+// restores the draft dir from HEAD — so a failed retract leaves no dangling
+// staged deletion (which an unrelated commit could sweep under the wrong
+// message) and the next scan can rediscover the orphan and retry it.
+func (s *SyncScheduler) restoreDraftForRetry(ctx context.Context, ledgerPath, rel, name string, cause error) {
+	s.logger.Warn("retract orphaned draft: restoring after failed retraction", "session", name, "error", cause)
+	if _, err := s.git.RunGit(ctx, ledgerPath, "reset", "-q", "--", rel); err != nil {
+		s.logger.Warn("retract orphaned draft: reset failed", "session", name, "error", err)
+	}
+	if _, err := s.git.RunGit(ctx, ledgerPath, "checkout", "-q", "HEAD", "--", rel); err != nil {
+		s.logger.Warn("retract orphaned draft: checkout restore failed", "session", name, "error", err)
 	}
 }
 

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1811,8 +1811,14 @@ func (s *SyncScheduler) retractOrphanedDrafts(ctx context.Context, ledgerPath st
 			s.logger.Warn("retract orphaned draft: git rm failed", "session", name, "error", err)
 			continue
 		}
-		// Remove any untracked leftovers git rm --ignore-unmatch left behind.
-		_ = os.RemoveAll(filepath.Join(ledgerPath, "sessions", name))
+		// Remove any untracked leftovers git rm --ignore-unmatch left behind. If
+		// that fails, do NOT commit a partial retraction — restore and retry next
+		// scan, otherwise the remote loses meta.json while leftover files linger
+		// locally and no future scan rediscovers them.
+		if err := os.RemoveAll(filepath.Join(ledgerPath, "sessions", name)); err != nil {
+			s.restoreDraftForRetry(ctx, ledgerPath, rel, name, fmt.Errorf("remove leftovers: %w", err))
+			continue
+		}
 
 		// A published draft's meta.json is tracked, so git rm must have staged a
 		// deletion. If the diff errors or shows nothing staged, we cannot safely

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1769,7 +1769,8 @@ func (s *SyncScheduler) retractOrphanedDrafts(ctx context.Context, ledgerPath st
 		return
 	}
 
-	orphans, err := session.FindOrphanedDrafts(ledgerPath, s.draftCacheDirs(ledgerPath))
+	cacheDirs := s.draftCacheDirs(ledgerPath)
+	orphans, err := session.FindOrphanedDrafts(ledgerPath, cacheDirs)
 	if err != nil || len(orphans) == 0 {
 		return
 	}
@@ -1786,6 +1787,13 @@ func (s *SyncScheduler) retractOrphanedDrafts(ctx context.Context, ledgerPath st
 	var removed int
 	for _, name := range orphans {
 		if err := session.ValidateDraftSessionName(name); err != nil {
+			continue
+		}
+		// Revalidate under the lock. SaveRecordingState writes .recording.json /
+		// raw.jsonl WITHOUT ledgerMu, so a recording could have appeared for this
+		// name between detection and here. Never git-rm a draft that now has
+		// local recording data — recovering it is upload-retry's job.
+		if session.DraftHasLocalSessionData(cacheDirs, name) {
 			continue
 		}
 		rel := filepath.ToSlash(filepath.Join("sessions", name))
@@ -1818,7 +1826,14 @@ func (s *SyncScheduler) retractOrphanedDrafts(ctx context.Context, ledgerPath st
 // could live in, for the orphan detector to consult.
 func (s *SyncScheduler) draftCacheDirs(ledgerPath string) []string {
 	dirs := []string{filepath.Join(ledgerPath, ".sageox", "cache", "sessions")}
-	repoID := filepath.Base(ledgerPath)
+	// Resolve the repo ID the way the CLI does — from the configured project —
+	// so the XDG cache paths match where StartRecording actually wrote. A custom
+	// ledger path whose basename differs from the repo ID would otherwise miss a
+	// live recording and let a recoverable draft be retracted.
+	repoID := config.GetRepoID(s.config.ProjectRoot)
+	if repoID == "" {
+		repoID = filepath.Base(ledgerPath) // fallback: ledger dirs are named by repo id
+	}
 	if repoID != "" && repoID != "." {
 		dirs = append(dirs, filepath.Join(paths.SessionCacheDir(repoID), "sessions"))
 		for _, altDir := range paths.AlternateSessionCacheDirs(repoID) {

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -44,7 +44,9 @@ import (
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/observability"
+	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/perf"
+	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/version"
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
@@ -1523,10 +1525,13 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 		}
 	}
 
-	// push any unpushed session-draft commits (batched by sync cycle).
-	// Not gated on whisperRegistry — drafts are unrelated to murmurs, and a
+	// retract orphaned draft placeholders (crashed sessions), then push any
+	// unpushed session-draft commits (both batched by sync cycle). Retraction
+	// commits use the session-draft: subject prefix, so the push below carries
+	// them. Not gated on whisperRegistry — drafts are unrelated to murmurs, and a
 	// repo with whispers disabled still needs its /c/ links to resolve.
 	if l := s.workspaceRegistry.GetLedger(); l != nil && l.Path != "" && l.Exists {
+		s.retractOrphanedDrafts(ctx, l.Path)
 		s.pushSessionDraftCommits(ctx, l.Path)
 	}
 
@@ -1738,6 +1743,89 @@ func shouldPushSessionDrafts(logOutput string) (blockingSubject string, ok bool)
 		sawDraft = true
 	}
 	return "", sawDraft
+}
+
+// retractOrphanedDrafts git-removes committed draft placeholders whose recording
+// is gone, so a crashed session's "in progress" /c/ page stops resolving and the
+// phantom row leaves `ox session list`. Runs on the sync cycle just before
+// pushSessionDraftCommits, which carries the resulting `session-draft: retract`
+// commits to the remote.
+//
+// Why the daemon and not only `ox doctor --fix`: a draft is invisible to every
+// other reclaimer, and a crashed agent never reaches the clean-stop/abort paths
+// that would retract it. Without an automatic sweep the ledger accumulates
+// orphaned drafts until a human happens to run doctor. `checkSessionDraftOrphan`
+// remains the on-demand equivalent; both share session.FindOrphanedDrafts so
+// "orphaned" means exactly the same thing in both.
+//
+// Safety: only session.OrphanedDraftAge-stale drafts with no local recording are
+// touched (the updated_at heartbeat is committed to the shared ledger, so a
+// session live on another machine is never reaped). The mid-rebase guard is
+// load-bearing — an unguarded git rm/commit during a conflicted rebase marks the
+// conflict resolved and consumes the replay step, silently destroying whatever
+// was being replayed (see .claude/rules/cache-only-design.md).
+func (s *SyncScheduler) retractOrphanedDrafts(ctx context.Context, ledgerPath string) {
+	if gitutil.IsRebaseInProgress(ledgerPath) {
+		return
+	}
+
+	orphans, err := session.FindOrphanedDrafts(ledgerPath, s.draftCacheDirs(ledgerPath))
+	if err != nil || len(orphans) == 0 {
+		return
+	}
+
+	s.ledgerMu.Lock()
+	defer s.ledgerMu.Unlock()
+
+	// Re-check after taking the lock: a concurrent finalize/pull may have started
+	// a rebase or changed the tree between detection and mutation.
+	if gitutil.IsRebaseInProgress(ledgerPath) {
+		return
+	}
+
+	var removed int
+	for _, name := range orphans {
+		if err := session.ValidateDraftSessionName(name); err != nil {
+			continue
+		}
+		rel := filepath.ToSlash(filepath.Join("sessions", name))
+		if _, err := s.git.RunGit(ctx, ledgerPath, "rm", "-r", "--force", "--ignore-unmatch", "--", rel); err != nil {
+			s.logger.Warn("retract orphaned draft: git rm failed", "session", name, "error", err)
+			continue
+		}
+		// Remove any untracked leftovers git rm --ignore-unmatch left behind.
+		_ = os.RemoveAll(filepath.Join(ledgerPath, "sessions", name))
+
+		// Only commit if the rm actually staged a tracked deletion; a draft
+		// written-but-never-committed stages nothing and needs no commit.
+		staged, _ := s.git.RunGit(ctx, ledgerPath, "diff", "--cached", "--name-only", "--", rel)
+		if strings.TrimSpace(staged) == "" {
+			continue
+		}
+		if _, err := s.git.RunGit(ctx, ledgerPath, "commit", "--no-verify",
+			"-m", sessionDraftCommitPrefix+"retract "+name, "--", rel); err != nil {
+			s.logger.Warn("retract orphaned draft: git commit failed", "session", name, "error", err)
+			continue
+		}
+		removed++
+	}
+	if removed > 0 {
+		s.logger.Info("retracted orphaned session drafts", "path", ledgerPath, "count", removed)
+	}
+}
+
+// draftCacheDirs returns the local cache session directories a draft's recording
+// could live in, for the orphan detector to consult.
+func (s *SyncScheduler) draftCacheDirs(ledgerPath string) []string {
+	dirs := []string{filepath.Join(ledgerPath, ".sageox", "cache", "sessions")}
+	repoID := filepath.Base(ledgerPath)
+	if repoID != "" && repoID != "." {
+		dirs = append(dirs, filepath.Join(paths.SessionCacheDir(repoID), "sessions"))
+		for _, altDir := range paths.AlternateSessionCacheDirs(repoID) {
+			dirs = append(dirs, filepath.Join(altDir, "sessions"))
+		}
+	}
+	return dirs
 }
 
 func (s *SyncScheduler) pushSessionDraftCommits(ctx context.Context, ledgerPath string) {

--- a/internal/daemon/sync_session_draft_retract_test.go
+++ b/internal/daemon/sync_session_draft_retract_test.go
@@ -1,0 +1,120 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The daemon is the only automatic reclaimer of a committed draft placeholder
+// whose recording died: a crashed agent never reaches the clean-stop/abort paths
+// that would retract it, and without this sweep the ledger accumulates orphaned
+// "in progress" /c/ pages that also show as phantom rows in `ox session list`.
+//
+// The asymmetry that shapes every case: a false negative leaves a stale page; a
+// false positive git-removes a LIVE session's placeholder. So each guard — age,
+// local recording — gets a negative control.
+
+func newRetractScheduler(t *testing.T) (*SyncScheduler, string) {
+	t.Helper()
+	ledger := t.TempDir()
+	gitInit(t, ledger)
+
+	cfg := DefaultConfig()
+	cfg.ProjectRoot = ledger
+	cfg.LedgerPath = ledger
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return NewSyncScheduler(cfg, logger, WithGitRunner(gitutil.DefaultRunner())), ledger
+}
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	mustGit(t, dir, "init", "--quiet")
+	mustGit(t, dir, "config", "user.email", "test@example.com")
+	mustGit(t, dir, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("x\n"), 0o644))
+	mustGit(t, dir, "add", "README.md")
+	mustGit(t, dir, "commit", "--quiet", "-m", "init")
+}
+
+func mustGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+	return strings.TrimSpace(string(out))
+}
+
+// commitStaleDraft writes and commits a draft placeholder whose updated_at
+// heartbeat is `age` in the past, mirroring a real published draft commit.
+func commitStaleDraft(t *testing.T, ledger, name string, age time.Duration) {
+	t.Helper()
+	dir := filepath.Join(ledger, "sessions", name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	updated := time.Now().Add(-age).UTC()
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+		Version: "1.0", SessionName: name, SessionID: "ses_retract_test",
+		AgentID: "OxOrphan", CreatedAt: updated, Draft: true, TurnCount: 2,
+		UpdatedAt: &updated, Files: map[string]lfs.FileRef{},
+	}))
+	mustGit(t, ledger, "add", "-A", "sessions/")
+	mustGit(t, ledger, "commit", "--quiet", "-m", "session-draft: "+name)
+}
+
+// TestRetractOrphanedDrafts_RemovesStaleCommittedDraft is the core behavior: a
+// stale committed draft with no recording is git-removed, and the removal lands
+// as a session-draft: commit so pushSessionDraftCommits carries it to the remote.
+func TestRetractOrphanedDrafts_RemovesStaleCommittedDraft(t *testing.T) {
+	s, ledger := newRetractScheduler(t)
+	const name = "2026-01-01T00-00-testuser-OxDead1"
+	commitStaleDraft(t, ledger, name, 120*time.Hour)
+
+	s.retractOrphanedDrafts(context.Background(), ledger)
+
+	assert.NoDirExists(t, filepath.Join(ledger, "sessions", name),
+		"a stale committed draft with no recording must be git-removed")
+	subj := mustGit(t, ledger, "log", "-1", "--format=%s")
+	assert.Equal(t, "session-draft: retract "+name, subj,
+		"retraction must land as a session-draft: commit so the daemon push carries it")
+}
+
+// TestRetractOrphanedDrafts_KeepsFreshDraft — a draft whose heartbeat is recent
+// is a live session (possibly on another machine, via the shared updated_at).
+func TestRetractOrphanedDrafts_KeepsFreshDraft(t *testing.T) {
+	s, ledger := newRetractScheduler(t)
+	const name = "2026-01-01T00-00-testuser-OxLive1"
+	commitStaleDraft(t, ledger, name, 1*time.Minute)
+
+	s.retractOrphanedDrafts(context.Background(), ledger)
+
+	assert.DirExists(t, filepath.Join(ledger, "sessions", name),
+		"a fresh draft is a live session and must never be retracted")
+}
+
+// TestRetractOrphanedDrafts_KeepsDraftWithLocalRecording — a cached transcript is
+// recoverable work owned by upload-retry, not the reaper, even when stale.
+func TestRetractOrphanedDrafts_KeepsDraftWithLocalRecording(t *testing.T) {
+	s, ledger := newRetractScheduler(t)
+	const name = "2026-01-01T00-00-testuser-OxRec1"
+	commitStaleDraft(t, ledger, name, 120*time.Hour)
+	cache := filepath.Join(ledger, ".sageox", "cache", "sessions", name)
+	require.NoError(t, os.MkdirAll(cache, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cache, "raw.jsonl"),
+		[]byte(`{"type":"header"}`+"\n"), 0o644))
+
+	s.retractOrphanedDrafts(context.Background(), ledger)
+
+	assert.DirExists(t, filepath.Join(ledger, "sessions", name),
+		"a stale draft with a recoverable local recording must not be retracted")
+}

--- a/internal/daemon/sync_session_draft_retract_test.go
+++ b/internal/daemon/sync_session_draft_retract_test.go
@@ -39,12 +39,19 @@ func newRetractScheduler(t *testing.T) (*SyncScheduler, string) {
 
 func gitInit(t *testing.T, dir string) {
 	t.Helper()
-	mustGit(t, dir, "init", "--quiet")
+	mustGit(t, dir, "-c", "init.defaultBranch=main", "init", "--quiet")
 	mustGit(t, dir, "config", "user.email", "test@example.com")
 	mustGit(t, dir, "config", "user.name", "Test")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("x\n"), 0o644))
 	mustGit(t, dir, "add", "README.md")
 	mustGit(t, dir, "commit", "--quiet", "-m", "init")
+
+	// A bare upstream so draftPublishedOnRemote can resolve @{upstream}: the
+	// reaper only retracts drafts already present on the remote.
+	remote := t.TempDir()
+	mustGit(t, remote, "-c", "init.defaultBranch=main", "init", "--quiet", "--bare")
+	mustGit(t, dir, "remote", "add", "origin", remote)
+	mustGit(t, dir, "push", "-u", "--quiet", "origin", "main")
 }
 
 func mustGit(t *testing.T, dir string, args ...string) string {
@@ -56,9 +63,10 @@ func mustGit(t *testing.T, dir string, args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// commitStaleDraft writes and commits a draft placeholder whose updated_at
-// heartbeat is `age` in the past, mirroring a real published draft commit.
-func commitStaleDraft(t *testing.T, ledger, name string, age time.Duration) {
+// writeDraftCommit writes and commits a draft placeholder whose updated_at
+// heartbeat is `age` in the past. When push is true it is also pushed to the
+// bare upstream, mirroring a real published draft.
+func writeDraftCommit(t *testing.T, ledger, name string, age time.Duration, push bool) {
 	t.Helper()
 	dir := filepath.Join(ledger, "sessions", name)
 	require.NoError(t, os.MkdirAll(dir, 0o755))
@@ -70,6 +78,16 @@ func commitStaleDraft(t *testing.T, ledger, name string, age time.Duration) {
 	}))
 	mustGit(t, ledger, "add", "-A", "sessions/")
 	mustGit(t, ledger, "commit", "--quiet", "-m", "session-draft: "+name)
+	if push {
+		mustGit(t, ledger, "push", "--quiet", "origin", "main")
+	}
+}
+
+// commitStaleDraft writes, commits, and PUSHES a stale draft — the normal
+// published-then-abandoned case the reaper cleans.
+func commitStaleDraft(t *testing.T, ledger, name string, age time.Duration) {
+	t.Helper()
+	writeDraftCommit(t, ledger, name, age, true)
 }
 
 // TestRetractOrphanedDrafts_RemovesStaleCommittedDraft is the core behavior: a
@@ -87,6 +105,24 @@ func TestRetractOrphanedDrafts_RemovesStaleCommittedDraft(t *testing.T) {
 	subj := mustGit(t, ledger, "log", "-1", "--format=%s")
 	assert.Equal(t, "session-draft: retract "+name, subj,
 		"retraction must land as a session-draft: commit so the daemon push carries it")
+}
+
+// TestRetractOrphanedDrafts_SkipsUnpushedDraft — a stale draft whose publish
+// commit is still LOCAL must never be retracted. Stacking a retraction on an
+// unpushed publish would make pushSessionDraftCommits ship both, manufacturing a
+// publish the daemon should never send to the remote.
+func TestRetractOrphanedDrafts_SkipsUnpushedDraft(t *testing.T) {
+	s, ledger := newRetractScheduler(t)
+	const name = "2026-01-01T00-00-testuser-OxUnpub"
+	writeDraftCommit(t, ledger, name, 120*time.Hour, false) // committed but NOT pushed
+
+	s.retractOrphanedDrafts(context.Background(), ledger)
+
+	assert.DirExists(t, filepath.Join(ledger, "sessions", name),
+		"an unpushed draft belongs to the publish flow — the reaper must not touch it")
+	subj := mustGit(t, ledger, "log", "-1", "--format=%s")
+	assert.NotEqual(t, "session-draft: retract "+name, subj,
+		"no retraction commit may be created for an unpublished draft")
 }
 
 // TestRetractOrphanedDrafts_KeepsFreshDraft — a draft whose heartbeat is recent

--- a/internal/doctor/session.go
+++ b/internal/doctor/session.go
@@ -593,8 +593,14 @@ func (c *SessionOrphanedCheck) Category() string {
 
 // Run executes the orphaned recording check.
 func (c *SessionOrphanedCheck) Run(_ context.Context, _ bool) CheckResult {
-	// phase 1: instant ghost cleanup using PID liveness (no time threshold)
+	// phase 1: instant ghost cleanup using PID liveness (no time threshold),
+	// plus the marker-independent orphan sweep that reclaims header-only phantom
+	// stubs the ghost cleanup structurally cannot see (marker removed at
+	// finalize, dir left behind). Sweep runs on the local cache dirs only.
 	ghostResult := session.CleanupGhostSessions(c.gitRoot)
+	orphanResult := session.CleanupOrphanedStubs(c.gitRoot)
+	ghostResult.Removed += orphanResult.Removed
+	ghostResult.Names = append(ghostResult.Names, orphanResult.Names...)
 
 	status := getOrComputeHealth(c.cachedStatus, c.gitRoot)
 
@@ -610,7 +616,7 @@ func (c *SessionOrphanedCheck) Run(_ context.Context, _ bool) CheckResult {
 		return CheckResult{
 			Name:    c.Name(),
 			Status:  StatusPass,
-			Message: fmt.Sprintf("cleaned %d ghost session(s)", ghostResult.Removed),
+			Message: fmt.Sprintf("cleaned %d abandoned/phantom session(s)", ghostResult.Removed),
 		}
 	}
 

--- a/internal/session/classify.go
+++ b/internal/session/classify.go
@@ -3,6 +3,7 @@ package session
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -252,7 +253,13 @@ func ClassifyRawFile(rawPath string) RawKind {
 
 	f, err := os.Open(rawPath)
 	if err != nil {
-		return RawMissing
+		if errors.Is(err, os.ErrNotExist) {
+			return RawMissing
+		}
+		// Present but unreadable (permission / transient I/O). Fail SAFE — never
+		// let a cleanup path delete a raw.jsonl we simply could not open; only a
+		// genuinely absent file is RawMissing.
+		return RawSubstantive
 	}
 	defer f.Close()
 

--- a/internal/session/classify.go
+++ b/internal/session/classify.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bufio"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -266,6 +267,47 @@ func ClassifyRawFile(rawPath string) RawKind {
 		}
 	}
 	return RawHeaderOnly
+}
+
+// HasUserTurn reports whether a raw.jsonl file contains at least one user turn
+// (an entry of type "user") — i.e. a real coworker prompt was recorded. The
+// metadata header and machine-generated entries (assistant/tool/system) do NOT
+// count: a recording with no user turn never happened from the coworker's point
+// of view, and must not be git-committed as a draft nor registered with the
+// server. This is the floor that keeps phantom sessions off the ledger and out
+// of the team's session count.
+//
+// A content-store pointer stub reports true: its transcript is real and already
+// passed this gate when it was finalized.
+func HasUserTurn(rawPath string) bool {
+	if lfs.IsPointerFile(rawPath) {
+		return true
+	}
+
+	f, err := os.Open(rawPath)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(line, &entry) != nil {
+			continue
+		}
+		if entry.Type == "user" {
+			return true
+		}
+	}
+	return false
 }
 
 // HasSubstantiveEntries returns true if a raw.jsonl file holds at least one

--- a/internal/session/classify.go
+++ b/internal/session/classify.go
@@ -266,6 +266,14 @@ func ClassifyRawFile(rawPath string) RawKind {
 			return RawSubstantive // at least one line beyond header
 		}
 	}
+	// Fail SAFE on an incomplete read. A line exceeding the 256 KiB scanner
+	// buffer (a large paste or tool payload) stops the scan with an error; a
+	// too-long line is itself evidence of substantial content, and reporting
+	// RawHeaderOnly here would let the cleanup paths os.RemoveAll a real
+	// session. Never classify what we could not read as a deletable phantom.
+	if scanner.Err() != nil {
+		return RawSubstantive
+	}
 	return RawHeaderOnly
 }
 
@@ -306,6 +314,13 @@ func HasUserTurn(rawPath string) bool {
 		if entry.Type == "user" {
 			return true
 		}
+	}
+	// Fail safe on an incomplete read: a user entry larger than the 256 KiB
+	// scanner buffer stops the scan with an error, and reporting "no user turn"
+	// would suppress registration and draft publication for a real session with
+	// a large prompt. When we could not read the file fully, assume a user turn.
+	if scanner.Err() != nil {
+		return true
 	}
 	return false
 }

--- a/internal/session/draft_orphan.go
+++ b/internal/session/draft_orphan.go
@@ -1,0 +1,116 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// OrphanedDraftAge is how long a committed draft placeholder must go without a
+// refresh before it is considered abandoned and eligible for git-removal from
+// the ledger.
+//
+// A draft refreshes its updated_at heartbeat every few turns while a session is
+// live, and that heartbeat is committed to the SHARED ledger — so a session
+// running on ANOTHER machine keeps this fresh here too. That is what makes
+// removal cross-machine safe: only a draft nobody has touched in this whole
+// window, on any machine, is reaped.
+//
+// Set to a few days rather than a single day so a session merely paused across a
+// weekend (closed laptop, idle container) is never mistaken for a dead one. The
+// cost of waiting is a stale "in progress" page; the cost of being wrong is
+// git-removing a live session's placeholder, and that asymmetry says wait.
+const OrphanedDraftAge = 72 * time.Hour
+
+// ValidateDraftSessionName rejects empty and traversal-shaped names before any
+// path built from a session name is handed to `git rm` / os.RemoveAll. An
+// unvalidated name widens a pathspec to the whole sessions tree.
+func ValidateDraftSessionName(sessionName string) error {
+	if sessionName == "" || sessionName == "." || sessionName == ".." {
+		return fmt.Errorf("invalid session name %q", sessionName)
+	}
+	if strings.ContainsAny(sessionName, `/\`) || strings.Contains(sessionName, "..") {
+		return fmt.Errorf("session name %q must be a single path component", sessionName)
+	}
+	return nil
+}
+
+// FindOrphanedDrafts returns the names of ledger draft placeholders that have no
+// live or recoverable recording behind them, oldest first. cacheDirs are the
+// local cache session directories to consult for an in-flight recording.
+//
+// Three conditions must ALL hold, and each is deliberately conservative — a
+// false positive git-removes a live session's placeholder:
+//
+//  1. The ledger directory is a draft (never a finalized session).
+//  2. Its updated_at heartbeat is older than OrphanedDraftAge.
+//  3. No recording state or cached transcript exists for it locally. If either
+//     exists the session is alive or recoverable and upload-retry owns it.
+//
+// This is the single source of truth for "orphaned draft"; both `ox doctor` and
+// the daemon's periodic retraction call it.
+func FindOrphanedDrafts(ledgerPath string, cacheDirs []string) ([]string, error) {
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read ledger sessions: %w", err)
+	}
+
+	type candidate struct {
+		name      string
+		updatedAt time.Time
+	}
+	var found []candidate
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		meta, metaErr := lfs.ReadSessionMeta(filepath.Join(sessionsDir, name))
+		// Fail safe: an unreadable meta.json is not a draft we are willing to
+		// delete. Some other check owns diagnosing it.
+		if metaErr != nil || !meta.IsDraft() {
+			continue
+		}
+		// No updated_at means we cannot age it. Refuse rather than guess —
+		// deleting a placeholder for a session that might be live is worse than
+		// leaving a stale page.
+		if meta.UpdatedAt == nil || time.Since(*meta.UpdatedAt) < OrphanedDraftAge {
+			continue
+		}
+		if DraftHasLocalSessionData(cacheDirs, name) {
+			continue
+		}
+		found = append(found, candidate{name: name, updatedAt: *meta.UpdatedAt})
+	}
+
+	sort.Slice(found, func(i, j int) bool { return found[i].updatedAt.Before(found[j].updatedAt) })
+	names := make([]string, 0, len(found))
+	for _, c := range found {
+		names = append(names, c.name)
+	}
+	return names, nil
+}
+
+// DraftHasLocalSessionData reports whether any cache location still holds this
+// session, either as an active recording or as a transcript awaiting upload.
+func DraftHasLocalSessionData(cacheDirs []string, sessionName string) bool {
+	for _, dir := range cacheDirs {
+		sessionDir := filepath.Join(dir, sessionName)
+		for _, marker := range []string{".recording.json", "raw.jsonl"} {
+			if _, err := os.Stat(filepath.Join(sessionDir, marker)); err == nil {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -672,6 +672,15 @@ const staleEmptyThreshold = 48 * time.Hour
 // a transient shell PID that dies immediately after session start.
 const GhostGracePeriod = 10 * time.Minute
 
+// orphanStubGracePeriod is how long a header-only session dir must exist before
+// the marker-independent orphan sweep (CleanupOrphanedStubsInDir) will remove
+// it. Longer than GhostGracePeriod because the sweep runs WITHOUT a live
+// .recording.json marker to consult — the dir age is the only guard against
+// reaping a session that was just primed and has not yet captured its first
+// turn. One hour is comfortably longer than the gap between prime and the first
+// user prompt, while still reclaiming abandoned stubs the same day.
+const orphanStubGracePeriod = 1 * time.Hour
+
 // cleanupStaleEmptyRecordings removes stale recording stubs that have no session
 // content (no raw.jsonl). These accumulate when agents start sessions but exit
 // without calling session stop. Best-effort: errors are logged but not returned.
@@ -688,22 +697,26 @@ func cleanupStaleEmptyRecordings(projectRoot string) {
 		if state.SessionPath == "" {
 			continue
 		}
-		// only clean empty stubs (no raw.jsonl)
+		// only clean phantom stubs — a header-only or missing raw.jsonl. Since
+		// eager writes at recording start (ses_/c link, header, context-trace),
+		// an abandoned session leaves a dir with content, so a plain os.Stat
+		// "has raw.jsonl" test kept every phantom alive. Classify instead:
+		// substantive content is a recoverable orphan and a content-store
+		// pointer's transcript lives elsewhere — never delete those.
 		rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
-		if _, err := os.Stat(rawPath); err == nil {
-			continue // has content, don't auto-delete
-		} else if !os.IsNotExist(err) {
-			slog.Debug("cleanup stale empty recording: stat error", "path", rawPath, "error", err)
-			continue // transient/permission error, skip
+		switch ClassifyRawFile(rawPath) {
+		case RawSubstantive, RawPointerStub:
+			continue // real or recoverable data — don't auto-delete
+		case RawMissing, RawHeaderOnly:
+			// phantom — fall through to removal
 		}
-		// remove .recording.json
-		recPath := recordingStatePath(state.SessionPath)
-		if err := os.Remove(recPath); err != nil && !os.IsNotExist(err) {
-			slog.Debug("cleanup stale empty recording", "path", recPath, "error", err)
+		// remove the whole stub dir (header raw.jsonl + context-trace.jsonl +
+		// .recording.json). os.RemoveAll, not removeEmptyDir: the dir is not
+		// empty, which is exactly why these accumulated.
+		if err := os.RemoveAll(state.SessionPath); err != nil {
+			slog.Debug("cleanup stale empty recording", "path", state.SessionPath, "error", err)
 			continue
 		}
-		// remove empty session directory
-		removeEmptyDir(state.SessionPath)
 		slog.Debug("cleaned stale empty recording", "session", filepath.Base(state.SessionPath))
 	}
 }
@@ -774,8 +787,8 @@ func cleanupGhosts(states []*RecordingState) GhostCleanupResult {
 		//
 		// Only a header-only or missing raw.jsonl is a ghost. A pointer stub
 		// is a session whose transcript lives in the content store, so it has
-		// very much got recoverable data — deleting it (and, via
-		// removeEmptyDir below, its whole session directory) would destroy a
+		// very much got recoverable data — deleting it (and, via the
+		// os.RemoveAll below, its whole session directory) would destroy a
 		// synced session. HasSubstantiveEntries reports false for pointers as
 		// of GH #710, so this must not be collapsed back into that call.
 		rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
@@ -791,20 +804,126 @@ func cleanupGhosts(states []*RecordingState) GhostCleanupResult {
 			// fall through to ghost cleanup
 		}
 
-		// ghost confirmed: dead PID, no meaningful data
+		// ghost confirmed: dead PID, no meaningful data. Remove the whole dir
+		// (marker + header raw.jsonl + context-trace.jsonl). os.RemoveAll, not
+		// removeEmptyDir: eager writes at recording start mean the dir is never
+		// empty, so removeEmptyDir left the marker gone but the stub behind —
+		// invisible to every later pass and the source of the accumulation.
 		sessionName := filepath.Base(state.SessionPath)
-		recPath := recordingStatePath(state.SessionPath)
-		if err := os.Remove(recPath); err != nil && !os.IsNotExist(err) {
-			slog.Debug("ghost cleanup: failed to remove recording marker", "session", sessionName, "error", err)
+		if err := os.RemoveAll(state.SessionPath); err != nil {
+			slog.Debug("ghost cleanup: failed to remove stub dir", "session", sessionName, "error", err)
 			continue
 		}
-
-		// remove empty session directory
-		removeEmptyDir(state.SessionPath)
 
 		result.Removed++
 		result.Names = append(result.Names, sessionName)
 		slog.Debug("ghost cleanup: removed", "session", sessionName, "parent_pid", state.ParentPID)
+	}
+
+	return result
+}
+
+// CleanupOrphanedStubs sweeps a project's LOCAL CACHE session dirs for
+// header-only phantom stubs and removes them. It resolves cache paths from repo
+// identity and deliberately excludes the legacy in-repo sessions dir, so it can
+// never RemoveAll from the user's own project tree.
+func CleanupOrphanedStubs(projectRoot string) GhostCleanupResult {
+	var result GhostCleanupResult
+	for _, dir := range cacheSessionsDirs(projectRoot) {
+		r := CleanupOrphanedStubsInDir(dir)
+		result.Removed += r.Removed
+		result.Names = append(result.Names, r.Names...)
+	}
+	return result
+}
+
+// cacheSessionsDirs returns the LOCAL CACHE session directories for a project —
+// the ledger cache and XDG cache locations — excluding the legacy in-repo
+// sessions dir (projectRoot/sessions). The exclusion is load-bearing:
+// CleanupOrphanedStubsInDir uses os.RemoveAll, and the legacy path is the user's
+// own repo, never safe to reap.
+func cacheSessionsDirs(projectRoot string) []string {
+	legacy := filepath.Join(projectRoot, "sessions")
+	var out []string
+	for _, p := range sessionsSearchPaths(projectRoot) {
+		if p == legacy {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// CleanupOrphanedStubsInDir removes header-only / empty phantom session stubs
+// from a LOCAL CACHE sessions directory, whether or not they still carry a
+// .recording.json marker. This is the reclaimer for the accumulation that the
+// marker-based ghost cleanup structurally cannot see: once a header-only
+// session's marker is removed at finalize, loadRecordingStatesFromDir skips the
+// dir forever, and removeEmptyDir cannot delete it because the dir still holds
+// raw.jsonl (the header) plus context-trace.jsonl.
+//
+// MUST be called only with a cache sessions dir
+// (<ledger>/.sageox/cache/sessions or an XDG cache path), NEVER the git-tracked
+// <ledger>/sessions dir: a draft placeholder there is meta.json-only (classified
+// RawMissing), and deleting it would destroy a shared /c/ link and a session
+// another machine may still finalize. See .claude/rules/cache-only-design.md.
+//
+// A dir is removed only when ALL hold:
+//   - no meta.json present (a finalized or draft session is never a phantom);
+//   - raw.jsonl classifies RawHeaderOnly or RawMissing (never RawSubstantive,
+//     a recoverable orphan; never RawPointerStub, whose transcript is in the
+//     content store);
+//   - no live recording: .recording.json absent, or present with a dead PID;
+//   - the dir is older than orphanStubGracePeriod, so a just-primed session that
+//     has not yet captured its first turn survives.
+func CleanupOrphanedStubsInDir(cacheSessionsDir string) GhostCleanupResult {
+	var result GhostCleanupResult
+
+	entries, err := os.ReadDir(cacheSessionsDir)
+	if err != nil {
+		return result
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionPath := filepath.Join(cacheSessionsDir, entry.Name())
+
+		// a finalized or draft session (meta.json present) is never a phantom.
+		if _, statErr := os.Stat(filepath.Join(sessionPath, "meta.json")); statErr == nil {
+			continue
+		}
+
+		switch ClassifyRawFile(filepath.Join(sessionPath, "raw.jsonl")) {
+		case RawSubstantive, RawPointerStub:
+			continue // real or content-store-backed data
+		case RawMissing, RawHeaderOnly:
+			// phantom candidate — fall through
+		}
+
+		// a live recording (marker present + PID alive) is never a phantom.
+		if data, readErr := os.ReadFile(recordingStatePath(sessionPath)); readErr == nil {
+			var state RecordingState
+			if json.Unmarshal(data, &state) == nil && state.IsAgentAlive() {
+				continue
+			}
+		}
+
+		// age guard: only reap dirs older than the grace period, so a session
+		// primed moments ago that has not captured its first turn is spared.
+		info, statErr := os.Stat(sessionPath)
+		if statErr != nil || time.Since(info.ModTime()) < orphanStubGracePeriod {
+			continue
+		}
+
+		if rmErr := os.RemoveAll(sessionPath); rmErr != nil {
+			slog.Debug("orphan stub cleanup: remove failed", "session", entry.Name(), "error", rmErr)
+			continue
+		}
+		result.Removed++
+		result.Names = append(result.Names, entry.Name())
+		slog.Debug("orphan stub cleanup: removed", "session", entry.Name())
 	}
 
 	return result
@@ -837,17 +956,6 @@ func loadRecordingStatesFromDir(sessionsDir string) ([]*RecordingState, error) {
 		states = append(states, &state)
 	}
 	return states, nil
-}
-
-// removeEmptyDir removes a directory only if it's empty.
-func removeEmptyDir(dir string) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return
-	}
-	if len(entries) == 0 {
-		_ = os.Remove(dir)
-	}
 }
 
 // StartRecordingOptions contains options for starting a recording.

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -902,12 +902,21 @@ func CleanupOrphanedStubsInDir(cacheSessionsDir string) GhostCleanupResult {
 			// phantom candidate — fall through
 		}
 
-		// a live recording (marker present + PID alive) is never a phantom.
+		// A live OR unverifiable recording is never a phantom. Fail CLOSED when a
+		// .recording.json marker exists but cannot be read or parsed: an
+		// incomplete/concurrent write is exactly what an ACTIVE recording looks
+		// like mid-flight, and deleting it would destroy a live session's
+		// identity and recovery data. Only reap when the marker is ABSENT, or
+		// present-parseable-and-PID-dead.
 		if data, readErr := os.ReadFile(recordingStatePath(sessionPath)); readErr == nil {
 			var state RecordingState
-			if json.Unmarshal(data, &state) == nil && state.IsAgentAlive() {
-				continue
+			if json.Unmarshal(data, &state) != nil || state.IsAgentAlive() {
+				continue // unreadable-as-JSON or still alive → keep
 			}
+			// parsed cleanly and the PID is dead → eligible; fall through.
+		} else if !os.IsNotExist(readErr) {
+			// marker present but the read itself failed (permission/transient) → keep.
+			continue
 		}
 
 		// age guard: only reap dirs older than the grace period, so a session

--- a/internal/session/recording_cleanup_test.go
+++ b/internal/session/recording_cleanup_test.go
@@ -124,13 +124,18 @@ func TestCleanupStaleEmptyRecordings_KeepsRecentStubs(t *testing.T) {
 	assert.False(t, os.IsNotExist(err), ".recording.json should be preserved for recent stub")
 }
 
-func TestCleanupStaleEmptyRecordings_KeepsWithRawJSONL(t *testing.T) {
+// TestCleanupStaleEmptyRecordings_KeepsWithSubstantiveContent proves a stale
+// recording that captured real turns is preserved for recovery, not reaped.
+// Fixture is a header PLUS a user turn — the mere presence of raw.jsonl is not
+// enough, because eager writes made every abandoned session carry a header-only
+// raw.jsonl (that is the phantom removed by the sibling test below).
+func TestCleanupStaleEmptyRecordings_KeepsWithSubstantiveContent(t *testing.T) {
 	cacheDir := t.TempDir()
 	projectRoot, sessionsBase := setupRecordingTestWithSessionsBase(t, cacheDir)
 	sessionPath := filepath.Join(sessionsBase, "2026-01-01T00-00-user-OxHasR")
 	require.NoError(t, os.MkdirAll(sessionPath, 0755))
 
-	// create a .recording.json with StartedAt > 48h ago AND raw.jsonl present
+	// create a .recording.json with StartedAt > 48h ago AND substantive raw.jsonl
 	state := &RecordingState{
 		AgentID:     "OxHasR",
 		StartedAt:   time.Now().Add(-72 * time.Hour),
@@ -140,13 +145,44 @@ func TestCleanupStaleEmptyRecordings_KeepsWithRawJSONL(t *testing.T) {
 	require.NoError(t, err)
 	recPath := filepath.Join(sessionPath, recordingFile)
 	require.NoError(t, os.WriteFile(recPath, data, 0600))
-	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, "raw.jsonl"), []byte("{}\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, "raw.jsonl"),
+		[]byte(`{"type":"header"}`+"\n"+`{"type":"user"}`+"\n"), 0600))
 
 	cleanupStaleEmptyRecordings(projectRoot)
 
-	// .recording.json should still exist because raw.jsonl is present
+	// .recording.json should still exist because the recording has real content
 	_, err = os.Stat(recPath)
-	assert.False(t, os.IsNotExist(err), ".recording.json should be preserved when raw.jsonl exists")
+	assert.False(t, os.IsNotExist(err), ".recording.json should be preserved when raw.jsonl has real content")
+}
+
+// TestCleanupStaleEmptyRecordings_RemovesHeaderOnlyStub is the corrected-intent
+// test: a stale header-only recording (a real coworker prompt was never
+// captured) is a phantom and must be reclaimed, whole dir and all. This is the
+// class of ~10k orphans the old "any raw.jsonl means keep it" guard preserved
+// forever.
+func TestCleanupStaleEmptyRecordings_RemovesHeaderOnlyStub(t *testing.T) {
+	cacheDir := t.TempDir()
+	projectRoot, sessionsBase := setupRecordingTestWithSessionsBase(t, cacheDir)
+	sessionPath := filepath.Join(sessionsBase, "2026-01-01T00-00-user-OxHdr1")
+	require.NoError(t, os.MkdirAll(sessionPath, 0755))
+
+	state := &RecordingState{
+		AgentID:     "OxHdr1",
+		StartedAt:   time.Now().Add(-72 * time.Hour),
+		SessionPath: sessionPath,
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, recordingFile), data, 0600))
+	// header-only raw.jsonl + context-trace — the exact phantom shape.
+	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, "raw.jsonl"),
+		[]byte(`{"type":"header"}`+"\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, "context-trace.jsonl"),
+		[]byte(`{"type":"provided"}`+"\n"), 0600))
+
+	cleanupStaleEmptyRecordings(projectRoot)
+
+	assert.NoDirExists(t, sessionPath, "a stale header-only phantom must be removed, whole dir and all")
 }
 
 func TestCleanupStaleEmptyRecordings_RemovesEmptyDir(t *testing.T) {

--- a/internal/session/recording_orphan_sweep_test.go
+++ b/internal/session/recording_orphan_sweep_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -124,4 +125,70 @@ func TestCleanupOrphanedStubsInDir_KeepsNonPhantoms(t *testing.T) {
 	assert.DirExists(t, finalized, "a finalized/draft session must survive")
 	assert.DirExists(t, live, "a live recording must survive")
 	assert.DirExists(t, young, "a just-primed session inside the grace period must survive")
+}
+
+// TestCleanupOrphanedStubsInDir_KeepsOversizedContent guards the destructive
+// failure mode: a user turn larger than the 256 KiB scan buffer must NOT be
+// misread as a header-only phantom and deleted. Classification fails safe to
+// RawSubstantive on an incomplete scan, so the dir survives.
+func TestCleanupOrphanedStubsInDir_KeepsOversizedContent(t *testing.T) {
+	base := t.TempDir()
+	bigUserLine := `{"type":"user","content":"` + strings.Repeat("x", 300*1024) + `"}` + "\n"
+	dir := makeStub(t, base, "2026-08-25T19-11-ryan-OxBig1", map[string]string{
+		"raw.jsonl": headerLine + bigUserLine,
+	}, 2*orphanStubGracePeriod)
+
+	result := CleanupOrphanedStubsInDir(base)
+
+	assert.Equal(t, 0, result.Removed, "a session with an oversized real entry must never be reaped")
+	assert.DirExists(t, dir, "content too large for the scan buffer must fail safe to keep")
+}
+
+// TestClassifyAndUserTurn_FailSafeOnOversizedLine pins the classification
+// contract directly: a line past the 256 KiB buffer stops the scan with an
+// error, and both classifiers must fail safe rather than report "empty".
+func TestClassifyAndUserTurn_FailSafeOnOversizedLine(t *testing.T) {
+	dir := t.TempDir()
+
+	// Header only, but the header line itself exceeds the buffer.
+	bigHeader := filepath.Join(dir, "bighdr.jsonl")
+	require.NoError(t, os.WriteFile(bigHeader,
+		[]byte(`{"type":"header","x":"`+strings.Repeat("y", 300*1024)+`"}`+"\n"), 0o644))
+	assert.Equal(t, RawSubstantive, ClassifyRawFile(bigHeader),
+		"an unreadable (oversized) line must not classify as RawHeaderOnly")
+
+	// Header + an oversized user entry.
+	bigUser := filepath.Join(dir, "biguser.jsonl")
+	require.NoError(t, os.WriteFile(bigUser,
+		[]byte(headerLine+`{"type":"user","content":"`+strings.Repeat("z", 300*1024)+`"}`+"\n"), 0o644))
+	assert.True(t, HasUserTurn(bigUser),
+		"an oversized user entry must fail safe to 'has user turn', not suppress the session")
+}
+
+// TestCleanupOrphanedStubsInDir_ErrorPaths covers non-existent and non-directory
+// inputs: the sweep must return a zero result without panicking, never treating
+// an unreadable location as work done.
+func TestCleanupOrphanedStubsInDir_ErrorPaths(t *testing.T) {
+	t.Run("missing directory", func(t *testing.T) {
+		result := CleanupOrphanedStubsInDir(filepath.Join(t.TempDir(), "does-not-exist"))
+		assert.Equal(t, 0, result.Removed)
+		assert.Empty(t, result.Names)
+	})
+
+	t.Run("path is a file, not a directory", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "a-file")
+		require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
+		assert.NotPanics(t, func() {
+			result := CleanupOrphanedStubsInDir(f)
+			assert.Equal(t, 0, result.Removed)
+		})
+	})
+
+	t.Run("non-directory entries in the sweep dir are skipped", func(t *testing.T) {
+		base := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(base, "stray.txt"), []byte("x"), 0o644))
+		result := CleanupOrphanedStubsInDir(base)
+		assert.Equal(t, 0, result.Removed)
+		assert.FileExists(t, filepath.Join(base, "stray.txt"), "a stray file must be left untouched")
+	})
 }

--- a/internal/session/recording_orphan_sweep_test.go
+++ b/internal/session/recording_orphan_sweep_test.go
@@ -127,6 +127,23 @@ func TestCleanupOrphanedStubsInDir_KeepsNonPhantoms(t *testing.T) {
 	assert.DirExists(t, young, "a just-primed session inside the grace period must survive")
 }
 
+// TestCleanupOrphanedStubsInDir_KeepsMalformedMarker guards the P1: a
+// .recording.json that exists but cannot be parsed (an incomplete/concurrent
+// write — exactly what an ACTIVE recording looks like mid-flight) must fail
+// closed, not fall through to os.RemoveAll and destroy a live session.
+func TestCleanupOrphanedStubsInDir_KeepsMalformedMarker(t *testing.T) {
+	base := t.TempDir()
+	dir := makeStub(t, base, "2026-08-25T19-11-ryan-OxMalf", map[string]string{
+		"raw.jsonl":   headerLine,
+		recordingFile: `{"parent_pid": not-valid-json`,
+	}, 2*orphanStubGracePeriod)
+
+	result := CleanupOrphanedStubsInDir(base)
+
+	assert.Equal(t, 0, result.Removed, "an unparseable marker must fail closed (keep)")
+	assert.DirExists(t, dir, "a marker present but unreadable may be a live session mid-write")
+}
+
 // TestCleanupOrphanedStubsInDir_KeepsOversizedContent guards the destructive
 // failure mode: a user turn larger than the 256 KiB scan buffer must NOT be
 // misread as a header-only phantom and deleted. Classification fails safe to

--- a/internal/session/recording_orphan_sweep_test.go
+++ b/internal/session/recording_orphan_sweep_test.go
@@ -127,6 +127,28 @@ func TestCleanupOrphanedStubsInDir_KeepsNonPhantoms(t *testing.T) {
 	assert.DirExists(t, young, "a just-primed session inside the grace period must survive")
 }
 
+// TestClassifyRawFile_UnreadablePresentFileIsNotMissing guards the deletion
+// path: a raw.jsonl that exists but cannot be opened (permission / transient
+// I/O) must NOT classify as RawMissing (which the sweep would reap). Only a
+// genuinely absent file is RawMissing; anything present-but-unreadable fails
+// safe to RawSubstantive.
+func TestClassifyRawFile_UnreadablePresentFileIsNotMissing(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "raw.jsonl")
+	require.NoError(t, os.WriteFile(p, []byte(headerLine+`{"type":"user"}`+"\n"), 0o644))
+	require.NoError(t, os.Chmod(p, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(p, 0o644) })
+
+	// Running as root defeats mode bits — skip rather than assert a false pass.
+	if f, err := os.Open(p); err == nil {
+		_ = f.Close()
+		t.Skip("cannot make file unreadable (running as root?)")
+	}
+
+	assert.Equal(t, RawSubstantive, ClassifyRawFile(p),
+		"a present-but-unreadable raw.jsonl must never classify as RawMissing (deletable)")
+}
+
 // TestCleanupOrphanedStubsInDir_KeepsMalformedMarker guards the P1: a
 // .recording.json that exists but cannot be parsed (an incomplete/concurrent
 // write — exactly what an ACTIVE recording looks like mid-flight) must fail

--- a/internal/session/recording_orphan_sweep_test.go
+++ b/internal/session/recording_orphan_sweep_test.go
@@ -1,0 +1,127 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Phantom header-only session accumulation ---
+//
+// Eager writes at recording start (ses_/c link, header line, context-trace.jsonl)
+// turned an abandoned session from an empty dir into a header-only dir WITH
+// content. The marker-based ghost cleanup then structurally could not reclaim
+// it: once .recording.json was removed at finalize, the dir was invisible to
+// every later pass, and removeEmptyDir could not delete a non-empty dir. Result:
+// ~10k header-only orphans on one machine.
+//
+// CleanupOrphanedStubsInDir is the marker-independent reclaimer. These tests pin
+// the exact accumulation case and every non-phantom that must survive.
+
+// headerLine is the sole entry an abandoned recording ever captured.
+const headerLine = `{"metadata":{"agent_id":"OxTEST"},"type":"header"}` + "\n"
+
+// makeStub builds a session dir with the given files, then ages the directory
+// past orphanStubGracePeriod so the sweep will consider it. Writing files bumps
+// the dir mtime to now, so the Chtimes MUST come last.
+func makeStub(t *testing.T, base, name string, files map[string]string, age time.Duration) string {
+	t.Helper()
+	dir := filepath.Join(base, name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	for fname, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, fname), []byte(content), 0o644))
+	}
+	old := time.Now().Add(-age)
+	require.NoError(t, os.Chtimes(dir, old, old))
+	return dir
+}
+
+// TestCleanupOrphanedStubsInDir_RemovesMarkerlessHeaderOnly is THE regression:
+// a header-only recording that lost its .recording.json marker (the steady state
+// of every accumulated phantom) must be reclaimed. It fails against the old
+// removeEmptyDir path, which could never delete a dir holding raw.jsonl +
+// context-trace.jsonl.
+func TestCleanupOrphanedStubsInDir_RemovesMarkerlessHeaderOnly(t *testing.T) {
+	base := t.TempDir()
+	dir := makeStub(t, base, "2026-08-25T19-11-ryan-Ox4kYq", map[string]string{
+		"raw.jsonl":           headerLine,
+		"context-trace.jsonl": `{"type":"provided"}` + "\n",
+	}, 2*orphanStubGracePeriod)
+
+	result := CleanupOrphanedStubsInDir(base)
+
+	assert.Equal(t, 1, result.Removed, "a marker-less header-only stub is a phantom and must be reclaimed")
+	assert.NoDirExists(t, dir, "the whole stub dir (header + context-trace) must be removed")
+}
+
+// TestCleanupOrphanedStubsInDir_RemovesMissingRawAndDeadMarker covers the other
+// two phantom shapes: no raw.jsonl at all, and a header-only dir that still
+// carries a dead-PID marker.
+func TestCleanupOrphanedStubsInDir_RemovesMissingRawAndDeadMarker(t *testing.T) {
+	base := t.TempDir()
+	noRaw := makeStub(t, base, "2026-08-25T19-11-ryan-OxNONE", map[string]string{
+		"context-trace.jsonl": `{"type":"provided"}` + "\n",
+	}, 2*orphanStubGracePeriod)
+	// 0x7FFFFFFF is above any real pid_max — guaranteed dead.
+	deadMarker := makeStub(t, base, "2026-08-25T19-11-ryan-OxDEAD", map[string]string{
+		"raw.jsonl":   headerLine,
+		recordingFile: `{"parent_pid":2147483647}`,
+	}, 2*orphanStubGracePeriod)
+
+	result := CleanupOrphanedStubsInDir(base)
+
+	assert.Equal(t, 2, result.Removed)
+	assert.NoDirExists(t, noRaw)
+	assert.NoDirExists(t, deadMarker)
+}
+
+// TestCleanupOrphanedStubsInDir_KeepsNonPhantoms is the negative-control suite:
+// every dir here would survive the feature being removed, so it proves the sweep
+// is discriminating rather than a blanket rm.
+func TestCleanupOrphanedStubsInDir_KeepsNonPhantoms(t *testing.T) {
+	base := t.TempDir()
+
+	// substantive: a real transcript (header + user turn) — a recoverable orphan.
+	substantive := makeStub(t, base, "2026-08-25T19-11-ryan-OxREAL", map[string]string{
+		"raw.jsonl": headerLine + `{"type":"user"}` + "\n",
+	}, 2*orphanStubGracePeriod)
+
+	// pointer stub: transcript lives in the content store.
+	pointer := filepath.Join(base, "2026-08-25T19-11-ryan-OxPTR")
+	require.NoError(t, os.MkdirAll(pointer, 0o755))
+	writePointerStub(t, filepath.Join(pointer, "raw.jsonl"))
+	old := time.Now().Add(-2 * orphanStubGracePeriod)
+	require.NoError(t, os.Chtimes(pointer, old, old))
+
+	// finalized/draft: meta.json present.
+	finalized := makeStub(t, base, "2026-08-25T19-11-ryan-OxMETA", map[string]string{
+		"raw.jsonl": headerLine,
+		"meta.json": `{"session_id":"ses_x"}`,
+	}, 2*orphanStubGracePeriod)
+
+	// live recording: header-only but a marker with THIS (alive) process's PID.
+	live := makeStub(t, base, "2026-08-25T19-11-ryan-OxLIVE", map[string]string{
+		"raw.jsonl": headerLine,
+	}, 2*orphanStubGracePeriod)
+	require.NoError(t, os.WriteFile(filepath.Join(live, recordingFile),
+		[]byte(`{"parent_pid":`+strconv.Itoa(os.Getpid())+`}`), 0o644))
+
+	// too young: header-only but inside the grace period.
+	young := makeStub(t, base, "2026-08-25T19-11-ryan-OxYNG", map[string]string{
+		"raw.jsonl": headerLine,
+	}, orphanStubGracePeriod/2)
+
+	result := CleanupOrphanedStubsInDir(base)
+
+	assert.Equal(t, 0, result.Removed, "no non-phantom may be reclaimed")
+	assert.DirExists(t, substantive, "a recoverable transcript must survive")
+	assert.DirExists(t, pointer, "a content-store pointer must survive")
+	assert.DirExists(t, finalized, "a finalized/draft session must survive")
+	assert.DirExists(t, live, "a live recording must survive")
+	assert.DirExists(t, young, "a just-primed session inside the grace period must survive")
+}


### PR DESCRIPTION
## Summary

**Coworkers browsing "SageOx Internal" (and every other repo) were drowning in sessions that never happened** — one machine had **9,922 phantom sessions** in local caches (78–88% of all rows), and crashed sessions left "in progress" `/c/` pages and phantom draft rows on the ledger forever. This PR stops the buildup at the source, adds a user-turn floor so empty sessions never get published, and makes `ox doctor` **and the daemon** auto-reclaim the backlog — so `ox session list` and the dashboard show only real work.

### What broke

Recent eager-write work (the `/c/` link is minted at recording start so shared links resolve from t=0) changed the shape of an abandoned session. It used to leave an **empty** dir; now every `ox agent prime` writes a header line + `context-trace.jsonl` immediately, so an abandoned session leaves a **header-only dir with content**. The old cleanup couldn't cope:

- `removeEmptyDir` only deletes a **zero-entry** dir → a header-only dir is never empty → never deleted.
- `cleanupStaleEmptyRecordings` bailed whenever any `raw.jsonl` existed.
- Ghost cleanup can't even *see* a dir once its `.recording.json` marker is removed at finalize.

Result: header-only stubs accumulated without bound (only 6 of 1,682 dirs in one ledger still had a marker). Separately, a session that **crashed after turn 2** left a committed draft placeholder that nothing ever retracted — a permanent "in progress" page + phantom `ox session list` row.

```mermaid
flowchart TD
    A["ox agent prime / session start"] --> B["StartRecording: header line + context-trace.jsonl, no user turn yet"]
    B --> C{"Real user turn recorded?"}
    C -->|"yes"| D["Substantive session → upload / draft after turn 2"]
    C -->|"no (idle workspace, re-prime, crash)"| E["marker removed at finalize"]
    E --> F["header-only dir survives removeEmptyDir (not empty)"]
    F --> G["invisible to ghost cleanup (no marker) → accumulates"]
    G -.->|"this PR"| H["CleanupOrphanedStubsInDir: RemoveAll, cache-only, guarded"]
    C -->|"crash after turn 2"| I["committed draft placeholder, recording gone"]
    I -.->|"this PR"| J["daemon retractOrphanedDrafts: git rm + push, 3-day grace"]
```

### What this PR ships

- **Local phantom reclaimer** (`CleanupOrphanedStubsInDir`): marker-independent sweep that `RemoveAll`s a stub only when it is header-only/missing, has no live-PID recording, has no `meta.json`, and is >1h old. Never touches `RawSubstantive` (recoverable) or `RawPointerStub` (content-store) sessions. **Cache dirs only — never the git-tracked ledger dir.** Wired into `ox doctor` and the daemon finalize path.
- **≥1-user-turn floor**: a recording with no `type:"user"` entry is a phantom, so `publishDraftPlaceholder` (the git commit) and `notifySessionStartedAsync` (the cloud registration) now refuse it. Registration is deferred at t=0 and fires on the first real turn (Stop hook) / re-prime — the biggest lever on the inflated dashboard count.
- **Daemon auto-retracts stale draft commits** (`retractOrphanedDrafts`): git-removes a committed draft whose recording is gone and lands a `session-draft: retract` commit that the existing draft-push carries. Detection (`session.FindOrphanedDrafts`) is now shared verbatim with `ox doctor` so "orphaned" means one thing in both.
- **Grace period → 3 days** (`OrphanedDraftAge` 24h → 72h): the `updated_at` heartbeat is committed to the shared ledger, so a session live on another machine keeps its draft fresh — a paused-over-a-weekend session is never reaped.

### Cross-machine safety

The local sweep only touches per-machine, gitignored cache — a phantom here can't be in-flight elsewhere. The daemon retraction is guarded by a **mid-rebase check** (an unguarded `git rm`/commit during a conflicted rebase would consume the replay step — team-wide data loss), a traversal-safe name validator, and the shared-ledger heartbeat + 3-day grace. Retraction commits use the `session-draft:` subject so `pushSessionDraftCommits` refuses to ship them alongside any non-draft commit.

## Test Plan

- **Red-first proven** for both fixes: neutered the delete → `TestCleanupOrphanedStubsInDir_RemovesMarkerlessHeaderOnly` went red; neutered the daemon retraction → `TestRetractOrphanedDrafts_RemovesStaleCommittedDraft` went red; restored → both green.
- New unit + real-git tests cover every negative control: substantive / pointer-stub / `meta.json` / live-PID / too-young stubs all survive; fresh draft and draft-with-local-recording are never retracted.
- Corrected a pre-existing test that enshrined the old bug (kept a header-only stub); reaper fixtures moved clear of the new 72h threshold.
- `go build ./...`, `internal/session` + `internal/daemon` + `cmd/ox` draft/reaper suites green, **0 new lint** (`golangci-lint --new-from-rev`).

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — red-first unit + real-git daemon tests
- [ ] CHANGELOG entry added (if user-facing) — follow-up; behavior is cleanup/internal
- [x] Breaking change documented — none
- [x] Ran `/security-review` on the diff, **or** N/A documented — no `internal/auth`/`internal/mcp`/`raw_writer.go`/`prepush_scan.go`/`internal/upgrade`/`go.sum` surface; the daemon's new `git rm`/commit path is pathspec-scoped, name-validated against traversal, and mid-rebase guarded

</details>

Co-authored-by: SageOx <ox@sageox.ai>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790291338&installation_model_id=433550&pr_number=827&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F827&signature=1c795af96efa3cc2054af694e0ab7a0a4d61cf62e1a500c05621e6805a03228c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Session registration now waits for user activity and resumes automatically.
  - Empty or header-only recordings no longer create draft placeholders.
  - Added automatic cleanup of abandoned drafts and stale local session data.
  - Added a command for viewing locally recorded conversations.

- **Bug Fixes**
  - Improved deferred registration across recording lifecycle events.
  - Preserved active, recoverable, and substantive recordings during cleanup.
  - Session health checks now report abandoned and phantom sessions more accurately.

- **Documentation**
  - Updated session guidance, team context instructions, and conversation workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->