### PR TITLE
fix: ship v0.14.2 reliability fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.14.1"
+      "version": "0.14.2"
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Check generated CLI docs
+        run: make docs-check
+
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,10 @@ jobs:
         working-directory: docs
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN works when @sageox/cli-docs grants this repository
+          # Actions write access. DOCS_PACKAGE_TOKEN is the explicit fallback
+          # for organizations that do not inherit package access from source.
+          NODE_AUTH_TOKEN: ${{ secrets.DOCS_PACKAGE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Trigger docs site update
         uses: peter-evans/repository-dispatch@v3

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 > Calm, precise terminal output for humans and AI coworkers.
 
-ox's visual language inherits from the SageOx design system: sage-green primary, copper-gold secondary, forest accent, low-noise Tufte minimums. Components are reusable, theme-aware, and adapt to the terminal in front of them (light/dark, `NO_COLOR`, TTY vs piped, headless SSH).
+ox's visual language inherits from the SageOx design system: an all-sage brand hierarchy, warning-only gold, low-noise semantic accents, and Tufte minimums. Components are reusable, theme-aware, and adapt to the terminal in front of them (light/dark, `NO_COLOR`, TTY vs piped, headless SSH).
 
 This file is the entry point. It is intentionally short.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for ox CLI tool
 
 .PHONY: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw check-codedb-guarded-open
-.PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-timings test-all test-slow test-browser test-integration test-agents test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version check-release-drift beads-setup
+.PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-timings test-all test-slow test-browser test-integration test-agents test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-check docs-publish refresh-friction-catalog bump-version verify-version check-release-drift beads-setup
 
 # Variables
 GO := go
@@ -462,6 +462,20 @@ docs: ## Generate CLI reference docs
 	@echo "Generating CLI reference documentation..."
 	$(GO) run ./cmd/ox docs --output docs/reference
 	@echo "Documentation generated: docs/reference/"
+
+docs-check: ## Fail when committed CLI reference docs differ from Cobra
+	@docs_tmp=$$(mktemp -d); \
+		trap 'rm -rf "$$docs_tmp"' EXIT; \
+		cp docs/package.json "$$docs_tmp/package.json"; \
+		$(GO) run ./cmd/ox docs --output "$$docs_tmp/reference"; \
+		if ! diff -ru -x .gitkeep docs/reference "$$docs_tmp/reference"; then \
+			echo "Generated CLI docs are stale. Run 'make docs' and commit the result."; \
+			exit 1; \
+		fi; \
+		if ! cmp -s docs/package.json "$$docs_tmp/package.json"; then \
+			echo "docs/package.json is stale. Run 'make docs' and commit the result."; \
+			exit 1; \
+		fi
 
 docs-publish: docs ## Publish docs to GitHub Packages
 	@echo "Publishing docs to GitHub Packages..."

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -882,5 +882,5 @@ func startSessionRecordingIfConfigured(ctx *HookContext) {
 		agentID = ctx.Marker.AgentID
 	}
 
-	startSessionRecording(ctx.ProjectRoot, agentID, ctx.AgentType, "")
+	startSessionRecording(ctx.ProjectRoot, agentID, ctx.AgentType, "", recordingSessionIDFromMarker(ctx.Marker))
 }

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -36,6 +36,7 @@ import (
 	"github.com/sageox/ox/internal/runtime"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
+	"github.com/sageox/ox/internal/sessionid"
 	"github.com/sageox/ox/internal/teamdocs"
 	"github.com/sageox/ox/internal/telemetry"
 	"github.com/sageox/ox/internal/tips"
@@ -434,7 +435,9 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 
 	// attempt to start session recording if enabled (local, no auth needed)
 	phaseStart = time.Now()
-	sessionStat := startSessionRecording(projectRoot, agentID, agentType, parentAgentID)
+	continuedFromSessionID := recordingSessionIDFromMarker(existingMarker)
+	sessionStat := startSessionRecording(projectRoot, agentID, agentType, parentAgentID, continuedFromSessionID)
+	recordingSessionID := recordingSessionIDForMarker(projectRoot, agentID, continuedFromSessionID)
 	timing["session_start"] = time.Since(phaseStart).Milliseconds()
 
 	// check if user is authenticated — degraded mode if not (recording continues locally)
@@ -446,10 +449,11 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 			// write session marker so hooks can discover session file and continue recording
 			if agentSessionID != "" {
 				marker := &SessionMarker{
-					AgentID:        agentID,
-					AgentSessionID: agentSessionID,
-					PrimedAt:       time.Now(),
-					ParentPID:      proc.FindAgentAncestorPID(),
+					AgentID:            agentID,
+					RecordingSessionID: recordingSessionID,
+					AgentSessionID:     agentSessionID,
+					PrimedAt:           time.Now(),
+					ParentPID:          proc.FindAgentAncestorPID(),
 				}
 				if writeErr := WriteSessionMarker(marker); writeErr != nil {
 					slog.Warn("failed to write session marker in degraded mode", "error", writeErr)
@@ -918,11 +922,12 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	// write session marker for idempotent behavior (graceful failure)
 	if agentSessionID != "" {
 		marker := &SessionMarker{
-			AgentID:        agentID,
-			SessionID:      inst.ServerSessionID,
-			AgentSessionID: agentSessionID,
-			PrimedAt:       time.Now(),
-			ParentPID:      proc.FindAgentAncestorPID(),
+			AgentID:            agentID,
+			SessionID:          inst.ServerSessionID,
+			RecordingSessionID: recordingSessionID,
+			AgentSessionID:     agentSessionID,
+			PrimedAt:           time.Now(),
+			ParentPID:          proc.FindAgentAncestorPID(),
 		}
 		if err := WriteSessionMarker(marker); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to write session marker: %v\n", err)
@@ -1174,7 +1179,31 @@ func sessionWatchMode(agentType string) string {
 	return "hook"
 }
 
-func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string) *sessionStatus {
+// recordingSessionIDFromMarker returns the prior durable recording identity
+// carried by a native coding-agent session marker. Marker files are local,
+// long-lived inputs, so only a structurally valid ses_ ID is trusted.
+func recordingSessionIDFromMarker(marker *SessionMarker) string {
+	if marker == nil || !sessionid.IsValidSessionID(marker.RecordingSessionID) {
+		return ""
+	}
+	return marker.RecordingSessionID
+}
+
+// recordingSessionIDForMarker prefers the active recording's identity and
+// otherwise preserves the prior valid identity. The fallback matters when a
+// resume cannot start recording immediately (for example, before its ledger
+// clone arrives): a later prime can still establish the continuation link.
+func recordingSessionIDForMarker(projectRoot, agentID, prior string) string {
+	if state, err := session.LoadRecordingStateForAgent(projectRoot, agentID); err == nil && state != nil && sessionid.IsValidSessionID(state.SessionID) {
+		return state.SessionID
+	}
+	if sessionid.IsValidSessionID(prior) {
+		return prior
+	}
+	return ""
+}
+
+func startSessionRecording(projectRoot, agentID, agentType, parentAgentID, continuedFromSessionID string) *sessionStatus {
 	// resolve session mode from the config hierarchy. Sessions record into
 	// the project ledger; Knowledge Bubbles play no part (ox ADR-028).
 	resolved := config.ResolveSessionRecording(projectRoot)
@@ -1256,15 +1285,16 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string
 	watchMode := sessionWatchMode(agentType)
 
 	opts := session.StartRecordingOptions{
-		AgentID:       agentID,
-		AdapterName:   agentType,
-		OutputFile:    outputFile,
-		FilterMode:    resolved.Mode,
-		ParentPID:     parentPID,
-		Username:      identity.AttributionUsername(endpoint.GetForProject(projectRoot), config.GetDisplayName()),
-		WorkspacePath: projectRoot,
-		Branch:        repotools.GetCurrentBranch(projectRoot),
-		WatchMode:     watchMode,
+		AgentID:                agentID,
+		AdapterName:            agentType,
+		OutputFile:             outputFile,
+		FilterMode:             resolved.Mode,
+		ParentPID:              parentPID,
+		Username:               identity.AttributionUsername(endpoint.GetForProject(projectRoot), config.GetDisplayName()),
+		WorkspacePath:          projectRoot,
+		Branch:                 repotools.GetCurrentBranch(projectRoot),
+		WatchMode:              watchMode,
+		ContinuedFromSessionID: continuedFromSessionID,
 	}
 
 	// propagate parent agent info so the recording state knows this is a subagent

--- a/cmd/ox/agent_prime_conditional_writes_test.go
+++ b/cmd/ox/agent_prime_conditional_writes_test.go
@@ -36,10 +36,11 @@ func TestWriteSessionMarker_RoundTrip(t *testing.T) {
 	t.Cleanup(func() { DeleteSessionMarker(agentSessionID) })
 
 	marker := &SessionMarker{
-		AgentID:        "OxRoundTrip",
-		SessionID:      "oxsid_rt",
-		AgentSessionID: agentSessionID,
-		PrimedAt:       time.Now().Truncate(time.Second),
+		AgentID:            "OxRoundTrip",
+		SessionID:          "oxsid_rt",
+		RecordingSessionID: "ses_019f6f6a-d182-7f4e-a54d-8dcb44567c8d",
+		AgentSessionID:     agentSessionID,
+		PrimedAt:           time.Now().Truncate(time.Second),
 	}
 	require.NoError(t, WriteSessionMarker(marker))
 
@@ -48,6 +49,7 @@ func TestWriteSessionMarker_RoundTrip(t *testing.T) {
 	require.NotNil(t, read)
 	assert.Equal(t, "OxRoundTrip", read.AgentID)
 	assert.Equal(t, "oxsid_rt", read.SessionID)
+	assert.Equal(t, marker.RecordingSessionID, read.RecordingSessionID)
 	assert.Equal(t, agentSessionID, read.AgentSessionID)
 }
 

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1029,16 +1029,17 @@ func processAgentSession(projectRoot string, state *session.RecordingState) (*ag
 	// carrier of the start-minted ID on the reconstruct path too (daemon
 	// orphan-finalize recovers it from here when meta.json was never written)
 	meta := &session.StoreMeta{
-		Version:      "1.0",
-		SessionID:    state.SessionID,
-		CreatedAt:    state.StartedAt,
-		AgentID:      state.AgentID,
-		AgentType:    agentTypeForMeta,
-		AgentVersion: result.AgentVersion,
-		Model:        result.Model,
-		Username:     identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
-		RepoID:       repoID,
-		OxVersion:    version.Version,
+		Version:                "1.0",
+		SessionID:              state.SessionID,
+		ContinuedFromSessionID: state.ContinuedFromSessionID,
+		CreatedAt:              state.StartedAt,
+		AgentID:                state.AgentID,
+		AgentType:              agentTypeForMeta,
+		AgentVersion:           result.AgentVersion,
+		Model:                  result.Model,
+		Username:               identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
+		RepoID:                 repoID,
+		OxVersion:              version.Version,
 	}
 	if err := rawWriter.WriteHeader(meta); err != nil {
 		rawWriter.Close()
@@ -1362,6 +1363,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		EntryCount(result.EntryCount).
 		Summary(result.Summary).
 		StopReason(session.StopReasonStopped).
+		ContinuedFromSessionID(state.ContinuedFromSessionID).
 		ProducedCommits(state.ProducedCommits).
 		ProducedPlans(state.ProducedPlans).
 		LinkedPRs(state.LinkedPRs).

--- a/cmd/ox/agent_session_incremental.go
+++ b/cmd/ox/agent_session_incremental.go
@@ -36,15 +36,16 @@ func writeRawHeader(projectRoot string, state *session.RecordingState) error {
 	}
 
 	meta := &session.StoreMeta{
-		Version:   "1.0",
-		CreatedAt: state.StartedAt,
-		AgentID:   state.AgentID,
-		SessionID: state.SessionID,
-		AgentType: agentTypeForMeta,
-		Model:     state.Model,
-		Username:  identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
-		RepoID:    repoID,
-		OxVersion: version.Version,
+		Version:                "1.0",
+		CreatedAt:              state.StartedAt,
+		AgentID:                state.AgentID,
+		SessionID:              state.SessionID,
+		ContinuedFromSessionID: state.ContinuedFromSessionID,
+		AgentType:              agentTypeForMeta,
+		Model:                  state.Model,
+		Username:               identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
+		RepoID:                 repoID,
+		OxVersion:              version.Version,
 	}
 
 	// enrich with adapter metadata if available

--- a/cmd/ox/agent_session_incremental_test.go
+++ b/cmd/ox/agent_session_incremental_test.go
@@ -94,6 +94,23 @@ func TestWriteRawHeader(t *testing.T) {
 		assert.Equal(t, "OxTest1", meta["agent_id"])
 	})
 
+	t.Run("carries continuation identity", func(t *testing.T) {
+		projectRoot := setupIncrementalTest(t)
+		state, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+			AgentID:                "OxResume",
+			AdapterName:            "claude-code",
+			Username:               "testuser",
+			ContinuedFromSessionID: "ses_019f6f6a-d182-7f4e-a54d-8dcb44567c8d",
+		})
+		require.NoError(t, err)
+		require.NoError(t, writeRawHeader(projectRoot, state))
+
+		stored, err := session.ReadSessionFromPath(filepath.Join(state.SessionPath, "raw.jsonl"))
+		require.NoError(t, err)
+		require.NotNil(t, stored.Meta)
+		assert.Equal(t, state.ContinuedFromSessionID, stored.Meta.ContinuedFromSessionID)
+	})
+
 	t.Run("empty session path returns error", func(t *testing.T) {
 		state := &session.RecordingState{SessionPath: ""}
 		err := writeRawHeader("/tmp", state)

--- a/cmd/ox/agent_session_recover.go
+++ b/cmd/ox/agent_session_recover.go
@@ -238,6 +238,7 @@ func recoverFromCache(inst *agentinstance.Instance, projectRoot string, state *s
 					metaBuilder := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot, sessionID).
 						EntryCount(entryCount).
 						StopReason(session.StopReasonRecovered).
+						ContinuedFromSessionID(state.ContinuedFromSessionID).
 						ProducedCommits(state.ProducedCommits).
 						ProducedPlans(state.ProducedPlans).
 						WithFiles(fileRefs)

--- a/cmd/ox/config_settings_e2e_test.go
+++ b/cmd/ox/config_settings_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/ledger"
@@ -140,7 +141,7 @@ func TestConfigE2E_SessionRecordingGateControlsRecording(t *testing.T) {
 
 	// Disabled via the real command: the gate creates no recording.
 	oxConfigSetRepo(t, "session_recording", "disabled")
-	assert.Nil(t, startSessionRecording(f.projectRoot, agentID, "claude-code", ""),
+	assert.Nil(t, startSessionRecording(f.projectRoot, agentID, "claude-code", "", ""),
 		"session_recording=disabled must not start a recording")
 	st, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
 	require.NoError(t, err)
@@ -154,7 +155,7 @@ func TestConfigE2E_SessionRecordingGateControlsRecording(t *testing.T) {
 
 	// Auto via the real command: the gate creates a recording with a transcript.
 	oxConfigSetRepo(t, "session_recording", "auto")
-	status := startSessionRecording(f.projectRoot, agentID, "claude-code", "")
+	status := startSessionRecording(f.projectRoot, agentID, "claude-code", "", "")
 	require.NotNil(t, status, "session_recording=auto must start a recording")
 	assert.True(t, status.Recording, "auto must actually record")
 	st2, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
@@ -162,6 +163,60 @@ func TestConfigE2E_SessionRecordingGateControlsRecording(t *testing.T) {
 	require.NotNil(t, st2, "auto must persist recording state")
 	assert.FileExists(t, filepath.Join(st2.SessionPath, "raw.jsonl"),
 		"auto must create the session transcript on disk")
+}
+
+// TestConfigE2E_ResumeLinksNewRecordingToPriorSession exercises the durable
+// resume handoff: a native coding-agent session marker survives SessionEnd,
+// and a later prime uses its prior ses_ identity to link the new recording.
+func TestConfigE2E_ResumeLinksNewRecordingToPriorSession(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	t.Chdir(f.projectRoot)
+	cfg = &config.Config{}
+	oxConfigSetRepo(t, "session_recording", "auto")
+
+	const (
+		agentID        = "OxResume"
+		agentSessionID = "claude-resume-fixture"
+	)
+	t.Cleanup(func() { _ = DeleteSessionMarker(agentSessionID) })
+
+	firstStatus := startSessionRecording(f.projectRoot, agentID, "claude-code", "", "")
+	require.NotNil(t, firstStatus)
+	first, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	marker := &SessionMarker{
+		AgentID:            agentID,
+		RecordingSessionID: first.SessionID,
+		AgentSessionID:     agentSessionID,
+		PrimedAt:           time.Now(),
+	}
+	require.NoError(t, WriteSessionMarker(marker))
+
+	// SessionEnd finalizes the first recording and clears its active state.
+	// Removing the cache directory models the daemon's successful upload/prune.
+	_, err = session.StopRecording(f.projectRoot, agentID)
+	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(first.SessionPath))
+
+	resumedMarker, err := ReadSessionMarker(agentSessionID)
+	require.NoError(t, err)
+	continuedFrom := recordingSessionIDFromMarker(resumedMarker)
+	secondStatus := startSessionRecording(f.projectRoot, agentID, "claude-code", "", continuedFrom)
+	require.NotNil(t, secondStatus)
+	second, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+
+	assert.NotEqual(t, first.SessionID, second.SessionID, "each finalized half keeps its own identity")
+	assert.Equal(t, first.SessionID, second.ContinuedFromSessionID)
+
+	stored, err := session.ReadSessionFromPath(filepath.Join(second.SessionPath, "raw.jsonl"))
+	require.NoError(t, err)
+	require.NotNil(t, stored.Meta)
+	assert.Equal(t, first.SessionID, stored.Meta.ContinuedFromSessionID,
+		"continuation must survive loss of the ephemeral recording state")
 }
 
 // TestConfigE2E_CloudQueryGateControlsTheNetworkDecision proves the privacy

--- a/cmd/ox/docs.go
+++ b/cmd/ox/docs.go
@@ -22,6 +22,7 @@ func runDocsGenerate(cmd *cobra.Command, args []string) error {
 	output, _ := cmd.Flags().GetString("output")
 
 	fmt.Printf("Generating documentation to %s...\n", output)
+	prepareDocsCommandTree(rootCmd)
 
 	// Create temp directory for raw Cobra output
 	tmpDir, err := os.MkdirTemp("", "ox-docs-*")
@@ -71,6 +72,22 @@ func runDocsGenerate(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("Documentation generated successfully")
 	return nil
+}
+
+// prepareDocsCommandTree makes documentation generation independent of local
+// feature flags and cached server settings. Reference docs describe the public,
+// released CLI surface; experimental commands stay out until their gates are
+// removed from the command registration itself.
+func prepareDocsCommandTree(root *cobra.Command) {
+	root.CompletionOptions.DisableDefaultCmd = true
+	for _, child := range root.Commands() {
+		switch child.Name() {
+		case "attest", "scout", "memory", "completion":
+			root.RemoveCommand(child)
+		case "carts", "cart-analyze":
+			child.Hidden = true
+		}
+	}
 }
 
 // syncPackageVersion updates docs/package.json version to match CLI version

--- a/cmd/ox/docs_test.go
+++ b/cmd/ox/docs_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestPrepareDocsCommandTreeExcludesExperimentalCommands(t *testing.T) {
+	root := &cobra.Command{Use: "ox"}
+	attest := &cobra.Command{Use: "attest"}
+	scout := &cobra.Command{Use: "scout"}
+	memory := &cobra.Command{Use: "memory"}
+	completion := &cobra.Command{Use: "completion"}
+	carts := &cobra.Command{Use: "carts"}
+	cartAnalyze := &cobra.Command{Use: "cart-analyze"}
+	root.AddCommand(attest, scout, memory, carts, cartAnalyze, completion)
+
+	prepareDocsCommandTree(root)
+
+	for _, command := range []*cobra.Command{attest, scout, memory, completion} {
+		if commandRegistered(root, command) {
+			t.Errorf("%s command remains registered", command.Name())
+		}
+	}
+	if !carts.Hidden {
+		t.Error("carts command is visible")
+	}
+	if !cartAnalyze.Hidden {
+		t.Error("cart-analyze command is visible")
+	}
+	if !root.CompletionOptions.DisableDefaultCmd {
+		t.Error("default completion command remains enabled")
+	}
+}

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -475,6 +475,9 @@ func writeRetryUploadMeta(
 		// prefers a preserved meta.json id over minting a new one — so it
 		// is authoritative and never rotates across retries.
 		next.SessionID = sessionID
+		if orphan.Meta.ContinuedFromSessionID != "" {
+			next.ContinuedFromSessionID = orphan.Meta.ContinuedFromSessionID
+		}
 
 		// fields this retry actually owns
 		next.Model = orphan.Meta.Model

--- a/cmd/ox/prime_session_marker.go
+++ b/cmd/ox/prime_session_marker.go
@@ -39,11 +39,12 @@ func SessionMarkerDir() string {
 //   - Idempotency: re-priming the same session reuses the ox agent ID
 //   - Hook context: agent_hook.go reads markers to pass agent state to handlers
 type SessionMarker struct {
-	AgentID        string    `json:"agent_id"`
-	SessionID      string    `json:"session_id,omitempty"` // ox-generated server session ID
-	AgentSessionID string    `json:"agent_session_id"`     // coding agent's native session identifier
-	PrimedAt       time.Time `json:"primed_at"`            // when session was primed
-	ParentPID      int       `json:"parent_pid,omitempty"` // parent agent process ID
+	AgentID            string    `json:"agent_id"`
+	SessionID          string    `json:"session_id,omitempty"`           // ox-generated agent-instance server session ID
+	RecordingSessionID string    `json:"recording_session_id,omitempty"` // durable ses_ recording ID for resume linkage
+	AgentSessionID     string    `json:"agent_session_id"`               // coding agent's native session identifier
+	PrimedAt           time.Time `json:"primed_at"`                      // when session was primed
+	ParentPID          int       `json:"parent_pid,omitempty"`           // parent agent process ID
 }
 
 // AgentHookInput is an alias for agentx.HookInput.

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-08-25
+
+Resumed work stays connected, team rules recover reliably, and SageOx uses one calm visual language everywhere.
+
+### Improved
+
+- **Resumed AI coworker sessions stay connected** — a new recording keeps a durable link to the session it continues, including through drafts, recovery, and upload retries.
+- **The CLI and documentation stay in sync** — CI now detects generated-reference drift, the complete stable command set is published, and the docs workflow can use a dedicated package credential when repository permissions are insufficient.
+- **SageOx has one consistent palette** — CLI, TUI, plans, demos, and documentation now share an all-sage brand palette, reserving gold for warnings and using accessible light and dark variants.
+
+### Fixed
+
+- **Device login works with opaque session credentials** — the login flow uses the credential returned by device authentication to fetch identity while continuing to store the exchanged API token.
+- **Team rules survive sparse-checkout recovery** — fallback manifests include the `agents/` directory, so repositories without a usable manifest still materialize shared AI coworker guidance.
+
 ## [0.14.1] - 2026-08-25
 
 Decision context holds up in real plans, visual plans stay readable and recoverable, and routine Git workflows are safer.

--- a/cmd/ox/session_draft_publish.go
+++ b/cmd/ox/session_draft_publish.go
@@ -156,18 +156,19 @@ func publishDraftPlaceholder(projectRoot, ledgerPath, sessionName string, state 
 	sessionDir := draftLedgerSessionDir(ledgerPath, sessionName)
 
 	input := lfs.DraftInput{
-		SessionName: sessionName,
-		SessionID:   state.SessionID,
-		Username:    identity.AttributionDisplayName(ep, config.GetDisplayName()),
-		UserID:      auth.GetUserID(ep),
-		RepoID:      getRepoIDOrDefault(projectRoot),
-		AgentID:     state.AgentID,
-		AgentType:   state.AdapterName,
-		Model:       state.Model,
-		CreatedAt:   state.StartedAt,
-		TurnCount:   state.TurnCount,
-		EntryCount:  state.EntryCount,
-		Now:         time.Now(),
+		SessionName:            sessionName,
+		SessionID:              state.SessionID,
+		ContinuedFromSessionID: state.ContinuedFromSessionID,
+		Username:               identity.AttributionDisplayName(ep, config.GetDisplayName()),
+		UserID:                 auth.GetUserID(ep),
+		RepoID:                 getRepoIDOrDefault(projectRoot),
+		AgentID:                state.AgentID,
+		AgentType:              state.AdapterName,
+		Model:                  state.Model,
+		CreatedAt:              state.StartedAt,
+		TurnCount:              state.TurnCount,
+		EntryCount:             state.EntryCount,
+		Now:                    time.Now(),
 	}
 
 	// Bounded so a wedged flock on meta.json (a concurrent finalize holding it)

--- a/cmd/ox/session_stop.go
+++ b/cmd/ox/session_stop.go
@@ -173,16 +173,17 @@ func processSession(projectRoot string, state *session.RecordingState) (*process
 	// carrier of the start-minted ID on this reconstruct path too (daemon
 	// orphan-finalize recovers it from here when meta.json was never written)
 	meta := &session.StoreMeta{
-		Version:      "1.0",
-		SessionID:    state.SessionID,
-		CreatedAt:    state.StartedAt,
-		AgentID:      state.AgentID,
-		AgentType:    agentTypeForMeta,
-		AgentVersion: result.AgentVersion,
-		Model:        result.Model,
-		Username:     identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
-		RepoID:       repoID,
-		OxVersion:    version.Version,
+		Version:                "1.0",
+		SessionID:              state.SessionID,
+		ContinuedFromSessionID: state.ContinuedFromSessionID,
+		CreatedAt:              state.StartedAt,
+		AgentID:                state.AgentID,
+		AgentType:              agentTypeForMeta,
+		AgentVersion:           result.AgentVersion,
+		Model:                  result.Model,
+		Username:               identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
+		RepoID:                 repoID,
+		OxVersion:              version.Version,
 	}
 	if err := rawWriter.WriteHeader(meta); err != nil {
 		rawWriter.Close()

--- a/demo/mock/claude
+++ b/demo/mock/claude
@@ -17,12 +17,12 @@
 
 RUST='\033[38;2;199;122;80m'
 RB='\033[1;38;2;199;122;80m'
-GOLD='\033[38;2;224;165;106m'
-GB='\033[1;38;2;224;165;106m'
+HILITE='\033[38;2;173;207;163m'
+HB='\033[1;38;2;173;207;163m'
 DM='\033[38;2;143;153;163m'
 B='\033[1m'
 R='\033[0m'
-SAGE='\033[38;2;122;143;120m'
+SAGE='\033[38;2;122;170;119m'
 
 while [[ "${1:-}" == --* ]]; do shift; done
 
@@ -32,7 +32,7 @@ printf "${RB}✻ Claude Code${R}   ${DM}sonnet · /Users/oxy/code/myproject${R}\
 printf "${RUST}────────────────────────────────────────────────────────────${R}\n"
 printf "  ${B}Welcome back, Oxy!${R}  🐮\n"
 echo ""
-printf "${DM}Running ${R}${GOLD}ox agent prime${R}${DM}…${R}\n"
+printf "${DM}Running ${R}${HILITE}ox agent prime${R}${DM}…${R}\n"
 sleep 0.7
 printf "${SAGE}✓${R} Team context loaded · ${DM}14 prior sessions${R} · ${SAGE}recording this session${R}\n"
 echo ""
@@ -44,8 +44,8 @@ echo ""
 sleep 1.2
 printf "Live from your coworkers — ${B}in-flight work, before anything's pushed${R}:\n"
 echo ""
-printf "  ${SAGE}●${R} ${B}Ravi${R}   ${GOLD}Codex${R}        rate limiting on the gateway     ${DM}murmured 8m ago${R}\n"
-printf "  ${SAGE}●${R} ${B}Mira${R}   ${GOLD}Claude Code${R}  refactoring internal/auth/session.go  ${DM}3m ago${R}\n"
+printf "  ${SAGE}●${R} ${B}Ravi${R}   ${HILITE}Codex${R}        rate limiting on the gateway     ${DM}murmured 8m ago${R}\n"
+printf "  ${SAGE}●${R} ${B}Mira${R}   ${HILITE}Claude Code${R}  refactoring internal/auth/session.go  ${DM}3m ago${R}\n"
 printf "  ${DM}●${R} ${B}you${R}    ${DM}—${R}            this session\n"
 echo ""
 printf "Nobody's committed, merged, or opened a PR — ${B}yet you can already see it${R}.\n"
@@ -58,8 +58,8 @@ echo ""
 sleep 1.2
 printf "SageOx surfaced prior work — ${B}across agents, machines, and teammates${R}:\n"
 echo ""
-printf "  ${DM}session${R}     rate-limiter-spike     ${GOLD}Codex${R} · Ravi's laptop · ${DM}4 days ago${R}\n"
-printf "  ${DM}session${R}     rl-followup            ${GOLD}Claude Code${R} · your session · ${DM}2 days ago${R}\n"
+printf "  ${DM}session${R}     rate-limiter-spike     ${HILITE}Codex${R} · Ravi's laptop · ${DM}4 days ago${R}\n"
+printf "  ${DM}session${R}     rl-followup            ${HILITE}Claude Code${R} · your session · ${DM}2 days ago${R}\n"
 printf "  ${DM}discussion${R}  \"Rate Limiting Approach\"   ${DM}Ravi + you · recorded at sageox.ai${R}\n"
 echo ""
 printf "You and Ravi landed on a ${B}token-bucket backed by Redis${R} — Ravi's Codex\n"
@@ -75,7 +75,7 @@ printf "On it — letting the team know I'm in here.\n"
 printf "${SAGE}✓${R} ${DM}Murmured:${R} \"adding rate limiting to the auth endpoints\"\n"
 echo ""
 sleep 1.8
-printf "  ${GOLD}↩ Mira just murmured${R} ${DM}— \"refactoring internal/auth/session.go right now\"${R}\n"
+printf "  ${HILITE}↩ Mira just murmured${R} ${DM}— \"refactoring internal/auth/session.go right now\"${R}\n"
 echo ""
 sleep 1.5
 printf "${B}Heads up from SageOx:${R} Mira's live in that file. I'll stay clear and\n"
@@ -84,11 +84,11 @@ echo ""
 sleep 1.5
 printf "${DM}Plan ready — SageOx enriched it from team context:${R}\n"
 echo ""
-printf "  ${GB}⚡${R} ${B}2 collisions${R} in open PRs   ${DM}handler.go (PR #1847 · Ravi), session.go (Mira)${R}\n"
-printf "  ${GB}↺${R} ${B}prior art${R}            ${DM}\"Rate Limiting Approach\" — token-bucket spec${R}\n"
-printf "  ${GB}◆${R} ${B}expert${R}               ${DM}Ravi owns rate limiting${R}\n"
+printf "  ${HB}⚡${R} ${B}2 collisions${R} in open PRs   ${DM}handler.go (PR #1847 · Ravi), session.go (Mira)${R}\n"
+printf "  ${HB}↺${R} ${B}prior art${R}            ${DM}\"Rate Limiting Approach\" — token-bucket spec${R}\n"
+printf "  ${HB}◆${R} ${B}expert${R}               ${DM}Ravi owns rate limiting${R}\n"
 echo ""
-printf "  ${DM}Review it:${R} ${GOLD}ox plan render --open${R}\n"
+printf "  ${DM}Review it:${R} ${HILITE}ox plan render --open${R}\n"
 echo ""
 
 printf " ${RUST}❯${R} "

--- a/demo/mock/ox
+++ b/demo/mock/ox
@@ -9,10 +9,10 @@
 #   export PATH="$(pwd)/demo/mock:$PATH"
 
 # Colors (ox CLI dark theme - true color)
-G='\033[38;2;122;143;120m'      # sage green (success/primary)
-GB='\033[1;38;2;122;143;120m'   # sage green bold (section headers)
-C='\033[38;2;224;165;106m'      # copper gold (secondary/commands)
-CB='\033[1;38;2;224;165;106m'   # copper gold bold
+G='\033[38;2;122;170;119m'      # sage green (success/primary)
+GB='\033[1;38;2;122;170;119m'   # sage green bold (section headers)
+S='\033[38;2;173;207;163m'      # sage emphasis (secondary/commands)
+SB='\033[1;38;2;173;207;163m'   # sage emphasis bold
 DM='\033[38;2;143;153;163m'     # dim gray
 B='\033[1m'                      # bold
 R='\033[0m'                      # reset
@@ -31,7 +31,7 @@ mock_login() {
     echo ""
     printf "${G}✓${R} Git credentials synced\n"
     echo ""
-    printf "${C}✦${R} Next: ${C}ox init${R} — initialize SageOx in this repo\n"
+    printf "${S}✦${R} Next: ${S}ox init${R} — initialize SageOx in this repo\n"
 }
 
 mock_init() {
@@ -68,10 +68,10 @@ mock_init() {
     echo "════════════════════════════════════════════════════════════"
     echo ""
     printf "${GB}NEXT STEPS${R}\n"
-    printf "  1. Commit .sageox/:  ${C}git add .sageox/ && git commit${R}\n"
-    printf "  2. Verify setup:     ${C}ox doctor${R}\n"
+    printf "  1. Commit .sageox/:  ${S}git add .sageox/ && git commit${R}\n"
+    printf "  2. Verify setup:     ${S}ox doctor${R}\n"
     echo ""
-    printf "${DM}Your AI coworker auto-runs ${R}${C}ox agent prime${R}${DM} at session start.${R}\n"
+    printf "${DM}Your AI coworker auto-runs ${R}${S}ox agent prime${R}${DM} at session start.${R}\n"
 }
 
 mock_doctor() {
@@ -92,7 +92,7 @@ mock_doctor() {
     sleep 0.1
     printf "${G}✓${R} Redaction policy    active\n"
     echo ""
-    printf "${G}All checks passed.${R} ${DM}Run ${R}${C}ox doctor --fix${R}${DM} if any check is ever red.${R}\n"
+    printf "${G}All checks passed.${R} ${DM}Run ${R}${S}ox doctor --fix${R}${DM} if any check is ever red.${R}\n"
 }
 
 mock_status() {
@@ -117,7 +117,7 @@ mock_status() {
     printf "Status            ${G}✓ running, syncing${R} (pid 20966)\n"
     printf "Syncing           ${B}2 workspace(s)${R}\n"
     echo ""
-    printf "${C}✦${R} Ask your AI coworker about prior sessions — context loads on ${C}ox agent prime${R}\n"
+    printf "${S}✦${R} Ask your AI coworker about prior sessions — context loads on ${S}ox agent prime${R}\n"
 }
 
 mock_agent_prime() {

--- a/docs/design/theming.md
+++ b/docs/design/theming.md
@@ -42,8 +42,8 @@ Mechanism in code:
 ```go
 // internal/theme/generated.go (synced from sageox-design)
 ColorPrimary = compat.AdaptiveColor{
-    Light: lipgloss.Color("#4F6A48"),
-    Dark:  lipgloss.Color("#7A8F78"),
+    Light: lipgloss.Color("#3D643B"),
+    Dark:  lipgloss.Color("#7AAA77"),
 }
 ```
 
@@ -58,11 +58,11 @@ lipgloss v1 downsampled inside `Style.Render()`. **lipgloss v2 does not** — `R
 Skipping that step is not a cosmetic downgrade. A terminal without 24-bit support — macOS Terminal.app, or anything reporting `TERM=xterm-256color` with no `COLORTERM` — does not ignore an unrecognized `38;2;…`; it parses the parameters as independent SGR codes. Any channel landing in 100–107 becomes a **background** color:
 
 ```text
-#E0A56A  →  ESC[38;2;224;165;106m  →  224, 165, and 106 read separately
+#12346A  →  ESC[38;2;18;52;106m  →  18, 52, and 106 read separately
                                        106 = bright-cyan background
 ```
 
-That is how brand copper turned the `ox --help` command column and the login disclaimer into unreadable grey-on-cyan blocks. Other tokens sit one step from the same trap (`#2DD4BF` starts `0x2D` = 45 = magenta background), so the fix is the conversion, not a safer hex.
+That is how a prior brand color turned the `ox --help` command column and the login disclaimer into unreadable grey-on-cyan blocks. Other tokens sit one step from the same trap (`#2DD4BF` starts `0x2D` = 45 = magenta background), so the fix is the conversion, not a safer hex.
 
 | Profile | Emits | Typical terminal |
 |---|---|---|

--- a/docs/design/tokens.md
+++ b/docs/design/tokens.md
@@ -6,17 +6,17 @@ Semantic color tokens are the unit of design composition in ox. Components refer
 
 | Token | Light | Dark | When to use |
 |-------|-------|------|-------------|
-| `ColorPrimary` | `#4F6A48` | `#7A8F78` | App name, headers, spinners — the calm sage anchor |
-| `ColorSecondary` | `#B87D3A` | `#E0A56A` | Commands, interactive elements — copper highlight |
-| `ColorAccent` | `#3D5437` | `#8FA888` | File paths, callouts, "look here" |
+| `ColorPrimary` | `#3D643B` | `#7AAA77` | App name, headers, spinners — the calm sage anchor |
+| `ColorSecondary` | `#324F31` | `#ADCFA3` | Commands and selected elements — strongest sage emphasis, not a second brand hue |
+| `ColorAccent` | `#4E7D4C` | `#99C693` | File paths, callouts, "look here" |
 
 ## Semantic
 
 | Token | Light | Dark | When to use |
 |-------|-------|------|-------------|
-| `ColorSuccess` | `#4F6A48` | `#7A8F78` | Passed checks, confirmations |
-| `ColorWarning` | `#B87D3A` | `#E0A56A` | Cautions, dirty builds, soft warnings |
-| `ColorError` | `#A03030` | `#E07070` | Failures, blocked items, hard stops |
+| `ColorSuccess` | `#3D643B` | `#7AAA77` | Passed checks, confirmations |
+| `ColorWarning` | `#A5842F` | `#D9B654` | Cautions, dirty builds, soft warnings |
+| `ColorError` | `#9F4838` | `#D77E6C` | Failures, blocked items, hard stops |
 | `ColorInfo` | `#5580A0` | `#7FA7C8` | Flags, links, informational notes |
 | `ColorDim` | `#6B7580` | `#8F99A3` | Descriptions, secondary text, "still here but quiet" |
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,5 +13,5 @@
     "type": "git",
     "url": "https://github.com/sageox/ox.git"
   },
-  "version": "0.14.1"
+  "version": "0.14.2"
 }

--- a/docs/reference/adapter/index.mdx
+++ b/docs/reference/adapter/index.mdx
@@ -40,4 +40,3 @@ Discover, install, remove, and inspect ox adapter binaries that connect AI cowor
 * [ox adapter remove](/adapter/remove)	 - Remove an installed adapter
 * [ox adapter unlink](/adapter/unlink)	 - Remove a symlinked adapter
 * [ox adapter verify](/adapter/verify)	 - Run compliance tests against an adapter
-

--- a/docs/reference/adapter/info.mdx
+++ b/docs/reference/adapter/info.mdx
@@ -32,4 +32,3 @@ ox adapter info <name> [flags]
 ### SEE ALSO
 
 * [ox adapter](/adapter)	 - Manage external adapter binaries
-

--- a/docs/reference/adapter/install.mdx
+++ b/docs/reference/adapter/install.mdx
@@ -45,4 +45,3 @@ ox adapter install <name|github-url> [flags]
 ### SEE ALSO
 
 * [ox adapter](/adapter)	 - Manage external adapter binaries
-

--- a/docs/reference/adapter/link.mdx
+++ b/docs/reference/adapter/link.mdx
@@ -41,4 +41,3 @@ ox adapter link <path> [flags]
 ### SEE ALSO
 
 * [ox adapter](/adapter)	 - Manage external adapter binaries
-

--- a/docs/reference/adapter/list.mdx
+++ b/docs/reference/adapter/list.mdx
@@ -32,4 +32,3 @@ ox adapter list [flags]
 ### SEE ALSO
 
 * [ox adapter](/adapter)	 - Manage external adapter binaries
-

--- a/docs/reference/adapter/reload.mdx
+++ b/docs/reference/adapter/reload.mdx
@@ -32,4 +32,3 @@ ox adapter reload [flags]
 ### SEE ALSO
 
 * [ox adapter](/adapter)	 - Manage external adapter binaries
-

--- a/docs/reference/adapter/remove.mdx
+++ b/docs/reference/adapter/remove.mdx
@@ -32,4 +32,3 @@ ox adapter remove <name> [flags]
 ### SEE ALSO
 
 * [ox adapter](/adapter)	 - Manage external adapter binaries
-

--- a/docs/reference/adapter/unlink.mdx
+++ b/docs/reference/adapter/unlink.mdx
@@ -36,4 +36,3 @@ ox adapter unlink <name> [flags]
 ### SEE ALSO
 
 * [ox adapter](/adapter)	 - Manage external adapter binaries
-

--- a/docs/reference/adapter/verify.mdx
+++ b/docs/reference/adapter/verify.mdx
@@ -37,4 +37,3 @@ ox adapter verify <name> [flags]
 ### SEE ALSO
 
 * [ox adapter](/adapter)	 - Manage external adapter binaries
-

--- a/docs/reference/code/activity.mdx
+++ b/docs/reference/code/activity.mdx
@@ -42,4 +42,3 @@ ox code activity [flags]
 ### SEE ALSO
 
 * [ox code](/code)	 - Search code in this repo
-

--- a/docs/reference/code/index.mdx
+++ b/docs/reference/code/index.mdx
@@ -33,4 +33,3 @@ ox code index [url] [flags]
 ### SEE ALSO
 
 * [ox code](/code)	 - Search code in this repo
-

--- a/docs/reference/code/insights.mdx
+++ b/docs/reference/code/insights.mdx
@@ -34,4 +34,3 @@ ox code insights [flags]
 ### SEE ALSO
 
 * [ox code](/code)	 - Search code in this repo
-

--- a/docs/reference/code/prs.mdx
+++ b/docs/reference/code/prs.mdx
@@ -68,4 +68,3 @@ ox code prs [flags]
 ### SEE ALSO
 
 * [ox code](/code)	 - Search code in this repo
-

--- a/docs/reference/code/search.mdx
+++ b/docs/reference/code/search.mdx
@@ -35,4 +35,3 @@ ox code search <query> [flags]
 ### SEE ALSO
 
 * [ox code](/code)	 - Search code in this repo
-

--- a/docs/reference/code/status.mdx
+++ b/docs/reference/code/status.mdx
@@ -32,4 +32,3 @@ ox code status [flags]
 ### SEE ALSO
 
 * [ox code](/code)	 - Search code in this repo
-

--- a/docs/reference/conversation/index.mdx
+++ b/docs/reference/conversation/index.mdx
@@ -55,4 +55,3 @@ ox conversation [flags]
 * [ox conversation topic](/conversation/topic)	 - Show one distillation topic's atoms
 * [ox conversation topics](/conversation/topics)	 - List a conversation's distillation topics
 * [ox conversation transcript](/conversation/transcript)	 - Read a transcript slice by cue range or time window
-

--- a/docs/reference/conversation/list.mdx
+++ b/docs/reference/conversation/list.mdx
@@ -40,4 +40,3 @@ ox conversation list [flags]
 ### SEE ALSO
 
 * [ox conversation](/conversation)	 - Read recorded team conversations from the local Team Context
-

--- a/docs/reference/conversation/show.mdx
+++ b/docs/reference/conversation/show.mdx
@@ -38,4 +38,3 @@ ox conversation show <id> [flags]
 ### SEE ALSO
 
 * [ox conversation](/conversation)	 - Read recorded team conversations from the local Team Context
-

--- a/docs/reference/conversation/topic.mdx
+++ b/docs/reference/conversation/topic.mdx
@@ -39,4 +39,3 @@ ox conversation topic <id> <tp_id> [flags]
 ### SEE ALSO
 
 * [ox conversation](/conversation)	 - Read recorded team conversations from the local Team Context
-

--- a/docs/reference/conversation/topics.mdx
+++ b/docs/reference/conversation/topics.mdx
@@ -38,4 +38,3 @@ ox conversation topics <id> [flags]
 ### SEE ALSO
 
 * [ox conversation](/conversation)	 - Read recorded team conversations from the local Team Context
-

--- a/docs/reference/conversation/transcript.mdx
+++ b/docs/reference/conversation/transcript.mdx
@@ -50,4 +50,3 @@ ox conversation transcript <id> [flags]
 ### SEE ALSO
 
 * [ox conversation](/conversation)	 - Read recorded team conversations from the local Team Context
-

--- a/docs/reference/decision/index.mdx
+++ b/docs/reference/decision/index.mdx
@@ -43,4 +43,3 @@ LLM/network cost; every citation it emits resolves.
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
 * [ox decision enrich](/decision/enrich)	 - Enrich a Decision Record (or DR topic) with team context (JSON by default)
-

--- a/docs/reference/distill/history/index.mdx
+++ b/docs/reference/distill/history/index.mdx
@@ -47,4 +47,3 @@ ox distill history [flags]
 * [ox distill history list](/distill/history/list)	 - List distilled summary entries in a window
 * [ox distill history show](/distill/history/show)	 - Show one or more distilled summary entries by id
 * [ox distill history since](/distill/history/since)	 - Dump distilled summary entries from the last `<duration>`
-

--- a/docs/reference/distill/history/list.mdx
+++ b/docs/reference/distill/history/list.mdx
@@ -40,4 +40,3 @@ ox distill history list [flags]
 ### SEE ALSO
 
 * [ox distill history](/distill/history)	 - Inspect distilled daily/weekly/monthly summary entries
-

--- a/docs/reference/distill/history/show.mdx
+++ b/docs/reference/distill/history/show.mdx
@@ -34,4 +34,3 @@ ox distill history show <id>... [flags]
 ### SEE ALSO
 
 * [ox distill history](/distill/history)	 - Inspect distilled daily/weekly/monthly summary entries
-

--- a/docs/reference/distill/history/since.mdx
+++ b/docs/reference/distill/history/since.mdx
@@ -37,4 +37,3 @@ ox distill history since <duration> [flags]
 ### SEE ALSO
 
 * [ox distill history](/distill/history)	 - Inspect distilled daily/weekly/monthly summary entries
-

--- a/docs/reference/distill/index.mdx
+++ b/docs/reference/distill/index.mdx
@@ -58,4 +58,3 @@ ox distill [flags]
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
 * [ox distill history](/distill/history)	 - Inspect distilled daily/weekly/monthly summary entries
-

--- a/docs/reference/doctor.mdx
+++ b/docs/reference/doctor.mdx
@@ -43,4 +43,3 @@ ox doctor [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/export.mdx
+++ b/docs/reference/export.mdx
@@ -51,4 +51,3 @@ ox export [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/gc.mdx
+++ b/docs/reference/gc.mdx
@@ -32,4 +32,3 @@ ox gc [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/glance.mdx
+++ b/docs/reference/glance.mdx
@@ -47,4 +47,3 @@ ox glance [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/guide.mdx
+++ b/docs/reference/guide.mdx
@@ -47,4 +47,3 @@ ox guide [topic] [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/hooks/add.mdx
+++ b/docs/reference/hooks/add.mdx
@@ -58,4 +58,3 @@ ox hooks add <event> <command> [flags]
 ### SEE ALSO
 
 * [ox hooks](/hooks)	 - Manage event hooks for daemon notifications
-

--- a/docs/reference/hooks/index.mdx
+++ b/docs/reference/hooks/index.mdx
@@ -47,4 +47,3 @@ Git/CI hooks (backward compat, prefer 'ox agent hooks'):
 * [ox hooks list](/hooks/list)	 - List registered event hooks
 * [ox hooks log](/hooks/log)	 - Show how to view hook execution logs
 * [ox hooks test](/hooks/test)	 - Fire a synthetic event to test hooks
-

--- a/docs/reference/hooks/list.mdx
+++ b/docs/reference/hooks/list.mdx
@@ -36,4 +36,3 @@ ox hooks list [flags]
 ### SEE ALSO
 
 * [ox hooks](/hooks)	 - Manage event hooks for daemon notifications
-

--- a/docs/reference/hooks/log.mdx
+++ b/docs/reference/hooks/log.mdx
@@ -36,4 +36,3 @@ ox hooks log [flags]
 ### SEE ALSO
 
 * [ox hooks](/hooks)	 - Manage event hooks for daemon notifications
-

--- a/docs/reference/hooks/test.mdx
+++ b/docs/reference/hooks/test.mdx
@@ -43,4 +43,3 @@ ox hooks test <event> [flags]
 ### SEE ALSO
 
 * [ox hooks](/hooks)	 - Manage event hooks for daemon notifications
-

--- a/docs/reference/import.mdx
+++ b/docs/reference/import.mdx
@@ -67,4 +67,3 @@ ox import <file|url> [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -45,6 +45,7 @@ Shared team context between your AI and human coworkers. Sessions, ledgers, and 
 * [ox logout](/logout)	 - Log out of SageOx
 * [ox murmur](/murmur)	 - Publish a coordination signal to other AI coworkers
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
+* [ox pr](/pr)	 - Author SageOx content for pull requests
 * [ox query](/query)	 - Search team knowledge
 * [ox recap](/recap)	 - Show the concrete value SageOx has delivered to your work
 * [ox release-notes](/release-notes)	 - Display release notes for the current version
@@ -55,4 +56,3 @@ Shared team context between your AI and human coworkers. Sessions, ledgers, and 
 * [ox uninstall](/uninstall)	 - Remove SageOx from this repository
 * [ox upgrade](/upgrade)	 - Upgrade ox to the latest version
 * [ox viz](/viz)	 - Choose, author, render, and lint visual explanations
-

--- a/docs/reference/index/code.mdx
+++ b/docs/reference/index/code.mdx
@@ -33,4 +33,3 @@ ox index code [url] [flags]
 ### SEE ALSO
 
 * [ox index](/index)	 - Index code and project data for search
-

--- a/docs/reference/index/github.mdx
+++ b/docs/reference/index/github.mdx
@@ -48,4 +48,3 @@ ox index github [flags]
 ### SEE ALSO
 
 * [ox index](/index)	 - Index code and project data for search
-

--- a/docs/reference/index/index.mdx
+++ b/docs/reference/index/index.mdx
@@ -47,4 +47,3 @@ ox index [flags]
 * [ox index code](/index/code)	 - Index git history (commits, symbols, diffs)
 * [ox index github](/index/github)	 - Index GitHub PRs and issues
 * [ox index status](/index/status)	 - Show index status (alias for 'ox code status')
-

--- a/docs/reference/index/status.mdx
+++ b/docs/reference/index/status.mdx
@@ -32,4 +32,3 @@ ox index status [flags]
 ### SEE ALSO
 
 * [ox index](/index)	 - Index code and project data for search
-

--- a/docs/reference/init.mdx
+++ b/docs/reference/init.mdx
@@ -62,4 +62,3 @@ ox init [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/kb/describe.mdx
+++ b/docs/reference/kb/describe.mdx
@@ -49,4 +49,3 @@ ox kb describe <#slug|kb_id> [flags]
 ### SEE ALSO
 
 * [ox kb](/kb)	 - Work with knowledge bubbles
-

--- a/docs/reference/kb/index.mdx
+++ b/docs/reference/kb/index.mdx
@@ -43,4 +43,3 @@ Use `ox kb list` to see the bubbles you can access and
 * [ox kb describe](/kb/describe)	 - Describe a knowledge bubble
 * [ox kb list](/kb/list)	 - List knowledge bubbles you can access
 * [ox kb query](/kb/query)	 - Search files across knowledge bubbles
-

--- a/docs/reference/kb/list.mdx
+++ b/docs/reference/kb/list.mdx
@@ -50,4 +50,3 @@ ox kb list [flags]
 ### SEE ALSO
 
 * [ox kb](/kb)	 - Work with knowledge bubbles
-

--- a/docs/reference/kb/query.mdx
+++ b/docs/reference/kb/query.mdx
@@ -58,4 +58,3 @@ ox kb query <#slug|kb_id> [#slug|kb_id ...] "<question>" [flags]
 ### SEE ALSO
 
 * [ox kb](/kb)	 - Work with knowledge bubbles
-

--- a/docs/reference/login.mdx
+++ b/docs/reference/login.mdx
@@ -37,4 +37,3 @@ ox login [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/logout.mdx
+++ b/docs/reference/logout.mdx
@@ -39,4 +39,3 @@ ox logout [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/murmur/delete.mdx
+++ b/docs/reference/murmur/delete.mdx
@@ -43,4 +43,3 @@ ox murmur delete <murmur-id> [flags]
 ### SEE ALSO
 
 * [ox murmur](/murmur)	 - Publish a coordination signal to other AI coworkers
-

--- a/docs/reference/murmur/index.mdx
+++ b/docs/reference/murmur/index.mdx
@@ -56,4 +56,3 @@ ox murmur [content] [flags]
 * [ox murmur pause](/murmur/pause)	 - Pause murmur nudging for this session
 * [ox murmur resume](/murmur/resume)	 - Resume murmur nudging for this session
 * [ox murmur status](/murmur/status)	 - Show murmur delivery status and per-coworker rate limit state
-

--- a/docs/reference/murmur/list.mdx
+++ b/docs/reference/murmur/list.mdx
@@ -53,4 +53,3 @@ ox murmur list [topic] [flags]
 ### SEE ALSO
 
 * [ox murmur](/murmur)	 - Publish a coordination signal to other AI coworkers
-

--- a/docs/reference/murmur/pause.mdx
+++ b/docs/reference/murmur/pause.mdx
@@ -37,4 +37,3 @@ ox murmur pause [flags]
 ### SEE ALSO
 
 * [ox murmur](/murmur)	 - Publish a coordination signal to other AI coworkers
-

--- a/docs/reference/murmur/resume.mdx
+++ b/docs/reference/murmur/resume.mdx
@@ -37,4 +37,3 @@ ox murmur resume [flags]
 ### SEE ALSO
 
 * [ox murmur](/murmur)	 - Publish a coordination signal to other AI coworkers
-

--- a/docs/reference/murmur/status.mdx
+++ b/docs/reference/murmur/status.mdx
@@ -43,4 +43,3 @@ ox murmur status [flags]
 ### SEE ALSO
 
 * [ox murmur](/murmur)	 - Publish a coordination signal to other AI coworkers
-

--- a/docs/reference/plan/abandon.mdx
+++ b/docs/reference/plan/abandon.mdx
@@ -37,4 +37,3 @@ ox plan abandon <slug> [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/plan/approve.mdx
+++ b/docs/reference/plan/approve.mdx
@@ -38,4 +38,3 @@ ox plan approve <slug> [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/plan/enrich.mdx
+++ b/docs/reference/plan/enrich.mdx
@@ -50,4 +50,3 @@ ox plan enrich [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -63,4 +63,3 @@ inline review loop — those are human-opt-in, never auto-run.
 * [ox plan supersede](/plan/supersede)	 - Mark a saved plan superseded by a successor plan
 * [ox plan view](/plan/view)	 - Read a saved plan in the terminal
 * [ox plan work](/plan/work)	 - Record that a coding session worked on a saved plan
-

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -32,4 +32,3 @@ ox plan list [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/plan/realize.mdx
+++ b/docs/reference/plan/realize.mdx
@@ -42,4 +42,3 @@ ox plan realize <slug> [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/plan/render.mdx
+++ b/docs/reference/plan/render.mdx
@@ -56,4 +56,3 @@ ox plan render [slug] [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/plan/review/await.mdx
+++ b/docs/reference/plan/review/await.mdx
@@ -56,4 +56,3 @@ ox plan review await <slug> [flags]
 ### SEE ALSO
 
 * [ox plan review](/plan/review)	 - Open a live review loop for a saved plan (serve, collect, auto-reload, approve)
-

--- a/docs/reference/plan/review/index.mdx
+++ b/docs/reference/plan/review/index.mdx
@@ -50,4 +50,3 @@ ox plan review <slug> [flags]
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
 * [ox plan review await](/plan/review/await)	 - Block until reviewers submit feedback, then print open items as JSON (agent loop)
-

--- a/docs/reference/plan/status.mdx
+++ b/docs/reference/plan/status.mdx
@@ -38,4 +38,3 @@ ox plan status <slug> [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/plan/supersede.mdx
+++ b/docs/reference/plan/supersede.mdx
@@ -39,4 +39,3 @@ ox plan supersede <slug> [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/plan/view.mdx
+++ b/docs/reference/plan/view.mdx
@@ -32,4 +32,3 @@ ox plan view <slug> [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/plan/work.mdx
+++ b/docs/reference/plan/work.mdx
@@ -39,4 +39,3 @@ ox plan work <slug> [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
-

--- a/docs/reference/pr/header.mdx
+++ b/docs/reference/pr/header.mdx
@@ -1,0 +1,65 @@
+---
+title: "ox pr header"
+description: "CLI reference for ox pr header"
+sidebar_position: 73
+---
+
+## ox pr header
+
+Emit the SageOx credit line for the top of a PR description
+
+### Synopsis
+
+Emit a thin, on-brand credit line to paste at the very TOP of a pull-request
+description body — the human-facing counterpart to the 'SageOx-Session:' trailer.
+
+It names the team, links the session(s) and plan(s) that produced the change,
+and whispers a subtle enrichment stat. Paste the output above your description;
+keep the 'SageOx-Session:' trailer at the bottom.
+
+The line is built from the primitives that survive GitHub's PR-body sanitizer
+(a theme-adaptive <picture> wordmark, real <a> links, a <sub> caption) and
+degrades cleanly: no session, no plan, and no enrichment each still render.
+
+Examples:
+  # Auto-link the current session; no enrichment
+  ox pr header
+
+  # Link two plans the session produced, with enrichment counts
+  ox pr header --plan pln_4d8e2f --plan pln_1a6b9c --prior-art 2 --collisions 1
+
+  # Write straight into a PR body file (never a heredoc — it mangles the markup)
+  ox pr header > body.md && cat description.md >> body.md
+  gh pr create --body-file body.md
+
+```
+ox pr header [flags]
+```
+
+### Options
+
+```
+      --allow-unconfirmed     accept links that may not be server-visible yet — the current session before upload, and explicit --session/--plan refs — without a warning (may 404)
+      --collisions int        enrichment: concurrent edits flagged
+  -h, --help                  help for header
+      --no-stat               suppress the enrichment whisper
+      --plan stringArray      plan URL or pln_ id to link (repeatable)
+      --prior-art int         enrichment: related sessions surfaced
+      --session stringArray   session URL or ses_ id to link (repeatable; defaults to the current session)
+      --style string          whisper render: text | image | auto (default: pr_visuals.style)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox pr](/pr)	 - Author SageOx content for pull requests

--- a/docs/reference/pr/index.mdx
+++ b/docs/reference/pr/index.mdx
@@ -1,33 +1,30 @@
 ---
-title: "ox upgrade"
-description: "CLI reference for ox upgrade"
-sidebar_position: 99
+title: "ox pr"
+description: "CLI reference for ox pr"
+sidebar_position: 72
 ---
 
-## ox upgrade
+## ox pr
 
-Upgrade ox to the latest version
+Author SageOx content for pull requests
 
 ### Synopsis
 
-Detect how ox was installed and upgrade using the appropriate method: Homebrew, go install, or an in-place download that verifies and replaces the binary.
+Author SageOx content that goes into a pull request.
 
-```
-ox upgrade [flags]
-```
+Distinct from 'ox code prs', which lists indexed PRs for triage.
 
 ### Options
 
 ```
-  -h, --help            help for upgrade
-      --json            output as JSON
-      --target string   pin upgrade to a specific version tag (e.g. v0.18.0); empty = latest from GitHub releases API
+  -h, --help   help for pr
 ```
 
 ### Options inherited from parent commands
 
 ```
   -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
@@ -37,3 +34,4 @@ ox upgrade [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
+* [ox pr header](/pr/header)	 - Emit the SageOx credit line for the top of a PR description

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox query"
 description: "CLI reference for ox query"
-sidebar_position: 72
+sidebar_position: 74
 ---
 
 ## ox query
@@ -57,4 +57,3 @@ ox query [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/recap.mdx
+++ b/docs/reference/recap.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox recap"
 description: "CLI reference for ox recap"
-sidebar_position: 73
+sidebar_position: 75
 ---
 
 ## ox recap
@@ -47,4 +47,3 @@ ox recap [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox release-notes"
 description: "CLI reference for ox release-notes"
-sidebar_position: 74
+sidebar_position: 76
 ---
 
 ## ox release-notes
@@ -38,4 +38,3 @@ ox release-notes [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session audit"
 description: "CLI reference for ox session audit"
-sidebar_position: 77
+sidebar_position: 78
 ---
 
 ## ox session audit
@@ -57,4 +57,3 @@ ox session audit [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session"
 description: "CLI reference for ox session"
-sidebar_position: 76
+sidebar_position: 77
 ---
 
 ## ox session
@@ -54,4 +54,3 @@ Commands:
 * [ox session stop](/session/stop)	 - Stop a recording session
 * [ox session token-optimize](/session/token-optimize)	 - Compress a session raw.jsonl for summarization (streaming, deterministic)
 * [ox session view](/session/view)	 - View a session
-

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session lint"
 description: "CLI reference for ox session lint"
-sidebar_position: 78
+sidebar_position: 79
 ---
 
 ## ox session lint
@@ -53,4 +53,3 @@ ox session lint [session-name] [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session list"
 description: "CLI reference for ox session list"
-sidebar_position: 79
+sidebar_position: 80
 ---
 
 ## ox session list
@@ -58,4 +58,3 @@ ox session list [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/prune.mdx
+++ b/docs/reference/session/prune.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session prune"
 description: "CLI reference for ox session prune"
-sidebar_position: 80
+sidebar_position: 81
 ---
 
 ## ox session prune
@@ -60,4 +60,3 @@ ox session prune [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session redact"
 description: "CLI reference for ox session redact"
-sidebar_position: 81
+sidebar_position: 82
 ---
 
 ## ox session redact
@@ -68,4 +68,3 @@ ox session redact [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session regenerate"
 description: "CLI reference for ox session regenerate"
-sidebar_position: 82
+sidebar_position: 83
 ---
 
 ## ox session regenerate
@@ -64,4 +64,3 @@ ox session regenerate [session-name] [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session repair-meta-summary"
 description: "CLI reference for ox session repair-meta-summary"
-sidebar_position: 83
+sidebar_position: 84
 ---
 
 ## ox session repair-meta-summary
@@ -60,4 +60,3 @@ ox session repair-meta-summary [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session score"
 description: "CLI reference for ox session score"
-sidebar_position: 84
+sidebar_position: 85
 ---
 
 ## ox session score
@@ -52,4 +52,3 @@ ox session score [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session status"
 description: "CLI reference for ox session status"
-sidebar_position: 85
+sidebar_position: 86
 ---
 
 ## ox session status
@@ -48,4 +48,3 @@ ox session status [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session stop"
 description: "CLI reference for ox session stop"
-sidebar_position: 86
+sidebar_position: 87
 ---
 
 ## ox session stop
@@ -45,4 +45,3 @@ ox session stop [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session token-optimize"
 description: "CLI reference for ox session token-optimize"
-sidebar_position: 87
+sidebar_position: 88
 ---
 
 ## ox session token-optimize
@@ -48,4 +48,3 @@ ox session token-optimize <session-name> [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session view"
 description: "CLI reference for ox session view"
-sidebar_position: 88
+sidebar_position: 89
 ---
 
 ## ox session view
@@ -54,4 +54,3 @@ ox session view [session-name] [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
-

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox status"
 description: "CLI reference for ox status"
-sidebar_position: 89
+sidebar_position: 90
 ---
 
 ## ox status
@@ -39,4 +39,3 @@ ox status [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox sync"
 description: "CLI reference for ox sync"
-sidebar_position: 90
+sidebar_position: 91
 ---
 
 ## ox sync
@@ -58,4 +58,3 @@ ox sync [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/team/index.mdx
+++ b/docs/reference/team/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team"
 description: "CLI reference for ox team"
-sidebar_position: 91
+sidebar_position: 92
 ---
 
 ## ox team
@@ -53,4 +53,3 @@ ox team [flags]
 * [ox team members](/team/members)	 - List the team's coworkers (humans and AI coworkers)
 * [ox team open](/team/open)	 - Open a team's dashboard in the browser
 * [ox team show](/team/show)	 - Show one team's details
-

--- a/docs/reference/team/invite.mdx
+++ b/docs/reference/team/invite.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team invite"
 description: "CLI reference for ox team invite"
-sidebar_position: 92
+sidebar_position: 93
 ---
 
 ## ox team invite
@@ -57,4 +57,3 @@ ox team invite [email]... [flags]
 ### SEE ALSO
 
 * [ox team](/team)	 - Work with your teams and coworkers
-

--- a/docs/reference/team/list.mdx
+++ b/docs/reference/team/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team list"
 description: "CLI reference for ox team list"
-sidebar_position: 93
+sidebar_position: 94
 ---
 
 ## ox team list
@@ -40,4 +40,3 @@ ox team list [flags]
 ### SEE ALSO
 
 * [ox team](/team)	 - Work with your teams and coworkers
-

--- a/docs/reference/team/members.mdx
+++ b/docs/reference/team/members.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team members"
 description: "CLI reference for ox team members"
-sidebar_position: 94
+sidebar_position: 95
 ---
 
 ## ox team members
@@ -53,4 +53,3 @@ ox team members [flags]
 ### SEE ALSO
 
 * [ox team](/team)	 - Work with your teams and coworkers
-

--- a/docs/reference/team/open.mdx
+++ b/docs/reference/team/open.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team open"
 description: "CLI reference for ox team open"
-sidebar_position: 95
+sidebar_position: 96
 ---
 
 ## ox team open
@@ -41,4 +41,3 @@ ox team open [team] [flags]
 ### SEE ALSO
 
 * [ox team](/team)	 - Work with your teams and coworkers
-

--- a/docs/reference/team/show.mdx
+++ b/docs/reference/team/show.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team show"
 description: "CLI reference for ox team show"
-sidebar_position: 96
+sidebar_position: 97
 ---
 
 ## ox team show
@@ -47,4 +47,3 @@ ox team show [team] [flags]
 ### SEE ALSO
 
 * [ox team](/team)	 - Work with your teams and coworkers
-

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox uninstall"
 description: "CLI reference for ox uninstall"
-sidebar_position: 97
+sidebar_position: 98
 ---
 
 ## ox uninstall
@@ -79,4 +79,3 @@ ox uninstall [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
-

--- a/docs/reference/viz/index.mdx
+++ b/docs/reference/viz/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz"
 description: "CLI reference for ox viz"
-sidebar_position: 99
+sidebar_position: 100
 ---
 
 ## ox viz
@@ -48,4 +48,3 @@ ox viz [id] [flags]
 * [ox viz pr](/viz/pr)	 - Prepare a GitHub-compatible visualization for a pull request
 * [ox viz render](/viz/render)	 - Render a parameterized visualization from JSON data
 * [ox viz suggest](/viz/suggest)	 - Suggest visual patterns for what you need to explain
-

--- a/docs/reference/viz/lint.mdx
+++ b/docs/reference/viz/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz lint"
 description: "CLI reference for ox viz lint"
-sidebar_position: 100
+sidebar_position: 101
 ---
 
 ## ox viz lint
@@ -33,4 +33,3 @@ ox viz lint <file> [flags]
 ### SEE ALSO
 
 * [ox viz](/viz)	 - Choose, author, render, and lint visual explanations
-

--- a/docs/reference/viz/pr.mdx
+++ b/docs/reference/viz/pr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz pr"
 description: "CLI reference for ox viz pr"
-sidebar_position: 101
+sidebar_position: 102
 ---
 
 ## ox viz pr
@@ -37,4 +37,3 @@ ox viz pr [flags]
 ### SEE ALSO
 
 * [ox viz](/viz)	 - Choose, author, render, and lint visual explanations
-

--- a/docs/reference/viz/render.mdx
+++ b/docs/reference/viz/render.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz render"
 description: "CLI reference for ox viz render"
-sidebar_position: 102
+sidebar_position: 103
 ---
 
 ## ox viz render
@@ -39,4 +39,3 @@ ox viz render <id> [flags]
 ### SEE ALSO
 
 * [ox viz](/viz)	 - Choose, author, render, and lint visual explanations
-

--- a/docs/reference/viz/suggest.mdx
+++ b/docs/reference/viz/suggest.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz suggest"
 description: "CLI reference for ox viz suggest"
-sidebar_position: 103
+sidebar_position: 104
 ---
 
 ## ox viz suggest
@@ -33,4 +33,3 @@ ox viz suggest <intent> [flags]
 ### SEE ALSO
 
 * [ox viz](/viz)	 - Choose, author, render, and lint visual explanations
-

--- a/docs/specs/cli-design-system.md
+++ b/docs/specs/cli-design-system.md
@@ -10,17 +10,17 @@ Colors are sourced from `sageox-design` and generated into `internal/theme/gener
 
 | Token | Dark Mode | Light Mode | Usage |
 |-------|-----------|------------|-------|
-| Primary | `#7A8F78` | `#4F6A48` | Brand identity, headers, spinners |
-| Secondary | `#E0A56A` | `#B87D3A` | Commands, interactive elements |
-| Accent | `#8FA888` | `#3D5437` | File paths, callouts, highlights |
+| Primary | `#7AAA77` | `#3D643B` | Brand identity, headers, spinners |
+| Secondary | `#ADCFA3` | `#324F31` | Commands, interactive elements; strongest sage emphasis |
+| Accent | `#99C693` | `#4E7D4C` | File paths, callouts, highlights |
 
 ### Semantic Colors
 
 | Token | Dark Mode | Light Mode | Usage |
 |-------|-----------|------------|-------|
-| Success | `#7A8F78` | `#4F6A48` | Passed checks, confirmations |
-| Warning | `#E0A56A` | `#B87D3A` | Cautions, dirty builds |
-| Error | `#E07070` | `#A03030` | Failures, critical issues |
+| Success | `#7AAA77` | `#3D643B` | Passed checks, confirmations |
+| Warning | `#D9B654` | `#A5842F` | Cautions, dirty builds |
+| Error | `#D77E6C` | `#9F4838` | Failures, critical issues |
 | Info | `#7FA7C8` | `#5580A0` | Informational, flags, links |
 | Dim | `#8F99A3` | `#6B7580` | Secondary text, descriptions |
 
@@ -30,8 +30,8 @@ All colors use `lipgloss.AdaptiveColor` for automatic light/dark terminal detect
 
 ```go
 ColorPrimary = compat.AdaptiveColor{
-    Light: lipgloss.Color("#4F6A48"),
-    Dark:  lipgloss.Color("#7A8F78"),
+    Light: lipgloss.Color("#3D643B"),
+    Dark:  lipgloss.Color("#7AAA77"),
 }
 ```
 

--- a/docs/specs/plan-authoring-html.md
+++ b/docs/specs/plan-authoring-html.md
@@ -97,7 +97,7 @@ like a generic dev-tool doc instead of a SageOx one.
 
 **Colour carries one meaning each**, and never carries it alone — every hue is
 paired with a label or glyph: sage = aligns/shipped, gold = gate, amber =
-hold/warn, red = risk/blocker, teal = team context. **Copper is retired**
+hold/warn, red = risk/blocker, teal = team context. **The old warm brand accent is retired**
 (DDR-010, the green-black rebrand); gold, from the `warning` ramp, is its
 successor. Do not introduce a second brand hue.
 

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -212,8 +212,9 @@ func Login(ctx context.Context, deviceCode *DeviceCodeResponse, statusCallback f
 				refreshToken = jwtToken.RefreshToken
 			}
 
-			// fetch user info using JWT
-			userInfo, err := fetchUserInfo(client, apiURL, accessToken)
+			// Userinfo is part of the device flow and authenticates with the opaque
+			// session credential. The exchanged JWT is for SageOx API requests.
+			userInfo, err := fetchUserInfo(client, apiURL, token.AccessToken)
 			if err != nil {
 				return fmt.Errorf("failed to fetch user info: %w", err)
 			}
@@ -578,8 +579,9 @@ func (c *AuthClient) Login(ctx context.Context, deviceCode *DeviceCodeResponse, 
 				refreshToken = jwtToken.RefreshToken
 			}
 
-			// fetch user info using JWT
-			userInfo, err := fetchUserInfo(httpClient, apiURL, accessToken)
+			// Userinfo is part of the device flow and authenticates with the opaque
+			// session credential. The exchanged JWT is for SageOx API requests.
+			userInfo, err := fetchUserInfo(httpClient, apiURL, token.AccessToken)
 			if err != nil {
 				return fmt.Errorf("failed to fetch user info: %w", err)
 			}

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -159,7 +159,7 @@ func TestLogin_Success(t *testing.T) {
 		if r.URL.Path == UserInfoEndpoint {
 			// verify authorization header
 			auth := r.Header.Get("Authorization")
-			assert.Equal(t, "Bearer test-jwt-token", auth)
+			assert.Equal(t, "Bearer test-access-token", auth)
 
 			json.NewEncoder(w).Encode(UserInfo{
 				UserID: "user-123",

--- a/internal/badge/badge.go
+++ b/internal/badge/badge.go
@@ -19,8 +19,8 @@ import (
 
 const (
 	// BadgeMarkdown is the markdown snippet for the SageOx badge.
-	// Uses shields.io with SageOx brand sage green (#7A8F78).
-	BadgeMarkdown = `[![powered by SageOx](https://img.shields.io/badge/powered%20by-SageOx-7A8F78?labelColor=555)](https://github.com/sageox/ox)`
+	// Uses shields.io with SageOx brand sage green (#7AAA77).
+	BadgeMarkdown = `[![powered by SageOx](https://img.shields.io/badge/powered%20by-SageOx-7AAA77?labelColor=555)](https://github.com/sageox/ox)`
 
 	// StatusNotAsked indicates badge has not been suggested yet.
 	StatusNotAsked = ""

--- a/internal/badge/badge_test.go
+++ b/internal/badge/badge_test.go
@@ -223,7 +223,7 @@ func TestFindBadgeInsertionPoint(t *testing.T) {
 func TestBadgeMarkdown(t *testing.T) {
 	// verify badge contains expected elements
 	assert.Contains(t, BadgeMarkdown, "powered%20by-SageOx", "BadgeMarkdown should contain 'powered by SageOx'")
-	assert.Contains(t, BadgeMarkdown, "7A8F78", "BadgeMarkdown should contain SageOx brand color")
+	assert.Contains(t, BadgeMarkdown, "7AAA77", "BadgeMarkdown should contain SageOx brand color")
 	assert.Contains(t, BadgeMarkdown, "github.com/sageox/ox", "BadgeMarkdown should link to ox repo")
 }
 

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -8,8 +8,8 @@ import (
 
 // SageOx brand color palette (unified, CLI-optimized)
 // Primary: Sage green - earthy, wise, calm
-// Secondary: Copper gold - premium, trustworthy
-// Accent: Forest green - depth, nature
+// Secondary: strongest sage step - selected, interactive
+// Accent: sage callout step - paths, highlights
 // AdaptiveColor automatically adjusts for light/dark terminals
 //
 // Colors are sourced from the sageox-design system.

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -1374,6 +1374,9 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 		next.AgentID = agentID
 		next.AgentType = agentType
 		next.SessionID = sessionIDForMeta
+		if stored.Meta != nil && stored.Meta.ContinuedFromSessionID != "" {
+			next.ContinuedFromSessionID = stored.Meta.ContinuedFromSessionID
+		}
 
 		// Clear the draft placeholder markers (ADR-029). MANDATORY on this
 		// path, not defensive: `next := current` above deliberately preserves
@@ -1849,7 +1852,7 @@ func (h *SessionFinalizeHandler) gitCommitPointerRewrite(payload *SessionFinaliz
 func (h *SessionFinalizeHandler) synthesizeMeta(sessionDir, sessionName string) *lfs.SessionMeta {
 	rawPath := filepath.Join(sessionDir, "raw.jsonl")
 
-	var agentID, agentType, username, headerSessionID string
+	var agentID, agentType, username, headerSessionID, continuedFromSessionID string
 	var createdAt time.Time
 	if stored, err := session.ReadSessionFromPath(rawPath); err == nil && stored != nil && stored.Meta != nil {
 		agentID = stored.Meta.AgentID
@@ -1857,6 +1860,7 @@ func (h *SessionFinalizeHandler) synthesizeMeta(sessionDir, sessionName string) 
 		username = stored.Meta.Username
 		createdAt = stored.Meta.CreatedAt
 		headerSessionID = stored.Meta.SessionID
+		continuedFromSessionID = stored.Meta.ContinuedFromSessionID
 	}
 	// Crash-safe carrier read: a recording written by an older writer can fail
 	// to parse into StoreMeta while its raw first line still carries the ID.
@@ -1878,6 +1882,7 @@ func (h *SessionFinalizeHandler) synthesizeMeta(sessionDir, sessionName string) 
 	// recording already had — exactly what ResolveOrMintSessionID exists to stop.
 	return lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).
 		SessionID(session.ResolveOrMintSessionID("", headerSessionID)).
+		ContinuedFromSessionID(continuedFromSessionID).
 		StopReason(session.StopReasonRecovered).
 		Build()
 }
@@ -2317,6 +2322,9 @@ func recoverRawFromSessionFile(logger *slog.Logger, recPath, sessionDir, rawPath
 	}
 	if state.SessionID != "" {
 		metaFields["session_id"] = state.SessionID
+	}
+	if state.ContinuedFromSessionID != "" {
+		metaFields["continued_from_session_id"] = state.ContinuedFromSessionID
 	}
 	header := map[string]any{
 		"_meta": metaFields,

--- a/internal/daemon/agentwork/session_finalize_session_id_test.go
+++ b/internal/daemon/agentwork/session_finalize_session_id_test.go
@@ -29,6 +29,7 @@ import (
 //   - The preserved ID comes from an actual meta.json written via the
 //     same lfs.NewSessionMeta/WriteSessionMetaOnly path production uses.
 func TestWriteMetaAndUploadLFS_SessionIDPrecedence(t *testing.T) {
+	continuedFromSessionID := sessionid.GenerateSessionID()
 	tests := []struct {
 		name string
 		// preservedID, when non-empty, is written into a pre-existing
@@ -85,10 +86,10 @@ func TestWriteMetaAndUploadLFS_SessionIDPrecedence(t *testing.T) {
 			if tt.headerID != "" {
 				sessionIDField = fmt.Sprintf(`,"session_id":%q`, tt.headerID)
 			}
-			rawContent := fmt.Sprintf(`{"type":"header","metadata":{"version":"1.0","agent_id":"Ox7f3a","agent_type":"claude-code"%s}}
+			rawContent := fmt.Sprintf(`{"type":"header","metadata":{"version":"1.0","agent_id":"Ox7f3a","agent_type":"claude-code","continued_from_session_id":%q%s}}
 {"type":"user","content":"hello","seq":1}
 {"type":"assistant","content":"hi","seq":2}
-`, sessionIDField)
+`, continuedFromSessionID, sessionIDField)
 			rawPath := filepath.Join(sessionDir, "raw.jsonl")
 			if err := os.WriteFile(rawPath, []byte(rawContent), 0o644); err != nil {
 				t.Fatal(err)
@@ -129,6 +130,9 @@ func TestWriteMetaAndUploadLFS_SessionIDPrecedence(t *testing.T) {
 			meta, err := lfs.ReadSessionMeta(sessionDir)
 			if err != nil {
 				t.Fatalf("ReadSessionMeta after writeMetaAndUploadLFS: %v", err)
+			}
+			if meta.ContinuedFromSessionID != continuedFromSessionID {
+				t.Errorf("ContinuedFromSessionID = %q, want %q", meta.ContinuedFromSessionID, continuedFromSessionID)
 			}
 
 			switch {

--- a/internal/daemon/sync_team_clone_test.go
+++ b/internal/daemon/sync_team_clone_test.go
@@ -112,7 +112,7 @@ func TestApplySparseCheckout_FallbackWithFilePatterns(t *testing.T) {
 		"TEAM.md":   "# Team\n",
 		"MEMORY.md": "# Memory\n",
 	}
-	fallbackDirs := []string{"docs", "memory", "coworkers", ".sageox"}
+	fallbackDirs := []string{"docs", "memory", "agents", "coworkers", ".sageox"}
 	for _, dir := range fallbackDirs {
 		require.NoError(t, os.MkdirAll(filepath.Join(teamDir, dir), 0755))
 		require.NoError(t, os.WriteFile(
@@ -150,6 +150,7 @@ func TestApplySparseCheckout_FallbackWithFilePatterns(t *testing.T) {
 	// verify directory patterns too
 	assert.Contains(t, sparseList, "docs/", "directory patterns must work in sparse-checkout")
 	assert.Contains(t, sparseList, "memory/", "directory patterns must work in sparse-checkout")
+	assert.Contains(t, sparseList, "agents/", "team rules must work in sparse-checkout")
 }
 
 func TestTwoPhaseClone_Success(t *testing.T) {
@@ -208,7 +209,9 @@ func TestTwoPhaseClone_NoManifest(t *testing.T) {
 	isolateCredentials(t)
 
 	// no manifest content — should use fallback
-	bareDir := setupTeamContextBareRepo(t, "", nil)
+	bareDir := setupTeamContextBareRepo(t, "", map[string]string{
+		"agents/rules/review.md": "# Team review rules\n",
+	})
 	cloneURL := "file://" + bareDir
 
 	projectDir := setupProjectWithConfig(t, "")
@@ -228,6 +231,7 @@ func TestTwoPhaseClone_NoManifest(t *testing.T) {
 	assert.FileExists(t, filepath.Join(targetDir, "SOUL.md"))
 	assert.FileExists(t, filepath.Join(targetDir, "TEAM.md"))
 	assert.FileExists(t, filepath.Join(targetDir, "memory", "notes.md"))
+	assert.FileExists(t, filepath.Join(targetDir, "agents", "rules", "review.md"))
 }
 
 func TestTwoPhaseClone_DeniedPathsExcluded(t *testing.T) {

--- a/internal/dashboard/overlays/help/help.go
+++ b/internal/dashboard/overlays/help/help.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 
+	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/dashboard/overlays"
 	"github.com/sageox/ox/internal/dashboard/theme"
 )
@@ -102,7 +103,7 @@ func (o *Overlay) View(width, height int) string {
 
 	keyStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#E0A56A")). // copper gold — matches NavSelectedStyle intent
+		Foreground(cli.ColorSecondary).
 		Width(14)
 	descStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#AAAAAA"))

--- a/internal/docs/postprocess.go
+++ b/internal/docs/postprocess.go
@@ -195,6 +195,18 @@ func transformFile(srcPath, destPath string, sidebarPosition int) error {
 	scanner := bufio.NewScanner(srcFile)
 	writer := bufio.NewWriter(destFile)
 	defer writer.Flush()
+	pendingBlankLines := 0
+	writeLine := func(line string) {
+		if line == "" {
+			pendingBlankLines++
+			return
+		}
+		for range pendingBlankLines {
+			writer.WriteString("\n")
+		}
+		pendingBlankLines = 0
+		writer.WriteString(line + "\n")
+	}
 
 	// Track frontmatter processing
 	inFrontmatter := false
@@ -212,14 +224,14 @@ func transformFile(srcPath, destPath string, sidebarPosition int) error {
 		// Detect frontmatter boundaries
 		if lineNum == 1 && strings.TrimSpace(line) == "---" {
 			inFrontmatter = true
-			writer.WriteString(line + "\n")
+			writeLine(line)
 			continue
 		}
 
 		if inFrontmatter && strings.TrimSpace(line) == "---" {
 			// End of frontmatter, add sidebar_position before closing
-			fmt.Fprintf(writer, "sidebar_position: %d\n", sidebarPosition)
-			writer.WriteString(line + "\n")
+			writeLine(fmt.Sprintf("sidebar_position: %d", sidebarPosition))
+			writeLine(line)
 			inFrontmatter = false
 			frontmatterEnded = true
 			continue
@@ -227,7 +239,7 @@ func transformFile(srcPath, destPath string, sidebarPosition int) error {
 
 		// If we're in frontmatter, write line as-is
 		if inFrontmatter {
-			writer.WriteString(line + "\n")
+			writeLine(line)
 			continue
 		}
 
@@ -242,7 +254,7 @@ func transformFile(srcPath, destPath string, sidebarPosition int) error {
 			})
 		}
 
-		writer.WriteString(line + "\n")
+		writeLine(line)
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -70,6 +70,10 @@ type SessionMeta struct {
 	//     and silently break dedup/lookup.
 	SessionID string `json:"session_id,omitempty"`
 
+	// ContinuedFromSessionID links this recording to the prior finalized
+	// recording created for the same native coding-agent session.
+	ContinuedFromSessionID string `json:"continued_from_session_id,omitempty"`
+
 	AgentType           string     `json:"agent_type"` // "claude-code", "cursor", etc.
 	Model               string     `json:"model,omitempty"`
 	Title               string     `json:"title,omitempty"`
@@ -584,6 +588,13 @@ func (b *SessionMetaBuilder) LinkageStatus(status string) *SessionMetaBuilder {
 // round-trip.
 func (b *SessionMetaBuilder) SessionID(id string) *SessionMetaBuilder {
 	b.meta.SessionID = id
+	return b
+}
+
+// ContinuedFromSessionID links this recording to the prior finalized half of
+// the same native coding-agent session.
+func (b *SessionMetaBuilder) ContinuedFromSessionID(id string) *SessionMetaBuilder {
+	b.meta.ContinuedFromSessionID = id
 	return b
 }
 

--- a/internal/lfs/meta_draft.go
+++ b/internal/lfs/meta_draft.go
@@ -55,18 +55,19 @@ const draftBlockingFile = "raw.jsonl"
 // session is being shared. The server renders drafts by session name and
 // counters; that is sufficient and it is safe.
 type DraftInput struct {
-	SessionName string
-	SessionID   string // ses_<UUIDv7> minted at StartRecording — REQUIRED
-	Username    string // privacy-safe display name via identity.AttributionDisplayName(); never an email
-	UserID      string
-	RepoID      string
-	AgentID     string
-	AgentType   string
-	Model       string
-	CreatedAt   time.Time
-	TurnCount   int
-	EntryCount  int
-	Now         time.Time
+	SessionName            string
+	SessionID              string // ses_<UUIDv7> minted at StartRecording — REQUIRED
+	ContinuedFromSessionID string
+	Username               string // privacy-safe display name via identity.AttributionDisplayName(); never an email
+	UserID                 string
+	RepoID                 string
+	AgentID                string
+	AgentType              string
+	Model                  string
+	CreatedAt              time.Time
+	TurnCount              int
+	EntryCount             int
+	Now                    time.Time
 }
 
 // Validate checks the required identity fields. A draft without a valid
@@ -79,6 +80,9 @@ func (in DraftInput) Validate() error {
 	}
 	if !sessionid.IsValidSessionID(in.SessionID) {
 		return fmt.Errorf("draft requires a valid ses_ session id, got %q", in.SessionID)
+	}
+	if in.ContinuedFromSessionID != "" && !sessionid.IsValidSessionID(in.ContinuedFromSessionID) {
+		return fmt.Errorf("draft continuation requires a valid ses_ session id, got %q", in.ContinuedFromSessionID)
 	}
 	return nil
 }
@@ -141,23 +145,28 @@ func WriteDraftSessionMeta(ctx context.Context, sessionDir string, in DraftInput
 		if current != nil && current.SessionID != "" {
 			sessionID = current.SessionID
 		}
+		continuedFromSessionID := in.ContinuedFromSessionID
+		if current != nil && current.ContinuedFromSessionID != "" {
+			continuedFromSessionID = current.ContinuedFromSessionID
+		}
 
 		next := &SessionMeta{
-			Version:     "1.0",
-			SessionName: in.SessionName,
-			SessionID:   sessionID,
-			Username:    in.Username,
-			UserID:      in.UserID,
-			RepoID:      in.RepoID,
-			AgentID:     in.AgentID,
-			AgentType:   in.AgentType,
-			Model:       in.Model,
-			CreatedAt:   in.CreatedAt,
-			EntryCount:  in.EntryCount,
-			Draft:       true,
-			TurnCount:   in.TurnCount,
-			UpdatedAt:   &now,
-			Files:       map[string]FileRef{},
+			Version:                "1.0",
+			SessionName:            in.SessionName,
+			SessionID:              sessionID,
+			ContinuedFromSessionID: continuedFromSessionID,
+			Username:               in.Username,
+			UserID:                 in.UserID,
+			RepoID:                 in.RepoID,
+			AgentID:                in.AgentID,
+			AgentType:              in.AgentType,
+			Model:                  in.Model,
+			CreatedAt:              in.CreatedAt,
+			EntryCount:             in.EntryCount,
+			Draft:                  true,
+			TurnCount:              in.TurnCount,
+			UpdatedAt:              &now,
+			Files:                  map[string]FileRef{},
 		}
 		if current != nil && !current.CreatedAt.IsZero() {
 			next.CreatedAt = current.CreatedAt

--- a/internal/lfs/meta_draft_test.go
+++ b/internal/lfs/meta_draft_test.go
@@ -277,6 +277,21 @@ func TestWriteDraftSessionMeta_PreservesPublishedSessionID(t *testing.T) {
 	assert.Equal(t, 12, meta.TurnCount, "counters still advance")
 }
 
+func TestWriteDraftSessionMeta_PreservesPublishedContinuation(t *testing.T) {
+	dir := t.TempDir()
+	initial := draftInputFixture("s")
+	initial.ContinuedFromSessionID = "ses_01950000-0000-7000-8000-000000000002"
+	require.NoError(t, WriteDraftSessionMeta(context.Background(), dir, initial))
+
+	refresh := draftInputFixture("s")
+	refresh.TurnCount = 12
+	require.NoError(t, WriteDraftSessionMeta(context.Background(), dir, refresh))
+
+	meta, err := ReadSessionMeta(dir)
+	require.NoError(t, err)
+	assert.Equal(t, initial.ContinuedFromSessionID, meta.ContinuedFromSessionID)
+}
+
 // TestWriteDraftSessionMeta_CountersAreMonotonic.
 //
 // RecordingState is an unlocked load-modify-save, so a lost increment is
@@ -334,7 +349,8 @@ func TestWriteDraftSessionMeta_RequiresValidSessionID(t *testing.T) {
 // than in review.
 func TestDraftInput_CarriesNoTranscriptDerivedText(t *testing.T) {
 	allowed := map[string]bool{
-		"SessionName": true, "SessionID": true, "Username": true, "UserID": true,
+		"SessionName": true, "SessionID": true, "ContinuedFromSessionID": true,
+		"Username": true, "UserID": true,
 		"RepoID": true, "AgentID": true, "AgentType": true, "Model": true,
 		"CreatedAt": true, "TurnCount": true, "EntryCount": true, "Now": true,
 	}

--- a/internal/lfs/meta_test.go
+++ b/internal/lfs/meta_test.go
@@ -225,6 +225,7 @@ func TestSessionMeta_LinkageFieldsRoundTrip(t *testing.T) {
 	meta := NewSessionMeta("linked-session", "user", "Ox1234", "claude-code",
 		time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)).
 		RepoID("repo_xyz").
+		ContinuedFromSessionID("ses_019f6f6a-d182-7f4e-a54d-8dcb44567c8d").
 		ProducedCommits([]string{"abc1234", "def5678"}).
 		LinkedPRs([]string{"https://github.com/owner/repo/pull/42"}).
 		LinkedIssues([]string{"#101", "#103"}).
@@ -239,6 +240,7 @@ func TestSessionMeta_LinkageFieldsRoundTrip(t *testing.T) {
 	assert.Equal(t, []string{"https://github.com/owner/repo/pull/42"}, got.LinkedPRs)
 	assert.Equal(t, []string{"#101", "#103"}, got.LinkedIssues)
 	assert.Equal(t, LinkageStatusUploaded, got.LinkageStatus)
+	assert.Equal(t, meta.ContinuedFromSessionID, got.ContinuedFromSessionID)
 }
 
 // TestSessionMeta_LegacyWithoutLinkageFields verifies a meta.json written

--- a/internal/manifest/fallback.go
+++ b/internal/manifest/fallback.go
@@ -35,6 +35,7 @@ var teamContextFallbackIncludes = []string{
 	"AGENTS.md",
 	"memory/",
 	"docs/",
+	"agents/",
 	"coworkers/",
 	"discussions/", // all discussion artifacts synced by cloud pipeline
 	"agent-context/",

--- a/internal/manifest/fallback_test.go
+++ b/internal/manifest/fallback_test.go
@@ -20,7 +20,7 @@ func TestFallbackConfigFor_KB(t *testing.T) {
 	assert.ElementsMatch(t, []string{".sageox/", "AGENTS.md", "knowledge/"}, cfg.Includes,
 		"kb fallback must be exactly control-plane + AGENTS.md + knowledge/")
 
-	for _, teamOnly := range []string{"SOUL.md", "TEAM.md", "MEMORY.md", "memory/", "docs/", "coworkers/", "discussions/", "agent-context/"} {
+	for _, teamOnly := range []string{"SOUL.md", "TEAM.md", "MEMORY.md", "memory/", "docs/", "agents/", "coworkers/", "discussions/", "agent-context/"} {
 		assert.NotContains(t, cfg.Includes, teamOnly,
 			"kb fallback must not inherit team-context path %q", teamOnly)
 	}
@@ -36,6 +36,7 @@ func TestFallbackConfigFor_TeamContext(t *testing.T) {
 
 	assert.Contains(t, cfg.Includes, "SOUL.md")
 	assert.Contains(t, cfg.Includes, "discussions/")
+	assert.Contains(t, cfg.Includes, "agents/", "team rules must survive manifest fallback")
 	assert.NotContains(t, cfg.Includes, "knowledge/",
 		"team-context fallback must not include the bubble knowledge/ tree")
 }

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -313,7 +313,7 @@ func TestFallbackConfig(t *testing.T) {
 		t.Errorf("gc_interval = %d, want %d", cfg.GCIntervalDays, DefaultGCIntervalDays)
 	}
 
-	expectedPaths := []string{".sageox/", "SOUL.md", "TEAM.md", "MEMORY.md", "AGENTS.md", "memory/", "docs/", "coworkers/", "discussions/", "agent-context/"}
+	expectedPaths := []string{".sageox/", "SOUL.md", "TEAM.md", "MEMORY.md", "AGENTS.md", "memory/", "docs/", "agents/", "coworkers/", "discussions/", "agent-context/"}
 	for _, p := range expectedPaths {
 		assertContains(t, "fallback includes", cfg.Includes, p)
 	}

--- a/internal/manifest/sparse_checkout_test.go
+++ b/internal/manifest/sparse_checkout_test.go
@@ -67,6 +67,7 @@ func TestComputeSparseSet_FallbackConfigExcludesData(t *testing.T) {
 
 	// verify known fallback paths are present
 	assert.Contains(t, result, "/memory/")
+	assert.Contains(t, result, "/agents/")
 	assert.Contains(t, result, "/.sageox/")
 }
 

--- a/internal/plan/assets/scaffold.css
+++ b/internal/plan/assets/scaffold.css
@@ -9,10 +9,9 @@
    from reading as a foreign object inside the app that frames it
    (apps/web .../plans/[plan_dir] renders this file in an iframe).
 
-   The accents are the "earthed, never neon" semantic ramps. Copper is RETIRED
-   (DDR-010, the green-black rebrand) — the variable is `--gold`, and its value
-   comes from the `warning` ramp, which the token file names as the successor to
-   copper's premium-accent role. Do not reintroduce a second brand hue: hierarchy
+   The accents are the "earthed, never neon" semantic ramps. The old warm brand
+   accent is retired (DDR-010, the green-black rebrand) — `--gold` comes only
+   from the warning ramp. Do not reintroduce a second brand hue: hierarchy
    here is weight and position, not another colour. */
 :root{
   --bg:#0b0d0b; --panel:#111411; --panel2:#171b17; --hair:#212620; --hair2:#1d221d;

--- a/internal/plan/autoviz.go
+++ b/internal/plan/autoviz.go
@@ -50,7 +50,7 @@ var (
 // gets the most distinct openers.
 var swimPalette = []string{
 	"#99c693", // sage-400
-	"#d9b654", // warning-400 — copper's successor (DDR-010)
+	"#d9b654", // warning-400 — semantic warning only (DDR-010)
 	"#97aebd", // info
 	"#d77e6c", // error-400
 	"#b7b6a3", // silt-300

--- a/internal/session/enrich_test.go
+++ b/internal/session/enrich_test.go
@@ -167,7 +167,7 @@ func TestStripANSI(t *testing.T) {
 		want  string
 	}{
 		{"hello world", "hello world"},
-		{"\x1b[38;2;224;165;106m\u2726\x1b[m Use ox", "\u2726 Use ox"},
+		{"\x1b[38;2;173;207;163m\u2726\x1b[m Use ox", "\u2726 Use ox"},
 		{"\x1b[1mBold\x1b[0m Normal", "Bold Normal"},
 	}
 

--- a/internal/session/rawjsonl_schema_test.go
+++ b/internal/session/rawjsonl_schema_test.go
@@ -205,6 +205,8 @@ func TestRawJSONLSchema_RejectsMalformedLines(t *testing.T) {
 		// to the wrong recording — so the native side pins the prefix.
 		{"native header session_id without ses_ prefix",
 			`{"type":"header","metadata":{"version":"1.0","session_id":"test-session-001"}}`},
+		{"native header continuation without ses_ prefix",
+			`{"type":"header","metadata":{"version":"1.0","created_at":"2026-01-01T00:00:00Z","continued_from_session_id":"test-session-001"}}`},
 		{"not an object", `"just a string"`},
 	}
 

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -69,19 +69,23 @@ type RecordingState struct {
 	// keep resolving after upload. omitempty: recordings started under an
 	// older binary round-trip with an empty ID and fall back to name-based
 	// URLs.
-	SessionID        string    `json:"session_id,omitempty"`
-	StartedAt        time.Time `json:"started_at"`
-	AdapterName      string    `json:"adapter_name"`
-	SessionFile      string    `json:"session_file"` // source file from adapter (Claude Code JSONL)
-	OutputFile       string    `json:"output_file"`  // output file being recorded
-	SessionPath      string    `json:"session_path"` // path to session folder
-	Title            string    `json:"title,omitempty"`
-	EntryCount       int       `json:"entry_count"`
-	LastReminderSeq  int       `json:"last_reminder_seq"`
-	ReminderInterval int       `json:"reminder_interval"`
-	FilterMode       string    `json:"filter_mode,omitempty"`    // "infra" or "all" - controls event filtering
-	WorkspacePath    string    `json:"workspace_path,omitempty"` // git root / project directory
-	Branch           string    `json:"branch,omitempty"`         // git branch at recording start
+	SessionID string `json:"session_id,omitempty"`
+	// ContinuedFromSessionID links this recording to the prior recording made
+	// for the same native coding-agent session after SessionEnd finalized it.
+	// It is a durable ses_<UUID> identity, not a path or agent-instance ID.
+	ContinuedFromSessionID string    `json:"continued_from_session_id,omitempty"`
+	StartedAt              time.Time `json:"started_at"`
+	AdapterName            string    `json:"adapter_name"`
+	SessionFile            string    `json:"session_file"` // source file from adapter (Claude Code JSONL)
+	OutputFile             string    `json:"output_file"`  // output file being recorded
+	SessionPath            string    `json:"session_path"` // path to session folder
+	Title                  string    `json:"title,omitempty"`
+	EntryCount             int       `json:"entry_count"`
+	LastReminderSeq        int       `json:"last_reminder_seq"`
+	ReminderInterval       int       `json:"reminder_interval"`
+	FilterMode             string    `json:"filter_mode,omitempty"`    // "infra" or "all" - controls event filtering
+	WorkspacePath          string    `json:"workspace_path,omitempty"` // git root / project directory
+	Branch                 string    `json:"branch,omitempty"`         // git branch at recording start
 
 	// Parent-child session tracking for subagent workflows
 	// When a parent spawns subagents, each subagent can report its session
@@ -874,6 +878,11 @@ type StartRecordingOptions struct {
 	Origin      string // session origin: "human", "subagent", "agent" (from agentx.DetectOrigin)
 	StartOffset int64  // byte offset of SessionFile at recording start; entries before this are pre-session
 	WatchMode   string // "hook" or "tail" — how entries are captured
+
+	// ContinuedFromSessionID is the prior durable recording identity when a
+	// native coding-agent session is reopened after its previous recording was
+	// finalized. Invalid values are ignored rather than persisted.
+	ContinuedFromSessionID string
 }
 
 // StartRecording begins a new recording session.
@@ -979,30 +988,36 @@ func StartRecording(projectRoot string, opts StartRecordingOptions) (*RecordingS
 		origin = string(agentx.DetectOriginFromOS(""))
 	}
 
+	continuedFromSessionID := opts.ContinuedFromSessionID
+	if !sessionid.IsValidSessionID(continuedFromSessionID) {
+		continuedFromSessionID = ""
+	}
+
 	state := &RecordingState{
-		AgentID:           opts.AgentID,
-		SessionID:         sessionid.GenerateSessionID(),
-		AdapterName:       opts.AdapterName,
-		SessionFile:       opts.SessionFile,
-		OutputFile:        sessionFile,
-		SessionPath:       sessionPath,
-		Title:             opts.Title,
-		StartedAt:         time.Now().UTC(),
-		EntryCount:        0,
-		LastReminderSeq:   0,
-		ReminderInterval:  reminderInterval,
-		FilterMode:        opts.FilterMode,
-		WorkspacePath:     opts.WorkspacePath,
-		Branch:            opts.Branch,
-		ParentSessionPath: opts.ParentSessionPath,
-		ParentAgentID:     opts.ParentAgentID,
-		AgentType:         opts.AgentType,
-		Model:             opts.Model,
-		ParentPID:         opts.ParentPID,
-		Origin:            origin,
-		CacheDir:          paths.CacheDir(),
-		StartOffset:       opts.StartOffset,
-		WatchMode:         opts.WatchMode,
+		AgentID:                opts.AgentID,
+		SessionID:              sessionid.GenerateSessionID(),
+		ContinuedFromSessionID: continuedFromSessionID,
+		AdapterName:            opts.AdapterName,
+		SessionFile:            opts.SessionFile,
+		OutputFile:             sessionFile,
+		SessionPath:            sessionPath,
+		Title:                  opts.Title,
+		StartedAt:              time.Now().UTC(),
+		EntryCount:             0,
+		LastReminderSeq:        0,
+		ReminderInterval:       reminderInterval,
+		FilterMode:             opts.FilterMode,
+		WorkspacePath:          opts.WorkspacePath,
+		Branch:                 opts.Branch,
+		ParentSessionPath:      opts.ParentSessionPath,
+		ParentAgentID:          opts.ParentAgentID,
+		AgentType:              opts.AgentType,
+		Model:                  opts.Model,
+		ParentPID:              opts.ParentPID,
+		Origin:                 origin,
+		CacheDir:               paths.CacheDir(),
+		StartOffset:            opts.StartOffset,
+		WatchMode:              opts.WatchMode,
 	}
 
 	// always capture parent PID for liveness detection and ghost cleanup

--- a/internal/session/session_id_birth_test.go
+++ b/internal/session/session_id_birth_test.go
@@ -44,6 +44,34 @@ func TestStartRecording_MintsSessionIDAtBirth(t *testing.T) {
 	assert.Equal(t, state.SessionID, reloaded.SessionID)
 }
 
+func TestStartRecording_ContinuationIdentity(t *testing.T) {
+	cacheDir := t.TempDir()
+	projectRoot := setupRecordingTest(t, cacheDir)
+
+	validPrior := sessionid.GenerateSessionID()
+	state, err := StartRecording(projectRoot, StartRecordingOptions{
+		AgentID:                "OxCont",
+		AdapterName:            "claude-code",
+		Username:               "testuser",
+		ContinuedFromSessionID: validPrior,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, validPrior, state.ContinuedFromSessionID)
+
+	_, err = StopRecording(projectRoot, state.AgentID)
+	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(state.SessionPath))
+
+	invalid, err := StartRecording(projectRoot, StartRecordingOptions{
+		AgentID:                "OxCont",
+		AdapterName:            "claude-code",
+		Username:               "testuser",
+		ContinuedFromSessionID: "not-a-session-id",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, invalid.ContinuedFromSessionID, "untrusted marker values must not create cross-links")
+}
+
 // TestStartRecording_EveryRecordingGetsItsOwnID verifies the other half of
 // the birth contract: the ID is minted PER RECORDING, never shared or carried
 // over. TestStartRecording_MintsSessionIDAtBirth only proves one recording

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -188,13 +188,16 @@ type StoreMeta struct {
 	// NOTE: the alternative header format overloads the "session_id" key as
 	// an agent identifier — ParseStoreMeta only accepts ses_-prefixed values
 	// into this field to keep the two meanings apart.
-	SessionID    string `json:"session_id,omitempty"`
-	AgentType    string `json:"agent_type,omitempty"`
-	AgentVersion string `json:"agent_version,omitempty"` // version of the coding agent (e.g., "1.0.3")
-	Model        string `json:"model,omitempty"`         // LLM model used (e.g., "claude-sonnet-4-20250514")
-	Username     string `json:"username,omitempty"`      // privacy-safe display name — via identity.AttributionDisplayName(). NOT an email.
-	RepoID       string `json:"repo_id,omitempty"`
-	OxVersion    string `json:"ox_version,omitempty"` // version of ox that created this session
+	SessionID string `json:"session_id,omitempty"`
+	// ContinuedFromSessionID is the prior durable recording identity when
+	// this raw session continues a reopened native coding-agent session.
+	ContinuedFromSessionID string `json:"continued_from_session_id,omitempty"`
+	AgentType              string `json:"agent_type,omitempty"`
+	AgentVersion           string `json:"agent_version,omitempty"` // version of the coding agent (e.g., "1.0.3")
+	Model                  string `json:"model,omitempty"`         // LLM model used (e.g., "claude-sonnet-4-20250514")
+	Username               string `json:"username,omitempty"`      // privacy-safe display name — via identity.AttributionDisplayName(). NOT an email.
+	RepoID                 string `json:"repo_id,omitempty"`
+	OxVersion              string `json:"ox_version,omitempty"` // version of ox that created this session
 }
 
 // Writable is an interface for entries that can be written to a session.
@@ -1047,6 +1050,9 @@ func ParseStoreMeta(m map[string]any) *StoreMeta {
 	// agent identifiers never land here)
 	if v, ok := m["session_id"].(string); ok && sessionid.IsValidSessionID(v) {
 		meta.SessionID = v
+	}
+	if v, ok := m["continued_from_session_id"].(string); ok && sessionid.IsValidSessionID(v) {
+		meta.ContinuedFromSessionID = v
 	}
 
 	if v, ok := m["agent_type"].(string); ok {

--- a/internal/theme/generated.go
+++ b/internal/theme/generated.go
@@ -2,7 +2,7 @@
 //
 // Source: https://github.com/sageox/sageox-design
 // Token file: tokens/colors.yaml
-// Generated: 2026-01-10
+// Generated: 2026-08-25
 // Regenerate: cd ../sageox-design && npm run sync
 //
 // This file provides the unified SageOx brand color palette for CLI output.
@@ -17,36 +17,36 @@ import (
 
 // Brand colors
 const (
-	BrandPrimary   = "#7a8f78"
-	BrandSecondary = "#c47a4a"
+	BrandPrimary   = "#7aaa77"
+	BrandSecondary = "#adcfa3"
 	BrandNeutral   = "#111518"
 )
 
 // Adaptive colors for light/dark terminal detection
 var (
 	ColorPrimary = compat.AdaptiveColor{
-		Light: lipgloss.Color("#4F6A48"),
-		Dark:  lipgloss.Color("#7A8F78"),
+		Light: lipgloss.Color("#3D643B"),
+		Dark:  lipgloss.Color("#7AAA77"),
 	}
 	ColorSecondary = compat.AdaptiveColor{
-		Light: lipgloss.Color("#B87D3A"),
-		Dark:  lipgloss.Color("#E0A56A"),
+		Light: lipgloss.Color("#324F31"),
+		Dark:  lipgloss.Color("#ADCFA3"),
 	}
 	ColorAccent = compat.AdaptiveColor{
-		Light: lipgloss.Color("#3D5437"),
-		Dark:  lipgloss.Color("#8FA888"),
+		Light: lipgloss.Color("#4E7D4C"),
+		Dark:  lipgloss.Color("#99C693"),
 	}
 	ColorSuccess = compat.AdaptiveColor{
-		Light: lipgloss.Color("#4F6A48"),
-		Dark:  lipgloss.Color("#7A8F78"),
+		Light: lipgloss.Color("#3D643B"),
+		Dark:  lipgloss.Color("#7AAA77"),
 	}
 	ColorWarning = compat.AdaptiveColor{
-		Light: lipgloss.Color("#B87D3A"),
-		Dark:  lipgloss.Color("#E0A56A"),
+		Light: lipgloss.Color("#A5842F"),
+		Dark:  lipgloss.Color("#D9B654"),
 	}
 	ColorError = compat.AdaptiveColor{
-		Light: lipgloss.Color("#A03030"),
-		Dark:  lipgloss.Color("#E07070"),
+		Light: lipgloss.Color("#9F4838"),
+		Dark:  lipgloss.Color("#D77E6C"),
 	}
 	ColorInfo = compat.AdaptiveColor{
 		Light: lipgloss.Color("#5580A0"),
@@ -92,14 +92,14 @@ const (
 
 // Hex color constants (dark terminal/theme optimized)
 const (
-	HexPrimary   = "#7A8F78"
-	HexSecondary = "#E0A56A"
-	HexAccent    = "#8FA888"
+	HexPrimary   = "#7AAA77"
+	HexSecondary = "#ADCFA3"
+	HexAccent    = "#99C693"
 	HexInfo      = "#7FA7C8"
-	HexPass      = "#7A8F78"
-	HexWarn      = "#E0A56A"
-	HexFail      = "#C44747"
-	HexError     = "#E07070"
+	HexPass      = "#7AAA77"
+	HexWarn      = "#D9B654"
+	HexFail      = "#D77E6C"
+	HexError     = "#D77E6C"
 	HexMuted     = "#6F767C"
 	HexText      = "#E6E8E6"
 	HexTextDim   = "#7E8784"
@@ -115,14 +115,14 @@ const (
 
 // Hex color constants (light terminal/theme optimized)
 const (
-	HexLightPrimary   = "#5A7558"
-	HexLightSecondary = "#B8824A"
-	HexLightAccent    = "#4A7A9C"
-	HexLightInfo      = "#4A7A9C"
-	HexLightPass      = "#5A7558"
-	HexLightWarn      = "#B8824A"
-	HexLightFail      = "#A33636"
-	HexLightError     = "#A33636"
+	HexLightPrimary   = "#3D643B"
+	HexLightSecondary = "#324F31"
+	HexLightAccent    = "#4E7D4C"
+	HexLightInfo      = "#5580A0"
+	HexLightPass      = "#3D643B"
+	HexLightWarn      = "#A5842F"
+	HexLightFail      = "#9F4838"
+	HexLightError     = "#9F4838"
 	HexLightMuted     = "#5A6066"
 	HexLightText      = "#1A1A1A"
 	HexLightTextDim   = "#5A6066"

--- a/internal/theme/profile.go
+++ b/internal/theme/profile.go
@@ -25,7 +25,7 @@ import (
 // Terminal.app; anything reporting TERM=xterm-256color with no COLORTERM) does
 // not ignore an unrecognized "38;2;..." — it parses the parameters as
 // independent SGR codes. Any channel landing in 100-107 therefore becomes a
-// *background* color: brand copper #E0A56A ends in 0x6A = 106 = bright-cyan
+// *background* color: a prior brand hex ended in 0x6A = 106 = bright-cyan
 // background, which painted the `ox --help` command column and the login
 // disclaimer as unreadable grey-on-cyan blocks. Several other palette entries
 // sit one token away from the same trap (#2DD4BF starts 0x2D = 45 = magenta
@@ -124,7 +124,7 @@ func Adapt(c color.Color) color.Color {
 	return Profile.Convert(c)
 }
 
-// Color parses a hex ("#7A8F78") or ANSI index ("214") color and adapts it to
+// Color parses a hex ("#7AAA77") or ANSI index ("214") color and adapts it to
 // the terminal's profile. Use this anywhere lipgloss.Color would be reached for
 // in non-TUI code.
 func Color(s string) color.Color {

--- a/internal/theme/profile_test.go
+++ b/internal/theme/profile_test.go
@@ -27,7 +27,7 @@ func withProfile(t *testing.T, p colorprofile.Profile) {
 // "38;2;R;G;B" as independent SGR codes, so a channel in 100-107 silently
 // becomes a background color. Emitting no "38;2;" at all below TrueColor is the
 // property that makes that class of bug impossible, for every token — not just
-// the copper #E0A56A that happened to trip it.
+// the prior brand hex that happened to trip it.
 func TestAdapt_NoTruecolorBelowTrueColor(t *testing.T) {
 	degraded := []colorprofile.Profile{colorprofile.ANSI256, colorprofile.ANSI, colorprofile.ASCII, colorprofile.NoTTY}
 
@@ -45,14 +45,14 @@ func TestAdapt_NoTruecolorBelowTrueColor(t *testing.T) {
 	}
 }
 
-// TestAdapt_CopperRendersAsOneIndexedColor pins the exact byte shape of the
-// reported bug: brand copper on a 256-color terminal must be a single indexed
+// TestAdapt_LowByteBackgroundCodeRendersAsOneIndexedColor pins the exact byte shape of the
+// reported bug: a truecolor hex on a 256-color terminal must be a single indexed
 // foreground, never the four-parameter form whose trailing 106 reads as
 // bright-cyan background.
-func TestAdapt_CopperRendersAsOneIndexedColor(t *testing.T) {
+func TestAdapt_LowByteBackgroundCodeRendersAsOneIndexedColor(t *testing.T) {
 	withProfile(t, colorprofile.ANSI256)
 
-	got := lipgloss.NewStyle().Foreground(Color("#E0A56A")).Render("code")
+	got := lipgloss.NewStyle().Foreground(Color("#12346A")).Render("code")
 
 	assert.Contains(t, got, "38;5;")
 	assert.NotContains(t, got, "106")
@@ -63,9 +63,9 @@ func TestAdapt_CopperRendersAsOneIndexedColor(t *testing.T) {
 func TestAdapt_TrueColorIsPassthrough(t *testing.T) {
 	withProfile(t, colorprofile.TrueColor)
 
-	got := lipgloss.NewStyle().Foreground(Color("#E0A56A")).Render("code")
+	got := lipgloss.NewStyle().Foreground(Color("#12346A")).Render("code")
 
-	assert.Contains(t, got, "38;2;224;165;106")
+	assert.Contains(t, got, "38;2;18;52;106")
 }
 
 // TestAdapt_AdaptiveTokensDegrade covers the generated compat.AdaptiveColor
@@ -93,9 +93,9 @@ func TestAdapt_NoColorProfilesEmitNoColor(t *testing.T) {
 	for _, p := range []colorprofile.Profile{colorprofile.ASCII, colorprofile.NoTTY} {
 		withProfile(t, p)
 
-		require.Nil(t, Adapt(lipgloss.Color("#E0A56A")))
+		require.Nil(t, Adapt(lipgloss.Color("#12346A")))
 
-		got := lipgloss.NewStyle().Foreground(Color("#E0A56A")).Bold(true).Render("x")
+		got := lipgloss.NewStyle().Foreground(Color("#12346A")).Bold(true).Render("x")
 		assert.NotContains(t, got, "38;")
 		assert.True(t, strings.Contains(got, "1m"), "bold should survive on %s", p)
 	}

--- a/internal/theme/tokens.go
+++ b/internal/theme/tokens.go
@@ -25,17 +25,18 @@ type TokenInfo struct {
 	UseCase  string        // one-line description
 }
 
-// Tokens is the authoritative ordered list of every semantic color
-// the CLI exposes. The component catalog uses this to render swatches;
-// docs/design/tokens.md references it as the canonical reference.
+// Tokens is the authoritative ordered list of every semantic color the CLI
+// exposes. Values mirror sageox-design tokens/colors.yaml's CLI hex and
+// hex-light mappings. Secondary is a stronger sage emphasis step, not a second
+// brand hue; gold is reserved exclusively for Warning.
 var Tokens = []TokenInfo{
-	{"Primary", CategoryBrand, "#4F6A48", "#7A8F78", "App name, headers, spinners — the calm sage anchor"},
-	{"Secondary", CategoryBrand, "#B87D3A", "#E0A56A", "Commands, interactive elements — copper highlight"},
-	{"Accent", CategoryBrand, "#3D5437", "#8FA888", "File paths, callouts, \"look here\""},
+	{"Primary", CategoryBrand, "#3D643B", "#7AAA77", "App name, headers, spinners — the calm sage anchor"},
+	{"Secondary", CategoryBrand, "#324F31", "#ADCFA3", "Commands and selected elements — strongest sage emphasis"},
+	{"Accent", CategoryBrand, "#4E7D4C", "#99C693", "File paths, callouts, \"look here\""},
 
-	{"Success", CategorySemantic, "#4F6A48", "#7A8F78", "Passed checks, confirmations"},
-	{"Warning", CategorySemantic, "#B87D3A", "#E0A56A", "Cautions, dirty builds, soft warnings"},
-	{"Error", CategorySemantic, "#A03030", "#E07070", "Failures, blocked items, hard stops"},
+	{"Success", CategorySemantic, "#3D643B", "#7AAA77", "Passed checks, confirmations"},
+	{"Warning", CategorySemantic, "#A5842F", "#D9B654", "Cautions, dirty builds, soft warnings"},
+	{"Error", CategorySemantic, "#9F4838", "#D77E6C", "Failures, blocked items, hard stops"},
 	{"Info", CategorySemantic, "#5580A0", "#7FA7C8", "Flags, links, informational notes"},
 	{"Dim", CategorySemantic, "#6B7580", "#8F99A3", "Descriptions, secondary text"},
 

--- a/internal/theme/tokens_test.go
+++ b/internal/theme/tokens_test.go
@@ -1,0 +1,38 @@
+package theme
+
+import (
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/compat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenCatalogMatchesGeneratedAdaptiveColors(t *testing.T) {
+	generated := map[string]compat.AdaptiveColor{
+		"Primary":   ColorPrimary,
+		"Secondary": ColorSecondary,
+		"Accent":    ColorAccent,
+		"Success":   ColorSuccess,
+		"Warning":   ColorWarning,
+		"Error":     ColorError,
+		"Info":      ColorInfo,
+		"Dim":       ColorDim,
+		"Public":    ColorPublic,
+		"Private":   ColorPrivate,
+	}
+
+	for _, token := range Tokens {
+		color, ok := generated[token.Name]
+		if !ok {
+			assert.Equal(t, CategoryWordmark, token.Category,
+				"non-wordmark token %s has no generated adaptive color", token.Name)
+			continue
+		}
+		require.NotEmpty(t, token.LightHex, token.Name+" light value")
+		require.NotEmpty(t, token.DarkHex, token.Name+" dark value")
+		assert.Equal(t, lipgloss.Color(token.LightHex), color.Light, token.Name+" light")
+		assert.Equal(t, lipgloss.Color(token.DarkHex), color.Dark, token.Name+" dark")
+	}
+}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -40,7 +40,7 @@ var (
 
 	// Semantic status colors (aligned with brand)
 	ColorPass   = theme.Color(HexPass)   // sage green - brand success
-	ColorWarn   = theme.Color(HexWarn)   // copper gold - brand warning
+	ColorWarn   = theme.Color(HexWarn)   // gold - semantic warning only
 	ColorFail   = theme.Color(HexFail)   // ox red - brand error
 	ColorMuted  = theme.Color(HexMuted)  // charcoal gray - recessive
 	ColorAccent = theme.Color(HexAccent) // info blue - brand accent

--- a/internal/uicatalog/htmlexport.go
+++ b/internal/uicatalog/htmlexport.go
@@ -267,12 +267,12 @@ const inlineCSS = `
   --fg: #1a1d1a;
   --fg-dim: #6b7580;
   --border: #d9d3c5;
-  --primary: #4F6A48;
-  --secondary: #B87D3A;
-  --accent: #3D5437;
-  --success: #4F6A48;
-  --warning: #B87D3A;
-  --error: #A03030;
+  --primary: #3D643B;
+  --secondary: #324F31;
+  --accent: #4E7D4C;
+  --success: #3D643B;
+  --warning: #A5842F;
+  --error: #9F4838;
   --info: #5580A0;
   --mono: ui-monospace, "JetBrains Mono", SFMono-Regular, Menlo, Consolas, monospace;
   --sans: Inter, -apple-system, "Segoe UI", system-ui, sans-serif;
@@ -283,12 +283,12 @@ html[data-mode="dark"] {
   --fg: #e8e6df;
   --fg-dim: #8F99A3;
   --border: #2a2f33;
-  --primary: #7A8F78;
-  --secondary: #E0A56A;
-  --accent: #8FA888;
-  --success: #7A8F78;
-  --warning: #E0A56A;
-  --error: #E07070;
+  --primary: #7AAA77;
+  --secondary: #ADCFA3;
+  --accent: #99C693;
+  --success: #7AAA77;
+  --warning: #D9B654;
+  --error: #D77E6C;
   --info: #7FA7C8;
 }
 html[data-calm="on"] .component { border-color: transparent; box-shadow: none; }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.14.1"
+	Version   = "0.14.2"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )

--- a/internal/viz/assets/viz-catalog.md
+++ b/internal/viz/assets/viz-catalog.md
@@ -29,7 +29,7 @@
 
 ## sequence-diagram
 use: an ordered call/response path that crosses components, services, or async boundaries — when "in what order, how many round-trips" is the question.
-why: shows ordering and latency a flowchart can't; use 2–5 participants, explicit return paths, and one copper focal exchange. Static editorial SVG is the default; Mermaid remains a quick fallback for throwaway work.
+why: shows ordering and latency a flowchart can't; use 2–5 participants, explicit return paths, and one gold focal exchange. Static editorial SVG is the default; Mermaid remains a quick fallback for throwaway work.
 ```html
 <svg data-ox-viz="sequence-diagram" class="oxv-seq" viewBox="0 0 960 600" role="img" aria-labelledby="seq-title seq-desc" style="max-width:100%;height:auto;background:var(--panel,#111411);color:var(--ink,#f4f2ef)">
   <title id="seq-title">Request and response sequence</title>
@@ -559,7 +559,7 @@ why: a top-to-bottom decision spine makes the happy path and exceptional exits i
 
 ## data-flow
 use: data moving from sources through transformations to stores or consumers — when lineage, responsibility, and handoff shape matter more than control flow.
-why: a role-scoped pipeline shows what changes at each boundary and where state becomes durable. Use plain verbs on edges and reserve copper for the transformation under review.
+why: a role-scoped pipeline shows what changes at each boundary and where state becomes durable. Use plain verbs on edges and reserve gold for the transformation under review.
 ```html
 <svg data-ox-viz="data-flow" class="oxv-data" viewBox="0 0 960 600" role="img" aria-labelledby="data-title data-desc" style="max-width:100%;height:auto;background:var(--panel,#111411);color:var(--ink,#f4f2ef)">
   <title id="data-title">Context data flow</title><desc id="data-desc">Loose inputs are normalized, enriched, stored, and then consumed by AI coworkers.</desc>

--- a/schema/v1/raw-jsonl.schema.json
+++ b/schema/v1/raw-jsonl.schema.json
@@ -48,6 +48,11 @@
               "type": "string",
               "description": "CAUTION — in THIS dialect `session_id` is an agent-supplied identifier, NOT the ses_ recording identity that the native header's metadata.session_id carries. One key, two meanings, split by dialect. ox's reader keeps them apart by only accepting ses_-prefixed values into the recording-identity field; a consumer that conflates them will attribute a session to the wrong recording."
             },
+            "continued_from_session_id": {
+              "type": "string",
+              "pattern": "^ses_",
+              "description": "Prior finalized recording identity when this import is a continuation."
+            },
             "started_at": { "$ref": "#/$defs/rfc3339" },
             "username": { "$ref": "#/$defs/username" }
           }
@@ -76,6 +81,11 @@
           "type": "string",
           "pattern": "^ses_",
           "description": "The ses_ recording identity minted at session start. The header is its crash-safe carrier: the on-disk recording-state file is deleted at stop/abort, so an orphan-finalize can only recover this id from here. See the import dialect's _meta.session_id, which overloads the same key with a DIFFERENT meaning."
+        },
+        "continued_from_session_id": {
+          "type": "string",
+          "pattern": "^ses_",
+          "description": "Prior finalized recording identity when this recording continues a reopened native coding-agent session."
         },
         "agent_type": { "type": "string", "description": "Coding agent identifier, e.g. \"claude-code\"." },
         "agent_version": { "type": "string", "description": "Version of the coding agent." },


### PR DESCRIPTION
## What broke

- Device login exchanged an opaque device credential for an API JWT, then incorrectly used the JWT for the identity endpoint that expects the original credential.
- Reopening a native coding-agent conversation minted an unrelated Ledger recording, so resumed work lost its durable connection to the prior session.
- Sparse-checkout recovery omitted `agents/`, which could leave shared AI coworker rules unavailable when the committed manifest was missing or unusable.
- Generated CLI docs depended on local feature flags, omitted stable `ox pr` pages, and had no CI drift gate; package publishing also assumed the repository token always had package write access.
- CLI, TUI, plan, demo, and documentation colors had drifted from the current all-sage design tokens.

## What this PR ships

- **Device auth (#812):** fetches identity with the opaque device credential while persisting the exchanged API JWT, with a regression assertion for both values.
- **Session continuation (#541):** carries a validated `continued_from_session_id` from the native-session marker through recording state, raw headers, drafts, recovery, final metadata, upload retries, and JSON schema validation.
- **Sparse recovery (#710):** adds `agents/` to the canonical fallback manifest and proves the two-phase clone materializes nested team rules without a usable manifest.
- **Docs reliability (#806):** makes generation independent of cached feature flags, publishes the stable `ox pr` command family, normalizes generated EOFs, adds `make docs-check` to CI, and supports a dedicated `DOCS_PACKAGE_TOKEN` fallback.
- **Theme consistency (#762):** synchronizes semantic tokens and all downstream surfaces to sage primary/secondary/accent colors, warning-only gold, and accessible light/dark variants, with a drift test between source and generated tokens.
- **Patch release:** bumps the CLI, docs package, Claude plugin manifests, embedded release notes, and changelog to `0.14.2`.

## Session continuation flow

```mermaid
flowchart LR
    A[Native session marker] -->|prior ses_ id| B[Start recording]
    B --> C[Recording state]
    C --> D[Raw header]
    C --> E[Draft metadata]
    D --> F[Finalize or recover]
    E --> F
    F --> G[Ledger meta.json backlink]
```

## Review notes

- **Required Ryan review:** adding `agents/` to fallback sparse materialization changes a SageOx data-access path, so this part needs explicit approval under the repository review policy.
- **Docs deployment:** the workflow code is ready, but `#806` should remain open until the package permission or `DOCS_PACKAGE_TOKEN` is configured and the live docs site is verified.
- **Security:** `make sec` completed all six orchestration phases; one advisory `llm-trust` hunter was unavailable. Confirmed findings were verified as pre-existing rather than introduced by this diff and are tracked privately in `ox-e4v2.1`.

## Test Plan

- [x] `make lint`
- [x] `make test` — 19,874 tests, 18,533 passed, 1,341 skipped, 0 failed
- [x] `make build`
- [x] `make docs-check`
- [x] `make verify-version`
- [x] `git diff --check origin/main...`
- [x] `make sec` — advisory run triaged; one hunter unavailable as noted above

## Issues

Fixes #812

Fixes #710

Fixes #541

Fixes #762

Addresses #806

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added
- [x] CHANGELOG entry added
- [x] Breaking change: N/A — metadata fields are optional and backward-compatible
- [x] Security review run and triaged

</details>

Co-authored-by: SageOx <ox@sageox.ai>

SageOx-Session: https://sageox.ai/c/ses_01a03b6d-c524-7dea-a0ba-6c0776ec602f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resumed sessions now retain links to their prior recordings for improved continuity and traceability.
  - Added CLI documentation for pull-request commands, including header generation and related options.
  - Team-context recovery now includes agent rules during sparse checkouts.
- **Bug Fixes**
  - Improved device-login authentication reliability.
  - Preserved session relationships across recovery, retries, drafts, and finalized recordings.
- **Documentation**
  - Updated CLI references, upgrade guidance, release notes, and documentation validation.
- **Style**
  - Refreshed SageOx colors and terminal themes with a sage-focused brand palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->