### PR TITLE
release: finalize 0.14.2 notes (session hygiene + codedb self-heal)

### DIFF
--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.2] - 2026-08-25
 
-Resumed work stays connected, team rules recover reliably, and SageOx uses one calm visual language everywhere.
+Resumed work stays connected, stale sessions clean up after themselves, code indexing self-heals, team rules recover reliably, and SageOx uses one calm visual language everywhere.
 
 ### Improved
 
@@ -19,6 +19,8 @@ Resumed work stays connected, team rules recover reliably, and SageOx uses one c
 
 ### Fixed
 
+- **Session history stays clean** — sessions that were only primed or never captured a prompt no longer pile up on your machine or linger as stale "in progress" conversation links. ox reclaims them automatically in the background and during `ox doctor`, and a session is only registered once real work happens.
+- **Code indexing recovers from a damaged cache** — a corrupted index now rebuilds itself instead of crash-looping `ox`.
 - **Device login works with opaque session credentials** — the login flow uses the credential returned by device authentication to fetch identity while continuing to store the exchanged API token.
 - **Team rules survive sparse-checkout recovery** — fallback manifests include the `agents/` directory, so repositories without a usable manifest still materialize shared AI coworker guidance.
 


### PR DESCRIPTION
Readers of the 0.14.2 release notes now see its two headline reliability wins — both already merged into this release but missing from the notes.

## Why
The prepared 0.14.2 notes (#829) omitted two user-facing fixes shipping in the same release:
- **#827** — phantom session buildup fix + auto-reclaim (the session-hygiene win this whole effort delivered).
- **#826** — codedb self-heals a torn cache instead of crash-looping `ox index`.

## What changed
- **Docs only.** Added two `Fixed` bullets to the `[0.14.2]` section and refreshed the one-line summary. No code, no version change (already `0.14.2` and consistent across all version files).

## Release notes added
- **Session history stays clean** — primed-but-unused / no-prompt sessions no longer pile up locally or linger as stale "in progress" links; ox reclaims them in the background and during `ox doctor`, and only registers a session once real work happens.
- **Code indexing recovers from a damaged cache** — a corrupted index rebuilds itself instead of crash-looping `ox`.

## Test plan
- `make verify-version` → all files match `0.14.2`.
- Docs-only change; no behavioral code touched.

## Post-merge
- Tag `v0.14.2` on main, publish the draft GitHub release (triggers GoReleaser).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790299334&installation_model_id=433550&pr_number=830&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F830&signature=e0925b9bce2a2221f61f5fe0def969983cf5091423c675fc61bd228f83ddf2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added self-healing code indexing that automatically rebuilds corrupted indexes.
  - Added automatic cleanup of stale sessions that did not capture meaningful work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->