### PR TITLE
fix(ledger): guard sacred plans/sessions against mass-delete wipe (#832)

### DIFF
--- a/cmd/ox/ledger_commit_snapshot.go
+++ b/cmd/ox/ledger_commit_snapshot.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/sacred"
 )
 
 // commitLedgerSnapshot commits the ledger index as an IMMUTABLE, pre-validated
@@ -69,10 +71,74 @@ func commitLedgerSnapshot(ctx context.Context, ledgerPath, message string) (comm
 			"(likely a concurrent autostash-pop conflict; resolve it before retrying)", bad)
 	}
 
+	// ADR-024 backstop: never let a single commit wipe sacred trees. Scans the
+	// exact snapshot being committed (parent→tree), so it binds the same
+	// immutable tree the conflict scan above vetted — TOCTOU-safe.
+	if err := assertNoSacredMassDeletion(ctx, ledgerPath, parent, tree); err != nil {
+		return false, err
+	}
+
 	if err := commitTreeToBranch(ctx, ledgerPath, tree, parent, message); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// assertNoSacredMassDeletion fails a ledger commit whose snapshot (parent→tree)
+// would delete more than sacredMassDeleteThreshold files under a sacredPrefix.
+// Call it AFTER snapshotting the index tree and BEFORE writing the commit, so
+// the check binds exactly the tree being committed.
+//
+// Fail-closed, matching firstConflictMarkerInTree: an unborn branch (parent=="")
+// has no deletions and passes; if the diff itself cannot be computed the caller
+// must NOT commit, so the error propagates rather than defaulting to "safe".
+func assertNoSacredMassDeletion(ctx context.Context, ledgerPath, parent, tree string) error {
+	if parent == "" {
+		return nil // first commit: nothing pre-existing to delete
+	}
+	// diff-tree lists only paths whose status is Deletion between the two trees.
+	out, err := ledgerGit(ctx, ledgerPath,
+		"diff-tree", "--no-commit-id", "--name-only", "-r", "--diff-filter=D", parent, tree)
+	if err != nil {
+		return fmt.Errorf("sacred mass-delete guard: git diff-tree %s..%s: %w",
+			shortOID(parent), shortOID(tree), err)
+	}
+	deleted := sacred.Filter(strings.Split(string(out), "\n"))
+	if len(deleted) <= sacred.MassDeleteThreshold {
+		return nil
+	}
+	if os.Getenv(sacred.OverrideEnv) == "1" {
+		slog.WarnContext(ctx, "ledger sacred mass-deletion allowed by explicit override",
+			"repo", ledgerPath, "sacred_deletions", len(deleted), "override_env", sacred.OverrideEnv)
+		return nil
+	}
+	// Loud alert: this is a data-loss event caught at the last line of defense.
+	slog.ErrorContext(ctx, "REFUSING ledger commit: sacred mass-deletion detected",
+		"repo", ledgerPath,
+		"sacred_deletions", len(deleted),
+		"threshold", sacred.MassDeleteThreshold,
+		"sample", sampleStrings(deleted, 5),
+		"override_env", sacred.OverrideEnv)
+	return fmt.Errorf("refusing commit: would delete %d files under sacred paths (%s) in one commit, "+
+		"exceeds guard threshold %d — likely a sparse/GC-reconcile wipe (see ADR-024); "+
+		"if this bulk removal is intentional, set %s=1",
+		len(deleted), strings.Join(sacred.Prefixes, ", "), sacred.MassDeleteThreshold, sacred.OverrideEnv)
+}
+
+// sampleStrings returns at most n elements of s, for bounded log output.
+func sampleStrings(s []string, n int) []string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// shortOID abbreviates a git object id for log/error readability.
+func shortOID(oid string) string {
+	if len(oid) > 8 {
+		return oid[:8]
+	}
+	return oid
 }
 
 // snapshotLedgerIndexTree writes the current index to an immutable tree and

--- a/cmd/ox/ledger_commit_snapshot_sacred_test.go
+++ b/cmd/ox/ledger_commit_snapshot_sacred_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/sacred"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedSacredPlans writes n plan dirs (data/plans/<slug>/plan.md) and commits
+// them, so they form the parent tree the sacred-deletion guard diffs against.
+func seedSacredPlans(t *testing.T, repo string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		dir := filepath.Join(repo, "data", "plans", fmt.Sprintf("2026-06-%02d-plan", i+1))
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "plan.md"),
+			[]byte(fmt.Sprintf("# plan %d\n", i)), 0o644))
+	}
+	mustRunGit(t, repo, "add", "data/plans")
+	mustRunGit(t, repo, "commit", "-m", "seed plans")
+}
+
+// TestCommitLedgerSnapshot_RefusesSacredMassDeletion reproduces the 2026-08-25
+// Ox Dot wipe at the guard boundary: an index that stages deletion of every
+// saved plan must be REFUSED and nothing committed — the sacred trees stay in
+// HEAD.
+//
+// Failure prevented: a sparse/GC-reconciled index whose bulk deletions get
+// snapshotted into a ledger commit and pushed to origin (ADR-024). Without
+// assertNoSacredMassDeletion this commit succeeds and the plans are gone from
+// the tip — exactly what happened to repo_019d56e0.
+func TestCommitLedgerSnapshot_RefusesSacredMassDeletion(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+	ctx := context.Background()
+
+	seedSacredPlans(t, repo, sacred.MassDeleteThreshold+5)
+	headBefore, err := runIsolatedGit(t, repo, "rev-parse", "HEAD")
+	require.NoError(t, err)
+
+	// stage deletion of ALL plans — what the reconcile did before the bare commit
+	mustRunGit(t, repo, "rm", "-r", "data/plans")
+
+	committed, err := commitLedgerSnapshot(ctx, repo,
+		"chore: add .sageox/.gitignore to exclude daemon cache files")
+	require.Error(t, err, "a mass sacred deletion must be refused")
+	assert.False(t, committed)
+	assert.Contains(t, err.Error(), "sacred")
+
+	// no commit happened; the plans are still in HEAD
+	headAfter, err := runIsolatedGit(t, repo, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, headBefore, headAfter, "HEAD must not advance on a refused wipe")
+	tree, err := runIsolatedGit(t, repo, "ls-tree", "-r", "--name-only", "HEAD", "--", "data/plans")
+	require.NoError(t, err)
+	assert.Contains(t, tree, "plan.md", "sacred plans must remain in HEAD after refusal")
+}
+
+// TestCommitLedgerSnapshot_AllowsSmallSacredDeletion proves the guard does not
+// block routine churn: deleting a single plan (well under the threshold) commits
+// normally, so an `ox plan` delete keeps working.
+func TestCommitLedgerSnapshot_AllowsSmallSacredDeletion(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+	ctx := context.Background()
+
+	seedSacredPlans(t, repo, 3)
+	mustRunGit(t, repo, "rm", "-r", "data/plans/2026-06-01-plan")
+
+	committed, err := commitLedgerSnapshot(ctx, repo, "Delete plan 2026-06-01-plan")
+	require.NoError(t, err)
+	assert.True(t, committed, "a single-plan delete is normal churn and must commit")
+}
+
+// TestCommitLedgerSnapshot_OverrideAllowsSacredMassDeletion proves the explicit
+// escape hatch works for a deliberate bulk removal — and, with the guard thereby
+// disabled, that the wipe otherwise commits (the "red" the guard turns green).
+func TestCommitLedgerSnapshot_OverrideAllowsSacredMassDeletion(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+	ctx := context.Background()
+
+	seedSacredPlans(t, repo, sacred.MassDeleteThreshold+5)
+	mustRunGit(t, repo, "rm", "-r", "data/plans")
+
+	t.Setenv(sacred.OverrideEnv, "1")
+	committed, err := commitLedgerSnapshot(ctx, repo, "chore: intentional bulk plan removal")
+	require.NoError(t, err)
+	assert.True(t, committed, "override must let a deliberate bulk removal through")
+}

--- a/internal/doctor/autofix/default_checks.go
+++ b/internal/doctor/autofix/default_checks.go
@@ -61,6 +61,13 @@ func Default() *Registry {
 		BlastRadius: "single ledger; git rebase --abort/--quit on a STALE wedge only (fresh in-flight rebases untouched); no history rewrite, HEAD unchanged",
 		Run:         checkLedgerRebaseWedge,
 	})
+	r.Register(&Check{
+		Slug:        "ledger-sacred-deletion",
+		Description: "Detect and alert on any commit in recent ledger history that mass-deleted sacred plans/sessions (ADR-024 data-loss guard); detection only, never auto-restores",
+		MinInterval: 15 * time.Minute,
+		BlastRadius: "read-only; scans recent ledger history and reports, no writes",
+		Run:         checkLedgerSacredDeletion,
+	})
 	return r
 }
 

--- a/internal/doctor/autofix/sacred_deletion.go
+++ b/internal/doctor/autofix/sacred_deletion.go
@@ -1,0 +1,136 @@
+package autofix
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/sacred"
+)
+
+// sacredDeletionScanDepth bounds how far back the periodic detector looks. The
+// commit-time guard (cmd/ox assertNoSacredMassDeletion) prevents NEW wipes; this
+// catches one that still landed — via an older binary with no guard, a
+// force-push, or any path that bypassed the guard — so it only needs to cover
+// recent history: a wipe is loud the moment it lands, and lingering ones are
+// caught on the first pass after upgrade.
+const sacredDeletionScanDepth = 200
+
+// commitMarker prefixes each commit's log line so the per-commit deletion groups
+// can't be split by a blank line or an odd path. \x1e (ASCII record separator)
+// is a legal argv byte (unlike NUL) and never appears in a ledger path.
+const commitMarker = "\x1e"
+
+// checkLedgerSacredDeletion is the daemon's periodic deep check for the
+// data-loss class the 2026-08-25 Ox Dot wipe belongs to: a single commit that
+// deleted every saved plan + session. It resolves the workspace's ledger and
+// scans recent history for any commit deleting more than sacred.MassDeleteThreshold
+// files under a sacred prefix.
+//
+// DETECTION ONLY — it never restores. Per ADR-024 sacred-data deletion needs
+// explicit human approval, and the content is always recoverable from history,
+// so a hit is surfaced as StatusFound and alerted for a human to recover. This
+// is the belt to the commit-time guard's suspenders: it fires even when the
+// guard never ran (old binary) or was bypassed (force-push).
+func checkLedgerSacredDeletion(ctx context.Context, repoPath string) CheckResult {
+	if repoPath == "" {
+		return CheckResult{Status: StatusClean}
+	}
+	pctx, err := config.LoadProjectContext(repoPath)
+	if err != nil || pctx == nil {
+		// uninitialized workspace or no ledger configured — nothing to scan
+		return CheckResult{Status: StatusClean, Repo: repoPath}
+	}
+	ledgerPath := pctx.DefaultLedgerPath()
+	if ledgerPath == "" {
+		return CheckResult{Status: StatusClean, Repo: repoPath}
+	}
+	return scanLedgerSacredDeletions(ctx, ledgerPath, repoPath)
+}
+
+// scanLedgerSacredDeletions is the side-effect-free core, split out so tests can
+// drive it against a real repo without standing up a ProjectContext.
+func scanLedgerSacredDeletions(ctx context.Context, ledgerPath, repoPath string) CheckResult {
+	// One bounded log walk: for each commit, its deleted paths under the sacred
+	// prefixes, grouped by a marker-prefixed header line.
+	args := append([]string{
+		"log",
+		fmt.Sprintf("-n%d", sacredDeletionScanDepth),
+		"--no-merges",
+		"--diff-filter=D",
+		"--pretty=format:" + commitMarker + "%H",
+		"--name-only",
+		"--",
+	}, sacred.Prefixes...)
+	out, err := gitutil.RunGit(ctx, ledgerPath, args...)
+	if err != nil {
+		return CheckResult{
+			Status:  StatusError,
+			Repo:    repoPath,
+			Summary: fmt.Sprintf("sacred-deletion scan: git log failed: %v", err),
+		}
+	}
+
+	type wipe struct {
+		commit string
+		count  int
+	}
+	var hits []wipe
+	var cur string
+	var cnt int
+	flush := func() {
+		if cur != "" && cnt > sacred.MassDeleteThreshold {
+			hits = append(hits, wipe{cur, cnt})
+		}
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, commitMarker) {
+			flush()
+			cur = strings.TrimSpace(strings.TrimPrefix(line, commitMarker))
+			cnt = 0
+			continue
+		}
+		if sacred.HasPrefix(strings.TrimSpace(line)) {
+			cnt++
+		}
+	}
+	flush()
+
+	if len(hits) == 0 {
+		return CheckResult{Status: StatusClean, Repo: repoPath}
+	}
+
+	total := 0
+	sample := make([]string, 0, 3)
+	for _, h := range hits {
+		total += h.count
+		if len(sample) < 3 {
+			sample = append(sample, fmt.Sprintf("%s(%d)", shortSHA(h.commit), h.count))
+		}
+	}
+	// Loud alert: a data-loss event is sitting in history right now.
+	slog.ErrorContext(ctx, "ALERT: sacred mass-deletion found in ledger history",
+		"repo", repoPath,
+		"ledger", ledgerPath,
+		"wipe_commits", len(hits),
+		"sacred_deletions_total", total,
+		"sample", sample,
+		"threshold", sacred.MassDeleteThreshold)
+	return CheckResult{
+		Status: StatusFound,
+		Repo:   repoPath,
+		Summary: fmt.Sprintf("sacred mass-deletion in ledger history: %d commit(s) deleting %d plan/session files (e.g. %s) — recover from history; do NOT auto-delete (ADR-024)",
+			len(hits), total, strings.Join(sample, ", ")),
+	}
+}
+
+// shortSHA abbreviates a commit id for bounded log/summary output.
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}

--- a/internal/doctor/autofix/sacred_deletion_test.go
+++ b/internal/doctor/autofix/sacred_deletion_test.go
@@ -1,0 +1,74 @@
+package autofix
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/sacred"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSacredTestRepo makes a real git repo with an identity and a base commit.
+// Uses a SageOx-owned test domain per the test-email-domains hard rule.
+func newSacredTestRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	afGit(t, repo, "init", "--initial-branch=main")
+	afGit(t, repo, "config", "user.name", "Test")
+	afGit(t, repo, "config", "user.email", "sacred-test@test.sageox.ai")
+	afGit(t, repo, "config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "base.txt"), []byte("base\n"), 0o644))
+	afGit(t, repo, "add", "base.txt")
+	afGit(t, repo, "commit", "-m", "base")
+	return repo
+}
+
+func seedSacredPlansAF(t *testing.T, repo string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		dir := filepath.Join(repo, "data", "plans", fmt.Sprintf("2026-06-%02d-plan", i+1))
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "plan.md"), []byte("x\n"), 0o644))
+	}
+	afGit(t, repo, "add", "data/plans")
+	afGit(t, repo, "commit", "-m", "seed plans")
+}
+
+// TestScanLedgerSacredDeletions_FlagsHistoricalWipe: a commit that deleted every
+// plan sits in history. The detector must surface it (StatusFound) even though
+// the wipe already landed — this is the belt to the commit guard's suspenders,
+// catching a wipe that reached history via an old binary or a force-push.
+func TestScanLedgerSacredDeletions_FlagsHistoricalWipe(t *testing.T) {
+	repo := newSacredTestRepo(t)
+	seedSacredPlansAF(t, repo, sacred.MassDeleteThreshold+5)
+	afGit(t, repo, "rm", "-r", "data/plans")
+	afGit(t, repo, "commit", "-m", "chore: add .sageox/.gitignore to exclude daemon cache files")
+
+	res := scanLedgerSacredDeletions(context.Background(), repo, "/fake/repo")
+	assert.Equal(t, StatusFound, res.Status, "a historical sacred wipe must be surfaced")
+	assert.Contains(t, res.Summary, "sacred mass-deletion")
+}
+
+// TestScanLedgerSacredDeletions_CleanWhenNoWipe: a ledger that only ever added
+// plans has nothing to flag.
+func TestScanLedgerSacredDeletions_CleanWhenNoWipe(t *testing.T) {
+	repo := newSacredTestRepo(t)
+	seedSacredPlansAF(t, repo, 3)
+	res := scanLedgerSacredDeletions(context.Background(), repo, "/fake/repo")
+	assert.Equal(t, StatusClean, res.Status)
+}
+
+// TestScanLedgerSacredDeletions_IgnoresSmallDeletion: deleting a single plan is
+// routine churn (below the threshold) and must not be flagged.
+func TestScanLedgerSacredDeletions_IgnoresSmallDeletion(t *testing.T) {
+	repo := newSacredTestRepo(t)
+	seedSacredPlansAF(t, repo, 3)
+	afGit(t, repo, "rm", "-r", "data/plans/2026-06-01-plan")
+	afGit(t, repo, "commit", "-m", "Delete plan 2026-06-01-plan")
+	res := scanLedgerSacredDeletions(context.Background(), repo, "/fake/repo")
+	assert.Equal(t, StatusClean, res.Status)
+}

--- a/internal/gitserver/gitignore.go
+++ b/internal/gitserver/gitignore.go
@@ -297,8 +297,16 @@ func commitCheckoutGitignore(ctx context.Context, repoPath string) error {
 		return fmt.Errorf("git add .sageox/.gitignore: %s: %w", strings.TrimSpace(string(output)), err)
 	}
 
+	// Commit ONLY .sageox/.gitignore — the trailing pathspec makes this a
+	// path-limited (--only) commit, so any OTHER changes already staged in the
+	// index (e.g. deletions a sparse/GC reconcile removed from the cone) are NOT
+	// swept into this commit. Without the pathspec, this bare `git commit`
+	// snapshotted the whole index: on 2026-08-25 it recorded 10,373 deletions
+	// (every plan + session on the Ox Dot ledger) under this very message and
+	// pushed them. See ADR-024 and the assertNoSacredMassDeletion backstop.
 	commitCmd := exec.CommandContext(ctx, "git", "-C", repoPath,
-		"commit", "-m", "chore: add .sageox/.gitignore to exclude daemon cache files")
+		"commit", "-m", "chore: add .sageox/.gitignore to exclude daemon cache files",
+		"--", ".sageox/.gitignore")
 	if output, err := commitCmd.CombinedOutput(); err != nil {
 		// exit code 1 = nothing to commit (file already committed)
 		var exitErr *exec.ExitError

--- a/internal/sacred/sacred.go
+++ b/internal/sacred/sacred.go
@@ -1,0 +1,57 @@
+// Package sacred defines the ledger paths that hold never-auto-delete work
+// product per ADR-024 (data-protection hierarchy) — saved plans and recorded
+// sessions — plus the mass-deletion policy shared by the two lines of defense:
+//
+//   - the commit-time guard in cmd/ox (assertNoSacredMassDeletion), which
+//     refuses a ledger commit that would delete a mass of sacred files, and
+//   - the periodic daemon detector in internal/doctor/autofix, which flags a
+//     sacred mass-deletion that already landed in history (e.g. via an older
+//     binary with no guard, or a force-push).
+//
+// One source of truth so the two cannot drift: if the guard tightens, the
+// detector tightens with it.
+package sacred
+
+import "strings"
+
+// Prefixes are the ledger paths holding never-auto-delete work product.
+var Prefixes = []string{"data/plans/", "sessions/"}
+
+// MassDeleteThreshold is the maximum number of sacred-path files a single ledger
+// commit may delete before it is treated as a suspected wipe. Set deliberately
+// tight: a routine `ox plan` delete or session removal touches one dir (its ~5
+// artifact files) and passes; removing two or more plans/sessions at once trips
+// it. Per ADR-024 sacred deletion needs explicit human approval, so err toward
+// refusing. The 2026-08-25 incident staged 1000+ sacred deletions in one commit.
+const MassDeleteThreshold = 5
+
+// OverrideEnv, when set to "1", lets a deliberate bulk removal through the
+// commit-time guard. The detector ignores it — a historical mass deletion is
+// always worth surfacing, override or not.
+const OverrideEnv = "OX_ALLOW_SACRED_MASS_DELETE"
+
+// HasPrefix reports whether p lives under a sacred prefix.
+func HasPrefix(p string) bool {
+	for _, pre := range Prefixes {
+		if strings.HasPrefix(p, pre) {
+			return true
+		}
+	}
+	return false
+}
+
+// Filter returns the subset of paths that live under a sacred prefix, preserving
+// order. Blank entries are dropped so callers can pass raw `git` output lines.
+func Filter(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if HasPrefix(p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

A single ox daemon commit silently deleted **every saved plan and recorded session** on a teammate's Ox Dot ledger and pushed the wipe to origin, so those plans vanished for everyone syncing that ledger. Nothing was permanently lost only because the content survived in git history and one machine's local cache. This PR makes that class of loss structurally hard: no ledger commit can mass-delete plans/sessions, and if one ever slips in anyway (older binary, force-push), the daemon detects and alerts on it.

**Approach:** two independent lines of defense over one shared policy (`internal/sacred`) — a **commit-time guard** at the single validated ledger-commit chokepoint that refuses + loudly alerts on any commit deleting more than 5 sacred files, and a **periodic daemon deep-check** that flags a sacred mass-deletion already sitting in history (detection only — restore needs human approval per ADR-024). Plus the exact bug fix: the bare `git commit` that authored the wipe is scoped to its one intended pathspec.

## Root cause

`commitCheckoutGitignore` staged only `.sageox/.gitignore` but ran a **bare `git commit`**, which snapshotted the *entire* index — including deletions a sparse/GC reconcile had already staged (the manifest didn't re-include `data/plans/` or `sessions/`). One commit, 10,373 deletions, pushed. The `*` ignore-everything gitignore strategy is load-bearing (it prevents the #129 GC-block) and is deliberately **left unchanged** here.

```mermaid
flowchart LR
  A["sparse/GC reconcile stages plan+session deletions"] --> B["bare git commit (only .gitignore intended)"]
  B --> C["10,373 deletions committed and pushed"]
  D["Fix 1: scoped commit"] -.blocks.-> B
  E["Fix 2: commit-time guard"] -.refuses.-> C
  F["Fix 3: daemon detector"] -.alerts on.-> C
```

## What changed

| File | Change |
|---|---|
| `internal/sacred/sacred.go` | New shared policy: sacred prefixes (`data/plans/`, `sessions/`), threshold (5), override env, helpers. One source of truth for both defenses. |
| `cmd/ox/ledger_commit_snapshot.go` | `assertNoSacredMassDeletion` at the validated `commitLedgerSnapshot` chokepoint — refuses + alerts on more than 5 sacred deletions in one commit (TOCTOU-safe: scans the exact `parent`→`tree` being committed). Override: `OX_ALLOW_SACRED_MASS_DELETE=1`. |
| `internal/gitserver/gitignore.go` | Scoped `commitCheckoutGitignore`'s commit to `-- .sageox/.gitignore` so its bare commit can never again sweep pre-staged deletions (the exact wipe vector). |
| `internal/doctor/autofix/sacred_deletion.go` (+ registration) | New periodic daemon deep-check `ledger-sacred-deletion` (every 15m, read-only) that scans recent ledger history and surfaces any commit that mass-deleted plans/sessions. Detection only. |
| tests | Red-first regression tests for both the guard and the detector. |

## Test plan

- [x] `go test ./cmd/ox/ -run TestCommitLedgerSnapshot` — guard refuses a 10-plan wipe, allows a single-plan delete, and (override on) proves the wipe otherwise commits — the red the guard turns green.
- [x] `go test ./internal/doctor/autofix/ -run TestScanLedgerSacredDeletions` — detector flags a historical wipe (`StatusFound` + alert), clean when no wipe, ignores small deletions.
- [x] `go test ./internal/gitserver/` and `go vet` on all changed packages — green.

## Not in this PR

- **Root-cause manifest fix** (always pin `data/plans/` + `sessions/` in the sparse manifest) and any change to the `*` strategy — riskier (reintroduces #129), tracked separately.
- **Data recovery** of the affected ledger — separate op (see #832). A force-pushing sync daemon currently reverts restores, so recovery should follow deploy of this fix.

Refs #832.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790302600&installation_model_id=433550&pr_number=833&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F833&signature=2d4077d2d9c4e6a0602854c7d48cbdb0b485d03747e4b727911ae938874d0f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added protection against large accidental deletions of important ledger plans and sessions.
  - Added periodic health checks that detect and report historical mass deletions with recovery guidance.
  - Added an explicit override for intentional large deletions.

- **Bug Fixes**
  - Prevented unrelated staged changes from being included when updating Git ignore configuration.

- **Tests**
  - Added coverage for blocked, permitted, small, and historical deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->