### PR TITLE
fix(codedb): serialize concurrent bleve self-heal race (#828)

### DIFF
--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -789,6 +789,10 @@ var (
 	// ("adopt"/"nuke"/"defer") so race tests can assert exact counts rather than
 	// inferring the loser's behavior from side effects.
 	subIndexRebuildActionHook = func(action string) {}
+	// acquireSubIndexHealLockFn is the seam rebuildSubIndexLocked uses to take the
+	// heal lock. Overridable so a test can simulate a flock-hostile filesystem —
+	// a setup error, distinct from a timeout — without an actual unsupported FS.
+	acquireSubIndexHealLockFn = acquireSubIndexHealLock
 )
 
 // subIndexHealLockPath returns the lock-file path serializing destructive
@@ -801,10 +805,22 @@ func subIndexHealLockPath(path string) string {
 }
 
 // acquireSubIndexHealLock takes the exclusive cross-process heal lock for one
-// sub-index. Returns (fl, true, nil) when held (caller must Unlock), (nil,
-// false, nil) on timeout (a live process holds it — flock is released on process
-// death, so a timeout is never a dead holder), or (nil, false, err) when the
-// lock file itself cannot be created (flock-hostile FS).
+// sub-index. It reports three distinct outcomes the caller must handle
+// differently — a timeout and a setup failure are NOT the same:
+//
+//   - (fl, true, nil):  lock held; caller must Unlock.
+//   - (nil, false, nil): TIMEOUT — a live process holds the lock (flock is
+//     released on process death, so a timeout is never a dead holder). The
+//     caller should defer to that peer, never nuke.
+//   - (nil, false, err): SETUP FAILURE — the lock file could not be created or
+//     the filesystem does not support flock. There is no peer to defer to, so
+//     the caller must fall back to healing without the lock.
+//
+// flock.TryLockContext returns (false, context.DeadlineExceeded) when our own
+// deadline expires (see gofrs/flock tryCtx), so a plain timeout arrives here as
+// an error. We translate that back into the (nil, false, nil) timeout outcome
+// and surface only genuine setup errors — otherwise a healthy peer holding the
+// lock would be misread as a broken filesystem.
 func acquireSubIndexHealLock(path string) (*flock.Flock, bool, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, false, fmt.Errorf("create dir for heal lock: %w", err)
@@ -814,7 +830,10 @@ func acquireSubIndexHealLock(path string) (*flock.Flock, bool, error) {
 	defer cancel()
 	locked, err := fl.TryLockContext(ctx, subIndexHealLockPoll)
 	if err != nil {
-		return nil, false, err
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, false, nil // normal timeout: a live peer holds the lock
+		}
+		return nil, false, err // genuine flock-setup failure (hostile FS)
 	}
 	if !locked {
 		return nil, false, nil
@@ -893,17 +912,27 @@ func reclassifyUnderLock(path, name string, requireVersion bool) (bleve.Index, h
 //   - healNuke  → we hold the lock and it is still corrupt/stale: RemoveAll +
 //     recreate empty + write the .needs_reindex marker.
 //
-// On lock-acquisition failure (timeout or flock-hostile FS) it never nukes
-// racily: it reclassifies once, adopts a ready replacement, and otherwise
-// surfaces a retryable error the next open picks up (the winner's heal lands on
-// a subsequent pass).
+// Lock-acquisition outcomes are handled distinctly (never a racy nuke):
+//   - TIMEOUT (a live peer holds a working lock): reclassify once and adopt a
+//     ready replacement, else return a retryable deferral — never nuke, the peer
+//     is on it.
+//   - SETUP FAILURE (flock-hostile FS, no peer): fall back to applyRebuildVerdict
+//     WITHOUT the lock. reclassifyUnderLock's bounded bbolt probe still resolves a
+//     healthy/held index to adopt/defer, so honoring healNuke here repairs a
+//     genuinely corrupt index instead of leaving it permanently unrepairable.
 func rebuildSubIndexLocked(root, path, name string, requireVersion bool, openErrForLog error) (bleve.Index, error) {
-	fl, locked, lockErr := acquireSubIndexHealLock(path)
+	fl, locked, lockErr := acquireSubIndexHealLockFn(path)
 	if !locked {
 		if lockErr != nil {
-			slog.Warn("bleve self-heal lock unavailable; deferring to concurrent healer",
+			// No peer holds the lock — flock is unusable on this filesystem. We
+			// cannot serialize, but the bbolt probe in reclassifyUnderLock still
+			// guards against clobbering a healthy index, so heal without the lock.
+			slog.Warn("bleve self-heal lock unavailable on this filesystem; healing without cross-process lock",
 				"name", name, "path", path, "err", lockErr)
+			return applyRebuildVerdict(root, path, name, requireVersion, openErrForLog)
 		}
+		// Clean timeout: a live peer holds the heal lock and will complete the
+		// rebuild. Adopt if it already did; otherwise return a retryable deferral.
 		if idx, verdict := reclassifyUnderLock(path, name, requireVersion); verdict == healAdopt {
 			subIndexRebuildActionHook("adopt")
 			return idx, nil
@@ -912,7 +941,16 @@ func rebuildSubIndexLocked(root, path, name string, requireVersion bool, openErr
 		return nil, fmt.Errorf("bleve sub-index %s self-heal deferred to a concurrent healer: %w", name, openErrForLog)
 	}
 	defer func() { _ = fl.Unlock() }()
+	return applyRebuildVerdict(root, path, name, requireVersion, openErrForLog)
+}
 
+// applyRebuildVerdict reclassifies the sub-index and acts on the verdict:
+// adopt a concurrent repair, defer to a live writer, or nuke+recreate+marker a
+// still-corrupt/stale index. Callers invoke it while HOLDING the heal lock, or —
+// on a flock-hostile filesystem where the lock is unavailable — without it; in
+// both cases the bounded bbolt probe in reclassifyUnderLock resolves a healthy
+// index to healAdopt/healDefer, so a nuke here never clobbers good data.
+func applyRebuildVerdict(root, path, name string, requireVersion bool, openErrForLog error) (bleve.Index, error) {
 	idx, verdict := reclassifyUnderLock(path, name, requireVersion)
 	switch verdict {
 	case healAdopt:
@@ -925,9 +963,9 @@ func rebuildSubIndexLocked(root, path, name string, requireVersion bool, openErr
 		return nil, fmt.Errorf("bleve index appears to be in use (lock contention): %w", openErrForLog)
 	}
 
-	// healNuke: lock held and the index is still provably corrupt/stale. The
-	// specific trigger (parse error vs stale mapping version) is in open_err.
-	slog.Warn("bleve sub-index rebuild under heal lock (nuke + recreate)",
+	// healNuke: the index is still provably corrupt/stale. The specific trigger
+	// (parse error vs stale mapping version) is in open_err.
+	slog.Warn("bleve sub-index rebuild (nuke + recreate)",
 		"name", name, "path", path, "open_err", openErrForLog)
 	if removeErr := os.RemoveAll(path); removeErr != nil {
 		return nil, fmt.Errorf("remove corrupt bleve sub-index %s: %w", path, removeErr)

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -965,33 +965,35 @@ func boundedAdoptOpen(path string, timeout time.Duration) (bleve.Index, error) {
 //   - healNuke  → we hold the lock and it is still corrupt/stale: RemoveAll +
 //     recreate empty + write the .needs_reindex marker.
 //
-// Lock-acquisition outcomes are handled distinctly (never a racy nuke):
-//   - TIMEOUT (a live peer holds a working lock): reclassify once and adopt a
-//     ready replacement, else return a retryable deferral — never nuke, the peer
-//     is on it.
-//   - SETUP FAILURE (flock-hostile FS, no peer): fall back to applyRebuildVerdict
-//     WITHOUT the lock. reclassifyUnderLock's bounded bbolt probe still resolves a
-//     healthy/held index to adopt/defer, so honoring healNuke here repairs a
-//     genuinely corrupt index instead of leaving it permanently unrepairable.
+// A destructive rebuild (RemoveAll + recreate) runs ONLY while the heal lock is
+// held. When the lock cannot be acquired — for EITHER reason — we never nuke,
+// because a lockless nuke lets two processes RemoveAll each other's fresh
+// replacement (REMOVE CREATE REMOVE CREATE). The two no-lock cases:
+//   - TIMEOUT (a live peer holds a working lock): the peer will complete the
+//     rebuild; adopt a ready replacement, else return a retryable deferral.
+//   - SETUP FAILURE (flock-hostile FS, no peer): we cannot serialize at all, so
+//     we still refuse to nuke. Adopt an already-healthy index; otherwise defer.
+//     A genuinely corrupt sub-index on a flock-less filesystem is recovered by a
+//     full reindex (which wipes the whole dataDir), not by a racy per-sub-index
+//     nuke — the codedb is a rebuildable derived cache, so this trades an exotic-
+//     FS repair for the stronger no-racy-nuke guarantee.
 func rebuildSubIndexLocked(root, path, name string, requireVersion bool, openErrForLog error) (bleve.Index, error) {
 	fl, locked, lockErr := acquireSubIndexHealLockFn(path)
 	if !locked {
 		if lockErr != nil {
-			// No peer holds the lock — flock is unusable on this filesystem. We
-			// cannot serialize, but the bbolt probe in reclassifyUnderLock still
-			// guards against clobbering a healthy index, so heal without the lock.
-			slog.Warn("bleve self-heal lock unavailable on this filesystem; healing without cross-process lock",
+			// flock is unusable on this filesystem: no peer, and no safe way to
+			// serialize a destructive rebuild. Refuse to nuke without the lock.
+			slog.Warn("bleve self-heal lock unavailable on this filesystem; deferring (no lockless nuke)",
 				"name", name, "path", path, "err", lockErr)
-			return applyRebuildVerdict(root, path, name, requireVersion, openErrForLog)
 		}
-		// Clean timeout: a live peer holds the heal lock and will complete the
-		// rebuild. Adopt if it already did; otherwise return a retryable deferral.
+		// No lock held (timeout or setup failure): adopt an already-repaired index,
+		// otherwise return a retryable deferral. Never nuke here.
 		if idx, verdict := reclassifyUnderLock(path, name, requireVersion); verdict == healAdopt {
 			subIndexRebuildActionHook("adopt")
 			return idx, nil
 		}
 		subIndexRebuildActionHook("defer")
-		return nil, fmt.Errorf("bleve sub-index %s self-heal deferred to a concurrent healer: %w", name, openErrForLog)
+		return nil, fmt.Errorf("bleve sub-index %s self-heal deferred (heal lock unavailable): %w", name, openErrForLog)
 	}
 	defer func() { _ = fl.Unlock() }()
 	return applyRebuildVerdict(root, path, name, requireVersion, openErrForLog)
@@ -999,10 +1001,9 @@ func rebuildSubIndexLocked(root, path, name string, requireVersion bool, openErr
 
 // applyRebuildVerdict reclassifies the sub-index and acts on the verdict:
 // adopt a concurrent repair, defer to a live writer, or nuke+recreate+marker a
-// still-corrupt/stale index. Callers invoke it while HOLDING the heal lock, or —
-// on a flock-hostile filesystem where the lock is unavailable — without it; in
-// both cases the bounded bbolt probe in reclassifyUnderLock resolves a healthy
-// index to healAdopt/healDefer, so a nuke here never clobbers good data.
+// still-corrupt/stale index. Callers MUST hold the heal lock — the healNuke path
+// does a destructive RemoveAll, which is safe to run only under cross-process
+// serialization (see rebuildSubIndexLocked; the no-lock paths never reach here).
 func applyRebuildVerdict(root, path, name string, requireVersion bool, openErrForLog error) (bleve.Index, error) {
 	idx, verdict := reclassifyUnderLock(path, name, requireVersion)
 	switch verdict {

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/mapping"
+	"github.com/gofrs/flock"
 	lru "github.com/hashicorp/golang-lru/v2"
 	codedbsqlc "github.com/sageox/ox/internal/codedb/sqlc"
 	"go.etcd.io/bbolt"
@@ -364,18 +365,12 @@ func createBleveSubIndex(path, name string) (bleve.Index, error) {
 func upgradeBleveSubIndex(root, path, name string, fromVersion int) (bleve.Index, error) {
 	slog.Info("bleve mapping version upgrade, rebuilding",
 		"name", name, "from", fromVersion, "to", bleveMappingVersion(name))
-	if err := os.RemoveAll(path); err != nil {
-		return nil, fmt.Errorf("remove out-of-date bleve sub-index %s: %w", path, err)
-	}
-	idx, err := createBleveSubIndex(path, name)
-	if err != nil {
-		return nil, fmt.Errorf("recreate bleve sub-index %s: %w", path, err)
-	}
-	if err := WriteNeedsReindexMarker(root, name); err != nil {
-		slog.Warn("failed to write needs_reindex marker after mapping upgrade",
-			"name", name, "err", err)
-	}
-	return idx, nil
+	// Serialize with the same per-sub-index heal lock the corruption path uses,
+	// with requireVersion=true so the recheck adopts only a replacement whose
+	// mapping is already current — a concurrent process that beat us to the
+	// upgrade is respected instead of racing to re-nuke its result (#828).
+	return rebuildSubIndexLocked(root, path, name, true,
+		fmt.Errorf("mapping version %d below current %d", fromVersion, bleveMappingVersion(name)))
 }
 
 // openBleveIndexes opens (or self-heals + recreates) the three bleve
@@ -743,28 +738,210 @@ func openOrCreateBleveIndex(root, path, name string) (bleve.Index, error) {
 // `.needs_reindex_<name>` marker so the next daemon pass does a full rebuild.
 // Logs a single warn line so the recovery is visible in daemon logs.
 //
+// The destructive rebuild is serialized across processes by a per-sub-index
+// filesystem lock (see rebuildSubIndexLocked) so two concurrent codedb.Open
+// callers cannot race to delete each other's freshly-created replacement — the
+// nuke+recreate race in issue #828. requireVersion is false: any bleve that now
+// opens cleanly is an acceptable replacement (the healed index is empty and
+// carries the current mapping version).
+//
 // The marker is best-effort: if the marker write fails (disk full, permission
 // denied) the function still returns the empty index — the daemon will see
 // the empty bleve on its next freshness check via different signals (empty
 // search results) but the explicit signal is preferred. Marker failure is
 // logged at warn level.
 func selfHealBleveSubIndex(root, path, name string, openErr error) (bleve.Index, error) {
-	slog.Warn("bleve sub-index structurally corrupt, self-healing (nuke + recreate)",
-		"name", name, "path", path, "open_err", openErr)
+	return rebuildSubIndexLocked(root, path, name, false, openErr)
+}
 
+// healVerdict is the decision reclassifyUnderLock reaches once the per-sub-index
+// heal lock is held: adopt a replacement a concurrent process already produced,
+// nuke a still-corrupt/stale index ourselves, or defer to a live writer that
+// holds an otherwise-healthy index open.
+type healVerdict int
+
+const (
+	// healAdopt: the on-disk index now opens cleanly under the current mapping —
+	// a concurrent process already repaired it. Return that index; do not nuke.
+	healAdopt healVerdict = iota
+	// healNuke: the index is still provably corrupt (self-heal) or still stale
+	// (upgrade). We hold the lock; rebuild it.
+	healNuke
+	// healDefer: the index cannot be reopened but is NOT provably corrupt — a
+	// live writer holds its exclusive bbolt lock. Never nuke a healthy-but-held
+	// index; surface the pre-existing retryable "lock contention" error.
+	healDefer
+)
+
+var (
+	// subIndexHealLockTimeout bounds how long a caller waits for the per-sub-index
+	// heal lock before conceding another process holds it. The lock is held only
+	// for the brief nuke+recreate critical section (not the store's lifetime), so
+	// this is generous. Overridable in tests.
+	subIndexHealLockTimeout = 10 * time.Second
+	subIndexHealLockPoll    = 50 * time.Millisecond
+	// subIndexHealLockAcquiredHook fires immediately after the heal lock is
+	// acquired (never on a failed acquisition). Overridable so a concurrency test
+	// can deterministically interleave a second healer instead of racing on
+	// wall-clock timing (see .claude/rules/testing.md).
+	subIndexHealLockAcquiredHook = func(path string) {}
+	// subIndexRebuildActionHook fires with the verdict actually taken
+	// ("adopt"/"nuke"/"defer") so race tests can assert exact counts rather than
+	// inferring the loser's behavior from side effects.
+	subIndexRebuildActionHook = func(action string) {}
+)
+
+// subIndexHealLockPath returns the lock-file path serializing destructive
+// self-heal / upgrade of one bleve sub-index across processes. It is a SIBLING
+// of the sub-index dir (path + ".heal.lock"), never a child, so os.RemoveAll(path)
+// cannot delete the lock file out from under a healer mid-nuke — which would
+// hand a second healer a fresh, uncontended lock and reopen the race.
+func subIndexHealLockPath(path string) string {
+	return path + ".heal.lock"
+}
+
+// acquireSubIndexHealLock takes the exclusive cross-process heal lock for one
+// sub-index. Returns (fl, true, nil) when held (caller must Unlock), (nil,
+// false, nil) on timeout (a live process holds it — flock is released on process
+// death, so a timeout is never a dead holder), or (nil, false, err) when the
+// lock file itself cannot be created (flock-hostile FS).
+func acquireSubIndexHealLock(path string) (*flock.Flock, bool, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, false, fmt.Errorf("create dir for heal lock: %w", err)
+	}
+	fl := flock.New(subIndexHealLockPath(path))
+	ctx, cancel := context.WithTimeout(context.Background(), subIndexHealLockTimeout)
+	defer cancel()
+	locked, err := fl.TryLockContext(ctx, subIndexHealLockPoll)
+	if err != nil {
+		return nil, false, err
+	}
+	if !locked {
+		return nil, false, nil
+	}
+	subIndexHealLockAcquiredHook(path)
+	return fl, true, nil
+}
+
+// reclassifyUnderLock re-runs the corruption/staleness decision after the heal
+// lock is held, so a concurrent process's repair is adopted rather than
+// clobbered.
+//
+// It must NEVER call the blocking bleve.Open (safeOpenBleve) against an index a
+// live writer may hold: bleve.Open takes bbolt's exclusive lock with no timeout
+// and would hang forever. So the classification uses only BOUNDED bbolt probes —
+// the same non-blocking primitives openOrCreateBleveIndex uses — and only calls
+// the blocking open once it has PROVEN the index is free (we briefly held the
+// exclusive lock ourselves). A healthy index held open by the winning process
+// therefore resolves to healDefer, never to a hang and never to a nuke (the #828
+// data-loss path).
+//
+// requireVersion additionally treats a clean, free-but-stale index as healNuke
+// (the mapping-version upgrade path); for plain self-heal it is false.
+func reclassifyUnderLock(path, name string, requireVersion bool) (bleve.Index, healVerdict) {
+	boltPath := filepath.Join(path, "store", "root.bolt")
+	if _, statErr := os.Stat(boltPath); statErr != nil {
+		// bolt absent / path structure broken → still needs a (re)build.
+		return nil, healNuke
+	}
+	// Provable structural corruption via the read-only peek (100ms per attempt).
+	if isBleveIndexCorrupt(boltPath) {
+		return nil, healNuke
+	}
+	// Bounded EXCLUSIVE probe: distinguishes free / held / corrupt without ever
+	// blocking. A live writer (the winner holding its fresh index open) yields
+	// ErrTimeout → healDefer.
+	db, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: bleveExclusiveProbeTimeout})
+	if err != nil {
+		if errors.Is(err, bbolterrors.ErrInvalid) ||
+			errors.Is(err, bbolterrors.ErrVersionMismatch) ||
+			errors.Is(err, bbolterrors.ErrChecksum) {
+			return nil, healNuke // proven on-disk corruption
+		}
+		return nil, healDefer // held by a live writer, or transient — never nuke
+	}
+	// We hold the exclusive lock: the index is healthy AND free. Release it and
+	// hand back a real bleve handle to adopt. Under the heal lock no other healer
+	// competes; the only remaining opener is a brief reader, so the follow-on
+	// blocking open is safe (and matches the pre-existing top-level open).
+	_ = db.Close()
+	idx, openErr := safeOpenBleve(path)
+	if openErr != nil {
+		// Raced away between probe and open, or a non-corruption open failure —
+		// defer rather than nuke a possibly-healthy index.
+		return nil, healDefer
+	}
+	if requireVersion {
+		got, verErr := readMappingVersion(path)
+		if verErr == nil && got < bleveMappingVersion(name) {
+			_ = idx.Close()
+			return nil, healNuke // clean + free but still stale → upgrade it
+		}
+	}
+	return idx, healAdopt
+}
+
+// rebuildSubIndexLocked serializes a destructive sub-index rebuild across
+// processes and skips it when a concurrent process already produced an
+// acceptable replacement. It is the shared core of self-heal and mapping-version
+// upgrade — the two nuke+recreate+marker sites that raced in #828.
+//
+// Flow: acquire the per-sub-index heal lock, then reclassify under it:
+//   - healAdopt → return the replacement the winner created; never nuke it.
+//   - healDefer → return the pre-existing retryable "lock contention" error; a
+//     healthy index is being held open, not corrupt.
+//   - healNuke  → we hold the lock and it is still corrupt/stale: RemoveAll +
+//     recreate empty + write the .needs_reindex marker.
+//
+// On lock-acquisition failure (timeout or flock-hostile FS) it never nukes
+// racily: it reclassifies once, adopts a ready replacement, and otherwise
+// surfaces a retryable error the next open picks up (the winner's heal lands on
+// a subsequent pass).
+func rebuildSubIndexLocked(root, path, name string, requireVersion bool, openErrForLog error) (bleve.Index, error) {
+	fl, locked, lockErr := acquireSubIndexHealLock(path)
+	if !locked {
+		if lockErr != nil {
+			slog.Warn("bleve self-heal lock unavailable; deferring to concurrent healer",
+				"name", name, "path", path, "err", lockErr)
+		}
+		if idx, verdict := reclassifyUnderLock(path, name, requireVersion); verdict == healAdopt {
+			subIndexRebuildActionHook("adopt")
+			return idx, nil
+		}
+		subIndexRebuildActionHook("defer")
+		return nil, fmt.Errorf("bleve sub-index %s self-heal deferred to a concurrent healer: %w", name, openErrForLog)
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	idx, verdict := reclassifyUnderLock(path, name, requireVersion)
+	switch verdict {
+	case healAdopt:
+		slog.Info("bleve sub-index already repaired by a concurrent process; adopting replacement",
+			"name", name, "path", path)
+		subIndexRebuildActionHook("adopt")
+		return idx, nil
+	case healDefer:
+		subIndexRebuildActionHook("defer")
+		return nil, fmt.Errorf("bleve index appears to be in use (lock contention): %w", openErrForLog)
+	}
+
+	// healNuke: lock held and the index is still provably corrupt/stale. The
+	// specific trigger (parse error vs stale mapping version) is in open_err.
+	slog.Warn("bleve sub-index rebuild under heal lock (nuke + recreate)",
+		"name", name, "path", path, "open_err", openErrForLog)
 	if removeErr := os.RemoveAll(path); removeErr != nil {
 		return nil, fmt.Errorf("remove corrupt bleve sub-index %s: %w", path, removeErr)
 	}
-	idx, err := createBleveSubIndex(path, name)
+	newIdx, err := createBleveSubIndex(path, name)
 	if err != nil {
 		return nil, fmt.Errorf("recreate empty bleve sub-index %s: %w", path, err)
 	}
-
 	if markerErr := WriteNeedsReindexMarker(root, name); markerErr != nil {
 		slog.Warn("failed to write needs_reindex marker; daemon may not auto-rebuild",
 			"name", name, "root", root, "err", markerErr)
 	}
-	return idx, nil
+	subIndexRebuildActionHook("nuke")
+	return newIdx, nil
 }
 
 // WriteNeedsReindexMarker creates the marker file that signals to the daemon's

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -846,12 +846,13 @@ func acquireSubIndexHealLock(path string) (*flock.Flock, bool, error) {
 // lock is held, so a concurrent process's repair is adopted rather than
 // clobbered.
 //
-// It must NEVER call the blocking bleve.Open (safeOpenBleve) against an index a
-// live writer may hold: bleve.Open takes bbolt's exclusive lock with no timeout
-// and would hang forever. So the classification uses only BOUNDED bbolt probes —
-// the same non-blocking primitives openOrCreateBleveIndex uses — and only calls
-// the blocking open once it has PROVEN the index is free (we briefly held the
-// exclusive lock ourselves). A healthy index held open by the winning process
+// It must NEVER block on bleve.Open against an index a live writer may hold:
+// bleve.Open takes bbolt's exclusive lock with no timeout and would hang forever.
+// So the classification uses only BOUNDED bbolt probes — the same non-blocking
+// primitives openOrCreateBleveIndex uses — and adopts only once it has PROVEN the
+// index is free (we briefly held the exclusive lock ourselves), via
+// boundedAdoptOpen so even a writer that races into the post-probe window caps
+// the wait rather than hanging. A healthy index held open by the winning process
 // therefore resolves to healDefer, never to a hang and never to a nuke (the #828
 // data-loss path).
 //
@@ -860,8 +861,14 @@ func acquireSubIndexHealLock(path string) (*flock.Flock, bool, error) {
 func reclassifyUnderLock(path, name string, requireVersion bool) (bleve.Index, healVerdict) {
 	boltPath := filepath.Join(path, "store", "root.bolt")
 	if _, statErr := os.Stat(boltPath); statErr != nil {
-		// bolt absent / path structure broken → still needs a (re)build.
-		return nil, healNuke
+		if errors.Is(statErr, os.ErrNotExist) {
+			// bolt genuinely absent / path structure broken → needs a (re)build.
+			return nil, healNuke
+		}
+		// A transient stat failure (permission, I/O) on a bolt that may well exist
+		// must NOT be read as "rebuild": that would let a retryable error destroy a
+		// healthy index. Defer and let a later pass reclassify.
+		return nil, healDefer
 	}
 	// Provable structural corruption via the read-only peek (100ms per attempt).
 	if isBleveIndexCorrupt(boltPath) {
@@ -880,24 +887,70 @@ func reclassifyUnderLock(path, name string, requireVersion bool) (bleve.Index, h
 		return nil, healDefer // held by a live writer, or transient — never nuke
 	}
 	// We hold the exclusive lock: the index is healthy AND free. Release it and
-	// hand back a real bleve handle to adopt. Under the heal lock no other healer
-	// competes; the only remaining opener is a brief reader, so the follow-on
-	// blocking open is safe (and matches the pre-existing top-level open).
+	// hand back a real bleve handle to adopt. There is a narrow window between the
+	// Close here and the adopt open below in which an ordinary codedb.Open could
+	// grab bbolt's exclusive lock; because bleve.Open has no deadline, a naked
+	// open would then block for that store's whole lifetime. boundedAdoptOpen caps
+	// the wait and maps that contention to healDefer instead of a hang.
 	_ = db.Close()
-	idx, openErr := safeOpenBleve(path)
+	idx, openErr := boundedAdoptOpen(path, bleveExclusiveProbeTimeout)
 	if openErr != nil {
-		// Raced away between probe and open, or a non-corruption open failure —
-		// defer rather than nuke a possibly-healthy index.
+		// Raced away between probe and open, timed out on a late writer, or a
+		// non-corruption open failure — defer rather than nuke a possibly-healthy
+		// index.
 		return nil, healDefer
 	}
 	if requireVersion {
 		got, verErr := readMappingVersion(path)
-		if verErr == nil && got < bleveMappingVersion(name) {
+		if verErr != nil {
+			// Staleness was already established at the top-level upgrade call; if we
+			// cannot re-confirm the version under the lock, adopting would silently
+			// return a maybe-stale index and skip both the upgrade and the marker.
+			// Defer instead so a later pass makes the call on solid ground.
+			_ = idx.Close()
+			return nil, healDefer
+		}
+		if got < bleveMappingVersion(name) {
 			_ = idx.Close()
 			return nil, healNuke // clean + free but still stale → upgrade it
 		}
 	}
 	return idx, healAdopt
+}
+
+// boundedAdoptOpen opens a bleve index but never blocks longer than timeout.
+// bleve.Open takes bbolt's exclusive lock with no deadline, so if an ordinary
+// codedb.Open races in and grabs the lock between reclassifyUnderLock's freedom
+// probe and this open, a naked open would hang until that store closes. We cap
+// it: on timeout we return an error (the caller maps it to healDefer) and, if
+// the abandoned open later succeeds, close the handle so it cannot leak.
+func boundedAdoptOpen(path string, timeout time.Duration) (bleve.Index, error) {
+	type openResult struct {
+		idx bleve.Index
+		err error
+	}
+	ch := make(chan openResult, 1)
+	go func() {
+		idx, err := safeOpenBleve(path)
+		ch <- openResult{idx, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.idx, r.err
+	case <-time.After(timeout):
+		// Reap a late success so the orphaned handle can't leak. Guard defensively:
+		// the abandoned open may resolve after the index dir has been torn down,
+		// where Close can hit a typed-nil handle or panic — neither may crash us.
+		go func() {
+			r := <-ch
+			if r.err != nil || r.idx == nil {
+				return
+			}
+			defer func() { _ = recover() }()
+			_ = r.idx.Close()
+		}()
+		return nil, fmt.Errorf("adopt open of %s timed out after %s (index became busy)", path, timeout)
+	}
 }
 
 // rebuildSubIndexLocked serializes a destructive sub-index rebuild across

--- a/internal/codedb/store/store_selfheal_concurrent_test.go
+++ b/internal/codedb/store/store_selfheal_concurrent_test.go
@@ -1,0 +1,512 @@
+package store
+
+// Concurrency + cross-process regression coverage for the bleve self-heal race
+// (GitHub #828): two codedb.Open callers must not race to delete each other's
+// freshly-created replacement sub-index. The destructive nuke+recreate is now
+// serialized by a per-sub-index filesystem lock (rebuildSubIndexLocked), and the
+// recheck-under-lock reuses the real corruption classifier so a healthy index
+// held open by the winner is DEFERRED to, never nuked.
+//
+// Failure prevented: a concurrent in-process `ox index`, two `ox index` runs, or
+// two worktrees sharing one ledger codedb both self-healing the same sub-index
+// and clobbering each other's fresh empty bleve — transient churn today, and a
+// data-loss-shaped race that widened with the torn-bolt trigger in #826.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/stretchr/testify/require"
+)
+
+// Env vars set on a re-exec of the test binary make TestMain run
+// runSelfHealHelper instead of the normal test suite (env values cannot contain
+// NUL, so the spec is passed as three separate vars).
+const (
+	selfHealHelperEnv = "OX_STORE_SELFHEAL_HELPER"
+	selfHealRootEnv   = "OX_STORE_SELFHEAL_ROOT"
+	selfHealPathEnv   = "OX_STORE_SELFHEAL_PATH"
+	selfHealNameEnv   = "OX_STORE_SELFHEAL_NAME"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(selfHealHelperEnv) != "" {
+		os.Exit(runSelfHealHelper(
+			os.Getenv(selfHealRootEnv),
+			os.Getenv(selfHealPathEnv),
+			os.Getenv(selfHealNameEnv),
+		))
+	}
+	os.Exit(m.Run())
+}
+
+// runSelfHealHelper is the child-process body for the real multi-process race
+// test. It drives the actual production entry point (openOrCreateBleveIndex) on
+// a shared, already-corrupted sub-index, retrying on the retryable "lock
+// contention" verdict exactly as a real daemon/CLI caller would, and exits 0
+// once it holds a working index. Any process that permanently fails to get a
+// working index exits non-zero — which the parent treats as the #828 race
+// destroying the replacement.
+func runSelfHealHelper(root, path, name string) int {
+	if root == "" || path == "" || name == "" {
+		fmt.Fprintf(os.Stderr, "bad helper spec root=%q path=%q name=%q\n", root, path, name)
+		return 2
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < 400; attempt++ {
+		idx, err := openOrCreateBleveIndex(root, path, name)
+		if err == nil {
+			// Hold briefly, as a real caller would while it indexes, then release
+			// so peers can make progress. This is what makes the winner's fresh
+			// index visible-but-momentarily-locked to the losers.
+			_ = idx.Close()
+			return 0
+		}
+		lastErr = err
+		time.Sleep(15 * time.Millisecond)
+	}
+	fmt.Fprintf(os.Stderr, "helper never obtained a working index: %v\n", lastErr)
+	return 1
+}
+
+// installFastCorruptionProbes shrinks the read-only peek and exclusive-probe
+// budgets so a reclassify against a genuinely-held index (which must time out to
+// reach the DEFER verdict) resolves in tens of ms instead of seconds. Restores
+// the defaults on cleanup. Timeouts only ever bias toward the safe "don't nuke"
+// verdict, so shrinking them cannot manufacture a false result.
+func installFastCorruptionProbes(t *testing.T) {
+	t.Helper()
+	origAttempts, origDelay := bleveCorruptionPeekAttempts, bleveCorruptionPeekDelay
+	origProbe := bleveExclusiveProbeTimeout
+	t.Cleanup(func() {
+		bleveCorruptionPeekAttempts = origAttempts
+		bleveCorruptionPeekDelay = origDelay
+		bleveExclusiveProbeTimeout = origProbe
+	})
+	bleveCorruptionPeekAttempts = 1
+	bleveCorruptionPeekDelay = time.Millisecond
+	bleveExclusiveProbeTimeout = 200 * time.Millisecond
+}
+
+// actionCounter is a thread-safe tally of the verdicts rebuildSubIndexLocked
+// took, installed via subIndexRebuildActionHook so the concurrency tests assert
+// the exact loser behavior instead of inferring it from side effects.
+type actionCounter struct {
+	mu sync.Mutex
+	n  map[string]int
+}
+
+func installActionCounter(t *testing.T) *actionCounter {
+	t.Helper()
+	c := &actionCounter{n: map[string]int{}}
+	orig := subIndexRebuildActionHook
+	t.Cleanup(func() { subIndexRebuildActionHook = orig })
+	subIndexRebuildActionHook = func(action string) {
+		c.mu.Lock()
+		c.n[action]++
+		c.mu.Unlock()
+	}
+	return c
+}
+
+func (c *actionCounter) get(action string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n[action]
+}
+
+// --- A. Verdict units: the three branches of reclassify-under-lock ---
+
+// TestRebuildSubIndexLocked_Corrupt_Nukes proves the healNuke branch: a proven-
+// corrupt index held under the lock is rebuilt empty and gets a reindex marker.
+func TestRebuildSubIndexLocked_Corrupt_Nukes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+	counter := installActionCounter(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	emptyMappingForLatestSnapshot(t, filepath.Join(indexPath, "store", "root.bolt"))
+
+	idx, err := rebuildSubIndexLocked(tmp, indexPath, "test", false,
+		fmt.Errorf("simulated corrupt open"))
+	require.NoError(t, err, "corrupt index must self-heal")
+	defer func() { _ = idx.Close() }()
+
+	count, err := idx.DocCount()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), count, "healed index must be empty")
+	require.True(t, HasNeedsReindexMarker(tmp, "test"), "nuke must write reindex marker")
+	require.Equal(t, 1, counter.get("nuke"))
+	require.Equal(t, 0, counter.get("adopt"))
+}
+
+// TestRebuildSubIndexLocked_Healthy_Adopts proves the healAdopt branch: when the
+// on-disk index already opens cleanly (a concurrent process healed it first),
+// the caller adopts it instead of nuking — and writes NO new marker.
+func TestRebuildSubIndexLocked_Healthy_Adopts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+	counter := installActionCounter(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	// Index is healthy on disk and not held open. rebuildSubIndexLocked must
+	// recognize a fit replacement and adopt it.
+	idx, err := rebuildSubIndexLocked(tmp, indexPath, "test", false,
+		fmt.Errorf("simulated corrupt open"))
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	require.Equal(t, 1, counter.get("adopt"))
+	require.Equal(t, 0, counter.get("nuke"))
+	require.False(t, HasNeedsReindexMarker(tmp, "test"),
+		"adopting a healthy index must NOT write a marker (no rebuild happened)")
+}
+
+// TestRebuildSubIndexLocked_HeldOpen_Defers proves the healDefer branch: an index
+// that cannot be reopened only because a live writer holds its exclusive bbolt
+// lock is NOT corrupt — it must be deferred to (retryable contention error),
+// never nuked. This is the exact misclassification that would let a loser delete
+// the winner's healthy index in #828.
+func TestRebuildSubIndexLocked_HeldOpen_Defers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+	counter := installActionCounter(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	held, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, err)
+	defer func() { _ = held.Close() }() // keep the exclusive bbolt lock held
+
+	idx, err := rebuildSubIndexLocked(tmp, indexPath, "test", false,
+		fmt.Errorf("simulated corrupt open"))
+	require.Nil(t, idx)
+	require.Error(t, err, "a healthy-but-held index must not be healed")
+	require.Contains(t, err.Error(), "lock contention",
+		"held index must surface the retryable contention error")
+	require.Equal(t, 1, counter.get("defer"))
+	require.Equal(t, 0, counter.get("nuke"),
+		"a live-locked healthy index must never be nuked")
+	require.False(t, HasNeedsReindexMarker(tmp, "test"))
+}
+
+// --- B. Deterministic two-healer race (the #828 regression) ---
+
+// TestConcurrentSelfHeal_LoserDoesNotClobberWinner is the core #828 regression.
+// Two goroutines each call openOrCreateBleveIndex on the SAME corrupt sub-index.
+// The heal-lock acquired hook pins the winner (A) holding the lock while the
+// loser (B) is forced to wait; when A finishes it holds its fresh index open, so
+// B — reclassifying under the lock — sees a healthy-but-locked index and defers
+// instead of deleting A's replacement.
+//
+// Red-first: with the pre-fix unconditional os.RemoveAll+recreate, B would return
+// its OWN new index (errB == nil) after having RemoveAll'd A's — so the
+// "errB is a contention error" and "exactly one nuke" assertions fail.
+func TestConcurrentSelfHeal_LoserDoesNotClobberWinner(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations + goroutines")
+	}
+	installFastCorruptionProbes(t)
+	counter := installActionCounter(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+	emptyMappingForLatestSnapshot(t, filepath.Join(indexPath, "store", "root.bolt"))
+
+	// Pin the first acquirer holding the heal lock until we release it, so the
+	// second healer is provably blocked on the lock (no wall-clock racing).
+	var once sync.Once
+	gotLock := make(chan struct{})
+	proceed := make(chan struct{})
+	origHook := subIndexHealLockAcquiredHook
+	t.Cleanup(func() { subIndexHealLockAcquiredHook = origHook })
+	subIndexHealLockAcquiredHook = func(string) {
+		once.Do(func() {
+			close(gotLock)
+			<-proceed
+		})
+	}
+
+	type result struct {
+		idx interface{ Close() error }
+		err error
+	}
+	resA := make(chan result, 1)
+	resB := make(chan result, 1)
+
+	go func() {
+		idx, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+		resA <- result{idx, err}
+	}()
+
+	<-gotLock // A holds the heal lock, has not nuked yet
+
+	go func() {
+		idx, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+		resB <- result{idx, err}
+	}()
+
+	// Give B a beat to reach (and block on) the heal lock, then let A proceed.
+	time.Sleep(50 * time.Millisecond)
+	close(proceed)
+
+	a := <-resA
+	b := <-resB
+
+	// Winner healed a real, working index.
+	require.NoError(t, a.err, "winner must heal successfully")
+	require.NotNil(t, a.idx)
+	require.Equal(t, 1, counter.get("nuke"), "exactly one healer may nuke")
+
+	// Loser deferred — it did NOT create a competing index and did NOT nuke.
+	require.Error(t, b.err, "loser must defer to the winner, not heal in parallel")
+	require.Contains(t, b.err.Error(), "lock contention")
+	require.Nil(t, b.idx)
+	require.Equal(t, 1, counter.get("defer"))
+
+	// The winner's replacement survives: close it, then it reopens cleanly + empty.
+	require.NoError(t, a.idx.Close())
+	require.True(t, HasNeedsReindexMarker(tmp, "test"))
+	reopened, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, err, "winner's replacement must survive the loser")
+	defer func() { _ = reopened.Close() }()
+	n, err := reopened.DocCount()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), n)
+}
+
+// --- C. Real cross-process race (the issue's literal ask) ---
+
+// TestConcurrentSelfHeal_MultiProcess re-execs the test binary as several
+// independent OS processes that all self-heal the SAME corrupted sub-index at
+// once — the exact "multiple codedb.Open callers with no shared in-process lock"
+// scenario from #828 (concurrent `ox index`, multi-worktree shared ledger). It
+// proves the flock is genuinely cross-process: every process obtains a working
+// index and the final on-disk index is clean + empty + marked for reindex.
+func TestConcurrentSelfHeal_MultiProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns subprocesses")
+	}
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+	emptyMappingForLatestSnapshot(t, filepath.Join(indexPath, "store", "root.bolt"))
+
+	const procs = 6
+
+	var wg sync.WaitGroup
+	errs := make([]error, procs)
+	outs := make([]string, procs)
+	start := make(chan struct{})
+	for i := 0; i < procs; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cmd := exec.Command(os.Args[0], "-test.run=^$")
+			cmd.Env = append(os.Environ(),
+				selfHealHelperEnv+"=1",
+				selfHealRootEnv+"="+tmp,
+				selfHealPathEnv+"="+indexPath,
+				selfHealNameEnv+"=code",
+			)
+			<-start // fire as simultaneously as the scheduler allows
+			out, err := cmd.CombinedOutput()
+			errs[i] = err
+			outs[i] = string(out)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 0; i < procs; i++ {
+		require.NoErrorf(t, errs[i], "process %d failed (race destroyed the replacement): %s", i, outs[i])
+	}
+
+	// Final on-disk index must be usable and empty — no process left it deleted
+	// or half-created.
+	final, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err, "final index must open cleanly after the multi-process race")
+	defer func() { _ = final.Close() }()
+	n, err := final.DocCount()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), n)
+	require.True(t, HasNeedsReindexMarker(tmp, "code"),
+		"at least one process must have marked the sub-index for reindex")
+}
+
+// --- D. Lock unavailable: never nuke racily, recover on retry ---
+
+// TestSelfHeal_LockTimeout_DefersThenRecovers proves the safety valve: when the
+// heal lock cannot be acquired (a live healer holds it), a corrupt-index open
+// must NOT nuke without the lock (that would reopen the race) — it surfaces a
+// retryable error and writes no marker. Once the lock frees, the retry heals.
+//
+// This guards the #826 crash-loop fix from regressing in either direction: no
+// racy nuke, and no permanent error.
+func TestSelfHeal_LockTimeout_DefersThenRecovers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+
+	origTimeout := subIndexHealLockTimeout
+	t.Cleanup(func() { subIndexHealLockTimeout = origTimeout })
+	subIndexHealLockTimeout = 150 * time.Millisecond
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+	emptyMappingForLatestSnapshot(t, filepath.Join(indexPath, "store", "root.bolt"))
+
+	// Simulate a live healer holding the per-sub-index heal lock throughout.
+	holder := flock.New(subIndexHealLockPath(indexPath))
+	locked, err := holder.TryLock()
+	require.NoError(t, err)
+	require.True(t, locked, "test must hold the heal lock to simulate a live healer")
+
+	idx, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.Nil(t, idx)
+	require.Error(t, err, "must not nuke a corrupt index without the heal lock")
+	require.False(t, HasNeedsReindexMarker(tmp, "test"),
+		"no destructive rebuild may happen while the lock is held elsewhere")
+
+	// Holder releases → the retry now heals cleanly.
+	require.NoError(t, holder.Unlock())
+	healed, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, err, "retry after the lock frees must heal")
+	defer func() { _ = healed.Close() }()
+	require.True(t, HasNeedsReindexMarker(tmp, "test"))
+}
+
+// --- E. Lock placement guardrail ---
+
+// TestSelfHealLock_IsSiblingAndSurvivesNuke guards the load-bearing placement
+// choice: the heal lock file must live OUTSIDE the sub-index dir. If it were a
+// child, os.RemoveAll(path) during the nuke would delete the lock a healer is
+// holding, handing the next process a fresh uncontended lock and reopening the
+// race. Assert the lock path is a sibling and that it survives a real heal.
+func TestSelfHealLock_IsSiblingAndSurvivesNuke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "bleve", "code")
+	lockPath := subIndexHealLockPath(indexPath)
+
+	// Structural: the lock lives beside the dir, not inside it.
+	require.Equal(t, filepath.Dir(indexPath), filepath.Dir(lockPath),
+		"heal lock must be a sibling of the sub-index dir")
+	require.False(t, strings.HasPrefix(lockPath, indexPath+string(os.PathSeparator)),
+		"heal lock must not be a child of the sub-index dir (RemoveAll would delete it)")
+
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+	emptyMappingForLatestSnapshot(t, filepath.Join(indexPath, "store", "root.bolt"))
+
+	idx, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, idx.Close())
+
+	// The lock file created during acquisition must still exist after the nuke.
+	_, statErr := os.Stat(lockPath)
+	require.NoError(t, statErr, "sibling lock file must survive the sub-index RemoveAll")
+}
+
+// --- F. Mapping-version upgrade is serialized on the same lock ---
+
+// TestUpgradeSubIndex_StaleVersion_Nukes proves the mapping-version upgrade path
+// (the other #828 self-heal trigger named in the issue) routes through the same
+// locked rebuild: a clean-but-stale index is rebuilt to the current mapping
+// version with a reindex marker.
+func TestUpgradeSubIndex_StaleVersion_Nukes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+	counter := installActionCounter(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	// Force the on-disk mapping version below current so the reclassify treats a
+	// clean open as still-stale (healNuke), not adopt.
+	require.NoError(t, os.WriteFile(filepath.Join(indexPath, mappingVersionMarker), []byte("0"), 0o644))
+
+	idx, err := rebuildSubIndexLocked(tmp, indexPath, "code", true,
+		fmt.Errorf("mapping version 0 below current"))
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	require.Equal(t, 1, counter.get("nuke"))
+	got, err := readMappingVersion(indexPath)
+	require.NoError(t, err)
+	require.Equal(t, bleveMappingVersion("code"), got, "upgrade must land the current mapping version")
+	require.True(t, HasNeedsReindexMarker(tmp, "code"))
+}
+
+// TestUpgradeSubIndex_AlreadyCurrent_Adopts proves the upgrade recheck adopts a
+// replacement a concurrent process already upgraded to the current version,
+// instead of re-nuking it.
+func TestUpgradeSubIndex_AlreadyCurrent_Adopts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+	counter := installActionCounter(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	// On-disk version is already current (openOrCreateBleveIndex wrote it), so an
+	// upgrade-path recheck must adopt, not nuke.
+	idx, err := rebuildSubIndexLocked(tmp, indexPath, "code", true,
+		fmt.Errorf("simulated stale trigger"))
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+
+	require.Equal(t, 1, counter.get("adopt"))
+	require.Equal(t, 0, counter.get("nuke"))
+	require.False(t, HasNeedsReindexMarker(tmp, "code"),
+		"adopting an already-current index must not write a marker")
+}

--- a/internal/codedb/store/store_selfheal_concurrent_test.go
+++ b/internal/codedb/store/store_selfheal_concurrent_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 )
 
 // Env vars set on a re-exec of the test binary make TestMain run
@@ -457,6 +458,118 @@ func TestSelfHeal_FlockHostileFS_HealsWithoutLock(t *testing.T) {
 	n, err := healed.DocCount()
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), n)
+}
+
+// --- D2. reclassifyUnderLock must never destroy or adopt on a soft failure ---
+
+// TestReclassify_StatError_DefersNotNuke proves a transient stat failure on a
+// healthy sub-index's root.bolt is treated as "defer", never as "rebuild". A
+// permission/I/O blip must not reach RemoveAll and replace a good index with an
+// empty one.
+//
+// Failure prevented: a retryable os.Stat error destroying healthy index content.
+func TestReclassify_StatError_DefersNotNuke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions; cannot force EACCES")
+	}
+	installFastCorruptionProbes(t)
+	counter := installActionCounter(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	// Drop rx on the "store" dir so stat of its child root.bolt fails with EACCES
+	// (a non-ENOENT error) while the bolt itself still exists and is healthy.
+	storeDir := filepath.Join(indexPath, "store")
+	require.NoError(t, os.Chmod(storeDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(storeDir, 0o755) })
+
+	idx, err := rebuildSubIndexLocked(tmp, indexPath, "code", false,
+		fmt.Errorf("open failed"))
+	require.Nil(t, idx)
+	require.Error(t, err, "a transient stat failure must defer, never nuke a healthy index")
+	require.Equal(t, 1, counter.get("defer"))
+	require.Equal(t, 0, counter.get("nuke"))
+	require.False(t, HasNeedsReindexMarker(tmp, "code"))
+
+	// The healthy bolt must survive — no RemoveAll happened.
+	require.NoError(t, os.Chmod(storeDir, 0o755))
+	_, statErr := os.Stat(filepath.Join(storeDir, "root.bolt"))
+	require.NoError(t, statErr, "healthy bolt must survive a stat-error classification")
+}
+
+// TestReclassify_MarkerReadFailure_DefersNotAdoptStale proves the mapping-version
+// upgrade path defers when the under-lock version re-read fails, instead of
+// adopting a still-stale index and skipping both the upgrade and the reindex
+// marker.
+//
+// Failure prevented: a transient marker read error silently returning a
+// mapping-stale index as if it were current.
+func TestReclassify_MarkerReadFailure_DefersNotAdoptStale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+	counter := installActionCounter(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	// Make the mapping-version marker unreadable (replace the file with a dir) so
+	// the under-lock re-confirm returns a non-nil error. The index is healthy+free.
+	marker := filepath.Join(indexPath, mappingVersionMarker)
+	require.NoError(t, os.Remove(marker))
+	require.NoError(t, os.Mkdir(marker, 0o755))
+
+	idx, err := rebuildSubIndexLocked(tmp, indexPath, "code", true,
+		fmt.Errorf("stale mapping suspected"))
+	require.Nil(t, idx)
+	require.Error(t, err, "must defer when the version can't be re-confirmed, not adopt a maybe-stale index")
+	require.Equal(t, 1, counter.get("defer"))
+	require.Equal(t, 0, counter.get("adopt"))
+	require.Equal(t, 0, counter.get("nuke"))
+	require.False(t, HasNeedsReindexMarker(tmp, "code"))
+}
+
+// TestBoundedAdoptOpen_TimesOutUnderContention proves the adopt open is bounded:
+// if a live writer holds the sub-index bbolt lock, boundedAdoptOpen returns an
+// error near the timeout instead of blocking in bleve.Open for the writer's
+// whole lifetime (the post-probe race window in reclassifyUnderLock).
+//
+// Failure prevented: the self-heal path hanging indefinitely when an ordinary
+// codedb.Open grabs the lock between the freedom probe and the adopt open.
+func TestBoundedAdoptOpen_TimesOutUnderContention(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	// A live writer holds bbolt's exclusive lock for the sub-index, mimicking an
+	// ordinary codedb.Open that raced into the post-probe window.
+	boltPath := filepath.Join(indexPath, "store", "root.bolt")
+	held, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: time.Second})
+	require.NoError(t, err)
+	defer func() { _ = held.Close() }()
+
+	start := time.Now()
+	idx, err := boundedAdoptOpen(indexPath, 200*time.Millisecond)
+	elapsed := time.Since(start)
+	require.Nil(t, idx)
+	require.Error(t, err, "adopt open must time out, not hang, while a writer holds the lock")
+	require.Less(t, elapsed, 3*time.Second, "must return near the timeout, not block indefinitely")
 }
 
 // --- E. Lock placement guardrail ---

--- a/internal/codedb/store/store_selfheal_concurrent_test.go
+++ b/internal/codedb/store/store_selfheal_concurrent_test.go
@@ -413,18 +413,16 @@ func TestSelfHeal_LockTimeout_DefersThenRecovers(t *testing.T) {
 	require.True(t, HasNeedsReindexMarker(tmp, "test"))
 }
 
-// TestSelfHeal_FlockHostileFS_HealsWithoutLock proves the flock-hostile-FS
-// escape hatch: when the heal lock cannot be SET UP at all (not merely
-// contended by a live peer), there is no peer to defer to, so a provably-corrupt
-// index must still be healed rather than left permanently unrepairable. This is
-// the opposite verdict from the timeout case above — a setup error is not a
-// timeout — and the bounded bbolt probe in reclassifyUnderLock is what keeps the
-// lock-less nuke from clobbering a healthy index.
+// TestSelfHeal_FlockHostileFS_DefersNeverRacyNuke proves that when the heal lock
+// cannot be SET UP at all (flock-hostile filesystem, not a mere timeout), a
+// destructive rebuild is REFUSED, not run lockless. A lockless nuke would let two
+// concurrent healers RemoveAll each other's fresh replacement; since the codedb
+// is a rebuildable derived cache, we defer instead and leave recovery to a full
+// reindex. The no-racy-nuke guarantee holds even where flock does not work.
 //
-// Failure prevented: on a filesystem where flock is unsupported, every open of a
-// corrupt sub-index returns a deferral error forever and code search never
-// recovers (the availability bug flagged on #835).
-func TestSelfHeal_FlockHostileFS_HealsWithoutLock(t *testing.T) {
+// Failure prevented: two processes on a flock-less FS racing RemoveAll+recreate
+// (REMOVE CREATE REMOVE CREATE) and one healer losing metadata the other deleted.
+func TestSelfHeal_FlockHostileFS_DefersNeverRacyNuke(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short: Bleve + bbolt operations")
 	}
@@ -437,27 +435,31 @@ func TestSelfHeal_FlockHostileFS_HealsWithoutLock(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, first.Close())
 	emptyMappingForLatestSnapshot(t, filepath.Join(indexPath, "store", "root.bolt"))
+	boltPath := filepath.Join(indexPath, "store", "root.bolt")
+	infoBefore, err := os.Stat(boltPath)
+	require.NoError(t, err)
 
 	// Simulate a filesystem where flock setup fails: the seam returns
-	// (locked=false, err!=nil), which the caller must treat as "no peer", NOT as
-	// a timeout to defer on.
+	// (locked=false, err!=nil) — no peer, and no safe way to serialize a rebuild.
 	orig := acquireSubIndexHealLockFn
 	t.Cleanup(func() { acquireSubIndexHealLockFn = orig })
 	acquireSubIndexHealLockFn = func(string) (*flock.Flock, bool, error) {
 		return nil, false, errors.New("simulated flock-hostile filesystem")
 	}
 
-	healed, err := openOrCreateBleveIndex(tmp, indexPath, "code")
-	require.NoError(t, err, "a corrupt index on a flock-hostile FS must heal, not defer forever")
-	defer func() { _ = healed.Close() }()
+	idx, err := rebuildSubIndexLocked(tmp, indexPath, "code", false,
+		fmt.Errorf("corrupt mapping"))
+	require.Nil(t, idx)
+	require.Error(t, err, "must defer, never nuke without a cross-process lock")
+	require.Equal(t, 1, counter.get("defer"))
+	require.Equal(t, 0, counter.get("nuke"), "no lockless RemoveAll may happen")
+	require.False(t, HasNeedsReindexMarker(tmp, "code"))
 
-	require.Equal(t, 1, counter.get("nuke"),
-		"setup failure with a corrupt index must nuke+recreate, not defer")
-	require.Equal(t, 0, counter.get("defer"))
-	require.True(t, HasNeedsReindexMarker(tmp, "code"))
-	n, err := healed.DocCount()
-	require.NoError(t, err)
-	require.Equal(t, uint64(0), n)
+	// The corrupt index must be left exactly as-is (not RemoveAll'd + recreated).
+	infoAfter, err := os.Stat(boltPath)
+	require.NoError(t, err, "the sub-index must not be destroyed by a lockless heal")
+	require.Equal(t, infoBefore.ModTime(), infoAfter.ModTime(),
+		"root.bolt must be untouched — no rebuild ran")
 }
 
 // --- D2. reclassifyUnderLock must never destroy or adopt on a soft failure ---

--- a/internal/codedb/store/store_selfheal_concurrent_test.go
+++ b/internal/codedb/store/store_selfheal_concurrent_test.go
@@ -464,82 +464,93 @@ func TestSelfHeal_FlockHostileFS_DefersNeverRacyNuke(t *testing.T) {
 
 // --- D2. reclassifyUnderLock must never destroy or adopt on a soft failure ---
 
-// TestReclassify_StatError_DefersNotNuke proves a transient stat failure on a
-// healthy sub-index's root.bolt is treated as "defer", never as "rebuild". A
-// permission/I/O blip must not reach RemoveAll and replace a good index with an
-// empty one.
+// TestReclassify_SoftFailure_DefersNotDestructive proves that a SOFT failure
+// during reclassification — one that does NOT prove corruption — resolves to
+// healDefer, never to a destructive rebuild or a silent adoption. Both cases
+// share the "must not nuke, must not adopt, must not mark" contract; each induces
+// a different soft failure and adds its own survival check.
 //
-// Failure prevented: a retryable os.Stat error destroying healthy index content.
-func TestReclassify_StatError_DefersNotNuke(t *testing.T) {
+// Failure prevented: a retryable error (a stat blip, an unreadable version
+// marker) either destroying a healthy index or laundering a stale one as current.
+func TestReclassify_SoftFailure_DefersNotDestructive(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short: Bleve + bbolt operations")
 	}
-	if os.Geteuid() == 0 {
-		t.Skip("root bypasses directory permissions; cannot force EACCES")
+	cases := []struct {
+		name string
+		// requireVersion selects the plain self-heal (false) vs mapping-upgrade
+		// (true) path through rebuildSubIndexLocked.
+		requireVersion bool
+		skip           func(t *testing.T)
+		// induce corrupts the soft classification input on an otherwise
+		// healthy+free index, and returns an extra post-run assertion (or nil).
+		induce func(t *testing.T, indexPath string) func(t *testing.T)
+	}{
+		{
+			name:           "transient stat error never nukes a healthy index",
+			requireVersion: false,
+			skip: func(t *testing.T) {
+				if os.Geteuid() == 0 {
+					t.Skip("root bypasses directory permissions; cannot force EACCES")
+				}
+			},
+			induce: func(t *testing.T, indexPath string) func(t *testing.T) {
+				// Drop rx on "store" so stat of its child root.bolt fails with EACCES
+				// (a non-ENOENT error) while the bolt still exists and is healthy.
+				storeDir := filepath.Join(indexPath, "store")
+				require.NoError(t, os.Chmod(storeDir, 0o000))
+				t.Cleanup(func() { _ = os.Chmod(storeDir, 0o755) })
+				return func(t *testing.T) {
+					// The healthy bolt must survive — no RemoveAll happened.
+					require.NoError(t, os.Chmod(storeDir, 0o755))
+					_, statErr := os.Stat(filepath.Join(storeDir, "root.bolt"))
+					require.NoError(t, statErr, "healthy bolt must survive a stat-error classification")
+				}
+			},
+		},
+		{
+			name:           "marker read failure never adopts a stale index",
+			requireVersion: true,
+			induce: func(t *testing.T, indexPath string) func(t *testing.T) {
+				// Replace the version marker file with a dir so the under-lock re-read
+				// returns a non-nil error. The index is healthy + free.
+				marker := filepath.Join(indexPath, mappingVersionMarker)
+				require.NoError(t, os.Remove(marker))
+				require.NoError(t, os.Mkdir(marker, 0o755))
+				return nil
+			},
+		},
 	}
-	installFastCorruptionProbes(t)
-	counter := installActionCounter(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skip != nil {
+				tc.skip(t)
+			}
+			installFastCorruptionProbes(t)
+			counter := installActionCounter(t)
 
-	tmp := t.TempDir()
-	indexPath := filepath.Join(tmp, "test-index")
-	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
-	require.NoError(t, err)
-	require.NoError(t, first.Close())
+			tmp := t.TempDir()
+			indexPath := filepath.Join(tmp, "test-index")
+			first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+			require.NoError(t, err)
+			require.NoError(t, first.Close())
 
-	// Drop rx on the "store" dir so stat of its child root.bolt fails with EACCES
-	// (a non-ENOENT error) while the bolt itself still exists and is healthy.
-	storeDir := filepath.Join(indexPath, "store")
-	require.NoError(t, os.Chmod(storeDir, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(storeDir, 0o755) })
+			extraCheck := tc.induce(t, indexPath)
 
-	idx, err := rebuildSubIndexLocked(tmp, indexPath, "code", false,
-		fmt.Errorf("open failed"))
-	require.Nil(t, idx)
-	require.Error(t, err, "a transient stat failure must defer, never nuke a healthy index")
-	require.Equal(t, 1, counter.get("defer"))
-	require.Equal(t, 0, counter.get("nuke"))
-	require.False(t, HasNeedsReindexMarker(tmp, "code"))
+			idx, err := rebuildSubIndexLocked(tmp, indexPath, "code", tc.requireVersion,
+				fmt.Errorf("soft failure"))
+			require.Nil(t, idx)
+			require.Error(t, err, "a soft failure must defer, not rebuild or adopt")
+			require.Equal(t, 1, counter.get("defer"))
+			require.Equal(t, 0, counter.get("nuke"), "no destructive rebuild on a soft failure")
+			require.Equal(t, 0, counter.get("adopt"), "no silent adoption on a soft failure")
+			require.False(t, HasNeedsReindexMarker(tmp, "code"))
 
-	// The healthy bolt must survive — no RemoveAll happened.
-	require.NoError(t, os.Chmod(storeDir, 0o755))
-	_, statErr := os.Stat(filepath.Join(storeDir, "root.bolt"))
-	require.NoError(t, statErr, "healthy bolt must survive a stat-error classification")
-}
-
-// TestReclassify_MarkerReadFailure_DefersNotAdoptStale proves the mapping-version
-// upgrade path defers when the under-lock version re-read fails, instead of
-// adopting a still-stale index and skipping both the upgrade and the reindex
-// marker.
-//
-// Failure prevented: a transient marker read error silently returning a
-// mapping-stale index as if it were current.
-func TestReclassify_MarkerReadFailure_DefersNotAdoptStale(t *testing.T) {
-	if testing.Short() {
-		t.Skip("short: Bleve + bbolt operations")
+			if extraCheck != nil {
+				extraCheck(t)
+			}
+		})
 	}
-	installFastCorruptionProbes(t)
-	counter := installActionCounter(t)
-
-	tmp := t.TempDir()
-	indexPath := filepath.Join(tmp, "test-index")
-	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
-	require.NoError(t, err)
-	require.NoError(t, first.Close())
-
-	// Make the mapping-version marker unreadable (replace the file with a dir) so
-	// the under-lock re-confirm returns a non-nil error. The index is healthy+free.
-	marker := filepath.Join(indexPath, mappingVersionMarker)
-	require.NoError(t, os.Remove(marker))
-	require.NoError(t, os.Mkdir(marker, 0o755))
-
-	idx, err := rebuildSubIndexLocked(tmp, indexPath, "code", true,
-		fmt.Errorf("stale mapping suspected"))
-	require.Nil(t, idx)
-	require.Error(t, err, "must defer when the version can't be re-confirmed, not adopt a maybe-stale index")
-	require.Equal(t, 1, counter.get("defer"))
-	require.Equal(t, 0, counter.get("adopt"))
-	require.Equal(t, 0, counter.get("nuke"))
-	require.False(t, HasNeedsReindexMarker(tmp, "code"))
 }
 
 // TestBoundedAdoptOpen_TimesOutUnderContention proves the adopt open is bounded:

--- a/internal/codedb/store/store_selfheal_concurrent_test.go
+++ b/internal/codedb/store/store_selfheal_concurrent_test.go
@@ -13,6 +13,7 @@ package store
 // data-loss-shaped race that widened with the torn-bolt trigger in #826.
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -333,6 +334,7 @@ func TestConcurrentSelfHeal_MultiProcess(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			cmd := exec.Command(os.Args[0], "-test.run=^$")
+			cmd.Dir = tmp // keep the re-exec'd child out of the repo working tree
 			cmd.Env = append(os.Environ(),
 				selfHealHelperEnv+"=1",
 				selfHealRootEnv+"="+tmp,
@@ -408,6 +410,53 @@ func TestSelfHeal_LockTimeout_DefersThenRecovers(t *testing.T) {
 	require.NoError(t, err, "retry after the lock frees must heal")
 	defer func() { _ = healed.Close() }()
 	require.True(t, HasNeedsReindexMarker(tmp, "test"))
+}
+
+// TestSelfHeal_FlockHostileFS_HealsWithoutLock proves the flock-hostile-FS
+// escape hatch: when the heal lock cannot be SET UP at all (not merely
+// contended by a live peer), there is no peer to defer to, so a provably-corrupt
+// index must still be healed rather than left permanently unrepairable. This is
+// the opposite verdict from the timeout case above — a setup error is not a
+// timeout — and the bounded bbolt probe in reclassifyUnderLock is what keeps the
+// lock-less nuke from clobbering a healthy index.
+//
+// Failure prevented: on a filesystem where flock is unsupported, every open of a
+// corrupt sub-index returns a deferral error forever and code search never
+// recovers (the availability bug flagged on #835).
+func TestSelfHeal_FlockHostileFS_HealsWithoutLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+	counter := installActionCounter(t)
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+	emptyMappingForLatestSnapshot(t, filepath.Join(indexPath, "store", "root.bolt"))
+
+	// Simulate a filesystem where flock setup fails: the seam returns
+	// (locked=false, err!=nil), which the caller must treat as "no peer", NOT as
+	// a timeout to defer on.
+	orig := acquireSubIndexHealLockFn
+	t.Cleanup(func() { acquireSubIndexHealLockFn = orig })
+	acquireSubIndexHealLockFn = func(string) (*flock.Flock, bool, error) {
+		return nil, false, errors.New("simulated flock-hostile filesystem")
+	}
+
+	healed, err := openOrCreateBleveIndex(tmp, indexPath, "code")
+	require.NoError(t, err, "a corrupt index on a flock-hostile FS must heal, not defer forever")
+	defer func() { _ = healed.Close() }()
+
+	require.Equal(t, 1, counter.get("nuke"),
+		"setup failure with a corrupt index must nuke+recreate, not defer")
+	require.Equal(t, 0, counter.get("defer"))
+	require.True(t, HasNeedsReindexMarker(tmp, "code"))
+	n, err := healed.DocCount()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), n)
 }
 
 // --- E. Lock placement guardrail ---


### PR DESCRIPTION
Keeps a teammate's code-search index intact when two ox processes heal it at the same moment — no more silently wiping a freshly-rebuilt index out from under the process that just created it. Closes a data-loss-shaped race in the codedb self-heal path that the torn-bolt trigger in #826 made materially more likely.

## What broke

`codedb` self-heals a structurally-corrupt bleve sub-index by nuking it (`os.RemoveAll`) and recreating it empty. That destructive rebuild had **no cross-process serialization**. Two `codedb.Open` callers hitting the same sub-index concurrently — e.g.

- an in-process `ox index` racing the daemon,
- two `ox index` runs, or
- two worktrees sharing one ledger codedb

— could each decide to nuke, and the **loser deletes the winner's brand-new index**. Worse, a caller could nuke an index that a live writer was legitimately holding open (healthy, just locked), destroying good data instead of backing off. #826's torn-bolt self-heal widened the window by making "reopen fails → nuke" fire more often.

```mermaid
flowchart LR
  subgraph before["Before — unserialized nuke race"]
    A1[Process A: open fails] --> A2[RemoveAll + recreate]
    B1[Process B: open fails] --> B2[RemoveAll + recreate]
    A2 -.clobbers.-> B2
    B2 -.clobbers.-> A2
    A2 --> X([one healer's fresh index deleted])
  end
```

## What this PR ships

A single per-sub-index **cross-process file lock** (`gofrs/flock`, already in `go.mod`) around the destructive rebuild, plus a **recheck-under-lock** that reuses the real corruption classifier instead of blindly nuking. Both self-heal and the mapping-version upgrade path (the two sites that raced) now flow through one shared `rebuildSubIndexLocked`.

Once the heal lock is held, `reclassifyUnderLock` reaches one of three verdicts using only **bounded, non-blocking** bbolt probes (never the blocking `bleve.Open`, which would hang forever against a held index):

- **adopt** — a concurrent process already repaired it; return that index, don't nuke.
- **defer** — the index is healthy but held open by a live writer; surface the retryable "lock contention" error, never nuke a good index.
- **nuke** — still provably corrupt/stale and we hold the lock; `RemoveAll` + recreate empty + write the `.needs_reindex` marker.

```mermaid
flowchart LR
  O[open fails] --> L{acquire per-sub-index<br/>heal lock}
  L -->|held by peer| R[reclassify once]
  L -->|acquired| R
  R -->|repaired| AD[adopt replacement]
  R -->|healthy + held| DE[defer: retryable err]
  R -->|still corrupt/stale| NU[nuke + recreate + marker]
```

Design details worth a reviewer's eye:

- **Lock file is a sibling** (`<path>.heal.lock`), never a child of the sub-index dir — so `os.RemoveAll(path)` can't delete the lock out from under a mid-nuke healer and reopen the race.
- **flock releases on process death**, so a lock-acquire timeout means "a live peer holds it," never a dead holder — the loser surfaces a retryable error and the winner's heal lands.
- **Fail-safe on lock-acquire failure** (timeout / flock-hostile FS): reclassify once, adopt a ready replacement, otherwise return a retryable error rather than racily nuking.

## Test Plan

New cross-process regression suite `internal/codedb/store/store_selfheal_concurrent_test.go` (re-execs the test binary to get real separate processes), covering adopt / defer / nuke, the multi-process loser-doesn't-clobber invariant, lock-timeout recovery, sibling-lock-survives-nuke, and the mapping-upgrade adopt/nuke paths.

- **Green:** full `internal/codedb/store` package passes (`go test ./internal/codedb/store/... -count=1` → ok, ~21s).
- **Red-first proof:** temporarily forced `reclassifyUnderLock` to always return `nuke` (removing the adopt/defer safety) and watched the claims fail on their own assertions, not on compile:
  - `TestConcurrentSelfHeal_LoserDoesNotClobberWinner` → `exactly one healer may nuke: expected 1, actual 2`
  - `TestRebuildSubIndexLocked_HeldOpen_Defers` → returned a live index instead of `nil` (nuked a held index)
  - `TestRebuildSubIndexLocked_Healthy_Adopts` → `expected 1 adopt, actual 0`
  - Restored the fix; all three green again.
- `go vet` and package-scoped `golangci-lint` clean on the changed files (the one errcheck hit is pre-existing in `blob_reader_test.go`, untouched here).

## Scope / notes

- codedb-only; no dependency or schema changes (`gofrs/flock v0.13.0` already vendored).
- Complements the reliability line already in flight: #826 (torn-bolt self-heal), #829 (0.14.2 patch), #830 (release notes).

Closes #828

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790303254&installation_model_id=433550&pr_number=835&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F835&signature=01da218fd48f631307168fd855156e601fdd78c2e15f2eb98e3e86e319d7e432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search index recovery when indexes are corrupted, outdated, or unavailable.
  - Prevented concurrent recovery operations from overwriting valid repairs.
  - Preserved healthy indexes during temporary storage or coordination failures.
  - Deferred recovery safely when an index is in use or its status cannot be confirmed.
  - Added bounded recovery attempts to prevent indefinite blocking.
  - Improved reliability across concurrent activity and multiple running processes.
  - Restricted destructive rebuilds to coordinated recovery operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->