### PR TITLE
chore(lint): enable curated errcheck + unused linters

### DIFF
--- a/.config/golangci.yml
+++ b/.config/golangci.yml
@@ -19,6 +19,7 @@ linters:
 
     # Error handling
     - errorlint
+    - errcheck
 
     # Code quality
     - misspell
@@ -31,6 +32,45 @@ linters:
     - paralleltest
 
   settings:
+    # errcheck is curated, not blanket: a CLI legitimately ignores errors on
+    # terminal output, best-effort drains, and deferred cleanup Close. Excluding
+    # those (below) collapses ~2,900 context-blind hits to the meaningful set —
+    # unchecked Write/WriteString/Encode to a real sink, Sscanf, and lifecycle
+    # calls (Start/Register/Shutdown) whose failure is otherwise silent. Test
+    # files are excluded wholesale (see exclusions.rules).
+    errcheck:
+      check-type-assertions: false
+      check-blank: false # `_ = f()` is the sanctioned explicit-ignore escape hatch
+      exclude-functions:
+        # Terminal output — a broken stdout/stderr pipe is not actionable.
+        - fmt.Print
+        - fmt.Printf
+        - fmt.Println
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        # Best-effort drains/copies (e.g. io.Copy(io.Discard, resp.Body)).
+        - io.Copy
+        - io.WriteString
+        # Deferred cleanup Close: read paths, DB handles, rows, connections,
+        # response bodies — a close error after the useful work is not
+        # actionable. Write-side flush-Close durability is handled in code, not
+        # by this coarse matcher.
+        - (io.Closer).Close
+        - (io.ReadCloser).Close
+        - (*os.File).Close
+        - (*database/sql.DB).Close
+        - (*database/sql.Rows).Close
+        - (*database/sql.Tx).Rollback
+        # Best-effort filesystem/env mutations (teardown, idempotent cleanup).
+        - os.Remove
+        - os.RemoveAll
+        - os.Unsetenv
+        # Cobra/pflag wiring errors fire only on a programmer mistake (unknown
+        # flag name at init), caught immediately in dev — not a runtime error.
+        - (*github.com/spf13/pflag.FlagSet).SetAnnotation
+        - (*github.com/spf13/pflag.FlagSet).MarkHidden
+
     misspell:
       locale: US
 
@@ -61,12 +101,25 @@ linters:
 
   exclusions:
     rules:
-      # Test files - exclude security, strict error checks, and logging strictness
+      # Test files - exclude security, strict error checks, and logging strictness.
+      # errcheck is off for tests: a failed os.Chdir/Setenv/WriteFile in setup or
+      # teardown surfaces as a test failure anyway; flagging them is pure noise.
       - path: _test\.go
         linters:
           - gosec
           - errorlint
           - sloglint
+          - errcheck
+
+      # errcheck: method-name classes that are always best-effort, regardless of
+      # receiver type (the exclude-functions matcher keys on static type, so it
+      # can't catch these on internal concrete types). Deferred Close is cleanup;
+      # colored writers (color.Color.Fprint*) are terminal output; conn deadline
+      # setters fail only on an already-closed conn; Process.Kill / lock Unlock
+      # are best-effort. Genuine data ops (Write/Index/Exec/Encode/Scan) are NOT
+      # excluded and must be handled.
+      - linters: [errcheck]
+        text: 'Error return value of `[^`]+\.(Close|Fprint|Fprintf|Fprintln|SetDeadline|SetReadDeadline|SetWriteDeadline|Kill|Unlock)` is not checked'
 
       # Adapter rules.go files are deliberately-unwired scaffolds — each file's
       # header documents "not yet wired into main.go", kept as a documented

--- a/.config/golangci.yml
+++ b/.config/golangci.yml
@@ -11,6 +11,9 @@ linters:
     - govet
     - staticcheck
 
+    # Dead code
+    - unused
+
     # Security
     - gosec
 
@@ -64,6 +67,14 @@ linters:
           - gosec
           - errorlint
           - sloglint
+
+      # Adapter rules.go files are deliberately-unwired scaffolds — each file's
+      # header documents "not yet wired into main.go", kept as a documented
+      # future-integration point. Exempt them from `unused` so the intentional
+      # handlers don't have to be deleted or littered with per-func nolints.
+      - path: cmd/ox-adapter-(aider|gemini|pi)/rules\.go
+        linters:
+          - unused
 
       # SA5011 false-positives in tests. The pattern
       #   x := f(); if x == nil { t.Fatal(...) }; x.Field

--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -1431,7 +1431,7 @@ func formatWhispers(w io.Writer, entries []whisperstore.WhisperEntry) bool {
 			writeXMLAttribute(w, "metadata", metadata)
 		}
 		fmt.Fprint(w, ">")
-		xml.EscapeText(w, []byte(e.Content))
+		_ = xml.EscapeText(w, []byte(e.Content)) // best-effort terminal output
 		fmt.Fprint(w, "</entry>\n")
 	}
 	fmt.Fprintln(w, "</system-reminder>")

--- a/cmd/ox/conversation.go
+++ b/cmd/ox/conversation.go
@@ -132,8 +132,8 @@ func writeConversationEnvelope(w io.Writer, format string, env *read.Envelope, r
 		fmt.Fprintf(w, `{"success":false,"error":{"code":"envelope_marshal_failed","message":%q,"retryable":false}}`+"\n", err.Error())
 		return
 	}
-	w.Write(b)
-	w.Write([]byte{'\n'})
+	_, _ = w.Write(b)            // best-effort terminal output
+	_, _ = w.Write([]byte{'\n'}) // best-effort terminal output
 }
 
 // conversationExitCode maps a typed read error to a process exit code:

--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -138,8 +138,8 @@ func inferWeeklyHighWater(tcPath string) time.Time {
 			continue
 		}
 		var y, w int
-		fmt.Sscanf(m[1], "%d", &y)
-		fmt.Sscanf(m[2], "%d", &w)
+		_, _ = fmt.Sscanf(m[1], "%d", &y) // input is regex-validated digits
+		_, _ = fmt.Sscanf(m[2], "%d", &w) // input is regex-validated digits
 		if !found || y > latestYear || (y == latestYear && w > latestWeek) {
 			latestYear, latestWeek = y, w
 			found = true
@@ -314,8 +314,8 @@ func readWeeklyFilesForMonth(weeklyDir string, year, month int) ([]string, []str
 			continue
 		}
 		var wy, ww int
-		fmt.Sscanf(m[1], "%d", &wy)
-		fmt.Sscanf(m[2], "%d", &ww)
+		_, _ = fmt.Sscanf(m[1], "%d", &wy) // input is regex-validated digits
+		_, _ = fmt.Sscanf(m[2], "%d", &ww) // input is regex-validated digits
 
 		wStart, wEnd := isoWeekRange(wy, ww)
 		// week overlaps month if week starts before month ends AND week ends after month starts

--- a/cmd/ox/distill_history_list.go
+++ b/cmd/ox/distill_history_list.go
@@ -283,8 +283,8 @@ func writeJournalEnvelope(w io.Writer, format string, env *distillHistoryEnvelop
 		fmt.Fprintf(w, `{"success":false,"error":{"code":"envelope_marshal_failed","message":%q,"retryable":false}}`+"\n", err.Error())
 		return
 	}
-	w.Write(b)
-	w.Write([]byte{'\n'})
+	_, _ = w.Write(b)            // best-effort terminal output
+	_, _ = w.Write([]byte{'\n'}) // best-effort terminal output
 }
 
 // writeJournalRuntimeError emits an error envelope (exit code 1) onto

--- a/cmd/ox/distill_history_show.go
+++ b/cmd/ox/distill_history_show.go
@@ -304,9 +304,9 @@ func renderDistillHistoryShowContent(w io.Writer, entries []read.Entry) {
 		} else {
 			fmt.Fprintf(w, "\n---\n<!-- entry: %s -->\n", e.ID)
 		}
-		w.Write([]byte(e.BodyMD))
+		_, _ = w.Write([]byte(e.BodyMD)) // best-effort terminal output
 		if len(e.BodyMD) > 0 && e.BodyMD[len(e.BodyMD)-1] != '\n' {
-			w.Write([]byte{'\n'})
+			_, _ = w.Write([]byte{'\n'}) // best-effort terminal output
 		}
 	}
 }

--- a/cmd/ox/distill_history_since.go
+++ b/cmd/ox/distill_history_since.go
@@ -263,9 +263,9 @@ func renderDistillHistorySinceContent(w io.Writer, entries []read.Entry, bodies 
 			fmt.Fprint(w, "\n---\n")
 			fmt.Fprintln(w, marker)
 		}
-		w.Write([]byte(body))
+		_, _ = w.Write([]byte(body)) // best-effort terminal output
 		if body[len(body)-1] != '\n' {
-			w.Write([]byte{'\n'})
+			_, _ = w.Write([]byte{'\n'}) // best-effort terminal output
 		}
 	}
 }

--- a/cmd/ox/docs.go
+++ b/cmd/ox/docs.go
@@ -61,7 +61,9 @@ func runDocsGenerate(cmd *cobra.Command, args []string) error {
 
 	// Restore .gitkeep if it existed
 	if hasGitkeep {
-		os.WriteFile(gitkeepPath, []byte{}, 0644)
+		if err := os.WriteFile(gitkeepPath, []byte{}, 0644); err != nil {
+			return fmt.Errorf("failed to restore .gitkeep: %w", err)
+		}
 	}
 
 	// Sync package.json version with CLI version

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -293,8 +293,8 @@ func checkLedgerBranchStatus(fix bool) checkResult {
 
 	aheadCount := 0
 	behindCount := 0
-	fmt.Sscanf(ahead, "%d", &aheadCount)
-	fmt.Sscanf(behind, "%d", &behindCount)
+	_, _ = fmt.Sscanf(ahead, "%d", &aheadCount)   // git rev-list --count always emits digits
+	_, _ = fmt.Sscanf(behind, "%d", &behindCount) // git rev-list --count always emits digits
 
 	if aheadCount > 0 && behindCount > 0 {
 		if fix {
@@ -484,8 +484,8 @@ func fixLedgerBranchDiverged(ledgerPath string, aheadCount, behindCount int) che
 		parts := strings.Fields(strings.TrimSpace(string(revOut)))
 		if len(parts) == 2 {
 			behind, ahead := 0, 0
-			fmt.Sscanf(parts[0], "%d", &behind)
-			fmt.Sscanf(parts[1], "%d", &ahead)
+			_, _ = fmt.Sscanf(parts[0], "%d", &behind) // git rev-list --count always emits digits
+			_, _ = fmt.Sscanf(parts[1], "%d", &ahead)  // git rev-list --count always emits digits
 
 			switch {
 			case ahead == 0 && behind == 0:

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -368,7 +368,7 @@ func runInit() error {
 		if resolvedEndpoint == "" {
 			return fmt.Errorf("invalid --endpoint value: %q", initEndpointFlag)
 		}
-		os.Setenv(endpoint.EnvVar, resolvedEndpoint)
+		_ = os.Setenv(endpoint.EnvVar, resolvedEndpoint) // Setenv fails only on an invalid name
 		if !initQuiet {
 			fmt.Println()
 			fmt.Printf("Using endpoint: %s\n", cli.StyleBold.Render(endpoint.NormalizeSlug(resolvedEndpoint)))
@@ -385,7 +385,7 @@ func runInit() error {
 				fmt.Printf("Run %s to authenticate.\n", cli.StyleCommand.Render("ox login"))
 				return nil
 			}
-			os.Setenv(endpoint.EnvVar, selectedEndpoint)
+			_ = os.Setenv(endpoint.EnvVar, selectedEndpoint) // Setenv fails only on an invalid name
 			fmt.Println()
 			fmt.Printf("Using endpoint: %s\n", cli.StyleBold.Render(endpoint.NormalizeSlug(selectedEndpoint)))
 		}

--- a/cmd/ox/logout.go
+++ b/cmd/ox/logout.go
@@ -75,7 +75,12 @@ var logoutCmd = &cobra.Command{
 			for {
 				fmt.Print("Select endpoint to logout (1-", maxSelection, "): ")
 				var input string
-				fmt.Scanln(&input)
+				if _, err := fmt.Scanln(&input); err != nil {
+					// unreadable input (e.g. closed/EOF stdin) — cancel rather than
+					// spin forever re-prompting against a stream that can't answer.
+					fmt.Println("Logout canceled.")
+					return nil
+				}
 				n, err := fmt.Sscanf(input, "%d", &selection)
 				if err == nil && n == 1 && selection >= 1 && selection <= maxSelection {
 					break

--- a/cmd/ox/main.go
+++ b/cmd/ox/main.go
@@ -49,7 +49,7 @@ func init() {
 	//
 	// Override: Set NO_COLOR=0 to force colors even in agent context.
 	if agentx.IsAgentContext() && os.Getenv("NO_COLOR") == "" {
-		os.Setenv("NO_COLOR", "1")
+		_ = os.Setenv("NO_COLOR", "1") // Setenv fails only on an invalid name
 	}
 
 	// Escape hatch: CLICOLOR_FORCE=1 disables the global ANSI stripper below
@@ -66,7 +66,7 @@ func init() {
 	// fmt.Print(style.Render(...)) which bypasses it. These pipes catch
 	// everything globally for both streams.
 	if !forceColor && !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()) {
-		os.Setenv("NO_COLOR", "1") // keep for libraries that do check it
+		_ = os.Setenv("NO_COLOR", "1") // keep for libraries that do check it; Setenv fails only on an invalid name
 
 		pr, pw, err := os.Pipe()
 		if err == nil {
@@ -142,7 +142,7 @@ func executeWithFrictionRecovery(args []string, attempt int) int {
 
 	// mark retry attempts to avoid telemetry double-counting
 	if attempt > 0 {
-		os.Setenv("OX_FRICTION_RETRY", "1")
+		_ = os.Setenv("OX_FRICTION_RETRY", "1") // Setenv fails only on an invalid name
 	}
 
 	err := rootCmd.Execute()

--- a/cmd/ox/session_notify.go
+++ b/cmd/ox/session_notify.go
@@ -79,7 +79,7 @@ func notifySessionAbortedAsync(projectRoot, sessionID string) {
 	if sessionID == "" {
 		return
 	}
-	runSessionSignal("aborted", func(client *api.RepoClient, repoID string) error {
+	_ = runSessionSignal("aborted", func(client *api.RepoClient, repoID string) error { // fire-and-forget
 		return client.NotifySessionAborted(api.SessionAbortedNotification{
 			SessionID: sessionID,
 			RepoID:    repoID,

--- a/cmd/ox/status_bubbles.go
+++ b/cmd/ox/status_bubbles.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"time"
 
-	lipgloss "charm.land/lipgloss/v2"
-
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/kb"
@@ -444,37 +442,10 @@ var statusBubblesFetchForRoot = func(projectRoot string) (statusBubblesFetch, st
 	}, ep
 }
 
-// commonDir returns the longest shared leading directory of a and b.
-func commonDir(a, b string) string {
-	if a == b {
-		return a
-	}
-	sep := string(os.PathSeparator)
-	as, bs := strings.Split(a, sep), strings.Split(b, sep)
-	n := len(as)
-	if len(bs) < n {
-		n = len(bs)
-	}
-	i := 0
-	for i < n && as[i] == bs[i] {
-		i++
-	}
-	return strings.Join(as[:i], sep)
-}
-
 // renderSlugRef styles a slug reference: the sigil (@ for an owner, # for a
 // bubble) is muted so the slug itself stands out — e.g. dim("@") + bright("sageox").
 func renderSlugRef(sigil, slug string) string {
 	return statusMutedStyle.Render(sigil) + statusValueStyle.Render(slug)
-}
-
-// padCell right-pads a (possibly ANSI-styled) cell to width w using its
-// visible width, so color codes don't break column alignment.
-func padCell(cell string, w int) string {
-	if gap := w - lipgloss.Width(cell); gap > 0 {
-		return cell + strings.Repeat(" ", gap)
-	}
-	return cell
 }
 
 // renderBubbleStatus renders the dense status cell for a bubble's local

--- a/internal/api/video.go
+++ b/internal/api/video.go
@@ -275,13 +275,3 @@ func (c *RepoClient) ListVideos(contextType, contextID string, limit, offset int
 
 	return &listResp, nil
 }
-
-// httpStatusError formats a non-2xx response into the same error shape the
-// other video methods produce.
-func httpStatusError(status int, reqURL string, body []byte) error {
-	errMsg := strings.TrimSpace(string(body))
-	if errMsg == "" {
-		return fmt.Errorf("HTTP %d from %s", status, reqURL)
-	}
-	return fmt.Errorf("HTTP %d from %s: %s", status, reqURL, errMsg)
-}

--- a/internal/carts/store.go
+++ b/internal/carts/store.go
@@ -120,7 +120,9 @@ func (s *Store) initSchema(ctx context.Context) error {
 		}
 	}
 
-	s.setMetadata(ctx, "schema_version", strconv.Itoa(currentSchemaVersion))
+	if err := s.setMetadata(ctx, "schema_version", strconv.Itoa(currentSchemaVersion)); err != nil {
+		return fmt.Errorf("set schema version: %w", err)
+	}
 	s.doltCommit(ctx, "schema: init carts v"+strconv.Itoa(currentSchemaVersion))
 	return nil
 }
@@ -215,8 +217,11 @@ func (s *Store) getMetadata(ctx context.Context, key string) (string, error) {
 	return value, err
 }
 
-func (s *Store) setMetadata(ctx context.Context, key, value string) {
-	s.db.ExecContext(ctx, "REPLACE INTO metadata (`key`, value) VALUES (?, ?)", key, value)
+func (s *Store) setMetadata(ctx context.Context, key, value string) error {
+	if _, err := s.db.ExecContext(ctx, "REPLACE INTO metadata (`key`, value) VALUES (?, ?)", key, value); err != nil {
+		return fmt.Errorf("set metadata %q: %w", key, err)
+	}
+	return nil
 }
 
 func splitStatements(sql string) []string {

--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -489,7 +489,10 @@ func BuildDirtyIndex(ctx context.Context, localPath, dirtyPath string, opts Inde
 			continue
 		}
 
-		batch.Index("dirty_"+relPath, BleveCodeDoc{Content: string(content)})
+		if err := batch.Index("dirty_"+relPath, BleveCodeDoc{Content: string(content)}); err != nil {
+			slog.Warn("dirty index: batch index failed", "path", relPath, "err", err)
+			continue
+		}
 		indexed++
 	}
 
@@ -1046,7 +1049,9 @@ func (st *indexState) insertDiff(commitDBID int64, path string, oldBlobDBID sql.
 
 	diffText := generateDiffText(st.repo, path, oldOID, newOID, hasOld, hasNew, oldText, newText)
 	if diffText != "" {
-		st.diffBatch.Index("diff_"+strconv.FormatInt(diffDBID, 10), BleveDiffDoc{Content: diffText})
+		if err := st.diffBatch.Index("diff_"+strconv.FormatInt(diffDBID, 10), BleveDiffDoc{Content: diffText}); err != nil {
+			return fmt.Errorf("index diff: %w", err)
+		}
 		st.diffBatchN++
 		if err := st.flushDiffBatch(false); err != nil {
 			return err
@@ -1150,10 +1155,12 @@ func getTreeEntries(repo *git.Repository, treeHash plumbing.Hash, cache map[plum
 	}
 
 	entries := make(map[string]plumbing.Hash)
-	tree.Files().ForEach(func(f *object.File) error {
+	if err := tree.Files().ForEach(func(f *object.File) error {
 		entries[f.Name] = f.Hash
 		return nil
-	})
+	}); err != nil {
+		return nil, fmt.Errorf("iterate tree files: %w", err)
+	}
 
 	cache[treeHash] = entries
 	return entries, nil
@@ -1208,7 +1215,9 @@ func (st *indexState) ensureBlob(blobOID plumbing.Hash, path string) (int64, str
 			reader.Close()
 			if readErr == nil && utf8.Valid(content) && len(content) > 0 {
 				blobText = string(content)
-				st.codeBatch.Index("blob_"+strconv.FormatInt(blobDBID, 10), BleveCodeDoc{Content: blobText})
+				if err := st.codeBatch.Index("blob_"+strconv.FormatInt(blobDBID, 10), BleveCodeDoc{Content: blobText}); err != nil {
+					return 0, "", false, fmt.Errorf("index blob: %w", err)
+				}
 				st.codeBatchN++
 				indexed = true
 				if err := st.flushCodeBatch(false); err != nil {
@@ -2031,7 +2040,10 @@ sendLoop2:
 					return 0, 0, fmt.Errorf("scan inserted comment id: %w", err)
 				}
 				if cmIdx < len(batch) {
-					commentBatch.Index("comment_"+strconv.FormatInt(commentID, 10), BleveCommentDoc{Content: batch[cmIdx].Text})
+					if err := commentBatch.Index("comment_"+strconv.FormatInt(commentID, 10), BleveCommentDoc{Content: batch[cmIdx].Text}); err != nil {
+						rows.Close()
+						return 0, 0, fmt.Errorf("index comment: %w", err)
+					}
 				}
 				cmIdx++
 				commentBatchN++

--- a/internal/config/team_backpointer.go
+++ b/internal/config/team_backpointer.go
@@ -159,8 +159,12 @@ func SaveBackpointers(teamContextPath string, backpointers []WorkspaceBackpointe
 		if err != nil {
 			continue
 		}
-		file.Write(data)
-		file.WriteString("\n")
+		if _, err := file.Write(data); err != nil {
+			return fmt.Errorf("write backpointer file: %w", err)
+		}
+		if _, err := file.WriteString("\n"); err != nil {
+			return fmt.Errorf("write backpointer file: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/daemon/adapter_supervisor.go
+++ b/internal/daemon/adapter_supervisor.go
@@ -586,7 +586,9 @@ func (s *AdapterSupervisor) handleCrash(adapterType string) (*AdapterProcess, er
 	// clean up old process
 	if old.cmd != nil && old.cmd.Process != nil {
 		old.cmd.Process.Kill()
-		go old.cmd.Wait() // reap zombie
+		go func() {
+			_ = old.cmd.Wait() // reap zombie, best-effort
+		}()
 	}
 	delete(s.processes, adapterType)
 

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -595,7 +595,9 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 			if baseDir := m.resolveLedgerDataDir(); baseDir != "" && baseDir != dataDir {
 				baseDB, bErr := codedb.Open(baseDir)
 				if bErr == nil {
-					baseDB.BuildDirtyIndex(ctx, projectRoot, opts)
+					if _, dErr := baseDB.BuildDirtyIndex(ctx, projectRoot, opts); dErr != nil {
+						m.logger.Warn("ledger dirty overlay build failed", "error", dErr)
+					}
 					baseDB.Close()
 				}
 			}
@@ -998,7 +1000,9 @@ func (m *CodeDBManager) RefreshDirtyOverlay(ctx context.Context) {
 		if baseDir := m.resolveLedgerDataDir(); baseDir != "" && baseDir != dataDir {
 			baseDB, bErr := codedb.Open(baseDir)
 			if bErr == nil {
-				baseDB.BuildDirtyIndex(ctx, projectRoot, opts)
+				if _, dErr := baseDB.BuildDirtyIndex(ctx, projectRoot, opts); dErr != nil {
+					m.logger.Warn("ledger dirty overlay build failed", "error", dErr)
+				}
 				baseDB.Close()
 			}
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1154,7 +1154,9 @@ func (d *Daemon) initComponents() time.Duration {
 		d.mu.Lock()
 		d.restartRequested = true
 		d.mu.Unlock()
-		go d.Stop()
+		go func() {
+			_ = d.Stop() // best-effort; caller checks RestartRequested() and re-execs regardless
+		}()
 	})
 	// pre-populate credentials from credential store (cold-start)
 	if creds, err := gitserver.LoadCredentialsForEndpoint(projectEndpoint); err == nil && creds != nil {

--- a/internal/daemon/sync_team.go
+++ b/internal/daemon/sync_team.go
@@ -327,7 +327,7 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 					"team", r.ws.TeamName, "count", len(changedFiles))
 				for _, cf := range changedFiles {
 					id, _ := uuid.NewV7()
-					s.whisperRegistry.Add("ledger", whisperstore.WhisperEntry{
+					if err := s.whisperRegistry.Add("ledger", whisperstore.WhisperEntry{
 						ID:         id.String(),
 						Scope:      "ledger",
 						Type:       whisperstore.WhisperTrigger,
@@ -336,7 +336,9 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 						Content:    fmt.Sprintf("Team context updated: %s", cf),
 						Importance: whisperstore.ImportanceNormal,
 						CreatedAt:  time.Now(),
-					})
+					}); err != nil {
+						s.logger.Warn("failed to add team context trigger whisper", "team", r.ws.TeamName, "file", cf, "error", err)
+					}
 				}
 			}
 		}

--- a/internal/daemon/testutil/dualmode.go
+++ b/internal/daemon/testutil/dualmode.go
@@ -419,7 +419,7 @@ func (m *MockDaemon) handleConn(conn net.Conn) {
 
 	data, _ := json.Marshal(resp)
 	data = append(data, '\n')
-	conn.Write(data)
+	_, _ = conn.Write(data) // best-effort test transport
 }
 
 // sendError sends an error response.
@@ -427,7 +427,7 @@ func (m *MockDaemon) sendError(conn net.Conn, errMsg string) {
 	resp := daemon.Response{Success: false, Error: errMsg}
 	data, _ := json.Marshal(resp)
 	data = append(data, '\n')
-	conn.Write(data)
+	_, _ = conn.Write(data) // best-effort test transport
 }
 
 // WithStatus configures the status response.

--- a/internal/daemon/whisper_registry.go
+++ b/internal/daemon/whisper_registry.go
@@ -284,10 +284,14 @@ func (r *WhisperRegistry) RemoveCursor(agentID string) {
 	defer r.mu.RUnlock()
 
 	if r.ledgerStore != nil {
-		r.ledgerStore.RemoveCursor(agentID)
+		if err := r.ledgerStore.RemoveCursor(agentID); err != nil {
+			r.logger.Warn("failed to remove ledger cursor", "agent", agentID, "error", err)
+		}
 	}
-	for _, store := range r.teamStores {
-		store.RemoveCursor(agentID)
+	for teamID, store := range r.teamStores {
+		if err := store.RemoveCursor(agentID); err != nil {
+			r.logger.Warn("failed to remove team cursor", "agent", agentID, "team", teamID, "error", err)
+		}
 	}
 }
 

--- a/internal/decision/sources.go
+++ b/internal/decision/sources.go
@@ -128,20 +128,16 @@ func loadCorpus(gitRoot string, cfg *config.DecisionConfig) corpusLoadResult {
 	return corpusLoadResult{records: records, unparsed: unparsed, err: errors.Join(loadErrs...)}
 }
 
-// listFiles expands dirs (recursive *.md) and doublestar globs into a deduped
-// file list. README.md is excluded everywhere — corpus index tables, not DRs.
-func listFiles(gitRoot string, patterns []string) []string {
-	return discoverFiles(gitRoot, patterns, false).files
-}
-
 type fileDiscovery struct {
 	files []string
 	err   error
 }
 
-// discoverFiles is listFiles plus source-status reporting. When configured is
-// true, a literal path was explicitly promised by decision.paths, so a missing
-// or inaccessible path is an unavailable source rather than an empty corpus.
+// discoverFiles expands dirs (recursive *.md) and doublestar globs into a
+// deduped file list (README.md excluded — corpus index tables, not DRs) with
+// source-status reporting. When configured is true, a literal path was
+// explicitly promised by decision.paths, so a missing or inaccessible path is
+// an unavailable source rather than an empty corpus.
 func discoverFiles(gitRoot string, patterns []string, configured bool) fileDiscovery {
 	seen := make(map[string]struct{})
 	var out []string

--- a/internal/docs/postprocess.go
+++ b/internal/docs/postprocess.go
@@ -169,7 +169,7 @@ func computeDestPath(filename string, allFiles []string) (string, error) {
 }
 
 // transformFile reads the source file, updates frontmatter, and writes to destination
-func transformFile(srcPath, destPath string, sidebarPosition int) error {
+func transformFile(srcPath, destPath string, sidebarPosition int) (err error) {
 	// Read source file
 	srcFile, err := os.Open(srcPath)
 	if err != nil {
@@ -194,7 +194,11 @@ func transformFile(srcPath, destPath string, sidebarPosition int) error {
 
 	scanner := bufio.NewScanner(srcFile)
 	writer := bufio.NewWriter(destFile)
-	defer writer.Flush()
+	defer func() {
+		if flushErr := writer.Flush(); flushErr != nil && err == nil {
+			err = fmt.Errorf("failed to flush destination file: %w", flushErr)
+		}
+	}()
 	pendingBlankLines := 0
 	writeLine := func(line string) {
 		if line == "" {
@@ -202,10 +206,10 @@ func transformFile(srcPath, destPath string, sidebarPosition int) error {
 			return
 		}
 		for range pendingBlankLines {
-			writer.WriteString("\n")
+			_, _ = writer.WriteString("\n") // error surfaces at the deferred Flush above
 		}
 		pendingBlankLines = 0
-		writer.WriteString(line + "\n")
+		_, _ = writer.WriteString(line + "\n") // error surfaces at the deferred Flush above
 	}
 
 	// Track frontmatter processing

--- a/internal/doctor/session.go
+++ b/internal/doctor/session.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1166,7 +1167,7 @@ func (c *SessionAutoStageCheck) findUnstagedSessionFiles(ledgerPath string) []st
 func (c *SessionAutoStageCheck) scanSessionFilesInDir(dir string) []string {
 	var files []string
 
-	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -1185,7 +1186,11 @@ func (c *SessionAutoStageCheck) scanSessionFilesInDir(dir string) []string {
 			files = append(files, relPath)
 		}
 		return nil
-	})
+	}); err != nil {
+		// an incomplete scan can leave session files unstaged; surface it rather
+		// than dropping it silently.
+		slog.Warn("scan session files: walk failed", "dir", dir, "err", err)
+	}
 
 	return files
 }
@@ -1380,7 +1385,9 @@ func (c *SessionPushCheck) countCommitsAhead(ledgerPath string) int {
 	}
 
 	var count int
-	fmt.Sscanf(strings.TrimSpace(string(aheadOutput)), "%d", &count)
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(aheadOutput)), "%d", &count); err != nil {
+		return 0
+	}
 	return count
 }
 

--- a/pkg/faultdaemon/fault_daemon.go
+++ b/pkg/faultdaemon/fault_daemon.go
@@ -246,11 +246,11 @@ func (d *FaultDaemon) handleConn(conn net.Conn) {
 		return
 
 	case FaultCorruptResponse:
-		conn.Write([]byte("not json garbage \x00\xff\xfe\n"))
+		_, _ = conn.Write([]byte("not json garbage \x00\xff\xfe\n")) // best-effort
 		return
 
 	case FaultPartialResponse:
-		conn.Write([]byte(`{"success":true,"data":`))
+		_, _ = conn.Write([]byte(`{"success":true,"data":`)) // best-effort
 		time.Sleep(100 * time.Millisecond)
 		return
 
@@ -272,8 +272,8 @@ func (d *FaultDaemon) handleConn(conn net.Conn) {
 		// send two responses
 		resp := d.generateResponse(request, cfg)
 		if resp != nil {
-			conn.Write(resp)
-			conn.Write(resp) // second response
+			_, _ = conn.Write(resp) // best-effort
+			_, _ = conn.Write(resp) // second response, best-effort
 		}
 		return
 
@@ -284,7 +284,7 @@ func (d *FaultDaemon) handleConn(conn net.Conn) {
 			if resp[len(resp)-1] == '\n' {
 				resp = resp[:len(resp)-1]
 			}
-			conn.Write(resp)
+			_, _ = conn.Write(resp) // best-effort
 		}
 		time.Sleep(200 * time.Millisecond)
 		return
@@ -292,7 +292,7 @@ func (d *FaultDaemon) handleConn(conn net.Conn) {
 	case FaultChunkedResponse:
 		resp := d.generateResponse(request, cfg)
 		for _, b := range resp {
-			conn.Write([]byte{b})
+			_, _ = conn.Write([]byte{b}) // best-effort
 			time.Sleep(500 * time.Microsecond)
 		}
 		return
@@ -315,23 +315,23 @@ func (d *FaultDaemon) handleConn(conn net.Conn) {
 		for i := range hugePayload {
 			hugePayload[i] = 'x'
 		}
-		conn.Write(append(hugePayload, '\n'))
+		_, _ = conn.Write(append(hugePayload, '\n')) // best-effort
 		return
 
 	case FaultInvalidJSON:
-		conn.Write([]byte("{\"success\":true,\"data\":\"bad\x00char\"}\n"))
+		_, _ = conn.Write([]byte("{\"success\":true,\"data\":\"bad\x00char\"}\n")) // best-effort
 		return
 
 	case FaultEmbeddedNewlines:
 		// send response with escaped newlines (valid JSON)
-		conn.Write([]byte("{\"success\":true,\"data\":\"line1\\nline2\\nline3\"}\n"))
+		_, _ = conn.Write([]byte("{\"success\":true,\"data\":\"line1\\nline2\\nline3\"}\n")) // best-effort
 		return
 
 	case FaultWriteHalfThenHang:
 		resp := d.generateResponse(request, cfg)
 		if resp != nil {
 			half := len(resp) / 2
-			conn.Write(resp[:half])
+			_, _ = conn.Write(resp[:half]) // best-effort
 		}
 		select {
 		case <-d.ctx.Done():
@@ -356,6 +356,6 @@ func (d *FaultDaemon) generateResponse(request []byte, cfg Config) []byte {
 func (d *FaultDaemon) sendNormalResponse(conn net.Conn, request []byte, cfg Config) {
 	resp := d.generateResponse(request, cfg)
 	if resp != nil {
-		conn.Write(resp)
+		_, _ = conn.Write(resp) // best-effort
 	}
 }


### PR DESCRIPTION
Tightens the Go lint gate so two classes of silent decay — dead code and unchecked errors on durable writes — now fail CI instead of accumulating unnoticed. Net effect for maintainers: the next unreferenced function or dropped write-error is caught at review, not discovered in production.

Two commits, each independently green.

## 1. Enable `unused`

`unused` (staticcheck U1000) was not in the gate. Enabling it surfaced 13 unreferenced funcs:

- **Deleted 4 genuine orphans:** `listFiles` (superseded by `discoverFiles`), `httpStatusError` (each video method inlines its own `HTTP %d` error), `commonDir`, `padCell` (+ orphaned `lipgloss` import).
- **Preserved 9 intentional scaffolds** — the aider/gemini/pi adapter `handle*Rules` handlers, each file documented as *"scaffold, not yet wired into main.go."* Exempted via one commented `exclusions` rule rather than deleting deliberate work or littering per-func `//nolint`.

## 2. Enable curated `errcheck`

Blanket errcheck is ~2,900 findings here — context-blind noise (CLI stdout writes, deferred cleanup `Close`, best-effort drains, test setup). Instead of chasing all of it or leaving errcheck off entirely, this enables it **curated**:

- **Excluded the always-best-effort classes** (in `.config/golangci.yml`): `fmt.Fprint*`, `io.Copy`, `.Close` / conn deadline setters / `.Kill` / `.Unlock` (via one method-name regex, since the type-based matcher can't catch internal concrete types), stdlib cleanup, and cobra/pflag wiring. Test files are excluded wholesale.
- **Fixed the ~58 genuine residual** — the unchecked errors that actually matter:
  - **Durable writes → handled** (wrap+return or `slog.Warn`): `os.WriteFile` (docs.go), backpointer `file.Write`/`WriteString`, bufio `writer.Flush` (named-return capture in postprocess), `db.ExecContext` (carts), bleve `batch.Index` / `FileIter.ForEach` (codedb indexer), `BuildDirtyIndex`, `RemoveCursor`, `whisperRegistry.Add`, `filepath.Walk`.
  - **Real bug caught:** `logout.go` ignored `fmt.Scanln`'s error, so a closed/EOF stdin spun the selection prompt in an **infinite loop** — now cancels cleanly.
  - **Genuinely best-effort → explicit `_ =` with reason**: terminal output, `os.Setenv`, fault-injection/test-daemon `conn.Write`, process reaping, regex-validated `Sscanf`.

```mermaid
flowchart TD
    E["errcheck: ~2,900 raw findings"] --> C{class}
    C -->|"output / cleanup / drain / test"| X["excluded in config (curated)"]
    C -->|"durable write, ~40"| H["handled: wrap+return / slog.Warn"]
    C -->|"best-effort, ~18"| B["explicit _ = with reason"]
    X --> G["gate: 0 issues; errcheck + unused enforced going forward"]
    H --> G
    B --> G
```

## Test plan

- `golangci-lint run -c .config/golangci.yml ./...` → **0 issues** (errcheck + unused enabled).
- `go build ./...`, `go vet`, `gofmt -l` — clean.
- `go test` green for every changed package: `internal/codedb/index`, `internal/daemon`, `pkg/faultdaemon`, `internal/carts`, `internal/docs`, `internal/doctor`, `internal/config`, `cmd/ox`.
- Every durable-write fix was reviewed for correct control flow (propagates vs logs, matching each function's existing error convention).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Logout now cancels cleanly when input ends or cannot be read, instead of repeatedly prompting.
  * Improved error reporting and handling for database updates, indexing, file processing, and session operations.

* **Documentation**
  * Expanded documentation for file discovery, including deduplication, README exclusions, and configuration error reporting.

* **Chores**
  * Improved static analysis coverage and removed unused internal code.
  * Clarified best-effort behavior for terminal and transport output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->