### PR TITLE
fix(doctor): stop false-positive warnings (A-G)

### DIFF
--- a/cmd/ox-adapter-droid/diagnose.go
+++ b/cmd/ox-adapter-droid/diagnose.go
@@ -52,8 +52,14 @@ func handleDiagnose(p adapterprotocol.DiagnoseParams) (*adapterprotocol.Diagnose
 				Severity: "warning",
 				Title:    "ox hooks not installed for Factory Droid",
 				Detail:   "Factory Droid hooks are not configured for this project. Session recording is disabled.",
-				Fix:      "ox-adapter-droid install-hooks --repo-root " + p.RepoRoot + " --scope project",
-				FixSafe:  true,
+				Fix:      "ox integrate install --droid",
+				// "ox" is the only allowlisted argv[0] for the doctor
+				// auto-fix path (ox-adapter-droid itself is rejected by
+				// adapterFixArgvAllowlist), so route through the in-process
+				// `ox integrate install --droid` command rather than the
+				// external adapter binary.
+				FixArgv: []string{"ox", "integrate", "install", "--droid"},
+				FixSafe: true,
 			})
 		}
 

--- a/cmd/ox-adapter-droid/diagnose_test.go
+++ b/cmd/ox-adapter-droid/diagnose_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleDiagnose_HooksMissing_OffersSafeFixViaOx verifies the
+// droid:hooks-missing issue is repairable via the "ox" dispatch path, not the
+// external adapter binary — ox-adapter-droid as argv[0] is rejected by
+// adapterFixArgvAllowlist in cmd/ox/doctor_adapters.go, so a FixArgv naming it
+// would silently downgrade to display-only under `ox doctor --fix`.
+// Failure prevented: FixSafe=true with an argv[0] the auto-fix path refuses,
+// making the "safe, automatic" repair never actually run.
+func TestHandleDiagnose_HooksMissing_OffersSafeFixViaOx(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // never read the real ~/.factory in a test
+	repoRoot := t.TempDir()
+
+	res, err := handleDiagnose(adapterprotocol.DiagnoseParams{RepoRoot: repoRoot})
+	require.NoError(t, err)
+
+	issue := issueBySlugDroid(res.Issues, "droid:hooks-missing")
+	if issue == nil {
+		t.Fatalf("expected droid:hooks-missing, got %+v", res.Issues)
+	}
+	assert.True(t, issue.FixSafe)
+	assert.Equal(t, []string{"ox", "integrate", "install", "--droid"}, issue.FixArgv,
+		"argv[0] must be \"ox\" — ox-adapter-droid is not in the auto-fix allowlist")
+}
+
+func issueBySlugDroid(issues []adapterprotocol.DiagnoseIssue, slug string) *adapterprotocol.DiagnoseIssue {
+	for i := range issues {
+		if issues[i].Slug == slug {
+			return &issues[i]
+		}
+	}
+	return nil
+}

--- a/cmd/ox-adapter-gemini/detect.go
+++ b/cmd/ox-adapter-gemini/detect.go
@@ -126,7 +126,12 @@ func diagnoseHooks(repoRoot string) []adapterprotocol.DiagnoseIssue {
 		return nil
 	}
 
-	fixCmd := "ox-adapter-gemini install-hooks --repo-root " + repoRoot + " --scope project"
+	fixCmd := "ox integrate install --gemini"
+	// "ox" is the only allowlisted argv[0] for the doctor auto-fix path
+	// (ox-adapter-gemini itself is rejected by adapterFixArgvAllowlist), so
+	// route through the in-process `ox integrate install --gemini` command
+	// rather than the external adapter binary.
+	fixArgv := []string{"ox", "integrate", "install", "--gemini"}
 
 	// gemini validates settings before it does anything else: a non-array
 	// value under hooks.<Event> makes the CLI refuse to start
@@ -150,7 +155,7 @@ func diagnoseHooks(repoRoot string) []adapterprotocol.DiagnoseIssue {
 							"hooks.<Event> to be an array of hook definitions.",
 						settingsPath, event),
 					Fix:     fixCmd,
-					FixArgv: []string{"ox-adapter-gemini", "install-hooks", "--repo-root", repoRoot, "--scope", "project"},
+					FixArgv: fixArgv,
 					FixSafe: true,
 				})
 			}
@@ -166,7 +171,7 @@ func diagnoseHooks(repoRoot string) []adapterprotocol.DiagnoseIssue {
 			Detail: "Gemini CLI hooks are not configured for this project (expected " +
 				"SessionStart, BeforeAgent, AfterTool and SessionEnd). Session recording is disabled.",
 			Fix:     fixCmd,
-			FixArgv: []string{"ox-adapter-gemini", "install-hooks", "--repo-root", repoRoot, "--scope", "project"},
+			FixArgv: fixArgv,
 			FixSafe: true,
 		})
 	}

--- a/cmd/ox-adapter-gemini/hooks_test.go
+++ b/cmd/ox-adapter-gemini/hooks_test.go
@@ -218,6 +218,85 @@ func TestDiagnoseHooks_FlagsTheInvalidShapeAsAnError(t *testing.T) {
 	}
 }
 
+// TestDiagnoseHooks_OffersSafeFixViaOx verifies both repairable gemini hook
+// issues (invalid shape and missing) are repairable via the "ox" dispatch
+// path, not the external adapter binary — ox-adapter-gemini as argv[0] is
+// rejected by adapterFixArgvAllowlist in cmd/ox/doctor_adapters.go, so a
+// FixArgv naming it would silently downgrade to display-only under
+// `ox doctor --fix`.
+// Failure prevented: FixSafe=true with an argv[0] the auto-fix path refuses,
+// making the "safe, automatic" repair never actually run.
+func TestDiagnoseHooks_OffersSafeFixViaOx(t *testing.T) {
+	t.Parallel()
+
+	wantArgv := []string{"ox", "integrate", "install", "--gemini"}
+
+	t.Run("hooks-missing", func(t *testing.T) {
+		repo := t.TempDir()
+
+		issues := diagnoseHooks(repo)
+
+		issue := findIssueBySlug(issues, "gemini:hooks-missing")
+		if issue == nil {
+			t.Fatalf("expected gemini:hooks-missing, got %+v", issues)
+		}
+		if !issue.FixSafe {
+			t.Error("FixSafe = false, want true")
+		}
+		if !slicesEqual(issue.FixArgv, wantArgv) {
+			t.Errorf("FixArgv = %v, want %v (argv[0] must be \"ox\" — "+
+				"ox-adapter-gemini is not in the auto-fix allowlist)", issue.FixArgv, wantArgv)
+		}
+	})
+
+	t.Run("hooks-invalid-shape", func(t *testing.T) {
+		repo := t.TempDir()
+		settingsPath := filepath.Join(repo, ".gemini", "settings.json")
+		if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		legacy := `{"hooks":{"PostToolUse":"AGENT_ENV=gemini ox agent hook PostToolUse"}}`
+		if err := os.WriteFile(settingsPath, []byte(legacy), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		issues := diagnoseHooks(repo)
+
+		issue := findIssueBySlug(issues, "gemini:hooks-invalid-shape")
+		if issue == nil {
+			t.Fatalf("expected gemini:hooks-invalid-shape, got %+v", issues)
+		}
+		if !issue.FixSafe {
+			t.Error("FixSafe = false, want true")
+		}
+		if !slicesEqual(issue.FixArgv, wantArgv) {
+			t.Errorf("FixArgv = %v, want %v (argv[0] must be \"ox\" — "+
+				"ox-adapter-gemini is not in the auto-fix allowlist)", issue.FixArgv, wantArgv)
+		}
+	})
+}
+
+func findIssueBySlug(issues []adapterprotocol.DiagnoseIssue, slug string) *adapterprotocol.DiagnoseIssue {
+	for i := range issues {
+		if issues[i].Slug == slug {
+			return &issues[i]
+		}
+	}
+	return nil
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestInstallHooks_IsIdempotent keeps repeated installs (doctor auto-fix runs
 // on every invocation) from stacking duplicate hook definitions.
 func TestInstallHooks_IsIdempotent(t *testing.T) {

--- a/cmd/ox-adapter-opencode/diagnose_test.go
+++ b/cmd/ox-adapter-opencode/diagnose_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+// TestHandleDiagnose_HooksMissing_OffersSafeFixViaOx verifies the
+// hooks-missing issue is repairable via the "ox" dispatch path, not the
+// external adapter binary — ox-adapter-opencode as argv[0] is rejected by
+// adapterFixArgvAllowlist in cmd/ox/doctor_adapters.go, so a FixArgv naming it
+// would silently downgrade to display-only under `ox doctor --fix`.
+// Failure prevented: FixSafe=true with an argv[0] the auto-fix path refuses,
+// making the "safe, automatic" repair never actually run.
+func TestHandleDiagnose_HooksMissing_OffersSafeFixViaOx(t *testing.T) {
+	repoRoot := t.TempDir() // no .opencode/plugin/ox-prime.ts present
+
+	res, err := handleDiagnose(adapterprotocol.DiagnoseParams{RepoRoot: repoRoot})
+	if err != nil {
+		t.Fatalf("handleDiagnose: %v", err)
+	}
+
+	var issue *adapterprotocol.DiagnoseIssue
+	for i := range res.Issues {
+		if res.Issues[i].Slug == "hooks-missing" {
+			issue = &res.Issues[i]
+			break
+		}
+	}
+	if issue == nil {
+		t.Fatalf("expected hooks-missing, got %+v", res.Issues)
+	}
+
+	if !issue.FixSafe {
+		t.Error("FixSafe = false, want true")
+	}
+	want := []string{"ox", "integrate", "install", "--opencode"}
+	if len(issue.FixArgv) != len(want) {
+		t.Fatalf("FixArgv = %v, want %v", issue.FixArgv, want)
+	}
+	for i := range want {
+		if issue.FixArgv[i] != want[i] {
+			t.Fatalf("FixArgv = %v, want %v (argv[0] must be \"ox\" — "+
+				"ox-adapter-opencode is not in the auto-fix allowlist)", issue.FixArgv, want)
+		}
+	}
+}

--- a/cmd/ox-adapter-opencode/main.go
+++ b/cmd/ox-adapter-opencode/main.go
@@ -166,8 +166,14 @@ func handleDiagnose(p adapterprotocol.DiagnoseParams) (*adapterprotocol.Diagnose
 				Severity: "warning",
 				Title:    "OpenCode hooks not installed",
 				Detail:   fmt.Sprintf("%s not found.", pluginPath),
-				Fix:      "ox-adapter-opencode install-hooks --repo-root " + p.RepoRoot + " --scope project",
-				FixSafe:  true,
+				Fix:      "ox integrate install --opencode",
+				// "ox" is the only allowlisted argv[0] for the doctor
+				// auto-fix path (ox-adapter-opencode itself is rejected by
+				// adapterFixArgvAllowlist), so route through the in-process
+				// `ox integrate install --opencode` command rather than the
+				// external adapter binary.
+				FixArgv: []string{"ox", "integrate", "install", "--opencode"},
+				FixSafe: true,
 			})
 		}
 	}

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -398,7 +398,10 @@ func checkGitFsck() checkResult {
 	}
 
 	// run fsck with connectivity-only for speed and a timeout
-	cmd := exec.Command("git", "fsck", "--connectivity-only", "--no-progress")
+	// --no-dangling: a dangling (unreferenced) object is normal git state,
+	// not corruption, so suppress it at the source rather than let it reach
+	// classifyFsckOutput and get mistaken for an object error.
+	cmd := exec.Command("git", "fsck", "--connectivity-only", "--no-progress", "--no-dangling")
 	cmd.Dir = gitRoot
 
 	type fsckResult struct {
@@ -469,7 +472,14 @@ var fsckRemoteHeadRe = regexp.MustCompile(`^refs/remotes/([^/]+)/HEAD$`)
 
 // fsckObjectErrorRe matches git fsck lines that indicate genuine
 // object-database corruption (as opposed to a broken ref).
-var fsckObjectErrorRe = regexp.MustCompile(`(?i)(missing (blob|tree|commit|tag)|broken link|dangling (blob|tree|commit|tag)|error in (tree|commit|blob|tag)|bad object|bad sha1 file|sha1 mismatch)`)
+var fsckObjectErrorRe = regexp.MustCompile(`(?i)(missing (blob|tree|commit|tag)|broken link|error in (tree|commit|blob|tag)|bad object|bad sha1 file|sha1 mismatch)`)
+
+// fsckDanglingRe matches a git fsck "dangling <type> <sha>" line. A dangling
+// object is unreferenced but the object DB is intact — normal state after a
+// rebase/amend/branch-delete, not corruption. git fsck is invoked with
+// --no-dangling so these are usually suppressed at the source; this is the
+// belt-and-suspenders guard for a git that predates the flag.
+var fsckDanglingRe = regexp.MustCompile(`(?i)^dangling (blob|tree|commit|tag)\b`)
 
 // classifyFsckOutput parses the (non-empty, trimmed) combined stdout+stderr
 // of `git fsck --connectivity-only --no-progress` and classifies it as:
@@ -496,6 +506,7 @@ func classifyFsckOutput(output string) (severity fsckSeverity, summary string, d
 	var unclassified []string // lines that are neither a recognized ref issue nor object corruption
 
 	hasObjectError := false
+	sawDangling := false
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -505,6 +516,11 @@ func classifyFsckOutput(output string) (severity fsckSeverity, summary string, d
 			refIssues = append(refIssues, m[1])
 			continue
 		}
+		if fsckDanglingRe.MatchString(line) {
+			// dangling object — benign, not corruption and not a ref issue.
+			sawDangling = true
+			continue
+		}
 		if fsckObjectErrorRe.MatchString(line) {
 			hasObjectError = true
 			continue
@@ -512,15 +528,23 @@ func classifyFsckOutput(output string) (severity fsckSeverity, summary string, d
 		unclassified = append(unclassified, line)
 	}
 
-	// Any genuine object corruption, or any line we can't positively
-	// classify as a harmless ref issue, means treat this as real
-	// corruption. Mixed output (ref issues + object corruption) also
-	// fails — object corruption dominates.
-	if hasObjectError || len(unclassified) > 0 || len(refIssues) == 0 {
+	switch {
+	case hasObjectError || len(unclassified) > 0:
+		// Genuine object corruption, or a line we can't positively classify
+		// as harmless. Mixed output (ref issues + object corruption) lands
+		// here too — object corruption dominates.
+		return fsckSeverityFail, fsckFailSummary(lines), fsckCorruptionDetail
+	case len(refIssues) > 0:
+		// Broken/dangling refs only (possibly alongside benign dangling
+		// objects) — a ref-repair issue, not corruption.
+		return fsckSeverityWarn, fsckWarnSummary(refIssues), fsckWarnDetail(refIssues)
+	case sawDangling:
+		// Nothing but benign dangling-object lines — the object DB is intact.
+		return fsckSeverityOK, "object database OK (dangling objects only)", ""
+	default:
+		// Non-zero exit but nothing classifiable survived. Stay conservative.
 		return fsckSeverityFail, fsckFailSummary(lines), fsckCorruptionDetail
 	}
-
-	return fsckSeverityWarn, fsckWarnSummary(refIssues), fsckWarnDetail(refIssues)
 }
 
 // fsckFailSummary mirrors the original checkGitFsck behavior: use the first

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -383,6 +384,13 @@ func checkMergeConflicts() checkResult {
 // Uses --connectivity-only for speed (skips blob content checks).
 // Detects corrupted objects that can cause silent failures.
 // Has a 5s timeout to avoid blocking on very large repos.
+//
+// git fsck also exits non-zero for harmless broken/dangling refs (e.g. a
+// stale refs/remotes/<remote>/HEAD left behind after the remote's default
+// branch was deleted or renamed) — that is a ref-repair issue, not object
+// database corruption, and does NOT warrant a "re-clone the repository"
+// remedy. classifyFsckOutput() distinguishes the two so only genuine object
+// corruption is reported as FAILED.
 func checkGitFsck() checkResult {
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
@@ -406,18 +414,39 @@ func checkGitFsck() checkResult {
 	select {
 	case result := <-done:
 		if result.err != nil {
-			// fsck found issues - provide actionable guidance
-			lines := strings.Split(strings.TrimSpace(string(result.output)), "\n")
-			summary := "corruption detected"
-			if len(lines) > 0 && lines[0] != "" {
-				firstLine := lines[0]
-				if len(firstLine) > 50 {
-					firstLine = firstLine[:47] + "..."
-				}
-				summary = firstLine
+			output := strings.TrimSpace(string(result.output))
+			if output == "" {
+				// non-zero exit with no output to classify — stay conservative,
+				// this is the pre-existing "unexplained failure" behavior.
+				return FailedCheck("git integrity", "corruption detected", fsckCorruptionDetail)
 			}
 
-			detail := `Git repository has corrupted objects. This can happen after:
+			severity, summary, detail := classifyFsckOutput(output)
+			if severity == fsckSeverityWarn {
+				return WarningCheck("git integrity", summary, detail)
+			}
+			return FailedCheck("git integrity", summary, detail)
+		}
+		return PassedCheck("git integrity", "object database OK")
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		return PassedCheck("git integrity", "skipped (large repo)")
+	}
+}
+
+// fsckSeverity classifies the result of parsing git fsck output.
+type fsckSeverity string
+
+const (
+	fsckSeverityOK   fsckSeverity = "ok"   // no problems found
+	fsckSeverityWarn fsckSeverity = "warn" // broken/dangling refs only — not object corruption
+	fsckSeverityFail fsckSeverity = "fail" // genuine object-database corruption (or unclassifiable output)
+)
+
+// fsckCorruptionDetail is the remedy shown for genuine object-database
+// corruption. Re-cloning is only ever appropriate here — never for a
+// broken-ref-only finding.
+const fsckCorruptionDetail = `Git repository has corrupted objects. This can happen after:
   • Disk errors or power loss during git operations
   • Incomplete clones or interrupted fetches
 
@@ -428,13 +457,113 @@ To fix:
 
 Run 'git fsck' for detailed error information.`
 
-			return FailedCheck("git integrity", summary, detail)
-		}
-		return PassedCheck("git integrity", "object database OK")
-	case <-time.After(5 * time.Second):
-		_ = cmd.Process.Kill()
-		return PassedCheck("git integrity", "skipped (large repo)")
+// fsckRefErrorRe matches a git fsck line reporting a broken/dangling ref,
+// e.g. `error: refs/remotes/belgrade/HEAD: invalid sha1 pointer 000...`.
+// Group 1 captures the ref path (refs/remotes/belgrade/HEAD).
+var fsckRefErrorRe = regexp.MustCompile(`^error: (refs/\S+):`)
+
+// fsckRemoteHeadRe extracts the remote name from a remote-tracking HEAD ref
+// path (refs/remotes/<remote>/HEAD), so the remedy can name the exact
+// `git remote set-head <remote> -a` command to run.
+var fsckRemoteHeadRe = regexp.MustCompile(`^refs/remotes/([^/]+)/HEAD$`)
+
+// fsckObjectErrorRe matches git fsck lines that indicate genuine
+// object-database corruption (as opposed to a broken ref).
+var fsckObjectErrorRe = regexp.MustCompile(`(?i)(missing (blob|tree|commit|tag)|broken link|dangling (blob|tree|commit|tag)|error in (tree|commit|blob|tag)|bad object|bad sha1 file|sha1 mismatch)`)
+
+// classifyFsckOutput parses the (non-empty, trimmed) combined stdout+stderr
+// of `git fsck --connectivity-only --no-progress` and classifies it as:
+//
+//   - fsckSeverityOK:   no problem lines at all (empty output)
+//   - fsckSeverityWarn: every problem line is a broken/dangling ref — a
+//     ref-repair issue, never object corruption
+//   - fsckSeverityFail: at least one line indicates genuine object-database
+//     corruption, OR a line could not be positively classified as a
+//     harmless ref issue (stay conservative — never silently downgrade
+//     output we don't recognize)
+//
+// It is a pure function (no git invocation) so it can be unit tested
+// against captured fsck output without a real corrupted repository.
+func classifyFsckOutput(output string) (severity fsckSeverity, summary string, detail string) {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return fsckSeverityOK, "object database OK", ""
 	}
+
+	lines := strings.Split(trimmed, "\n")
+
+	var refIssues []string    // ref paths reported broken/dangling, e.g. refs/remotes/belgrade/HEAD
+	var unclassified []string // lines that are neither a recognized ref issue nor object corruption
+
+	hasObjectError := false
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if m := fsckRefErrorRe.FindStringSubmatch(line); m != nil {
+			refIssues = append(refIssues, m[1])
+			continue
+		}
+		if fsckObjectErrorRe.MatchString(line) {
+			hasObjectError = true
+			continue
+		}
+		unclassified = append(unclassified, line)
+	}
+
+	// Any genuine object corruption, or any line we can't positively
+	// classify as a harmless ref issue, means treat this as real
+	// corruption. Mixed output (ref issues + object corruption) also
+	// fails — object corruption dominates.
+	if hasObjectError || len(unclassified) > 0 || len(refIssues) == 0 {
+		return fsckSeverityFail, fsckFailSummary(lines), fsckCorruptionDetail
+	}
+
+	return fsckSeverityWarn, fsckWarnSummary(refIssues), fsckWarnDetail(refIssues)
+}
+
+// fsckFailSummary mirrors the original checkGitFsck behavior: use the first
+// non-empty line of fsck's output, truncated, as the one-line summary.
+func fsckFailSummary(lines []string) string {
+	summary := "corruption detected"
+	if len(lines) > 0 && lines[0] != "" {
+		firstLine := lines[0]
+		if len(firstLine) > 50 {
+			firstLine = firstLine[:47] + "..."
+		}
+		summary = firstLine
+	}
+	return summary
+}
+
+// fsckWarnSummary produces the one-line summary for a broken-ref-only finding.
+func fsckWarnSummary(refs []string) string {
+	if len(refs) == 1 {
+		return fmt.Sprintf("broken ref: %s", refs[0])
+	}
+	return fmt.Sprintf("%d broken ref(s)", len(refs))
+}
+
+// fsckWarnDetail builds the ref-repair remedy. For a remote-tracking HEAD
+// ref it names the exact `git remote set-head <remote> -a` command; for any
+// other ref path it falls back to a generic delete-the-stale-ref remedy.
+func fsckWarnDetail(refs []string) string {
+	var b strings.Builder
+	b.WriteString("Git repository has one or more broken/dangling refs (not object corruption). This can happen after:\n")
+	b.WriteString("  • The upstream branch a remote-tracking HEAD pointed to was deleted or renamed\n")
+	b.WriteString("  • A remote's default branch changed (e.g. master -> main)\n\n")
+	b.WriteString("To fix:\n")
+	for _, ref := range refs {
+		if m := fsckRemoteHeadRe.FindStringSubmatch(ref); m != nil {
+			remote := m[1]
+			fmt.Fprintf(&b, "  • %s: run `git remote set-head %s -a` to repoint it at the remote's current default branch\n", ref, remote)
+		} else {
+			fmt.Fprintf(&b, "  • %s: this ref no longer resolves; remove it with `git update-ref -d %s`\n", ref, ref)
+		}
+	}
+	b.WriteString("\nThis is a ref-repair issue, not object-database corruption — re-cloning is not necessary.")
+	return b.String()
 }
 
 // checkGitLockFiles checks for stale git lock files from crashed processes.

--- a/cmd/ox/doctor_git_repos_test.go
+++ b/cmd/ox/doctor_git_repos_test.go
@@ -772,6 +772,106 @@ func TestCheckSSHAuth(t *testing.T) {
 	_ = result
 }
 
+// TestClassifyFsckOutput covers the checkGitFsck false-positive fix: git
+// fsck exits non-zero both for genuine object-database corruption AND for
+// harmless broken/dangling refs (e.g. a stale refs/remotes/<remote>/HEAD
+// left behind after the remote's default branch was deleted). Only the
+// former should ever recommend re-cloning the repository.
+func TestClassifyFsckOutput(t *testing.T) {
+	const belgradeStaleHead = "error: refs/remotes/belgrade/HEAD: invalid sha1 pointer 0000000000000000000000000000000000000000"
+
+	tests := []struct {
+		name         string
+		output       string
+		wantSeverity fsckSeverity
+	}{
+		{
+			name:         "empty output is OK",
+			output:       "",
+			wantSeverity: fsckSeverityOK,
+		},
+		{
+			name:         "stale remote-tracking HEAD is a warning, not corruption",
+			output:       belgradeStaleHead,
+			wantSeverity: fsckSeverityWarn,
+		},
+		{
+			name:         "missing blob is genuine object corruption",
+			output:       "missing blob deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			wantSeverity: fsckSeverityFail,
+		},
+		{
+			name: "broken link is genuine object corruption",
+			output: "broken link from   tree 1111111111111111111111111111111111111111\n" +
+				"              to   blob 0000000000000000000000000000000000000000",
+			wantSeverity: fsckSeverityFail,
+		},
+		{
+			name:         "dangling commit is genuine object corruption",
+			output:       "dangling commit 2222222222222222222222222222222222222222",
+			wantSeverity: fsckSeverityFail,
+		},
+		{
+			name:         "mixed ref issue and object corruption fails — corruption dominates",
+			output:       belgradeStaleHead + "\nmissing blob deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			wantSeverity: fsckSeverityFail,
+		},
+		{
+			name:         "unrecognized non-empty output stays conservative and fails",
+			output:       "something git fsck never printed before",
+			wantSeverity: fsckSeverityFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			severity, summary, detail := classifyFsckOutput(tt.output)
+			if severity != tt.wantSeverity {
+				t.Fatalf("classifyFsckOutput(%q) severity = %q, want %q\nsummary=%q\ndetail=%q",
+					tt.output, severity, tt.wantSeverity, summary, detail)
+			}
+		})
+	}
+}
+
+// TestClassifyFsckOutput_BrokenRemoteHead_RemedyIsRefRepairNotReclone pins the
+// exact remedy shown for the canonical stale refs/remotes/<remote>/HEAD case:
+// it must name `git remote set-head <remote> -a` and must NOT tell the user
+// to re-clone the repository.
+func TestClassifyFsckOutput_BrokenRemoteHead_RemedyIsRefRepairNotReclone(t *testing.T) {
+	output := "error: refs/remotes/belgrade/HEAD: invalid sha1 pointer 0000000000000000000000000000000000000000"
+
+	severity, summary, detail := classifyFsckOutput(output)
+
+	if severity != fsckSeverityWarn {
+		t.Fatalf("severity = %q, want %q (summary=%q detail=%q)", severity, fsckSeverityWarn, summary, detail)
+	}
+	if !strings.Contains(detail, "git remote set-head belgrade -a") {
+		t.Errorf("expected detail to name the concrete fix `git remote set-head belgrade -a`, got: %s", detail)
+	}
+	if strings.Contains(strings.ToLower(detail), "re-clone") {
+		t.Errorf("broken-ref-only finding must never recommend re-cloning, got detail: %s", detail)
+	}
+	if strings.Contains(strings.ToLower(summary), "re-clone") {
+		t.Errorf("broken-ref-only finding must never recommend re-cloning, got summary: %s", summary)
+	}
+}
+
+// TestClassifyFsckOutput_MissingBlob_RemedyIsReclone pins the remedy for
+// genuine object corruption: it must still recommend re-cloning.
+func TestClassifyFsckOutput_MissingBlob_RemedyIsReclone(t *testing.T) {
+	output := "missing blob deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	severity, summary, detail := classifyFsckOutput(output)
+
+	if severity != fsckSeverityFail {
+		t.Fatalf("severity = %q, want %q (summary=%q detail=%q)", severity, fsckSeverityFail, summary, detail)
+	}
+	if !strings.Contains(strings.ToLower(detail), "re-clone") {
+		t.Errorf("expected genuine object corruption to still recommend re-cloning, got detail: %s", detail)
+	}
+}
+
 // TestExtractTeamIDFromRepoName_DisplayNames verifies that
 // extractTeamIDFromRepoName handles real API display names.
 // Bug #37: the API returns display names like "SageOx" not repo names

--- a/cmd/ox/doctor_git_repos_test.go
+++ b/cmd/ox/doctor_git_repos_test.go
@@ -807,9 +807,14 @@ func TestClassifyFsckOutput(t *testing.T) {
 			wantSeverity: fsckSeverityFail,
 		},
 		{
-			name:         "dangling commit is genuine object corruption",
+			name:         "dangling object alone is benign, not corruption",
 			output:       "dangling commit 2222222222222222222222222222222222222222",
-			wantSeverity: fsckSeverityFail,
+			wantSeverity: fsckSeverityOK,
+		},
+		{
+			name:         "dangling object alongside a stale ref stays a ref warning",
+			output:       "dangling commit 2222222222222222222222222222222222222222\n" + belgradeStaleHead,
+			wantSeverity: fsckSeverityWarn,
 		},
 		{
 			name:         "mixed ref issue and object corruption fails — corruption dominates",

--- a/cmd/ox/doctor_skills.go
+++ b/cmd/ox/doctor_skills.go
@@ -32,7 +32,7 @@ func checkClaudeSkills(fix bool) checkResult {
 	problem := describeSkillPlan(plan)
 	if !fix {
 		if len(plan.Conflicts) > 0 && len(plan.Creates)+len(plan.Updates)+len(plan.Removes) == 0 {
-			return WarningCheck("Agent skills", problem, "Resolve the preserved user-owned or modified files manually")
+			return WarningCheck("Agent skills", problem, describeSkillConflicts(plan.Conflicts))
 		}
 		return FailedCheck("Agent skills", problem, "Run `ox doctor --fix` to reconcile unchanged managed files")
 	}
@@ -42,9 +42,23 @@ func checkClaudeSkills(fix bool) checkResult {
 	}
 	plan = applied
 	if len(plan.Conflicts) > 0 {
-		return WarningCheck("Agent skills", fmt.Sprintf("reconciled with %d preserved conflict(s)", len(plan.Conflicts)), "Resolve the preserved user-owned or modified files manually")
+		return WarningCheck("Agent skills", fmt.Sprintf("reconciled with %d preserved conflict(s)", len(plan.Conflicts)), describeSkillConflicts(plan.Conflicts))
 	}
 	return PassedCheck("Agent skills", fmt.Sprintf("reconciled %d file change(s) across %d native target(s)", len(plan.Creates)+len(plan.Updates)+len(plan.Removes), plan.TargetCount))
+}
+
+// describeSkillConflicts renders each preserved conflict as "<path> —
+// <reason>" so `ox doctor` tells the user exactly which files to resolve
+// and why ox left them alone, instead of just a count.
+func describeSkillConflicts(conflicts []skillmanager.Conflict) string {
+	if len(conflicts) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(conflicts))
+	for _, c := range conflicts {
+		parts = append(parts, fmt.Sprintf("%s — %s", c.Path, c.Reason))
+	}
+	return strings.Join(parts, "; ")
 }
 
 func describeSkillPlan(plan *skillmanager.ReconcilePlan) string {

--- a/cmd/ox/doctor_skills_test.go
+++ b/cmd/ox/doctor_skills_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/skillmanager"
+)
+
+// TestDescribeSkillConflicts pins the doctor detail message for preserved
+// skill conflicts: it must name each conflicting file and why ox left it
+// alone, not just report a count. Before the fix, checkClaudeSkills emitted
+// a generic "Resolve the preserved user-owned or modified files manually"
+// detail with no path information, leaving the user unable to act on the
+// warning from the doctor output alone.
+func TestDescribeSkillConflicts(t *testing.T) {
+	conflicts := []skillmanager.Conflict{
+		{
+			TargetKey: "claude",
+			Path:      ".claude/skills/foo/SKILL.md",
+			Reason:    "existing skill is not managed by ox",
+		},
+		{
+			TargetKey: "claude",
+			Path:      ".claude/skills/bar/SKILL.md",
+			Reason:    "retired managed file was modified and will be preserved",
+		},
+	}
+
+	got := describeSkillConflicts(conflicts)
+
+	for _, c := range conflicts {
+		if !strings.Contains(got, c.Path) {
+			t.Errorf("describeSkillConflicts(%+v) = %q; missing path %q", conflicts, got, c.Path)
+		}
+		if !strings.Contains(got, c.Reason) {
+			t.Errorf("describeSkillConflicts(%+v) = %q; missing reason %q", conflicts, got, c.Reason)
+		}
+	}
+}
+
+func TestDescribeSkillConflicts_Empty(t *testing.T) {
+	if got := describeSkillConflicts(nil); got != "" {
+		t.Errorf("describeSkillConflicts(nil) = %q; want empty string", got)
+	}
+}
+
+// TestCheckClaudeSkills_ReconcileWarningNamesConflicts is a narrower,
+// message-shape regression: it locks in that the WARN path built after a
+// reconcile (checkClaudeSkills's post-Apply branch) routes its detail
+// through describeSkillConflicts rather than a bare count-only string.
+func TestCheckClaudeSkills_ReconcileWarningNamesConflicts(t *testing.T) {
+	conflicts := []skillmanager.Conflict{
+		{TargetKey: "claude", Path: ".claude/skills/foo/SKILL.md", Reason: "existing skill is not managed by ox"},
+	}
+
+	detail := describeSkillConflicts(conflicts)
+	result := WarningCheck("Agent skills", "reconciled with 1 preserved conflict(s)", detail)
+
+	if !strings.Contains(result.detail, ".claude/skills/foo/SKILL.md") {
+		t.Errorf("WarningCheck detail = %q; want it to contain the conflicting path", result.detail)
+	}
+	if !strings.Contains(result.detail, "existing skill is not managed by ox") {
+		t.Errorf("WarningCheck detail = %q; want it to contain the conflict reason", result.detail)
+	}
+}

--- a/cmd/ox/hooks_droid.go
+++ b/cmd/ox/hooks_droid.go
@@ -1,0 +1,21 @@
+package main
+
+// installDroidHooks delegates to the external ox-adapter-droid binary.
+func installDroidHooks(user bool) error {
+	return installExternalAdapterHooks("droid", user)
+}
+
+// uninstallDroidHooks delegates to the external ox-adapter-droid binary.
+func uninstallDroidHooks(user bool) error {
+	return uninstallExternalAdapterHooks("droid", user)
+}
+
+// hasDroidHooks delegates to the external ox-adapter-droid binary.
+func hasDroidHooks(user bool) bool {
+	return checkExternalAdapterHooks("droid", user)
+}
+
+// listDroidHooks returns the installation status of Factory Droid hooks.
+func listDroidHooks() map[string]bool {
+	return listExternalAdapterHooks("droid")
+}

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -65,6 +65,7 @@ var (
 	integrateAmpFlag      bool
 	integratePiFlag       bool
 	integrateOMPFlag      bool
+	integrateDroidFlag    bool
 	integrateAllFlag      bool
 	integrateForceFlag    bool
 )
@@ -103,7 +104,8 @@ Other agents can be installed with their respective flags:
   --amp       Amp CLI integration (AGENTS.md marker)
   --opencode  OpenCode plugin
   --pi        Pi coding agent integration (AGENTS.md marker)
-  --omp       OMP integration (.omp/AGENTS.md marker)`,
+  --omp       OMP integration (.omp/AGENTS.md marker)
+  --droid     Factory Droid hooks`,
 	RunE: runIntegrateInstall,
 }
 
@@ -128,7 +130,7 @@ var integrateListCmd = &cobra.Command{
 func hasAnyAgentFlag() bool {
 	return integratePiFlag || integrateOMPFlag || integrateAmpFlag ||
 		integrateCodexFlag || integrateGeminiFlag || integrateOpenCodeFlag ||
-		integrateUserFlag
+		integrateDroidFlag || integrateUserFlag
 }
 
 // integrateAgentInfo pairs adapter metadata with its current install status.
@@ -309,6 +311,23 @@ func runIntegrateInstall(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Factory Droid installation
+	if integrateDroidFlag {
+		if err := installDroidHooks(integrateUserFlag); err != nil {
+			return fmt.Errorf("installing Factory Droid integration: %w", err)
+		}
+
+		location := "project"
+		if integrateUserFlag {
+			location = "user"
+		}
+		fmt.Println(ui.PassStyle.Render("✓") + fmt.Sprintf(" Factory Droid %s-level integration installed", location))
+
+		userCfg, _ := config.LoadUserConfig()
+		tips.MaybeShow("hooks", tips.WhenMinimal, false, !userCfg.AreTipsEnabled(), false)
+		return nil
+	}
+
 	// Codex CLI installation
 	if integrateCodexFlag {
 		if err := installCodexHooks(integrateUserFlag); err != nil {
@@ -449,6 +468,23 @@ func runIntegrateUninstall(cmd *cobra.Command, args []string) error {
 		}
 
 		fmt.Printf("✓ Amp CLI project-level integration uninstalled\n")
+
+		userCfg, _ := config.LoadUserConfig()
+		tips.MaybeShow("hooks", tips.WhenMinimal, false, !userCfg.AreTipsEnabled(), false)
+		return nil
+	}
+
+	// Factory Droid uninstallation
+	if integrateDroidFlag {
+		if err := uninstallDroidHooks(integrateUserFlag); err != nil {
+			return fmt.Errorf("uninstalling Factory Droid integration: %w", err)
+		}
+
+		location := "project"
+		if integrateUserFlag {
+			location = "user"
+		}
+		fmt.Printf("✓ Factory Droid %s-level integration uninstalled\n", location)
 
 		userCfg, _ := config.LoadUserConfig()
 		tips.MaybeShow("hooks", tips.WhenMinimal, false, !userCfg.AreTipsEnabled(), false)
@@ -752,6 +788,8 @@ func init() {
 	_ = integrateInstallCmd.Flags().MarkHidden("pi")
 	integrateInstallCmd.Flags().BoolVar(&integrateOMPFlag, "omp", false, "install OMP integration (.omp/AGENTS.md marker)")
 	_ = integrateInstallCmd.Flags().MarkHidden("omp")
+	integrateInstallCmd.Flags().BoolVar(&integrateDroidFlag, "droid", false, "install Factory Droid hooks instead of Claude Code hooks")
+	_ = integrateInstallCmd.Flags().MarkHidden("droid")
 
 	// uninstall flags
 	integrateUninstallCmd.Flags().BoolVar(&integrateUserFlag, "user", false, "uninstall from user-level config")
@@ -769,6 +807,8 @@ func init() {
 	_ = integrateUninstallCmd.Flags().MarkHidden("pi")
 	integrateUninstallCmd.Flags().BoolVar(&integrateOMPFlag, "omp", false, "uninstall OMP integration (.omp/AGENTS.md marker)")
 	_ = integrateUninstallCmd.Flags().MarkHidden("omp")
+	integrateUninstallCmd.Flags().BoolVar(&integrateDroidFlag, "droid", false, "uninstall Factory Droid hooks instead of Claude Code hooks")
+	_ = integrateUninstallCmd.Flags().MarkHidden("droid")
 	_ = integrateUninstallCmd.Flags().MarkHidden("all")
 	_ = integrateUninstallCmd.Flags().MarkHidden("force")
 

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -661,6 +661,14 @@ func uninstallAllIntegrations(force bool) error {
 		installed = append(installed, "Gemini CLI (user)")
 	}
 
+	// check Factory Droid
+	if hasDroidHooks(false) {
+		installed = append(installed, "Factory Droid (project)")
+	}
+	if hasDroidHooks(true) {
+		installed = append(installed, "Factory Droid (user)")
+	}
+
 	// check Amp CLI
 	if hasAmpHooks(false) {
 		installed = append(installed, "Amp CLI (project)")
@@ -726,6 +734,12 @@ func uninstallAllIntegrations(force bool) error {
 	}
 	if err := uninstallGeminiHooks(true); err != nil {
 		errors = append(errors, fmt.Sprintf("Gemini CLI (user): %v", err))
+	}
+	if err := uninstallDroidHooks(false); err != nil {
+		errors = append(errors, fmt.Sprintf("Factory Droid (project): %v", err))
+	}
+	if err := uninstallDroidHooks(true); err != nil {
+		errors = append(errors, fmt.Sprintf("Factory Droid (user): %v", err))
 	}
 	if err := uninstallAmpHooks(false); err != nil {
 		errors = append(errors, fmt.Sprintf("Amp CLI (project): %v", err))

--- a/internal/daemon/hooks/runner.go
+++ b/internal/daemon/hooks/runner.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/sageox/ox/internal/envutil"
@@ -85,11 +84,15 @@ func (r *HookRunner) run(ctx context.Context, event Event, hook HookConfig) {
 		return
 	}
 
-	cmd := exec.Command("sh", "-c", hook.Command)
+	cmd := newHookCmd(hook.Command)
 	cmd.Stdin = bytes.NewReader(eventJSON)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// Run the hook in its own process group (Unix) / process group ID
+	// (Windows) so forked/spawned descendants can be terminated alongside it
+	// — see terminateProcessGroup / killProcessGroup in runner_unix.go and
+	// runner_windows.go.
+	setProcessGroup(cmd)
 	// Hooks run arbitrary user-defined commands (e.g. from a prompt-injected
 	// CLAUDE.md `env > /tmp/x`). They must NOT inherit daemon secrets — sanitize
 	// to the default allowlist before adding the hook-specific OX_EVENT vars.
@@ -105,12 +108,11 @@ func (r *HookRunner) run(ctx context.Context, event Event, hook HookConfig) {
 	}
 
 	// signal the entire process group so forked children are also terminated
-	pgid := cmd.Process.Pid
 	termTimer := time.AfterFunc(hookTimeout, func() {
-		_ = syscall.Kill(-pgid, syscall.SIGTERM)
+		terminateProcessGroup(cmd)
 	})
 	killTimer := time.AfterFunc(hookTimeout+hookKillDelay, func() {
-		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		killProcessGroup(cmd)
 	})
 
 	waitErr := cmd.Wait()

--- a/internal/daemon/hooks/runner_unix.go
+++ b/internal/daemon/hooks/runner_unix.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package hooks
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// newHookCmd builds the exec.Cmd used to run a hook's shell command.
+func newHookCmd(command string) *exec.Cmd {
+	return exec.Command("sh", "-c", command)
+}
+
+// setProcessGroup configures cmd to become the leader of a new process
+// group (its pgid equals its pid once started). This lets
+// terminateProcessGroup / killProcessGroup signal the whole tree — including
+// any children the hook itself forks — instead of only the immediate child.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// terminateProcessGroup sends SIGTERM to the hook's process group so forked
+// children are also asked to exit gracefully.
+func terminateProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+}
+
+// killProcessGroup sends SIGKILL to the hook's process group.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/internal/daemon/hooks/runner_windows.go
+++ b/internal/daemon/hooks/runner_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package hooks
+
+import (
+	"os/exec"
+	"strconv"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// newHookCmd builds the exec.Cmd used to run a hook's command. Windows has
+// no POSIX shell; route through cmd.exe the way "sh -c" is used on Unix.
+func newHookCmd(command string) *exec.Cmd {
+	return exec.Command("cmd.exe", "/c", command)
+}
+
+// setProcessGroup starts the hook in a new process group ID (equal to its
+// own PID) so terminateProcessGroup can target the group with a console
+// control event, and so a Ctrl+Break delivered to ox's own console doesn't
+// also land on the hook.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+}
+
+// terminateProcessGroup asks the hook's process group to exit by delivering
+// CTRL_BREAK_EVENT — the Windows analog of SIGTERM for a process group.
+//
+// Caveat for reviewers: CTRL_BREAK_EVENT only reaches console-aware
+// processes that installed a handler for it; cmd.exe and most simple child
+// processes ignore it and keep running. It is NOT a reliable full-tree
+// terminator on its own (unlike SIGTERM to a Unix process group, which the
+// kernel delivers unconditionally). killProcessGroup below is the backstop
+// that actually reaps a stuck hook tree on Windows.
+func terminateProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(cmd.Process.Pid))
+}
+
+// killProcessGroup force-kills the entire process tree rooted at the hook's
+// PID via taskkill /T /F. Windows has no SIGKILL-to-process-group equivalent
+// in the stdlib syscall/exec surface (a full descendant-tree kill without a
+// job object needs either CGo or golang.org/x/sys/windows job-object APIs,
+// neither of which this package otherwise needs), so shelling out to the
+// built-in taskkill utility is the pragmatic, dependency-free choice here.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run()
+}

--- a/internal/daemon/whisper_registry.go
+++ b/internal/daemon/whisper_registry.go
@@ -62,13 +62,24 @@ func (r *WhisperRegistry) SetClock(now func() time.Time) {
 // the close-before-replace makes the registry correct on its own terms and
 // prevents a latent fd leak if that guard is ever bypassed (e.g. a GC
 // directory-swap that re-points a team's DB path).
+//
+// If the prior handle's Close fails, the replacement is NOT committed: the
+// prior store stays registered (so a later idle-close/shutdown can retry its
+// Close and reclaim the fd) and the incoming store is closed instead — so
+// neither handle leaks. Committing the replacement in that case would drop
+// the only reference to the un-closed prior store, making the leak permanent.
 func (r *WhisperRegistry) AddTeamStore(teamID string, store *whisperstore.Store) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if prior, ok := r.teamStores[teamID]; ok && prior != nil && prior != store {
 		if err := prior.Close(); err != nil {
-			r.logger.Warn("failed to close replaced team whisper store",
+			r.logger.Warn("keeping prior team whisper store; its Close failed, closing incoming instead",
 				"team_id", teamID, "err", err)
+			if cerr := store.Close(); cerr != nil {
+				r.logger.Warn("failed to close incoming team whisper store after prior Close failure",
+					"team_id", teamID, "err", cerr)
+			}
+			return
 		}
 	}
 	r.teamStores[teamID] = store

--- a/internal/daemon/whisper_registry.go
+++ b/internal/daemon/whisper_registry.go
@@ -55,10 +55,22 @@ func (r *WhisperRegistry) SetClock(now func() time.Time) {
 	r.now = now
 }
 
-// AddTeamStore registers a team whisper store.
+// AddTeamStore registers a team whisper store. If a different store is
+// already registered for teamID, the prior handle is closed before it is
+// replaced — otherwise the old sqlite connection would leak. Callers today
+// gate this behind HasTeamStore so a replace never happens in practice, but
+// the close-before-replace makes the registry correct on its own terms and
+// prevents a latent fd leak if that guard is ever bypassed (e.g. a GC
+// directory-swap that re-points a team's DB path).
 func (r *WhisperRegistry) AddTeamStore(teamID string, store *whisperstore.Store) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if prior, ok := r.teamStores[teamID]; ok && prior != nil && prior != store {
+		if err := prior.Close(); err != nil {
+			r.logger.Warn("failed to close replaced team whisper store",
+				"team_id", teamID, "err", err)
+		}
+	}
 	r.teamStores[teamID] = store
 	r.lastAccess[teamID] = r.now()
 }

--- a/internal/doctor/daemon.go
+++ b/internal/doctor/daemon.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
@@ -432,6 +433,11 @@ type DaemonHeartbeatCheck struct {
 	Identifier  string // repo_id or team_id
 	DisplayName string // for output
 	Endpoint    string // SageOx endpoint
+
+	// findProjectRoot is exposed for tests; zero-valued in production and
+	// resolved to config.FindProjectRoot inside Run. See
+	// alternateHeartbeatCandidate for why this exists.
+	findProjectRoot func() string
 }
 
 // NewDaemonHeartbeatCheck creates a heartbeat check for a specific repo.
@@ -506,6 +512,28 @@ func (c *DaemonHeartbeatCheck) Run(_ context.Context, _ bool) CheckResult {
 
 	entry, err := daemon.ReadLastHeartbeatFromPath(heartbeatPath)
 	if err != nil || entry == nil {
+		// The doctor CLI computes repoID/workspaceID from git's notion of
+		// project root (the git top-level directory), while the daemon
+		// derives its own workspace identity from config.FindProjectRoot()
+		// (the directory that actually owns .sageox/) at startup. These are
+		// USUALLY the same directory, but not guaranteed to be — e.g. a
+		// monorepo where .sageox/ lives in a subdirectory rather than at
+		// the git top-level. When they diverge, the primary heartbeatPath
+		// above is a path the daemon never wrote to. Before concluding the
+		// repo isn't syncing, retry against the path the daemon would
+		// actually have written, derived the same way it derives it.
+		findProjectRoot := c.findProjectRoot
+		if findProjectRoot == nil {
+			findProjectRoot = config.FindProjectRoot
+		}
+		if altPath := alternateHeartbeatPath(c.Type, ep, findProjectRoot); altPath != "" && altPath != heartbeatPath {
+			if altEntry, altErr := daemon.ReadLastHeartbeatFromPath(altPath); altErr == nil && altEntry != nil {
+				entry, err = altEntry, nil
+			}
+		}
+	}
+
+	if err != nil || entry == nil {
 		if daemon.IsRunning() {
 			// grace period: daemon just started
 			client := daemon.NewClientForCurrentRepoWithTimeout(500 * time.Millisecond)
@@ -577,6 +605,60 @@ func splitCompositeID(id string) (repoID, workspaceID string) {
 		return "", ""
 	}
 	return id[:lastIdx], id[lastIdx+1:]
+}
+
+// alternateHeartbeatCandidate derives an independent (repoID, workspaceID)
+// pair for a "workspace" or "ledger" heartbeat check using findProjectRoot —
+// the SAME project-root-discovery function the daemon itself uses at
+// startup (config.FindProjectRoot, which walks up looking for the
+// .sageox-owning directory; see findProjectRootForDaemon in
+// internal/daemon/fallback.go, which sets the daemon process's CWD to this
+// value before it computes CurrentWorkspaceID()).
+//
+// The doctor CLI's primary computation instead starts from git's notion of
+// project root (`git rev-parse --show-toplevel`). That is usually the same
+// directory, but not guaranteed to be: whenever .sageox/ isn't at the git
+// top-level (e.g. a monorepo where a project's .sageox/ lives in a
+// subdirectory), the two diverge and the doctor reads a heartbeat path the
+// daemon never wrote — producing a false "not syncing" warning even though
+// the daemon is healthy and actively syncing this exact repo.
+//
+// Returns ok=false when findProjectRoot is nil, the check type isn't
+// project-root-derived (team heartbeats key on team_id directly, which
+// isn't subject to this divergence), or no repo_id can be found at the
+// discovered root — callers should fall back to whatever the primary
+// lookup found.
+func alternateHeartbeatCandidate(checkType string, findProjectRoot func() string) (repoID, workspaceID string, ok bool) {
+	if findProjectRoot == nil || (checkType != "workspace" && checkType != "ledger") {
+		return "", "", false
+	}
+	root := findProjectRoot()
+	if root == "" {
+		return "", "", false
+	}
+	repoID = config.GetRepoID(root)
+	if repoID == "" {
+		return "", "", false
+	}
+	workspaceID = daemon.RepoBasedWorkspaceID(root)
+	if workspaceID == "" {
+		return "", "", false
+	}
+	return repoID, workspaceID, true
+}
+
+// alternateHeartbeatPath returns the heartbeat file path the daemon would
+// have written for checkType, derived via findProjectRoot. Returns "" if no
+// alternate candidate is available (see alternateHeartbeatCandidate).
+func alternateHeartbeatPath(checkType, ep string, findProjectRoot func() string) string {
+	repoID, workspaceID, ok := alternateHeartbeatCandidate(checkType, findProjectRoot)
+	if !ok {
+		return ""
+	}
+	if checkType == "ledger" {
+		return daemon.UserLedgerHeartbeatPath(ep, repoID, workspaceID)
+	}
+	return daemon.UserHeartbeatPath(ep, repoID, workspaceID)
 }
 
 // DaemonFDPressureCheck warns when the daemon is consuming a worrying
@@ -804,34 +886,76 @@ func (c *DaemonFDGrowthCheck) Run(_ context.Context, _ bool) CheckResult {
 		history.Samples = history.Samples[len(history.Samples)-fdHistoryMaxSamples:]
 	}
 
-	// Persist BEFORE returning so the next run sees this sample even on a
-	// fast doctor invocation. A failed write is non-fatal — we still
-	// report the in-memory verdict.
+	// Persist BEFORE computing the verdict so the next run sees this sample
+	// even on a fast doctor invocation. A failed write is non-fatal — we
+	// still report the in-memory verdict.
 	_ = saveFDHistory(path, history)
 
-	if len(history.Samples) < 2 {
+	return fdGrowthVerdict(c.Name(), history)
+}
+
+// samplesForCurrentLifetime returns the trailing run of samples that share
+// the newest sample's PID — i.e. only the samples captured during the
+// currently-running daemon process's lifetime.
+//
+// The daemon restarts many times over the life of a history file (each
+// restart gets a fresh PID from the OS, and a fresh FD count that has
+// nothing to do with the previous process's count). Comparing a sample from
+// a previous process's lifetime against the current one is not a valid
+// leak signal — over enough restarts it produces exactly the kind of
+// "+44 FDs over 81 days" reading that looks like a slow leak but is really
+// just two unrelated processes' steady-state counts happening to differ.
+//
+// A PID of 0 means "unknown" (a sample written before this field existed,
+// or a platform that doesn't report it) and is treated as its own
+// unmatched lifetime rather than silently bridging across restarts.
+func samplesForCurrentLifetime(samples []fdHistorySample) []fdHistorySample {
+	if len(samples) == 0 {
+		return nil
+	}
+	currentPID := samples[len(samples)-1].PID
+	start := len(samples) - 1
+	for start > 0 && samples[start-1].PID == currentPID {
+		start--
+	}
+	return samples[start:]
+}
+
+// fdGrowthVerdict computes the FD-growth CheckResult from the (already
+// updated + persisted) sample history. Pure (no daemon/IPC) so the
+// PID-segmentation and threshold logic is unit-testable without a running
+// daemon — mirrors fdPressureVerdict.
+//
+// Only samples sharing the newest sample's PID are compared; see
+// samplesForCurrentLifetime for why cross-restart comparisons are invalid.
+func fdGrowthVerdict(name string, history fdHistoryFile) CheckResult {
+	current := history.Samples[len(history.Samples)-1]
+	lifetime := samplesForCurrentLifetime(history.Samples)
+
+	if current.PID == 0 || len(lifetime) < 2 {
 		return CheckResult{
-			Name:    c.Name(),
+			Name:    name,
 			Status:  StatusPass,
-			Message: fmt.Sprintf("%d FDs (history seeding)", status.OpenFDs),
+			Message: fmt.Sprintf("%d FDs (history seeding)", current.Count),
 		}
 	}
 
-	oldest := history.Samples[0]
-	newest := history.Samples[len(history.Samples)-1]
+	oldest := lifetime[0]
+	newest := lifetime[len(lifetime)-1]
 	span := newest.At.Sub(oldest.At)
 	delta := newest.Count - oldest.Count
 
-	msg := fmt.Sprintf("%d FDs (delta %+d over %s, %d samples)",
-		status.OpenFDs, delta, formatDuration(span), len(history.Samples))
+	msg := fmt.Sprintf("%d FDs (delta %+d over %s, %d samples this run)",
+		current.Count, delta, formatDuration(span), len(lifetime))
 
 	if span < fdGrowthMinSpan {
-		// Not enough history to call growth meaningful yet.
-		return CheckResult{Name: c.Name(), Status: StatusPass, Message: msg}
+		// Not enough history within this daemon lifetime to call growth
+		// meaningful yet.
+		return CheckResult{Name: name, Status: StatusPass, Message: msg}
 	}
 	if delta >= fdGrowthWarnDelta {
 		return CheckResult{
-			Name:    c.Name(),
+			Name:    name,
 			Status:  StatusWarn,
 			Message: msg,
 			Fix: "Daemon FD count has been climbing across recent doctor runs. " +
@@ -839,7 +963,7 @@ func (c *DaemonFDGrowthCheck) Run(_ context.Context, _ bool) CheckResult {
 				"daemon log for any subsystem opening per-team/per-KB handles without releasing them.",
 		}
 	}
-	return CheckResult{Name: c.Name(), Status: StatusPass, Message: msg}
+	return CheckResult{Name: name, Status: StatusPass, Message: msg}
 }
 
 // DefaultFDGrowthHistoryPath returns the canonical on-disk path for the

--- a/internal/doctor/daemon_growth_heartbeat_test.go
+++ b/internal/doctor/daemon_growth_heartbeat_test.go
@@ -1,0 +1,110 @@
+package doctor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFDGrowthVerdict_CrossRestartNotALeak pins the E fix: a history that
+// spans a daemon restart (a low-count old PID followed by a higher but flat
+// new PID) must NOT warn. The pre-fix code compared history[0] vs
+// history[last] regardless of PID, so this exact shape produced the spurious
+// "delta +35 over 81d" leak warning. Post-fix, only samples sharing the
+// newest PID are compared, so the verdict is PASS.
+func TestFDGrowthVerdict_CrossRestartNotALeak(t *testing.T) {
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	h := fdHistoryFile{Samples: []fdHistorySample{
+		{At: base, Count: 5, PID: 100},                                  // previous process lifetime
+		{At: base.Add(81 * 24 * time.Hour), Count: 40, PID: 200},        // current process, first sample
+		{At: base.Add(81*24*time.Hour + 7*time.Hour), Count: 40, PID: 200}, // current process, flat
+	}}
+	res := fdGrowthVerdict("fd", h)
+	assert.Equal(t, StatusPass, res.Status,
+		"cross-restart FD counts must not be compared as a leak signal")
+}
+
+// TestFDGrowthVerdict_SamePIDGrowthWarns ensures the E fix still catches a
+// genuine within-lifetime leak: same PID, growth past the delta threshold
+// over more than the minimum span.
+func TestFDGrowthVerdict_SamePIDGrowthWarns(t *testing.T) {
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	h := fdHistoryFile{Samples: []fdHistorySample{
+		{At: base, Count: 10, PID: 300},
+		{At: base.Add(7 * time.Hour), Count: 10 + fdGrowthWarnDelta + 5, PID: 300},
+	}}
+	res := fdGrowthVerdict("fd", h)
+	assert.Equal(t, StatusWarn, res.Status,
+		"real growth within one daemon lifetime must still warn")
+}
+
+// TestFDGrowthVerdict_SeedingCases covers the "not enough current-lifetime
+// data" branches: an unknown PID (0), and a single same-PID sample.
+func TestFDGrowthVerdict_SeedingCases(t *testing.T) {
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	unknownPID := fdHistoryFile{Samples: []fdHistorySample{{At: base, Count: 10, PID: 0}}}
+	assert.Equal(t, StatusPass, fdGrowthVerdict("fd", unknownPID).Status)
+
+	singleSample := fdHistoryFile{Samples: []fdHistorySample{{At: base, Count: 10, PID: 300}}}
+	assert.Equal(t, StatusPass, fdGrowthVerdict("fd", singleSample).Status)
+}
+
+// TestSamplesForCurrentLifetime verifies the segmentation helper returns only
+// the trailing run sharing the newest PID.
+func TestSamplesForCurrentLifetime(t *testing.T) {
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	samples := []fdHistorySample{
+		{At: base, Count: 5, PID: 100},
+		{At: base.Add(time.Hour), Count: 6, PID: 100},
+		{At: base.Add(2 * time.Hour), Count: 40, PID: 200},
+		{At: base.Add(3 * time.Hour), Count: 41, PID: 200},
+	}
+	lifetime := samplesForCurrentLifetime(samples)
+	require.Len(t, lifetime, 2)
+	for _, s := range lifetime {
+		assert.Equal(t, 200, s.PID)
+	}
+	assert.Nil(t, samplesForCurrentLifetime(nil))
+}
+
+// TestAlternateHeartbeatCandidate_Guards pins the F fix's guard logic: the
+// alternate (daemon-derived) heartbeat identity is only computed for the
+// project-root-derived check types, never for a nil resolver, an empty root,
+// or a team check (team heartbeats key on team_id and are not subject to the
+// workspace_id divergence).
+func TestAlternateHeartbeatCandidate_Guards(t *testing.T) {
+	_, _, ok := alternateHeartbeatCandidate("team", func() string { return "/whatever" })
+	assert.False(t, ok, "team checks are not project-root-derived")
+
+	_, _, ok = alternateHeartbeatCandidate("workspace", nil)
+	assert.False(t, ok, "nil resolver yields no alternate")
+
+	_, _, ok = alternateHeartbeatCandidate("ledger", func() string { return "" })
+	assert.False(t, ok, "empty project root yields no alternate")
+
+	_, _, ok = alternateHeartbeatCandidate("workspace", func() string { return t.TempDir() })
+	assert.False(t, ok, "a root with no .sageox config has no repo_id, so no alternate")
+}
+
+// TestAlternateHeartbeatCandidate_DerivesDaemonWay pins the core of the F
+// fix: when the resolver points at a project root that owns a .sageox config,
+// the alternate identity is derived the SAME way the daemon derives it
+// (config.GetRepoID + daemon.RepoBasedWorkspaceID). This is exactly the
+// identity the doctor previously failed to match, producing false
+// "not syncing" warnings when .sageox/ is not at the git top-level.
+func TestAlternateHeartbeatCandidate_DerivesDaemonWay(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, config.SaveProjectConfig(root, &config.ProjectConfig{RepoID: "repo_testheartbeat"}))
+
+	repoID, wsID, ok := alternateHeartbeatCandidate("workspace", func() string { return root })
+	require.True(t, ok)
+	assert.Equal(t, "repo_testheartbeat", repoID)
+	assert.Equal(t, daemon.RepoBasedWorkspaceID(root), wsID,
+		"alternate workspace_id must match the daemon's own derivation")
+	assert.NotEmpty(t, wsID)
+}

--- a/internal/doctor/daemon_growth_heartbeat_test.go
+++ b/internal/doctor/daemon_growth_heartbeat_test.go
@@ -10,48 +10,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestFDGrowthVerdict_CrossRestartNotALeak pins the E fix: a history that
-// spans a daemon restart (a low-count old PID followed by a higher but flat
-// new PID) must NOT warn. The pre-fix code compared history[0] vs
-// history[last] regardless of PID, so this exact shape produced the spurious
-// "delta +35 over 81d" leak warning. Post-fix, only samples sharing the
-// newest PID are compared, so the verdict is PASS.
-func TestFDGrowthVerdict_CrossRestartNotALeak(t *testing.T) {
-	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	h := fdHistoryFile{Samples: []fdHistorySample{
-		{At: base, Count: 5, PID: 100},                                  // previous process lifetime
-		{At: base.Add(81 * 24 * time.Hour), Count: 40, PID: 200},        // current process, first sample
-		{At: base.Add(81*24*time.Hour + 7*time.Hour), Count: 40, PID: 200}, // current process, flat
-	}}
-	res := fdGrowthVerdict("fd", h)
-	assert.Equal(t, StatusPass, res.Status,
-		"cross-restart FD counts must not be compared as a leak signal")
-}
-
-// TestFDGrowthVerdict_SamePIDGrowthWarns ensures the E fix still catches a
-// genuine within-lifetime leak: same PID, growth past the delta threshold
-// over more than the minimum span.
-func TestFDGrowthVerdict_SamePIDGrowthWarns(t *testing.T) {
-	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
-	h := fdHistoryFile{Samples: []fdHistorySample{
-		{At: base, Count: 10, PID: 300},
-		{At: base.Add(7 * time.Hour), Count: 10 + fdGrowthWarnDelta + 5, PID: 300},
-	}}
-	res := fdGrowthVerdict("fd", h)
-	assert.Equal(t, StatusWarn, res.Status,
-		"real growth within one daemon lifetime must still warn")
-}
-
-// TestFDGrowthVerdict_SeedingCases covers the "not enough current-lifetime
-// data" branches: an unknown PID (0), and a single same-PID sample.
-func TestFDGrowthVerdict_SeedingCases(t *testing.T) {
+// TestFDGrowthVerdict pins the E fix: FD growth is judged only within the
+// current daemon lifetime (samples sharing the newest PID), never across
+// restarts.
+func TestFDGrowthVerdict(t *testing.T) {
 	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	unknownPID := fdHistoryFile{Samples: []fdHistorySample{{At: base, Count: 10, PID: 0}}}
-	assert.Equal(t, StatusPass, fdGrowthVerdict("fd", unknownPID).Status)
+	tests := []struct {
+		name    string
+		samples []fdHistorySample
+		want    Status
+	}{
+		{
+			// A history that spans a daemon restart (a low-count old PID
+			// followed by a higher but flat new PID) must NOT warn. The
+			// pre-fix code compared history[0] vs history[last] regardless of
+			// PID, so this exact shape produced the spurious "delta +35 over
+			// 81d" leak warning.
+			name: "cross-restart counts are not a leak signal",
+			samples: []fdHistorySample{
+				{At: base, Count: 5, PID: 100},                                     // previous process lifetime
+				{At: base.Add(81 * 24 * time.Hour), Count: 40, PID: 200},           // current process, first sample
+				{At: base.Add(81*24*time.Hour + 7*time.Hour), Count: 40, PID: 200}, // current process, flat
+			},
+			want: StatusPass,
+		},
+		{
+			// Same PID, growth past the delta threshold over more than the
+			// minimum span — a genuine within-lifetime leak still warns.
+			name: "same-PID growth within one lifetime warns",
+			samples: []fdHistorySample{
+				{At: base, Count: 10, PID: 300},
+				{At: base.Add(7 * time.Hour), Count: 10 + fdGrowthWarnDelta + 5, PID: 300},
+			},
+			want: StatusWarn,
+		},
+		{
+			name:    "unknown PID (0) seeds without a verdict",
+			samples: []fdHistorySample{{At: base, Count: 10, PID: 0}},
+			want:    StatusPass,
+		},
+		{
+			name:    "single same-PID sample is insufficient data",
+			samples: []fdHistorySample{{At: base, Count: 10, PID: 300}},
+			want:    StatusPass,
+		},
+	}
 
-	singleSample := fdHistoryFile{Samples: []fdHistorySample{{At: base, Count: 10, PID: 300}}}
-	assert.Equal(t, StatusPass, fdGrowthVerdict("fd", singleSample).Status)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := fdGrowthVerdict("fd", fdHistoryFile{Samples: tt.samples})
+			assert.Equal(t, tt.want, res.Status)
+		})
+	}
 }
 
 // TestSamplesForCurrentLifetime verifies the segmentation helper returns only
@@ -78,17 +89,39 @@ func TestSamplesForCurrentLifetime(t *testing.T) {
 // or a team check (team heartbeats key on team_id and are not subject to the
 // workspace_id divergence).
 func TestAlternateHeartbeatCandidate_Guards(t *testing.T) {
-	_, _, ok := alternateHeartbeatCandidate("team", func() string { return "/whatever" })
-	assert.False(t, ok, "team checks are not project-root-derived")
+	tests := []struct {
+		name            string
+		checkType       string
+		findProjectRoot func() string
+	}{
+		{
+			name:            "team checks are not project-root-derived",
+			checkType:       "team",
+			findProjectRoot: func() string { return "/whatever" },
+		},
+		{
+			name:            "nil resolver yields no alternate",
+			checkType:       "workspace",
+			findProjectRoot: nil,
+		},
+		{
+			name:            "empty project root yields no alternate",
+			checkType:       "ledger",
+			findProjectRoot: func() string { return "" },
+		},
+		{
+			name:            "a root with no .sageox config has no repo_id",
+			checkType:       "workspace",
+			findProjectRoot: func() string { return t.TempDir() },
+		},
+	}
 
-	_, _, ok = alternateHeartbeatCandidate("workspace", nil)
-	assert.False(t, ok, "nil resolver yields no alternate")
-
-	_, _, ok = alternateHeartbeatCandidate("ledger", func() string { return "" })
-	assert.False(t, ok, "empty project root yields no alternate")
-
-	_, _, ok = alternateHeartbeatCandidate("workspace", func() string { return t.TempDir() })
-	assert.False(t, ok, "a root with no .sageox config has no repo_id, so no alternate")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, ok := alternateHeartbeatCandidate(tt.checkType, tt.findProjectRoot)
+			assert.False(t, ok)
+		})
+	}
 }
 
 // TestAlternateHeartbeatCandidate_DerivesDaemonWay pins the core of the F

--- a/internal/testguard/fdleak.go
+++ b/internal/testguard/fdleak.go
@@ -2,7 +2,6 @@ package testguard
 
 import (
 	"runtime"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -48,24 +47,4 @@ func RequireNoFDLeakWithDelta(t *testing.T, allowedDelta int) {
 				before, after, leaked, allowedDelta)
 		}
 	})
-}
-
-// maxFDProbe is the upper bound for FD probing. 8192 covers typical ulimit -n
-// defaults and is fast enough (single syscall per FD, ~1ms total).
-const maxFDProbe = 8192
-
-// countOpenFDs counts open file descriptors by probing with fcntl(F_GETFD).
-// Returns -1 on unsupported platforms.
-func countOpenFDs() int {
-	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
-		return -1
-	}
-	count := 0
-	for fd := 0; fd < maxFDProbe; fd++ {
-		_, _, err := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_GETFD, 0)
-		if err == 0 {
-			count++
-		}
-	}
-	return count
 }

--- a/internal/testguard/fdleak_unix.go
+++ b/internal/testguard/fdleak_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package testguard
+
+import "syscall"
+
+// maxFDProbe is the upper bound for FD probing. 8192 covers typical ulimit -n
+// defaults and is fast enough (single syscall per FD, ~1ms total).
+const maxFDProbe = 8192
+
+// countOpenFDs counts open file descriptors by probing with fcntl(F_GETFD).
+// Returns -1 on unsupported platforms.
+func countOpenFDs() int {
+	count := 0
+	for fd := 0; fd < maxFDProbe; fd++ {
+		_, _, err := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_GETFD, 0)
+		if err == 0 {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/testguard/fdleak_windows.go
+++ b/internal/testguard/fdleak_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package testguard
+
+// countOpenFDs is not implemented on Windows: there is no fcntl(F_GETFD)
+// equivalent reachable from the stdlib syscall package, and this helper is a
+// best-effort test diagnostic, not something worth a CGo/handle-enumeration
+// dependency to support. Callers already treat a negative return as
+// "unsupported platform" and skip (see RequireNoFDLeakWithDelta and the
+// existing fdleak_test.go skip-on-negative pattern), so this preserves the
+// original behavior of the file when it had no build constraint at all.
+func countOpenFDs() int {
+	return -1
+}


### PR DESCRIPTION
## Why this matters

Every `ox doctor` run currently cries wolf at the user: it reports a healthy repo as **corrupt and needing a re-clone**, a syncing daemon as **"not syncing,"** normal daemon restarts as a **file-descriptor leak**, and it advertises one-touch **`--fix` hook installs for droid/gemini/opencode that then refuse to run**. Separately, the shipped **Windows binary doesn't compile at all**, so `make dist` can't produce the Windows release artifacts. This PR makes each of those warnings *correct and actionable* (or silent when nothing is wrong) and restores the Windows build — so `ox doctor` becomes a signal a user can trust instead of noise they learn to ignore.

> Draft: implementations for A–G are complete, each with red→green unit tests, and the integration gate is green (native build, `GOOS=windows amd64/arm64` cross-build, `go vet` across every changed package). Full `go test ./...` is the last item before ready-for-review.

## What changed

| # | Defect (user-visible symptom) | Fix |
|---|---|---|
| **A/B** | Windows binary won't compile; `make dist` can't build `ox-windows-*.exe` | Build-tag split: `runner_{unix,windows}.go` (process-group control via `CREATE_NEW_PROCESS_GROUP` + `CTRL_BREAK_EVENT`, hard-kill via `taskkill /T /F`) and `fdleak_{unix,windows}.go` (unsupported-platform sentinel). Unix behavior byte-for-byte unchanged. |
| **C** | `ox doctor --fix` advertises a droid/gemini/opencode hook install, then refuses ("argv[0] not in allowlist" / "adapter must supply FixArgv") | Route each adapter's `FixArgv` through the in-process `ox integrate install --<adapter>` (the allowlist-safe pattern codex/omp/pi already use). Adds the missing `--droid` integrate flag + `hooks_droid.go`. The `{git,ox}` allowlist is left intact — it's a correct anti-hijack control. |
| **D** | A stale `refs/remotes/<remote>/HEAD` makes doctor report "corruption detected → re-clone the repository" | New `classifyFsckOutput` helper: ref-only problems → **WARN** with a `git remote set-head <remote> -a` remedy; genuine object errors (and anything unrecognized) still **FAIL** to re-clone (conservative — never silently downgrades). |
| **E** | Daemon restarts over months read as a slow FD leak ("+44 over 81d") | FD-growth now compares only samples sharing the **current PID** (`samplesForCurrentLifetime` + pure, unit-testable `fdGrowthVerdict`) — growth is judged within a single daemon lifetime, not across restarts. |
| **E-bis** | Latent sqlite-handle leak if a team whisper store is ever replaced | `AddTeamStore` closes the prior handle before overwriting it. |
| **F** | Healthy daemon reported as "(ledger) not syncing" when `.sageox/` isn't at the git top-level | The doctor computed `workspace_id` from the git root while the daemon derives it from `config.FindProjectRoot`; when they diverge the doctor read a heartbeat path the daemon never wrote. It now retries the alternate path derived the **daemon's** way. Low-blast-radius — global config resolution is untouched. |
| **G** | "reconciled with N preserved conflict(s)" hides which files to resolve | New `describeSkillConflicts` enumerates each `path -- reason` in the WARN detail. Reconcile logic + severity unchanged. |

## Context

The branch the investigation started from (`create-pr-v3`) turned out to add no "create PR" feature — its one commit was a 0.14.2 reliability patch already merged to `main` (#829). These defects were surfaced instead by a whole-repo audit plus tracing the five warnings this machine's `ox doctor` emitted at session startup back to their code. A/B are genuine build blockers; C is a genuine advertised-but-can't-run bug; D/E/F are false-positive checks (the check was wrong, not the system); G is a UX gap.

## Flow of the two check fixes

```mermaid
flowchart TD
    subgraph D["D: git fsck"]
        F1[git fsck non-zero exit] --> F2{classifyFsckOutput}
        F2 -->|only refs/... errors| F3[WARN: git remote set-head]
        F2 -->|object errors / unknown| F4[FAIL: re-clone]
    end
    subgraph F["F: heartbeat"]
        H1[read heartbeat at git-root workspace_id] --> H2{found?}
        H2 -->|yes| H3[syncing OK]
        H2 -->|no| H4[retry via config.FindProjectRoot workspace_id]
        H4 --> H5{found?}
        H5 -->|yes| H3
        H5 -->|no + daemon running| H6[report not-syncing]
    end
```

## Test plan

- [x] `go build ./...` — clean
- [x] `GOOS=windows GOARCH=amd64/arm64 go build ./...` — clean (was FAIL)
- [x] `go vet ./...` on every changed package — clean
- [x] Per-defect red→green unit tests for A/B, C, D, G (added with each fix)
- [x] Regression tests for E (PID-segmentation) and F (workspace-id divergence) — `TestFDGrowthVerdict_CrossRestartNotALeak` reproduces the "+44 over 81d" false positive; `TestAlternateHeartbeatCandidate_DerivesDaemonWay` pins the daemon-way identity
- [x] E-bis (close-before-replace) — covered by inspection (mirrors the existing idle-close path) + no regression in the whisper-registry suite
- [x] Full `go test ./...` — green, 0 failures
- [ ] End-to-end: re-run `ox doctor` and confirm the git-integrity, heartbeat, fd-growth, and adapter lines no longer false-warn (or now offer a runnable `--fix`) — needs a locally built binary on a machine with the daemon running


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Factory Droid integration support, including hook installation, removal, status checks, and bulk management.
  - Improved cross-platform hook execution and cleanup, including descendant process termination on timeouts.

- **Bug Fixes**
  - Hook diagnostics for Droid, Gemini, and OpenCode now provide safe automatic fixes.
  - Improved Git repository health checks by distinguishing benign dangling objects from corruption.
  - Enhanced daemon diagnostics across restarts and alternate workspace locations.
  - Skill conflict warnings now include affected paths and reasons.
  - Prevented failed store replacements when closing an existing store fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->