### PR TITLE
release: 0.14.2 — finalize notes + uninstall-all droid fix

### DIFF
--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -662,10 +662,12 @@ func uninstallAllIntegrations(force bool) error {
 	}
 
 	// check Factory Droid
-	if hasDroidHooks(false) {
+	droidProjectInstalled := hasDroidHooks(false)
+	if droidProjectInstalled {
 		installed = append(installed, "Factory Droid (project)")
 	}
-	if hasDroidHooks(true) {
+	droidUserInstalled := hasDroidHooks(true)
+	if droidUserInstalled {
 		installed = append(installed, "Factory Droid (user)")
 	}
 
@@ -735,11 +737,18 @@ func uninstallAllIntegrations(force bool) error {
 	if err := uninstallGeminiHooks(true); err != nil {
 		errors = append(errors, fmt.Sprintf("Gemini CLI (user): %v", err))
 	}
-	if err := uninstallDroidHooks(false); err != nil {
-		errors = append(errors, fmt.Sprintf("Factory Droid (project): %v", err))
+	// only dispatch droid uninstall when detected — the external droid adapter
+	// may be absent, and uninstalling a non-installed external adapter errors
+	// with "adapter not found" (unlike the graceful skip that OMP gets below).
+	if droidProjectInstalled {
+		if err := uninstallDroidHooks(false); err != nil {
+			errors = append(errors, fmt.Sprintf("Factory Droid (project): %v", err))
+		}
 	}
-	if err := uninstallDroidHooks(true); err != nil {
-		errors = append(errors, fmt.Sprintf("Factory Droid (user): %v", err))
+	if droidUserInstalled {
+		if err := uninstallDroidHooks(true); err != nil {
+			errors = append(errors, fmt.Sprintf("Factory Droid (user): %v", err))
+		}
 	}
 	if err := uninstallAmpHooks(false); err != nil {
 		errors = append(errors, fmt.Sprintf("Amp CLI (project): %v", err))

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.2] - 2026-08-25
 
-Resumed work stays connected, stale sessions clean up after themselves, code indexing self-heals, team rules recover reliably, and SageOx uses one calm visual language everywhere.
+Resumed work stays connected, stale sessions clean up after themselves, AI coworkers navigate code more directly, code indexing self-heals, team rules recover reliably, and SageOx uses one calm visual language everywhere.
 
 ### Improved
 
 - **Resumed AI coworker sessions stay connected** — a new recording keeps a durable link to the session it continues, including through drafts, recovery, and upload retries.
+- **AI coworkers navigate code more directly** — `ox code` adds `callers`, `callees`, `defs`, `refs`, and `log` alongside inline result snippets and a clearer index status, so "who calls this?" or "where's this defined?" resolves in one step instead of several searches.
 - **The CLI and documentation stay in sync** — CI now detects generated-reference drift, the complete stable command set is published, and the docs workflow can use a dedicated package credential when repository permissions are insufficient.
 - **SageOx has one consistent palette** — CLI, TUI, plans, demos, and documentation now share an all-sage brand palette, reserving gold for warnings and using accessible light and dark variants.
 
@@ -21,6 +22,8 @@ Resumed work stays connected, stale sessions clean up after themselves, code ind
 
 - **Session history stays clean** — sessions that were only primed or never captured a prompt no longer pile up on your machine or linger as stale "in progress" conversation links. ox reclaims them automatically in the background and during `ox doctor`, and a session is only registered once real work happens.
 - **Code indexing recovers from a damaged cache** — a corrupted index now rebuilds itself instead of crash-looping `ox`.
+- **`ox doctor` no longer reports false-positive warnings** — a healthy setup checks clean instead of surfacing spurious issues.
+- **`ox integrate uninstall --all` no longer errors when an optional adapter isn't installed** — removing all integrations now skips adapters that aren't present instead of failing the whole run.
 - **Device login works with opaque session credentials** — the login flow uses the credential returned by device authentication to fetch identity while continuing to store the exchanged API token.
 - **Team rules survive sparse-checkout recovery** — fallback manifests include the `agents/` directory, so repositories without a usable manifest still materialize shared AI coworker guidance.
 


### PR DESCRIPTION
Ship **ox 0.14.2**: AI coworkers navigate code directly with new `ox code` verbs, `ox doctor` stops crying wolf, and `ox integrate uninstall --all` no longer fails when an optional adapter isn't installed.

This finalizes the 0.14.2 release notes for the work that landed on `main` **after** the notes were first cut, and fixes one real bug the release gate (`make test-all`) surfaced.

## What this PR ships

- **Release notes (`cmd/ox/release_notes.md`)** — fold in the user-facing changes that merged after 0.14.2 was first drafted, so the tag doesn't ship them undocumented:
  - **Improved:** `ox code` gains `callers`, `callees`, `defs`, `refs`, and `log` alongside inline result snippets and a clearer index status — "who calls this?" / "where's this defined?" now resolves in one step.
  - **Fixed:** `ox doctor` no longer reports false-positive warnings on a healthy setup.
  - **Fixed:** `ox integrate uninstall --all` no longer errors when an optional adapter isn't installed.

- **Bug fix (`cmd/ox/integrate.go`)** — `uninstallAllIntegrations` dispatched the Factory Droid uninstall **unconditionally**, unlike OMP (guarded by its detection). When the external droid adapter isn't resolvable, `uninstall-hooks` returns a hard `adapter not found` error, so `ox integrate uninstall --all` failed for anyone whose droid adapter wasn't present — even when nothing droid-related was installed. Droid uninstall is now guarded by its detection, mirroring the OMP pattern one block below.

## Why the bug matters

```mermaid
flowchart TD
    A["ox integrate uninstall --all"] --> B{droid adapter resolvable?}
    B -- "yes" --> C["check + uninstall hooks (no-op if none)"]
    B -- "no (adapter absent)" --> D["BEFORE: hard 'adapter not found' error<br/>→ whole --all run reports failure"]
    B -- "no (adapter absent)" --> E["AFTER: detection returns false<br/>→ droid skipped, run succeeds"]
```

`checkExternalAdapterHooks` already fails soft (returns `false`), but `uninstallExternalAdapterHooks` fails hard. Guarding the uninstall by detection makes the two consistent and matches the contract `TestUninstallAllIntegrationsSkipsMissingOMPAdapter` already asserts.

## Test Plan

- `make verify-version` — all version files at `0.14.2`.
- `make test-all` — **green, 20338 tests, 0 failures** after the fix.
- **Red→green proof for the fix:** `TestUninstallAllIntegrationsSkipsMissingOMPAdapter` failed before the guard (`adapter "droid" not found`) and passes after; `TestUninstallAllIntegrationsRemovesOMP` stays green.
- `make test-slow` — real-binary E2E tier, green.

## Notes

- The bug is **pre-existing** (present on 0.14.1 too), not a 0.14.2 regression; it only surfaces on a machine where the droid adapter isn't on the effective adapter path. The fix ships in 0.14.2.
- Two other `test-all` failures on the first run were environmental flakes, not bugs: a `modernc.org/sqlite` WAL SIGBUS under `-race -p8 -parallel32` (passed 3× isolated, did not recur on the clean re-run) and a `t.TempDir()` cleanup race (passed 5× isolated).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790316468&installation_model_id=433550&pr_number=838&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F838&signature=591a726ad7aa5e19e21bc861d49c5a1fddd5fa3a4ea106eec862f07b3323fe1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `ox code` navigation commands for callers, callees, definitions, references, and history.
  - Improved index status reporting with inline result details.

- **Bug Fixes**
  - Automatically cleans up unproductive sessions.
  - Recovers from corrupted indexes.
  - Prevents false positives in `ox doctor` checks.
  - Safely handles removal when integrations are already absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->