### PR TITLE
fix(codedb): self-heal corrupt or interrupted index cache

### DIFF
--- a/cmd/ox/hooks_droid.go
+++ b/cmd/ox/hooks_droid.go
@@ -14,8 +14,3 @@ func uninstallDroidHooks(user bool) error {
 func hasDroidHooks(user bool) bool {
 	return checkExternalAdapterHooks("droid", user)
 }
-
-// listDroidHooks returns the installation status of Factory Droid hooks.
-func listDroidHooks() map[string]bool {
-	return listExternalAdapterHooks("droid")
-}

--- a/cmd/ox/index.go
+++ b/cmd/ox/index.go
@@ -101,10 +101,20 @@ func indexCodeInProcess(cmd *cobra.Command, args []string, full bool) error {
 		}
 		stats, err := db.ParseSymbols(ctx, nil)
 		if err != nil {
+			// Cache corruption must abort the build so the recovery paths can
+			// react (OpenIndexWithHeal discards + retries; BuildCodeDBAtomic
+			// refuses to swap a partial index into place). Ordinary parse
+			// failures stay non-fatal.
+			if index.IsCorruptionError(err) {
+				return fmt.Errorf("parse symbols: %w", err)
+			}
 			slog.Warn("symbol parsing failed (non-fatal)", "error", err)
 		}
 		symbolsExtracted = stats.SymbolsExtracted
 		if _, err := db.ParseComments(ctx, nil); err != nil {
+			if index.IsCorruptionError(err) {
+				return fmt.Errorf("parse comments: %w", err)
+			}
 			slog.Warn("comment parsing failed (non-fatal)", "error", err)
 		}
 		return nil

--- a/cmd/ox/index.go
+++ b/cmd/ox/index.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/sageox/ox/internal/codedb"
 	"github.com/sageox/ox/internal/codedb/index"
-	"github.com/sageox/ox/internal/codedb/store"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
 	gh "github.com/sageox/ox/internal/github"
@@ -83,83 +82,67 @@ func indexCodeInProcess(cmd *cobra.Command, args []string, full bool) error {
 	}
 
 	dataDir := resolveCodeDBDir(gitRoot)
-
-	if full {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Full reindex (in-process)...\n")
-		if err := os.RemoveAll(dataDir); err != nil {
-			return fmt.Errorf("wipe index for full reindex: %w", err)
-		}
-	} else {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Indexing local repo (in-process)...\n")
-	}
-
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
-		return fmt.Errorf("create codedb dir: %w", err)
-	}
-
-	db, err := codedb.Open(dataDir)
-	if err != nil {
-		return fmt.Errorf("open codedb: %w", err)
-	}
-
-	// codedb.Open self-heals a corrupt cache transparently: it nukes and
-	// recreates a structurally broken bleve sub-index and writes a
-	// .needs_reindex marker mid-open. The daemon acts on that marker on its
-	// next pass, but a one-shot in-process `ox index` has no next pass — if we
-	// index incrementally now, the emptied sub-index stays empty, because the
-	// commits are already in SQLite and incremental indexing skips them (silent
-	// empty code search, worse than a hard error). So when a marker is present
-	// (from this open or a prior run), escalate to a full rebuild in this same
-	// invocation. Wiping dataDir also clears the markers, so it cannot loop.
-	if !full && len(store.NeedsReindexMarkers(dataDir)) > 0 {
-		fmt.Fprintf(cmd.ErrOrStderr(),
-			"codedb self-heal detected (corrupt cache recovered); rebuilding from scratch...\n")
-		if closeErr := db.Close(); closeErr != nil {
-			slog.Warn("close codedb before self-heal rebuild failed", "error", closeErr)
-		}
-		if err := os.RemoveAll(dataDir); err != nil {
-			return fmt.Errorf("wipe self-healed codedb for full reindex: %w", err)
-		}
-		if err := os.MkdirAll(dataDir, 0o755); err != nil {
-			return fmt.Errorf("recreate codedb dir after self-heal: %w", err)
-		}
-		db, err = codedb.Open(dataDir)
-		if err != nil {
-			return fmt.Errorf("reopen codedb after self-heal rebuild: %w", err)
-		}
-	}
-	defer db.Close()
-
 	ctx := cmd.Context()
 	opts := index.IndexOptions{}
 
-	if len(args) > 0 {
-		if err := db.IndexRepo(ctx, args[0], opts); err != nil {
-			return fmt.Errorf("index: %w", err)
-		}
-	} else {
-		if err := db.IndexLocalRepo(ctx, gitRoot, opts); err != nil {
-			if errors.Is(err, index.ErrAlternatesUnsupported) {
-				fmt.Fprintf(cmd.ErrOrStderr(),
-					"codedb: skipping local index — repo uses git alternates (go-git v6 limitation).\n"+
-						"  Remediation: `git repack -a -d --local` to copy objects locally, or\n"+
-						"  re-clone without --shared / --reference. See `ox doctor` (git-alternates check).\n")
-				return nil
+	// build performs the COMPLETE codedb build against db: git index + symbol and
+	// comment parse. Both the atomic from-scratch path and the incremental
+	// self-heal path run this exact closure, so they stay behaviorally identical.
+	var symbolsExtracted uint64
+	build := func(ctx context.Context, db *codedb.DB) error {
+		if len(args) > 0 {
+			if err := db.IndexRepo(ctx, args[0], opts); err != nil {
+				return fmt.Errorf("index: %w", err)
 			}
-			return fmt.Errorf("index local: %w", err)
+		} else {
+			if err := db.IndexLocalRepo(ctx, gitRoot, opts); err != nil {
+				return fmt.Errorf("index local: %w", err)
+			}
+		}
+		stats, err := db.ParseSymbols(ctx, nil)
+		if err != nil {
+			slog.Warn("symbol parsing failed (non-fatal)", "error", err)
+		}
+		symbolsExtracted = stats.SymbolsExtracted
+		if _, err := db.ParseComments(ctx, nil); err != nil {
+			slog.Warn("comment parsing failed (non-fatal)", "error", err)
+		}
+		return nil
+	}
+
+	var runErr error
+	if full {
+		// Prevent tier: build into a sibling temp dir and atomically swap it into
+		// place, so a kill mid-build never leaves a half-written cache that would
+		// crash-loop every subsequent run.
+		fmt.Fprintf(cmd.ErrOrStderr(), "Full reindex (in-process)...\n")
+		runErr = codedb.BuildCodeDBAtomic(ctx, dataDir, build)
+	} else {
+		// Recover tier: index in place. OpenIndexWithHeal escalates to a
+		// from-scratch rebuild when Open self-healed a corrupt sub-index (marker
+		// present), and discards + retries once if the pass itself fails on a
+		// corrupt cache — so a half-written cache neither crash-loops the caller
+		// nor silently leaves search empty.
+		fmt.Fprintf(cmd.ErrOrStderr(), "Indexing local repo (in-process)...\n")
+		var db *codedb.DB
+		db, runErr = codedb.OpenIndexWithHeal(ctx, dataDir, build)
+		if db != nil {
+			defer db.Close()
 		}
 	}
 
-	stats, err := db.ParseSymbols(ctx, nil)
-	if err != nil {
-		slog.Warn("symbol parsing failed (non-fatal)", "error", err)
+	if runErr != nil {
+		if errors.Is(runErr, index.ErrAlternatesUnsupported) {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"codedb: skipping local index — repo uses git alternates (go-git v6 limitation).\n"+
+					"  Remediation: `git repack -a -d --local` to copy objects locally, or\n"+
+					"  re-clone without --shared / --reference. See `ox doctor` (git-alternates check).\n")
+			return nil
+		}
+		return fmt.Errorf("index (in-process): %w", runErr)
 	}
 
-	if _, err := db.ParseComments(ctx, nil); err != nil {
-		slog.Warn("comment parsing failed (non-fatal)", "error", err)
-	}
-
-	fmt.Fprintf(cmd.ErrOrStderr(), "Done (in-process). %d symbols extracted\n", stats.SymbolsExtracted)
+	fmt.Fprintf(cmd.ErrOrStderr(), "Done (in-process). %d symbols extracted\n", symbolsExtracted)
 	return nil
 }
 

--- a/internal/codedb/codedb.go
+++ b/internal/codedb/codedb.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/sageox/ox/internal/codedb/index"
 	"github.com/sageox/ox/internal/codedb/search"
@@ -60,6 +61,136 @@ func (db *DB) IndexRepo(ctx context.Context, url string, opts index.IndexOptions
 // IndexLocalRepo indexes a local git repository's committed content.
 func (db *DB) IndexLocalRepo(ctx context.Context, localPath string, opts index.IndexOptions) error {
 	return index.IndexLocalRepo(ctx, db.store, localPath, opts)
+}
+
+// OpenIndexWithHeal opens the codedb at dataDir and runs indexFn against it. If
+// indexFn fails with an on-disk corruption error (see index.IsCorruptionError)
+// — the failure class that otherwise makes every subsequent `ox index` fail
+// identically against the same half-written cache, i.e. a permanent crash loop
+// — it discards the codedb cache and retries indexFn ONCE from a clean
+// directory. This is the indexing-pass analog of the git checkout's
+// discard-and-reclone recovery.
+//
+// The returned *DB is left open so the caller can run follow-up pipeline stages
+// (ParseSymbols/ParseComments) against the healed store; the caller owns Close.
+// A non-corruption failure (context cancellation/deadline, alternates
+// unsupported, disk error, …) is returned as-is WITHOUT discarding anything.
+// One retry only: the discard clears the corrupt state, so a second identical
+// failure is a genuine error, not a loop to keep spinning on.
+func OpenIndexWithHeal(ctx context.Context, dataDir string, indexFn func(context.Context, *DB) error) (*DB, error) {
+	db, err := Open(dataDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Open self-heals a structurally-corrupt bleve sub-index transparently: it
+	// empties the sub-index and writes a .needs_reindex marker. Incremental
+	// indexing would then skip the commits already recorded in SQLite and leave
+	// the emptied sub-index permanently empty — a silent empty search, worse than
+	// a hard error. When a marker is present, escalate to a from-scratch rebuild
+	// (wiping dataDir clears the stale SQL rows and the marker so the build
+	// re-walks every commit). A one-shot in-process `ox index` has no daemon
+	// "next pass" to do this, so it must happen here.
+	if len(store.NeedsReindexMarkers(dataDir)) > 0 {
+		slog.Warn("codedb self-heal marker present after open; rebuilding from scratch", "data_dir", dataDir)
+		db, err = reopenClean(db, dataDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	runErr := indexFn(ctx, db)
+	if runErr == nil {
+		return db, nil
+	}
+	if !index.IsCorruptionError(runErr) {
+		_ = db.Close()
+		return nil, runErr
+	}
+
+	slog.Warn("codedb indexing failed on a corrupt cache; discarding cache and retrying once",
+		"data_dir", dataDir, "error", runErr)
+	db, err = reopenClean(db, dataDir)
+	if err != nil {
+		return nil, err
+	}
+	if err := indexFn(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("codedb reindex after cache discard still failed: %w", err)
+	}
+	return db, nil
+}
+
+// reopenClean closes db, discards the codedb cache at dataDir, and returns a
+// freshly-opened empty DB. Shared by OpenIndexWithHeal's marker-escalation and
+// corruption-retry recovery paths so they wipe-and-reopen identically.
+func reopenClean(db *DB, dataDir string) (*DB, error) {
+	if closeErr := db.Close(); closeErr != nil {
+		slog.Warn("close codedb before discard failed", "error", closeErr)
+	}
+	if err := os.RemoveAll(dataDir); err != nil {
+		return nil, fmt.Errorf("discard codedb cache: %w", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return nil, fmt.Errorf("recreate codedb dir after discard: %w", err)
+	}
+	fresh, err := Open(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("reopen codedb after discard: %w", err)
+	}
+	return fresh, nil
+}
+
+// BuildCodeDBAtomic performs a from-scratch codedb build at finalDir
+// crash-atomically. It builds into a sibling "<finalDir>.building" directory and
+// os.Rename()s it into place only after buildFn returns successfully and the DB
+// is closed. A process killed mid-build therefore leaves finalDir untouched (or
+// absent) rather than half-written — so the next run starts clean instead of
+// crash-looping on a partially-written cache. Any "<finalDir>.building" left by a
+// prior killed build is discarded before starting.
+//
+// buildFn receives a *DB rooted at the temp directory and MUST perform the
+// COMPLETE build (git index + symbol/comment parse) — anything left for after
+// the swap would not be covered by the atomicity guarantee. Use this for
+// full / first-time builds; incremental refreshes of an existing healthy cache
+// write in place (a whole-directory swap would force a full rebuild every pass
+// and break concurrent readers).
+func BuildCodeDBAtomic(ctx context.Context, finalDir string, buildFn func(context.Context, *DB) error) error {
+	tmpDir := finalDir + ".building"
+	// clear any half-written temp dir left by a prior killed build
+	if err := os.RemoveAll(tmpDir); err != nil {
+		return fmt.Errorf("clear stale codedb build dir: %w", err)
+	}
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		return fmt.Errorf("create codedb build dir: %w", err)
+	}
+
+	db, err := Open(tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return err
+	}
+	if err := buildFn(ctx, db); err != nil {
+		_ = db.Close()
+		_ = os.RemoveAll(tmpDir)
+		return err
+	}
+	if err := db.Close(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return fmt.Errorf("close codedb build before swap: %w", err)
+	}
+
+	// swap into place: remove the stale final dir, then rename the freshly-built
+	// one on top. os.Rename within the same parent dir is atomic on POSIX.
+	if err := os.RemoveAll(finalDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return fmt.Errorf("remove stale codedb before swap: %w", err)
+	}
+	if err := os.Rename(tmpDir, finalDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return fmt.Errorf("atomic swap codedb into place: %w", err)
+	}
+	return nil
 }
 
 // BuildDirtyIndex builds an on-disk Bleve index of dirty (uncommitted) files.

--- a/internal/codedb/codedb.go
+++ b/internal/codedb/codedb.go
@@ -6,11 +6,17 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/sageox/ox/internal/codedb/index"
 	"github.com/sageox/ox/internal/codedb/search"
 	"github.com/sageox/ox/internal/codedb/store"
 )
+
+// renameDir indirects os.Rename so tests can inject a promotion failure and
+// verify the previous cache survives (BuildCodeDBAtomic).
+var renameDir = os.Rename
 
 // DB is the top-level CodeDB facade.
 type DB struct {
@@ -156,39 +162,68 @@ func reopenClean(db *DB, dataDir string) (*DB, error) {
 // write in place (a whole-directory swap would force a full rebuild every pass
 // and break concurrent readers).
 func BuildCodeDBAtomic(ctx context.Context, finalDir string, buildFn func(context.Context, *DB) error) error {
-	tmpDir := finalDir + ".building"
-	// clear any half-written temp dir left by a prior killed build
-	if err := os.RemoveAll(tmpDir); err != nil {
-		return fmt.Errorf("clear stale codedb build dir: %w", err)
+	parent := filepath.Dir(finalDir)
+	base := filepath.Base(finalDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create codedb parent dir: %w", err)
 	}
-	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+
+	// Unique staging dir per build. A fixed "<dir>.building" path lets two
+	// concurrent builds (e.g. one per worktree, sharing the ledger cache) delete
+	// each other's in-progress files; MkdirTemp gives each build its own.
+	tmpDir, err := os.MkdirTemp(parent, base+".building-*")
+	if err != nil {
 		return fmt.Errorf("create codedb build dir: %w", err)
 	}
+	// Always clean up the staging dir. On the success path it has already been
+	// renamed to finalDir, so this is a no-op; on every failure path it removes
+	// the abandoned build (no orphan accumulation in the shared ledger cache).
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	db, err := Open(tmpDir)
 	if err != nil {
-		_ = os.RemoveAll(tmpDir)
 		return err
 	}
 	if err := buildFn(ctx, db); err != nil {
 		_ = db.Close()
-		_ = os.RemoveAll(tmpDir)
 		return err
 	}
 	if err := db.Close(); err != nil {
-		_ = os.RemoveAll(tmpDir)
 		return fmt.Errorf("close codedb build before swap: %w", err)
 	}
 
-	// swap into place: remove the stale final dir, then rename the freshly-built
-	// one on top. os.Rename within the same parent dir is atomic on POSIX.
-	if err := os.RemoveAll(finalDir); err != nil {
-		_ = os.RemoveAll(tmpDir)
-		return fmt.Errorf("remove stale codedb before swap: %w", err)
+	// Promote without ever leaving a window where no usable cache exists: move
+	// any existing cache aside first, rename the freshly-built one into place,
+	// then discard the moved-aside copy. If the promoting rename fails, restore
+	// the previous cache — it stays available until the replacement is installed.
+	// os.Rename within the same parent dir is atomic on POSIX.
+	suffix := strings.TrimPrefix(filepath.Base(tmpDir), base+".building-")
+	backupDir := filepath.Join(parent, base+".old-"+suffix)
+	haveBackup := false
+	if _, statErr := os.Stat(finalDir); statErr == nil {
+		if err := renameDir(finalDir, backupDir); err != nil {
+			return fmt.Errorf("move stale codedb aside before swap: %w", err)
+		}
+		haveBackup = true
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("stat codedb before swap: %w", statErr)
 	}
-	if err := os.Rename(tmpDir, finalDir); err != nil {
-		_ = os.RemoveAll(tmpDir)
-		return fmt.Errorf("atomic swap codedb into place: %w", err)
+
+	if err := renameDir(tmpDir, finalDir); err != nil {
+		// Promotion failed: restore the previous healthy cache so it stays usable
+		// (the build simply re-runs on the next pass). The staging dir is removed
+		// by the deferred cleanup.
+		if haveBackup {
+			if restoreErr := renameDir(backupDir, finalDir); restoreErr != nil {
+				slog.Error("failed to restore previous codedb cache after swap failure",
+					"final_dir", finalDir, "backup_dir", backupDir, "error", restoreErr)
+			}
+		}
+		return fmt.Errorf("promote codedb build into place: %w", err)
+	}
+
+	if haveBackup {
+		_ = os.RemoveAll(backupDir)
 	}
 	return nil
 }

--- a/internal/codedb/codedb.go
+++ b/internal/codedb/codedb.go
@@ -215,8 +215,19 @@ func BuildCodeDBAtomic(ctx context.Context, finalDir string, buildFn func(contex
 		// by the deferred cleanup.
 		if haveBackup {
 			if restoreErr := renameDir(backupDir, finalDir); restoreErr != nil {
-				slog.Error("failed to restore previous codedb cache after swap failure",
-					"final_dir", finalDir, "backup_dir", backupDir, "error", restoreErr)
+				// Restore also failed. If finalDir now holds a usable cache — e.g.
+				// a concurrent builder promoted into it while ours was moved aside,
+				// so both of our renames hit a non-empty target — our backup is
+				// redundant; discard it so a full index copy does not leak into the
+				// shared ledger cache. Otherwise the backup is the only surviving
+				// copy: keep it and surface where to recover it from.
+				if _, statErr := os.Stat(finalDir); statErr == nil {
+					_ = os.RemoveAll(backupDir)
+				} else {
+					slog.Error("codedb cache stranded after failed swap and restore; recover from backup",
+						"final_dir", finalDir, "backup_dir", backupDir, "restore_error", restoreErr)
+					return fmt.Errorf("promote codedb build into place: %w (previous cache preserved at %s)", err, backupDir)
+				}
 			}
 		}
 		return fmt.Errorf("promote codedb build into place: %w", err)

--- a/internal/codedb/codedb_atomic_internal_test.go
+++ b/internal/codedb/codedb_atomic_internal_test.go
@@ -1,0 +1,56 @@
+package codedb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A failed promotion must never destroy the previous healthy cache. With the
+// naive "remove finalDir, then rename staging on top" order, an injected rename
+// failure loses both. The move-aside → rename → restore-on-failure sequence
+// keeps the previous cache intact. White-box so it can inject renameDir.
+func TestBuildCodeDBAtomic_PromotionFailurePreservesPreviousCache(t *testing.T) {
+	finalDir := filepath.Join(t.TempDir(), "codedb")
+	if err := os.MkdirAll(finalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(finalDir, "GOOD")
+	if err := os.WriteFile(good, []byte("healthy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := renameDir
+	defer func() { renameDir = orig }()
+	// Fail only the promoting rename (source is the staging dir); let the
+	// move-aside and restore renames run normally.
+	renameDir = func(oldpath, newpath string) error {
+		if strings.Contains(filepath.Base(oldpath), ".building-") {
+			return fmt.Errorf("injected promotion failure")
+		}
+		return orig(oldpath, newpath)
+	}
+
+	err := BuildCodeDBAtomic(context.Background(), finalDir, func(ctx context.Context, db *DB) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected BuildCodeDBAtomic to report the promotion failure")
+	}
+
+	// The previous healthy cache must have been restored, byte-for-byte.
+	b, readErr := os.ReadFile(good)
+	if readErr != nil {
+		t.Fatalf("previous cache must be restored after a failed promotion, GOOD missing: %v", readErr)
+	}
+	if string(b) != "healthy" {
+		t.Fatalf("previous cache corrupted after failed promotion, got %q", string(b))
+	}
+	// No staging or backup dirs left behind.
+	if leftovers, _ := filepath.Glob(finalDir + ".*"); len(leftovers) != 0 {
+		t.Fatalf("expected no staging/backup leftovers after failed promotion, found %v", leftovers)
+	}
+}

--- a/internal/codedb/codedb_atomic_internal_test.go
+++ b/internal/codedb/codedb_atomic_internal_test.go
@@ -54,3 +54,91 @@ func TestBuildCodeDBAtomic_PromotionFailurePreservesPreviousCache(t *testing.T) 
 		t.Fatalf("expected no staging/backup leftovers after failed promotion, found %v", leftovers)
 	}
 }
+
+// When both the promotion and the restore fail because a concurrent builder
+// already populated finalDir with a usable cache, our backup is redundant and
+// must be discarded — otherwise a full index copy leaks into the shared ledger
+// cache on every occurrence (and the concurrency test flakes on leftovers).
+func TestBuildCodeDBAtomic_RestoreFailureWithConcurrentWinner_DiscardsBackup(t *testing.T) {
+	finalDir := filepath.Join(t.TempDir(), "codedb")
+	if err := os.MkdirAll(finalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := renameDir
+	defer func() { renameDir = orig }()
+	renameDir = func(oldpath, newpath string) error {
+		b := filepath.Base(oldpath)
+		if strings.Contains(b, ".building-") {
+			// Promotion fails, but simulate a concurrent winner having placed a
+			// usable cache at finalDir in the meantime.
+			_ = os.MkdirAll(newpath, 0o755)
+			_ = os.WriteFile(filepath.Join(newpath, "WINNER"), []byte("winner"), 0o600)
+			return fmt.Errorf("injected promotion failure")
+		}
+		if strings.Contains(b, ".old-") {
+			return fmt.Errorf("injected restore failure")
+		}
+		return orig(oldpath, newpath)
+	}
+
+	err := BuildCodeDBAtomic(context.Background(), finalDir, func(ctx context.Context, db *DB) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected an error when promotion fails")
+	}
+	// The concurrent winner's cache remains, and no backup leaks.
+	if _, statErr := os.Stat(filepath.Join(finalDir, "WINNER")); statErr != nil {
+		t.Fatalf("expected the concurrent winner's cache to remain at finalDir, err=%v", statErr)
+	}
+	if leftovers, _ := filepath.Glob(finalDir + ".old-*"); len(leftovers) != 0 {
+		t.Fatalf("expected the redundant backup to be discarded, found %v", leftovers)
+	}
+}
+
+// When both renames fail and finalDir is genuinely absent (no concurrent winner),
+// the previous cache is the only surviving copy: it must be preserved in the
+// backup dir and the error must name it, not silently abandon it.
+func TestBuildCodeDBAtomic_RestoreFailureNoWinner_PreservesBackup(t *testing.T) {
+	finalDir := filepath.Join(t.TempDir(), "codedb")
+	if err := os.MkdirAll(finalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(finalDir, "GOOD"), []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := renameDir
+	defer func() { renameDir = orig }()
+	renameDir = func(oldpath, newpath string) error {
+		b := filepath.Base(oldpath)
+		if strings.Contains(b, ".building-") {
+			return fmt.Errorf("injected promotion failure") // no winner placed
+		}
+		if strings.Contains(b, ".old-") {
+			return fmt.Errorf("injected restore failure")
+		}
+		return orig(oldpath, newpath)
+	}
+
+	err := BuildCodeDBAtomic(context.Background(), finalDir, func(ctx context.Context, db *DB) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected an error when both promotion and restore fail")
+	}
+	// finalDir is absent, but the previous cache survives in the backup.
+	backups, _ := filepath.Glob(finalDir + ".old-*")
+	if len(backups) != 1 {
+		t.Fatalf("expected the previous cache preserved in exactly one backup dir, found %v", backups)
+	}
+	b, readErr := os.ReadFile(filepath.Join(backups[0], "GOOD"))
+	if readErr != nil || string(b) != "original" {
+		t.Fatalf("expected the previous cache intact in the backup, got %q err=%v", string(b), readErr)
+	}
+	// The error must name the backup location so it is recoverable, not abandoned.
+	if !strings.Contains(err.Error(), backups[0]) {
+		t.Fatalf("expected the error to name the preserved backup %q, got %q", backups[0], err.Error())
+	}
+}

--- a/internal/codedb/codedb_heal_test.go
+++ b/internal/codedb/codedb_heal_test.go
@@ -1,0 +1,137 @@
+package codedb_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/codedb"
+	"github.com/sageox/ox/internal/codedb/index"
+)
+
+// The crash-loop this fix targets: an indexing pass fails against a half-written
+// cache, and every retry fails identically. OpenIndexWithHeal must discard the
+// cache and retry exactly once on a corruption-class error.
+func TestOpenIndexWithHeal_DiscardsAndRetriesOnceOnCorruption(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "codedb")
+	marker := filepath.Join(dataDir, "CORRUPT_MARKER")
+
+	calls := 0
+	indexFn := func(ctx context.Context, db *codedb.DB) error {
+		calls++
+		if calls == 1 {
+			// leave a marker to prove the cache is discarded before the retry
+			if err := os.WriteFile(marker, []byte("x"), 0o644); err != nil {
+				t.Fatalf("write marker: %v", err)
+			}
+			return index.ErrBleveCorrupt
+		}
+		// second attempt: the discard must have wiped the whole cache dir
+		if _, err := os.Stat(marker); !os.IsNotExist(err) {
+			t.Fatalf("expected cache discarded before retry, marker still present (err=%v)", err)
+		}
+		return nil
+	}
+
+	db, err := codedb.OpenIndexWithHeal(context.Background(), dataDir, indexFn)
+	if err != nil {
+		t.Fatalf("OpenIndexWithHeal: %v", err)
+	}
+	defer db.Close()
+	if calls != 2 {
+		t.Fatalf("expected exactly 2 index attempts (fail + one retry), got %d", calls)
+	}
+}
+
+// The security-review guard: a timeout/cancel must NOT be treated as corruption.
+// The cache is preserved and no retry is attempted.
+func TestOpenIndexWithHeal_DoesNotDiscardOnNonCorruption(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "codedb")
+	marker := filepath.Join(dataDir, "KEEP_ME")
+
+	calls := 0
+	indexFn := func(ctx context.Context, db *codedb.DB) error {
+		calls++
+		if err := os.WriteFile(marker, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+		return context.Canceled
+	}
+
+	db, err := codedb.OpenIndexWithHeal(context.Background(), dataDir, indexFn)
+	if db != nil {
+		db.Close()
+		t.Fatal("expected nil DB when the pass fails with a non-corruption error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled returned as-is, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected no retry on a non-corruption error, got %d attempts", calls)
+	}
+	if _, statErr := os.Stat(marker); statErr != nil {
+		t.Fatalf("expected cache preserved on non-corruption failure, marker missing: %v", statErr)
+	}
+}
+
+// A kill mid from-scratch build must never leave a half-written cache: the prior
+// healthy cache stays untouched and only the temp build dir is cleaned up.
+func TestBuildCodeDBAtomic_PreservesFinalDirOnFailure(t *testing.T) {
+	finalDir := filepath.Join(t.TempDir(), "codedb")
+	if err := os.MkdirAll(finalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(finalDir, "GOOD")
+	if err := os.WriteFile(good, []byte("healthy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wantErr := errors.New("build blew up")
+	err := codedb.BuildCodeDBAtomic(context.Background(), finalDir, func(ctx context.Context, db *codedb.DB) error {
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected the build error propagated, got %v", err)
+	}
+	if _, statErr := os.Stat(good); statErr != nil {
+		t.Fatalf("expected finalDir preserved on failure, GOOD missing: %v", statErr)
+	}
+	if _, statErr := os.Stat(finalDir + ".building"); !os.IsNotExist(statErr) {
+		t.Fatalf("expected .building cleaned up on failure, err=%v", statErr)
+	}
+}
+
+// A successful from-scratch build atomically replaces the stale cache.
+func TestBuildCodeDBAtomic_SwapsFreshBuildIntoPlace(t *testing.T) {
+	finalDir := filepath.Join(t.TempDir(), "codedb")
+	if err := os.MkdirAll(finalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(finalDir, "STALE")
+	if err := os.WriteFile(stale, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	built := false
+	err := codedb.BuildCodeDBAtomic(context.Background(), finalDir, func(ctx context.Context, db *codedb.DB) error {
+		built = true // db is a real open store rooted at the temp build dir
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("BuildCodeDBAtomic: %v", err)
+	}
+	if !built {
+		t.Fatal("build closure was not invoked")
+	}
+	if _, statErr := os.Stat(stale); !os.IsNotExist(statErr) {
+		t.Fatalf("expected stale cache replaced, STALE still present (err=%v)", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(finalDir, "repos")); statErr != nil {
+		t.Fatalf("expected the freshly-built store swapped in (repos/ dir), err=%v", statErr)
+	}
+	if _, statErr := os.Stat(finalDir + ".building"); !os.IsNotExist(statErr) {
+		t.Fatalf("expected .building removed after swap, err=%v", statErr)
+	}
+}

--- a/internal/codedb/codedb_heal_test.go
+++ b/internal/codedb/codedb_heal_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/sageox/ox/internal/codedb"
@@ -98,8 +99,8 @@ func TestBuildCodeDBAtomic_PreservesFinalDirOnFailure(t *testing.T) {
 	if _, statErr := os.Stat(good); statErr != nil {
 		t.Fatalf("expected finalDir preserved on failure, GOOD missing: %v", statErr)
 	}
-	if _, statErr := os.Stat(finalDir + ".building"); !os.IsNotExist(statErr) {
-		t.Fatalf("expected .building cleaned up on failure, err=%v", statErr)
+	if leftovers, _ := filepath.Glob(finalDir + ".*"); len(leftovers) != 0 {
+		t.Fatalf("expected staging/backup dirs cleaned up on failure, found %v", leftovers)
 	}
 }
 
@@ -131,7 +132,47 @@ func TestBuildCodeDBAtomic_SwapsFreshBuildIntoPlace(t *testing.T) {
 	if _, statErr := os.Stat(filepath.Join(finalDir, "repos")); statErr != nil {
 		t.Fatalf("expected the freshly-built store swapped in (repos/ dir), err=%v", statErr)
 	}
-	if _, statErr := os.Stat(finalDir + ".building"); !os.IsNotExist(statErr) {
-		t.Fatalf("expected .building removed after swap, err=%v", statErr)
+	if leftovers, _ := filepath.Glob(finalDir + ".*"); len(leftovers) != 0 {
+		t.Fatalf("expected no staging/backup leftovers after swap, found %v", leftovers)
+	}
+}
+
+// Concurrent from-scratch builds share the ledger cache (one per worktree). A
+// fixed staging path let one build delete another's in-progress files and could
+// leave finalDir absent. With per-build staging dirs, finalDir must always end
+// as a valid, openable store — never absent or half-written.
+func TestBuildCodeDBAtomic_ConcurrentBuildsLeaveValidCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: opens several real stores concurrently")
+	}
+	finalDir := filepath.Join(t.TempDir(), "codedb")
+
+	const builders = 4
+	var wg sync.WaitGroup
+	for i := 0; i < builders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// A promotion race may make one builder error; that is acceptable, as
+			// long as no builder ever corrupts or removes the published cache.
+			_ = codedb.BuildCodeDBAtomic(context.Background(), finalDir, func(ctx context.Context, db *codedb.DB) error {
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+
+	// finalDir must exist and open cleanly — the data-loss failure was an absent
+	// finalDir after an overlapping build removed a just-published cache.
+	if _, statErr := os.Stat(filepath.Join(finalDir, "repos")); statErr != nil {
+		t.Fatalf("finalDir must be a valid store after concurrent builds, err=%v", statErr)
+	}
+	db, err := codedb.Open(finalDir)
+	if err != nil {
+		t.Fatalf("published cache must open cleanly after concurrent builds: %v", err)
+	}
+	_ = db.Close()
+	if leftovers, _ := filepath.Glob(finalDir + ".*"); len(leftovers) != 0 {
+		t.Fatalf("expected no staging/backup leftovers after concurrent builds, found %v", leftovers)
 	}
 }

--- a/internal/codedb/index/corruption.go
+++ b/internal/codedb/index/corruption.go
@@ -12,7 +12,7 @@ import (
 // analog of the git checkout's discard-and-reclone recovery.
 //
 // It deliberately returns false for context cancellation and deadline errors: a
-// timeout is not corruption. Discarding a large cache on every slow or cancelled
+// timeout is not corruption. Discarding a large cache on every slow or canceled
 // run would be wasteful and could mask the real problem — the exact
 // "timed out vs. corrupt on disk" conflation flagged in review of the external
 // shell workaround this replaces.

--- a/internal/codedb/index/corruption.go
+++ b/internal/codedb/index/corruption.go
@@ -1,0 +1,29 @@
+package index
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sageox/ox/internal/codedb/store"
+)
+
+// IsCorruptionError reports whether err indicates on-disk codedb corruption that
+// a discard-and-rebuild of the cache would recover from — the indexing-pass
+// analog of the git checkout's discard-and-reclone recovery.
+//
+// It deliberately returns false for context cancellation and deadline errors: a
+// timeout is not corruption. Discarding a large cache on every slow or cancelled
+// run would be wasteful and could mask the real problem — the exact
+// "timed out vs. corrupt on disk" conflation flagged in review of the external
+// shell workaround this replaces.
+func IsCorruptionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return errors.Is(err, ErrBleveCorrupt) ||
+		errors.Is(err, store.ErrCorrupt) ||
+		errors.Is(err, store.ErrFullReindexRequired)
+}

--- a/internal/codedb/index/corruption_test.go
+++ b/internal/codedb/index/corruption_test.go
@@ -1,0 +1,49 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/sageox/ox/internal/codedb/store"
+)
+
+// A panicking bleve batch (nil FST from a partial write) must surface as an
+// errors.Is-able corruption sentinel, not just a string, so callers can decide
+// to discard-and-rebuild rather than crash-loop.
+func TestSafeBatch_WrapsCorruptSentinelOnPanic(t *testing.T) {
+	err := safeBatch(func() error { panic("nil FST") })
+	if err == nil {
+		t.Fatal("expected an error from a panicking batch")
+	}
+	if !errors.Is(err, ErrBleveCorrupt) {
+		t.Fatalf("expected ErrBleveCorrupt sentinel in chain, got %v", err)
+	}
+}
+
+func TestIsCorruptionError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"bleve sentinel", ErrBleveCorrupt, true},
+		{"wrapped bleve sentinel", fmt.Errorf("flush code batch: %w", ErrBleveCorrupt), true},
+		{"store corrupt", store.ErrCorrupt, true},
+		{"store full reindex required", store.ErrFullReindexRequired, true},
+		// A timeout/cancel is NOT corruption — never discard the cache on it.
+		{"context canceled", context.Canceled, false},
+		{"context deadline", context.DeadlineExceeded, false},
+		{"wrapped canceled", fmt.Errorf("index local: %w", context.Canceled), false},
+		{"plain error", errors.New("disk full"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCorruptionError(tt.err); got != tt.want {
+				t.Fatalf("IsCorruptionError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/codedb/index/safebatch.go
+++ b/internal/codedb/index/safebatch.go
@@ -1,9 +1,17 @@
 package index
 
 import (
+	"errors"
 	"fmt"
 	"runtime/debug"
 )
+
+// ErrBleveCorrupt marks an error whose root cause is a structurally corrupt
+// bleve index — e.g. a nil FST left by a partial/interrupted write. Callers use
+// errors.Is(err, ErrBleveCorrupt) (via IsCorruptionError) to decide whether
+// discarding and rebuilding the codedb cache is the right recovery, rather than
+// matching on a fragile error string.
+var ErrBleveCorrupt = errors.New("bleve index corrupt")
 
 // safeBatch runs fn (a bleve.Index.Batch call) with panic recovery.
 //
@@ -19,7 +27,9 @@ import (
 func safeBatch(fn func() error) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("bleve batch panicked (likely corrupt index): %v\n%s", r, debug.Stack())
+			// Wrap the corruption sentinel so callers can errors.Is on it and
+			// trigger a discard-and-rebuild of the cache (see IsCorruptionError).
+			err = fmt.Errorf("bleve batch panicked (likely corrupt index): %v\n%s: %w", r, debug.Stack(), ErrBleveCorrupt)
 		}
 	}()
 	return fn()

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -455,12 +455,6 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 		return nil, fmt.Errorf("create codedb dir: %w", err)
 	}
 
-	db, err := codedb.Open(dataDir)
-	if err != nil {
-		return nil, fmt.Errorf("open codedb: %w", err)
-	}
-	defer db.Close()
-
 	totalStart := time.Now()
 
 	// periodic progress logging for long-running indexing
@@ -487,32 +481,40 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 		},
 	}
 
-	// stage 1: git indexing (committed content only)
+	// stage 1: git indexing (committed content only). OpenIndexWithHeal discards
+	// the cache and rebuilds once if the pass fails on a corrupt/interrupted
+	// cache — otherwise a half-written cache makes every subsequent index fail
+	// identically (a permanent crash loop the daemon's next-pass marker recovery
+	// can't break when the whole process is being restarted from scratch).
 	indexStart := time.Now()
-	if payload.URL != "" {
-		if pw != nil {
-			_ = pw.WriteStage("indexing", fmt.Sprintf("Indexing %s...", payload.URL))
+	indexFn := func(ctx context.Context, db *codedb.DB) error {
+		if payload.URL != "" {
+			if pw != nil {
+				_ = pw.WriteStage("indexing", fmt.Sprintf("Indexing %s...", payload.URL))
+			}
+			return db.IndexRepo(ctx, payload.URL, opts)
 		}
-		if err := db.IndexRepo(ctx, payload.URL, opts); err != nil {
-			m.setError(err)
-			return nil, fmt.Errorf("index: %w", err)
-		}
-	} else {
 		if pw != nil {
 			_ = pw.WriteStage("indexing", fmt.Sprintf("Indexing local repo %s...", projectRoot))
 		}
-		if err := db.IndexLocalRepo(ctx, projectRoot, opts); err != nil {
-			if errors.Is(err, index.ErrAlternatesUnsupported) {
-				m.logger.Info("codedb local: skipped (alternates configured)", "path", projectRoot)
-				if pw != nil {
-					_ = pw.WriteStage("indexing", "codedb: skipped (git alternates not supported)")
-				}
-				return nil, nil
-			}
-			m.setError(err)
-			return nil, fmt.Errorf("index local: %w", err)
-		}
+		return db.IndexLocalRepo(ctx, projectRoot, opts)
 	}
+	db, err := codedb.OpenIndexWithHeal(ctx, dataDir, indexFn)
+	if err != nil {
+		if errors.Is(err, index.ErrAlternatesUnsupported) {
+			m.logger.Info("codedb local: skipped (alternates configured)", "path", projectRoot)
+			if pw != nil {
+				_ = pw.WriteStage("indexing", "codedb: skipped (git alternates not supported)")
+			}
+			return nil, nil
+		}
+		m.setError(err)
+		if payload.URL != "" {
+			return nil, fmt.Errorf("index: %w", err)
+		}
+		return nil, fmt.Errorf("index local: %w", err)
+	}
+	defer db.Close()
 	indexDuration := time.Since(indexStart)
 	m.logger.Info("codedb stage complete", "stage", "git-index", "duration", indexDuration.Round(time.Millisecond))
 


### PR DESCRIPTION
## Summary

**An interrupted `ox index` no longer wedges code search — the index now repairs itself instead of failing identically on every retry.** If `ox index` was killed mid-write (or otherwise left the codedb cache half-written), every subsequent run failed the same way against the same corrupt cache: a permanent crash loop with no recovery. Unlike the git checkout (which self-repairs via `git reset --hard`), the codedb cache had no equivalent recovery on the indexing pass.

ox already self-healed *some* corruption at `Open` time — sqlite integrity, structurally-broken bleve sub-indexes (via a `.needs_reindex` marker), corrupt-FST panics. **The gap:** when the indexing **pass itself** failed mid-run against a stale cache, the command returned a hard error with no discard-and-retry, so the caller re-ran and hit the identical failure.

## What this PR ships

- **Recover — the indexing pass now self-heals.** A typed `ErrBleveCorrupt` sentinel (wrapped through `safeBatch`) plus an `IsCorruptionError` predicate let `OpenIndexWithHeal` discard the cache and retry **once** on real on-disk corruption. The predicate deliberately returns **false** for `context.Canceled` / `DeadlineExceeded` — a timeout is not corruption, so a slow or cancelled run never nukes the cache.
- **Prevent — from-scratch builds are crash-atomic.** `BuildCodeDBAtomic` builds into a sibling `<dir>.building` directory and atomically `rename`s it into place only on success (mirrors the existing `BuildDirtyIndex` swap). A process killed mid-build leaves the previous cache untouched instead of half-written, so the next run starts clean.
- **Wired into both entrypoints:** `cmd/ox/index.go` (in-process) and `internal/daemon/codedb.go`. The `.needs_reindex` marker escalation (Open self-heals a sub-index → force a full rebuild, since incremental would leave it silently empty) now lives inside `OpenIndexWithHeal`, shared by both.

```mermaid
flowchart LR
    A[ox index] --> B{full / first build?}
    B -->|yes| P[BuildCodeDBAtomic<br/>build into .building →<br/>atomic rename on success]
    B -->|no| R[OpenIndexWithHeal]
    R --> M{Open wrote<br/>.needs_reindex marker?}
    M -->|yes| W[discard cache → rebuild<br/>prevents silent-empty search]
    M -->|no| I[index in place]
    I --> C{pass failed on<br/>corrupt cache?}
    C -->|corruption| D[discard + retry once]
    C -->|timeout / cancel| X[return as-is,<br/>cache preserved]
```

## Test Plan

- **Recover:** `TestOpenIndexWithHeal_DiscardsAndRetriesOnceOnCorruption` (corruption → discard + retry exactly once); `TestOpenIndexWithHeal_DoesNotDiscardOnNonCorruption` (a `context.Canceled` failure preserves the cache and does not retry).
- **Prevent:** `TestBuildCodeDBAtomic_PreservesFinalDirOnFailure` / `_SwapsFreshBuildIntoPlace` (mid-build failure leaves the prior cache intact; success swaps atomically).
- **Sentinel / predicate:** `TestSafeBatch_WrapsCorruptSentinelOnPanic`, `TestIsCorruptionError` (table incl. context errors).
- **Command-altitude regression:** existing `TestIndexInProcess_AfterSelfHeal_RepopulatesCode` and daemon `TestDoIndex_HonorsSelfHealMarker_ForcesFullReindex` pass — the marker-escalation move was proven red→green.
- All `internal/codedb`, `internal/codedb/index`, and daemon self-heal/marker tests green. Each behavioral fix verified **red-first** (broke it, watched the gate fail, restored). `go build ./...`, `go vet`, and lint clean on changed files.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added
- [ ] CHANGELOG entry added (if user-facing) — N/A: internal reliability fix, no user-visible CLI surface change
- [ ] Breaking change documented — N/A: no behavior change on the happy path
- [x] Ran `/security-review` **or** N/A documented — N/A: no changes to `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, or `go.sum`. The one destructive path (cache discard) is explicitly gated to on-disk corruption and excludes `context` cancellation.

</details>

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790322992&installation_model_id=433550&pr_number=839&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F839&signature=0b350b92f79e7bff25e9e0d9d99bb7dfce6935bf20c73e3e1039963001527045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code index reliability by automatically detecting and recovering from corrupted indexes.
  * Prevented incomplete rebuilds from replacing a previously valid index.
  * Reduced indexing interruptions by treating parser failures as non-fatal.
  * Standardized handling of unsupported repository configurations and indexing errors.

* **Performance & Reliability**
  * Added safer incremental indexing and atomic full rebuilds.
  * Automatically cleans up stale or failed temporary index data.
  * Improved reliability when multiple indexing operations run concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->