### PR TITLE
fix(query): default --team from a team-scoped credential

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -45,6 +45,7 @@ ephemeral.sqlite3-shm
 
 # Dolt server management (auto-started by bd)
 dolt-config.log
+dolt-server-config.yaml
 dolt-server.pid
 dolt-server.log
 dolt-server.lock

--- a/cmd/ox/agent_query.go
+++ b/cmd/ox/agent_query.go
@@ -125,7 +125,7 @@ const queryUsage = `Usage: ox query "search text" [flags]
 Flags:
   --limit N      Max results to return (default: 5)
   --mode MODE    Search mode: hybrid, knn, or bm25 (default: hybrid)
-  --team ID      Team ID to search (default: from project config)
+  --team ID      Team ID to search (default: project config, else the credential's team)
   --repo ID      Repo ID to search (default: from project config)
   --source SRC   Search source: team (default), code, local, all
   --local        Shorthand for --source=local (zero-network ledger search)
@@ -266,6 +266,36 @@ func writeQueryResponse(combined *combinedQueryResponse, qa *queryArgs) (int, er
 	return outputBytes, err
 }
 
+// errNoTeamOrRepoID is the answer when nothing — flags, project config, or the
+// credential itself — names a team or a repo to search. `ox init` and the
+// explicit flags are the only remedies left at that point.
+var errNoTeamOrRepoID = errors.New("no team or repo ID available. Run 'ox init' first or pass --team/--repo flags")
+
+// teamIDFromCredential asks the introspection endpoint which team the bearer
+// credential authenticates as. Only a team-scoped credential names one; a
+// personal credential names a user, and for that caller `ox init` or --team
+// really is the remedy, so the error stays unchanged.
+//
+// An unreachable endpoint is reported as itself rather than as
+// errNoTeamOrRepoID: the credential may well name a team, we just could not
+// ask, and sending an offline caller to `ox init` would not fix it.
+func teamIDFromCredential(ep, accessToken string) (string, error) {
+	res, err := auth.Introspect(ep, accessToken)
+	if err != nil {
+		if errors.Is(err, auth.ErrEndpointUnreachable) {
+			return "", fmt.Errorf("no team or repo ID available and %s could not be reached to read the one your credential is bound to: %w",
+				endpoint.NormalizeEndpoint(ep), err)
+		}
+		slog.Debug("introspection did not supply a team id", "error", err)
+		return "", errNoTeamOrRepoID
+	}
+	if res.Team == nil || res.Team.TeamID == "" {
+		return "", errNoTeamOrRepoID
+	}
+	slog.Debug("team id defaulted from credential", "team_id", res.Team.TeamID)
+	return res.Team.TeamID, nil
+}
+
 // queryTeamContext searches team context via the vector search API.
 func queryTeamContext(qa *queryArgs, projectRoot, agentID, agentType string) (*api.QueryResponse, error) {
 	cfg, err := config.LoadProjectConfig(projectRoot)
@@ -293,14 +323,25 @@ func queryTeamContext(qa *queryArgs, projectRoot, agentID, agentType string) (*a
 	if qa.repoID != "" {
 		req.Repos = []string{qa.repoID}
 	}
-	if len(req.Teams) == 0 && len(req.Repos) == 0 {
-		return nil, fmt.Errorf("no team or repo ID available. Run 'ox init' first or pass --team/--repo flags")
-	}
 
 	ep := endpoint.GetForProject(projectRoot)
 	token, err := auth.EnsureValidTokenForEndpoint(ep, 300)
 	if err != nil || token == nil || token.AccessToken == "" {
 		return nil, fmt.Errorf("not authenticated. Run 'ox login' first")
+	}
+
+	// Outside an initialized repo the credential is the only identity there
+	// is, and a team-scoped one names exactly one team. Refusing here without
+	// asking sent the caller to `ox init` — wrong for a scratch directory or a
+	// CI checkout that only wants to read — for a fact the credential already
+	// carries and `ox status` already prints. Last resort by construction:
+	// --team/--repo and the project config are both resolved above.
+	if len(req.Teams) == 0 && len(req.Repos) == 0 {
+		teamID, err := teamIDFromCredential(ep, token.AccessToken)
+		if err != nil {
+			return nil, err
+		}
+		req.Teams = []string{teamID}
 	}
 
 	client := api.NewRepoClientWithEndpoint(ep).WithAuthToken(token.AccessToken)

--- a/cmd/ox/agent_query.go
+++ b/cmd/ox/agent_query.go
@@ -272,13 +272,14 @@ func writeQueryResponse(combined *combinedQueryResponse, qa *queryArgs) (int, er
 var errNoTeamOrRepoID = errors.New("no team or repo ID available. Run 'ox init' first or pass --team/--repo flags")
 
 // teamIDFromCredential asks the introspection endpoint which team the bearer
-// credential authenticates as. Only a team-scoped credential names one; a
-// personal credential names a user, and for that caller `ox init` or --team
-// really is the remedy, so the error stays unchanged.
+// credential authenticates as. Only a team-scoped credential names one.
 //
-// An unreachable endpoint is reported as itself rather than as
-// errNoTeamOrRepoID: the credential may well name a team, we just could not
-// ask, and sending an offline caller to `ox init` would not fix it.
+// errNoTeamOrRepoID is reserved for the one case it describes: introspection
+// ANSWERED, and the answer named no single team. Every way of failing to get an
+// answer — offline, rejected, unreadable — keeps its own error, because none of
+// them is an initialization problem and `ox init` cannot fix any of them (it
+// needs a working credential itself). Collapsing them would tell a coworker
+// holding a revoked token to run the one command that will fail the same way.
 func teamIDFromCredential(ep, accessToken string) (string, error) {
 	res, err := auth.Introspect(ep, accessToken)
 	if err != nil {
@@ -286,8 +287,12 @@ func teamIDFromCredential(ep, accessToken string) (string, error) {
 			return "", fmt.Errorf("no team or repo ID available and %s could not be reached to read the one your credential is bound to: %w",
 				endpoint.NormalizeEndpoint(ep), err)
 		}
-		slog.Debug("introspection did not supply a team id", "error", err)
-		return "", errNoTeamOrRepoID
+		// Rejected credential or an unreadable answer. Introspect deliberately
+		// carries no sentinel to tell those apart (the server returns a uniform
+		// 401 so a caller cannot enumerate which credentials exist), so name
+		// the likely remedy conditionally rather than assert the wrong one for
+		// what may be a protocol fault. Its message is already redacted.
+		return "", fmt.Errorf("could not read the team your credential is bound to: %w (run 'ox login' if it is stale)", err)
 	}
 	if res.Team == nil || res.Team.TeamID == "" {
 		return "", errNoTeamOrRepoID

--- a/cmd/ox/agent_query_test.go
+++ b/cmd/ox/agent_query_test.go
@@ -444,3 +444,163 @@ func TestQueryTeamContext_GivesUpIfRetryAlso401s(t *testing.T) {
 
 	assert.Equal(t, 2, queryCallCount, "expected exactly one retry, not a loop")
 }
+
+// --- team defaulted from a team-scoped credential (GH #840) ---
+// Failure prevented: `ox query` in a directory with no .sageox/ refused with
+// "no team or repo ID available. Run 'ox init' first" while `ox status`, in
+// the same directory with the same credential, printed the bound team. The
+// team-id check ran ABOVE the auth block, so the credential was never read.
+
+// serveQueryWithIntrospect stands up an endpoint that answers introspection
+// with introspectBody and records what the query request asked to search.
+// Counters let a test assert introspection was NOT consulted when the team was
+// already known — the precedence claim, not just the happy path.
+func serveQueryWithIntrospect(t *testing.T, introspectBody string) (srv *httptest.Server, introspectHits *int, queried *api.QueryRequest) {
+	t.Helper()
+	hits := 0
+	var lastReq api.QueryRequest
+
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case auth.IntrospectEndpoint:
+			hits++
+			if introspectBody == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte(introspectBody))
+		case "/api/v1/query":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&lastReq))
+			_ = json.NewEncoder(w).Encode(api.QueryResponse{Results: []api.QueryResult{{Text: "ok"}}})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits, &lastReq
+}
+
+// liveTokenFor saves a far-from-expiry credential for ep so the proactive
+// refresh in queryTeamContext stays out of the way of what these tests assert.
+func liveTokenFor(t *testing.T, ep string) {
+	t.Helper()
+	require.NoError(t, auth.SaveTokenForEndpoint(ep, &auth.StoredToken{
+		AccessToken:  "team-scoped-access",
+		RefreshToken: "test-refresh-token",
+		ExpiresAt:    time.Now().Add(1 * time.Hour),
+		TokenType:    "Bearer",
+	}))
+}
+
+const teamPrincipalBody = `{"active":true,"principal_kind":"team-service",` +
+	`"team":{"team_id":"team_from_credential"},"token":{"prefix":"oxt_","name":"ci-deploy"}}`
+
+// TestQueryTeamContext_DefaultsTeamFromTeamBoundCredential is the issue's
+// repro: no .sageox/, no flags, a credential bound to exactly one team. The
+// query must run against that team instead of erroring.
+func TestQueryTeamContext_DefaultsTeamFromTeamBoundCredential(t *testing.T) {
+	srv, introspectHits, queried := serveQueryWithIntrospect(t, teamPrincipalBody)
+	t.Setenv("SAGEOX_ENDPOINT", srv.URL)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	liveTokenFor(t, srv.URL)
+
+	// bare directory: no .sageox/, so the project config carries no team/repo
+	uninitialized := t.TempDir()
+	qa := &queryArgs{query: "authentication", mode: "hybrid", limit: 5, source: "team"}
+
+	resp, err := queryTeamContext(qa, uninitialized, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, 1, *introspectHits, "expected the credential to be introspected exactly once")
+	assert.Equal(t, []string{"team_from_credential"}, queried.Teams,
+		"query must search the team the credential is bound to")
+}
+
+// TestQueryTeamContext_PersonalCredentialKeepsInitError proves a credential
+// that names a user rather than a single team still gets today's error — there
+// is genuinely nothing to default from, so `ox init` / --team remain the
+// remedies.
+func TestQueryTeamContext_PersonalCredentialKeepsInitError(t *testing.T) {
+	userBody := `{"active":true,"principal_kind":"user","user":{"id":"u_1","email":"dev@example.test"}}`
+	srv, introspectHits, queried := serveQueryWithIntrospect(t, userBody)
+	t.Setenv("SAGEOX_ENDPOINT", srv.URL)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	liveTokenFor(t, srv.URL)
+
+	qa := &queryArgs{query: "authentication", mode: "hybrid", limit: 5, source: "team"}
+
+	resp, err := queryTeamContext(qa, t.TempDir(), "", "")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, errNoTeamOrRepoID)
+	assert.Equal(t, "no team or repo ID available. Run 'ox init' first or pass --team/--repo flags", err.Error(),
+		"error text is unchanged for a credential that names no single team")
+
+	assert.Equal(t, 1, *introspectHits)
+	assert.Empty(t, queried.Teams, "no query should have been sent")
+}
+
+// TestQueryTeamContext_KnownTeamSkipsIntrospection proves introspection is the
+// LAST resort: an explicit --team and a project-config team_id each win, and
+// neither pays a network round trip to learn what it already knows.
+func TestQueryTeamContext_KnownTeamSkipsIntrospection(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagTeam string
+		wantTeam string
+	}{
+		{name: "project config supplies the team", wantTeam: "test-team"},
+		{name: "explicit --team overrides project config", flagTeam: "team_flag", wantTeam: "team_flag"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, introspectHits, queried := serveQueryWithIntrospect(t, teamPrincipalBody)
+			token := &auth.StoredToken{
+				AccessToken:  "team-scoped-access",
+				RefreshToken: "test-refresh-token",
+				ExpiresAt:    time.Now().Add(1 * time.Hour),
+				TokenType:    "Bearer",
+			}
+			projectRoot, qa := newQueryTestProject(t, srv, token)
+			qa.repoID = "" // isolate team resolution from the repo fallback
+			qa.teamID = tt.flagTeam
+
+			cfg, err := config.LoadProjectConfig(projectRoot)
+			require.NoError(t, err)
+			cfg.RepoID = ""
+			require.NoError(t, config.SaveProjectConfig(projectRoot, cfg))
+
+			resp, err := queryTeamContext(qa, projectRoot, "", "")
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			assert.Equal(t, []string{tt.wantTeam}, queried.Teams)
+			assert.Zero(t, *introspectHits, "a known team must not trigger introspection")
+		})
+	}
+}
+
+// TestQueryTeamContext_UnreachableEndpointIsNotAnInitProblem proves an offline
+// caller is told the endpoint could not be reached rather than being sent to
+// `ox init`, which would not have fixed anything.
+func TestQueryTeamContext_UnreachableEndpointIsNotAnInitProblem(t *testing.T) {
+	srv, _, _ := serveQueryWithIntrospect(t, teamPrincipalBody)
+	deadURL := srv.URL
+	srv.Close()
+
+	t.Setenv("SAGEOX_ENDPOINT", deadURL)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	liveTokenFor(t, deadURL)
+
+	qa := &queryArgs{query: "authentication", mode: "hybrid", limit: 5, source: "team"}
+
+	resp, err := queryTeamContext(qa, t.TempDir(), "", "")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, auth.ErrEndpointUnreachable)
+	assert.NotContains(t, err.Error(), "ox init")
+}

--- a/cmd/ox/agent_query_test.go
+++ b/cmd/ox/agent_query_test.go
@@ -455,7 +455,7 @@ func TestQueryTeamContext_GivesUpIfRetryAlso401s(t *testing.T) {
 // with introspectBody and records what the query request asked to search.
 // Counters let a test assert introspection was NOT consulted when the team was
 // already known — the precedence claim, not just the happy path.
-func serveQueryWithIntrospect(t *testing.T, introspectBody string) (srv *httptest.Server, introspectHits *int, queried *api.QueryRequest) {
+func serveQueryWithIntrospect(t *testing.T, introspectStatus int, introspectBody string) (srv *httptest.Server, introspectHits *int, queried *api.QueryRequest) {
 	t.Helper()
 	hits := 0
 	var lastReq api.QueryRequest
@@ -465,10 +465,7 @@ func serveQueryWithIntrospect(t *testing.T, introspectBody string) (srv *httptes
 		switch r.URL.Path {
 		case auth.IntrospectEndpoint:
 			hits++
-			if introspectBody == "" {
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
+			w.WriteHeader(introspectStatus)
 			_, _ = w.Write([]byte(introspectBody))
 		case "/api/v1/query":
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&lastReq))
@@ -501,7 +498,7 @@ const teamPrincipalBody = `{"active":true,"principal_kind":"team-service",` +
 // repro: no .sageox/, no flags, a credential bound to exactly one team. The
 // query must run against that team instead of erroring.
 func TestQueryTeamContext_DefaultsTeamFromTeamBoundCredential(t *testing.T) {
-	srv, introspectHits, queried := serveQueryWithIntrospect(t, teamPrincipalBody)
+	srv, introspectHits, queried := serveQueryWithIntrospect(t, http.StatusOK, teamPrincipalBody)
 	t.Setenv("SAGEOX_ENDPOINT", srv.URL)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	liveTokenFor(t, srv.URL)
@@ -525,7 +522,7 @@ func TestQueryTeamContext_DefaultsTeamFromTeamBoundCredential(t *testing.T) {
 // remedies.
 func TestQueryTeamContext_PersonalCredentialKeepsInitError(t *testing.T) {
 	userBody := `{"active":true,"principal_kind":"user","user":{"id":"u_1","email":"dev@example.test"}}`
-	srv, introspectHits, queried := serveQueryWithIntrospect(t, userBody)
+	srv, introspectHits, queried := serveQueryWithIntrospect(t, http.StatusOK, userBody)
 	t.Setenv("SAGEOX_ENDPOINT", srv.URL)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	liveTokenFor(t, srv.URL)
@@ -558,7 +555,7 @@ func TestQueryTeamContext_KnownTeamSkipsIntrospection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv, introspectHits, queried := serveQueryWithIntrospect(t, teamPrincipalBody)
+			srv, introspectHits, queried := serveQueryWithIntrospect(t, http.StatusOK, teamPrincipalBody)
 			token := &auth.StoredToken{
 				AccessToken:  "team-scoped-access",
 				RefreshToken: "test-refresh-token",
@@ -588,7 +585,7 @@ func TestQueryTeamContext_KnownTeamSkipsIntrospection(t *testing.T) {
 // caller is told the endpoint could not be reached rather than being sent to
 // `ox init`, which would not have fixed anything.
 func TestQueryTeamContext_UnreachableEndpointIsNotAnInitProblem(t *testing.T) {
-	srv, _, _ := serveQueryWithIntrospect(t, teamPrincipalBody)
+	srv, _, _ := serveQueryWithIntrospect(t, http.StatusOK, teamPrincipalBody)
 	deadURL := srv.URL
 	srv.Close()
 
@@ -603,4 +600,53 @@ func TestQueryTeamContext_UnreachableEndpointIsNotAnInitProblem(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.ErrorIs(t, err, auth.ErrEndpointUnreachable)
 	assert.NotContains(t, err.Error(), "ox init")
+}
+
+// TestQueryTeamContext_IntrospectionFailureIsNotAnInitProblem covers the two
+// ways introspection can fail while the endpoint is perfectly reachable: the
+// server rejects the credential, or it answers 200 with something unreadable.
+// Neither is an initialization problem, and reporting one as "Run 'ox init'"
+// sends a coworker with a revoked token to a command that cannot help them
+// (and that needs a working login itself).
+func TestQueryTeamContext_IntrospectionFailureIsNotAnInitProblem(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantErrHas string
+	}{
+		{
+			name:       "credential rejected server-side",
+			status:     http.StatusUnauthorized,
+			body:       `{"error":"invalid_token","error_description":"session expired"}`,
+			wantErrHas: "session expired",
+		},
+		{
+			name:       "unreadable 200 response",
+			status:     http.StatusOK,
+			body:       `{{{ not json`,
+			wantErrHas: "malformed introspection response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _, queried := serveQueryWithIntrospect(t, tt.status, tt.body)
+			t.Setenv("SAGEOX_ENDPOINT", srv.URL)
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			liveTokenFor(t, srv.URL)
+
+			qa := &queryArgs{query: "authentication", mode: "hybrid", limit: 5, source: "team"}
+
+			resp, err := queryTeamContext(qa, t.TempDir(), "", "")
+			require.Error(t, err)
+			assert.Nil(t, resp)
+			assert.Contains(t, err.Error(), tt.wantErrHas,
+				"the real reason introspection failed must survive")
+			assert.NotContains(t, err.Error(), "ox init",
+				"`ox init` cannot fix a rejected or unreadable credential")
+			assert.NotErrorIs(t, err, errNoTeamOrRepoID)
+			assert.Empty(t, queried.Teams, "no query should have been sent")
+		})
+	}
 }

--- a/cmd/ox/query.go
+++ b/cmd/ox/query.go
@@ -36,7 +36,7 @@ Examples:
 
 func init() {
 	queryCmd.Flags().IntP("limit", "k", 5, "max results to return")
-	queryCmd.Flags().String("team", "", "team ID to search (default: from project config)")
+	queryCmd.Flags().String("team", "", "team ID to search (default: project config, else the credential's team)")
 	queryCmd.Flags().String("repo", "", "repo ID to search (default: from project config)")
 	queryCmd.Flags().String("mode", "hybrid", "search mode: hybrid, knn, or bm25")
 	queryCmd.Flags().String("source", "team", "search source: team (default), code, local, all")

--- a/docs/reference/code/activity.mdx
+++ b/docs/reference/code/activity.mdx
@@ -6,7 +6,7 @@ sidebar_position: 12
 
 ## ox code activity
 
-Assemble GitHub activity clusters for the fact extractor
+Recent GitHub activity (PRs, issues, commits) over a time window
 
 ### Synopsis
 
@@ -41,4 +41,4 @@ ox code activity [flags]
 
 ### SEE ALSO
 
-* [ox code](/code)	 - Search code in this repo
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo

--- a/docs/reference/code/callees.mdx
+++ b/docs/reference/code/callees.mdx
@@ -1,0 +1,48 @@
+---
+title: "ox code callees"
+description: "CLI reference for ox code callees"
+sidebar_position: 13
+---
+
+## ox code callees
+
+What does <name> call? (resolved call graph, transitive via --depth)
+
+### Synopsis
+
+List the callees of <name> using the ADR-019 resolved call graph.
+
+Equivalent DSL:  ox code search "" calls:<name> depth:<N>
+
+Examples:
+  ox code callees Handler
+  ox code callees authenticate --depth 3
+
+```
+ox code callees <name> [flags]
+```
+
+### Options
+
+```
+      --depth int     transitive call depth (1-10) (default 1)
+      --full-json     full uncompacted JSON output (~4x more context tokens)
+  -h, --help          help for callees
+      --limit int     max results to return (default 10)
+      --snippet int   max snippet length per result, in characters (default 200)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo

--- a/docs/reference/code/callers.mdx
+++ b/docs/reference/code/callers.mdx
@@ -1,0 +1,47 @@
+---
+title: "ox code callers"
+description: "CLI reference for ox code callers"
+sidebar_position: 14
+---
+
+## ox code callers
+
+Who calls <name>? (resolved call graph)
+
+### Synopsis
+
+List the callers of <name> using the ADR-019 resolved call graph.
+
+Equivalent DSL:  ox code search "" calledby:<name>
+
+Examples:
+  ox code callers authenticate
+  ox code callers ResolveSessionRecording --limit 20
+
+```
+ox code callers <name> [flags]
+```
+
+### Options
+
+```
+      --full-json     full uncompacted JSON output (~4x more context tokens)
+  -h, --help          help for callers
+      --limit int     max results to return (default 10)
+      --snippet int   max snippet length per result, in characters (default 200)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo

--- a/docs/reference/code/defs.mdx
+++ b/docs/reference/code/defs.mdx
@@ -1,22 +1,34 @@
 ---
-title: "ox code index"
-description: "CLI reference for ox code index"
-sidebar_position: 16
+title: "ox code defs"
+description: "CLI reference for ox code defs"
+sidebar_position: 15
 ---
 
-## ox code index
+## ox code defs
 
-Index a git repository (alias for 'ox index code')
+Where is <name> defined? (symbol search)
+
+### Synopsis
+
+Find symbol definitions matching <name>.
+
+Equivalent DSL:  ox code search "<name>" type:symbol
+
+Examples:
+  ox code defs ResolveSession
+  ox code defs Handler --limit 5
 
 ```
-ox code index [url] [flags]
+ox code defs <name> [flags]
 ```
 
 ### Options
 
 ```
-      --full   wipe index and rebuild from scratch
-  -h, --help   help for index
+      --full-json     full uncompacted JSON output (~4x more context tokens)
+  -h, --help          help for defs
+      --limit int     max results to return (default 10)
+      --snippet int   max snippet length per result, in characters (default 200)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/code/insights.mdx
+++ b/docs/reference/code/insights.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox code insights"
 description: "CLI reference for ox code insights"
-sidebar_position: 14
+sidebar_position: 17
 ---
 
 ## ox code insights
@@ -33,4 +33,4 @@ ox code insights [flags]
 
 ### SEE ALSO
 
-* [ox code](/code)	 - Search code in this repo
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo

--- a/docs/reference/code/log.mdx
+++ b/docs/reference/code/log.mdx
@@ -1,0 +1,50 @@
+---
+title: "ox code log"
+description: "CLI reference for ox code log"
+sidebar_position: 18
+---
+
+## ox code log
+
+Commits touching <path> (git history via the index)
+
+### Synopsis
+
+Show commits that touched <path> using the indexed git history.
+
+Equivalent DSL:  ox code search "" file:<path> type:commit [author:...] [after:...] [before:...]
+
+Examples:
+  ox code log internal/codedb/
+  ox code log cmd/ox/code.go --author rupak --after 2026-04-01
+
+```
+ox code log <path> [flags]
+```
+
+### Options
+
+```
+      --after string    include commits after this date (e.g. 2026-04-01)
+      --author string   restrict to commits by this author
+      --before string   include commits before this date
+      --full-json       full uncompacted JSON output (~4x more context tokens)
+  -h, --help            help for log
+      --limit int       max results to return (default 10)
+      --snippet int     max snippet length per result, in characters (default 200)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo

--- a/docs/reference/code/prs.mdx
+++ b/docs/reference/code/prs.mdx
@@ -1,12 +1,12 @@
 ---
 title: "ox code prs"
 description: "CLI reference for ox code prs"
-sidebar_position: 15
+sidebar_position: 19
 ---
 
 ## ox code prs
 
-List pull requests with triage signals
+List pull requests ranked for triage (stalled, age, activity)
 
 ### Synopsis
 
@@ -67,4 +67,4 @@ ox code prs [flags]
 
 ### SEE ALSO
 
-* [ox code](/code)	 - Search code in this repo
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo

--- a/docs/reference/code/refs.mdx
+++ b/docs/reference/code/refs.mdx
@@ -1,0 +1,50 @@
+---
+title: "ox code refs"
+description: "CLI reference for ox code refs"
+sidebar_position: 20
+---
+
+## ox code refs
+
+Where is <name> referenced in code text? (text search across the index)
+
+### Synopsis
+
+Find text occurrences of <name> in indexed code.
+
+Equivalent DSL:  ox code search "<name>" type:code
+
+For the resolved call graph use callers/callees — refs is plain text search.
+
+Examples:
+  ox code refs authenticate
+  ox code refs migration --lang go
+
+```
+ox code refs <name> [flags]
+```
+
+### Options
+
+```
+      --full-json     full uncompacted JSON output (~4x more context tokens)
+  -h, --help          help for refs
+      --lang string   restrict to a language (e.g. go, ts)
+      --limit int     max results to return (default 10)
+      --snippet int   max snippet length per result, in characters (default 200)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo

--- a/docs/reference/code/search.mdx
+++ b/docs/reference/code/search.mdx
@@ -1,12 +1,58 @@
 ---
 title: "ox code search"
 description: "CLI reference for ox code search"
-sidebar_position: 16
+sidebar_position: 21
 ---
 
 ## ox code search
 
-Search indexed code using queries
+Search the CodeDB index using a query DSL
+
+### Synopsis
+
+Search the indexed CodeDB for symbols, code, diffs, commits, comments, PRs, and issues.
+
+DSL grammar:
+  type:{code,symbol,diff,commit,comment,pr,issue}   what kind of record to match
+  repo:<name>[@<rev>]    file:<glob>    lang:<id>
+  author:<name>          message:<text>
+  before:<date>          after:<date>                ISO 8601 or relative
+  calls:<name>           calledby:<name>             resolved call graph (ADR-019)
+  returns:<type>         depth:1..10                 transitive call depth
+  confidence:{extracted,inferred,ambiguous}          ADR-019 edge confidence
+  ckind:<kind>           state:<pr_state>
+  select:{repo,file,symbol,symbol.<kind>}
+  count:<N>              case:yes
+  patterntype:{literal,keyword,regexp}
+  OR                                                 boolean across groups
+  /pattern/                                          forced regex
+  -<filter>                                          negate any filter
+
+Examples:
+  # symbol definition (what grep usually misses among text matches)
+  ox code search "ResolveSession" type:symbol
+
+  # resolved call graph — who calls authenticate()?
+  ox code search "" calledby:authenticate
+
+  # what does Handler call, two hops deep?
+  ox code search "" calls:Handler depth:2
+
+  # indexed PR titles + bodies + review comments
+  ox code search "rate limit" type:pr state:open
+
+  # source comments tagged TODO
+  ox code search "TODO" type:comment ckind:todo
+
+  # git log + content match together
+  ox code search "migration" author:rupak after:2026-04-01
+
+  # cross-language regex via /pattern/
+  ox code search "/Resolve[A-Z]\w+Recording/"
+
+When the index is unavailable (still building, not yet created), agent-context
+invocations emit a structured JSON status instead of erroring — callers should
+parse the status field before treating output as results.
 
 ```
 ox code search <query> [flags]
@@ -15,10 +61,11 @@ ox code search <query> [flags]
 ### Options
 
 ```
-      --decisions   only results from this repo's decision records (ADRs/DDRs)
-      --full-json   full uncompacted JSON output (~6x more context tokens)
-  -h, --help        help for search
-      --limit int   max results to return (default 10)
+      --decisions     only results from this repo's decision records (ADRs/DDRs)
+      --full-json     full uncompacted JSON output (~4x more context tokens)
+  -h, --help          help for search
+      --limit int     max results to return (default 10)
+      --snippet int   max snippet length per result, in characters (default 200)
 ```
 
 ### Options inherited from parent commands
@@ -34,4 +81,4 @@ ox code search <query> [flags]
 
 ### SEE ALSO
 
-* [ox code](/code)	 - Search code in this repo
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo

--- a/docs/reference/code/status.mdx
+++ b/docs/reference/code/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox code status"
 description: "CLI reference for ox code status"
-sidebar_position: 17
+sidebar_position: 22
 ---
 
 ## ox code status
@@ -31,4 +31,4 @@ ox code status [flags]
 
 ### SEE ALSO
 
-* [ox code](/code)	 - Search code in this repo
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo

--- a/docs/reference/conversation/index.mdx
+++ b/docs/reference/conversation/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox conversation"
 description: "CLI reference for ox conversation"
-sidebar_position: 18
+sidebar_position: 23
 ---
 
 ## ox conversation

--- a/docs/reference/conversation/list.mdx
+++ b/docs/reference/conversation/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox conversation list"
 description: "CLI reference for ox conversation list"
-sidebar_position: 19
+sidebar_position: 24
 ---
 
 ## ox conversation list

--- a/docs/reference/conversation/show.mdx
+++ b/docs/reference/conversation/show.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox conversation show"
 description: "CLI reference for ox conversation show"
-sidebar_position: 20
+sidebar_position: 25
 ---
 
 ## ox conversation show

--- a/docs/reference/conversation/topic.mdx
+++ b/docs/reference/conversation/topic.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox conversation topic"
 description: "CLI reference for ox conversation topic"
-sidebar_position: 21
+sidebar_position: 26
 ---
 
 ## ox conversation topic

--- a/docs/reference/conversation/topics.mdx
+++ b/docs/reference/conversation/topics.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox conversation topics"
 description: "CLI reference for ox conversation topics"
-sidebar_position: 22
+sidebar_position: 27
 ---
 
 ## ox conversation topics

--- a/docs/reference/conversation/transcript.mdx
+++ b/docs/reference/conversation/transcript.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox conversation transcript"
 description: "CLI reference for ox conversation transcript"
-sidebar_position: 23
+sidebar_position: 28
 ---
 
 ## ox conversation transcript

--- a/docs/reference/decision/enrich.mdx
+++ b/docs/reference/decision/enrich.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox decision enrich"
 description: "CLI reference for ox decision enrich"
-sidebar_position: 25
+sidebar_position: 30
 ---
 
 ## ox decision enrich

--- a/docs/reference/decision/index.mdx
+++ b/docs/reference/decision/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox decision"
 description: "CLI reference for ox decision"
-sidebar_position: 24
+sidebar_position: 29
 ---
 
 ## ox decision

--- a/docs/reference/distill/history/index.mdx
+++ b/docs/reference/distill/history/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill history"
 description: "CLI reference for ox distill history"
-sidebar_position: 27
+sidebar_position: 32
 ---
 
 ## ox distill history

--- a/docs/reference/distill/history/list.mdx
+++ b/docs/reference/distill/history/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill history list"
 description: "CLI reference for ox distill history list"
-sidebar_position: 28
+sidebar_position: 33
 ---
 
 ## ox distill history list

--- a/docs/reference/distill/history/show.mdx
+++ b/docs/reference/distill/history/show.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill history show"
 description: "CLI reference for ox distill history show"
-sidebar_position: 29
+sidebar_position: 34
 ---
 
 ## ox distill history show

--- a/docs/reference/distill/history/since.mdx
+++ b/docs/reference/distill/history/since.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill history since"
 description: "CLI reference for ox distill history since"
-sidebar_position: 30
+sidebar_position: 35
 ---
 
 ## ox distill history since

--- a/docs/reference/distill/index.mdx
+++ b/docs/reference/distill/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill"
 description: "CLI reference for ox distill"
-sidebar_position: 26
+sidebar_position: 31
 ---
 
 ## ox distill

--- a/docs/reference/doctor.mdx
+++ b/docs/reference/doctor.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox doctor"
 description: "CLI reference for ox doctor"
-sidebar_position: 31
+sidebar_position: 36
 ---
 
 ## ox doctor

--- a/docs/reference/export.mdx
+++ b/docs/reference/export.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox export"
 description: "CLI reference for ox export"
-sidebar_position: 32
+sidebar_position: 37
 ---
 
 ## ox export

--- a/docs/reference/gc.mdx
+++ b/docs/reference/gc.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox gc"
 description: "CLI reference for ox gc"
-sidebar_position: 33
+sidebar_position: 38
 ---
 
 ## ox gc

--- a/docs/reference/glance.mdx
+++ b/docs/reference/glance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox glance"
 description: "CLI reference for ox glance"
-sidebar_position: 34
+sidebar_position: 39
 ---
 
 ## ox glance

--- a/docs/reference/guide.mdx
+++ b/docs/reference/guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox guide"
 description: "CLI reference for ox guide"
-sidebar_position: 35
+sidebar_position: 40
 ---
 
 ## ox guide

--- a/docs/reference/hooks/add.mdx
+++ b/docs/reference/hooks/add.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks add"
 description: "CLI reference for ox hooks add"
-sidebar_position: 37
+sidebar_position: 42
 ---
 
 ## ox hooks add

--- a/docs/reference/hooks/index.mdx
+++ b/docs/reference/hooks/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks"
 description: "CLI reference for ox hooks"
-sidebar_position: 36
+sidebar_position: 41
 ---
 
 ## ox hooks

--- a/docs/reference/hooks/list.mdx
+++ b/docs/reference/hooks/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks list"
 description: "CLI reference for ox hooks list"
-sidebar_position: 38
+sidebar_position: 43
 ---
 
 ## ox hooks list

--- a/docs/reference/hooks/log.mdx
+++ b/docs/reference/hooks/log.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks log"
 description: "CLI reference for ox hooks log"
-sidebar_position: 39
+sidebar_position: 44
 ---
 
 ## ox hooks log

--- a/docs/reference/hooks/test.mdx
+++ b/docs/reference/hooks/test.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks test"
 description: "CLI reference for ox hooks test"
-sidebar_position: 40
+sidebar_position: 45
 ---
 
 ## ox hooks test

--- a/docs/reference/import.mdx
+++ b/docs/reference/import.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox import"
 description: "CLI reference for ox import"
-sidebar_position: 41
+sidebar_position: 46
 ---
 
 ## ox import

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -27,7 +27,7 @@ Shared team context between your AI and human coworkers. Sessions, ledgers, and 
 ### SEE ALSO
 
 * [ox adapter](/adapter)	 - Manage external adapter binaries
-* [ox code](/code)	 - Search code in this repo
+* [ox code](/code)	 - Search code, symbols, history, PRs, and comments in this repo
 * [ox conversation](/conversation)	 - Read recorded team conversations from the local Team Context
 * [ox decision](/decision)	 - Work with Decision Records (ADRs, DDRs) — enrich with team context
 * [ox distill](/distill)	 - Distill team observations into memory summaries

--- a/docs/reference/index/code.mdx
+++ b/docs/reference/index/code.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index code"
 description: "CLI reference for ox index code"
-sidebar_position: 43
+sidebar_position: 48
 ---
 
 ## ox index code

--- a/docs/reference/index/github.mdx
+++ b/docs/reference/index/github.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index github"
 description: "CLI reference for ox index github"
-sidebar_position: 44
+sidebar_position: 49
 ---
 
 ## ox index github

--- a/docs/reference/index/index.mdx
+++ b/docs/reference/index/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index"
 description: "CLI reference for ox index"
-sidebar_position: 42
+sidebar_position: 47
 ---
 
 ## ox index

--- a/docs/reference/index/status.mdx
+++ b/docs/reference/index/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index status"
 description: "CLI reference for ox index status"
-sidebar_position: 45
+sidebar_position: 50
 ---
 
 ## ox index status

--- a/docs/reference/init.mdx
+++ b/docs/reference/init.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox init"
 description: "CLI reference for ox init"
-sidebar_position: 46
+sidebar_position: 51
 ---
 
 ## ox init

--- a/docs/reference/kb/describe.mdx
+++ b/docs/reference/kb/describe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb describe"
 description: "CLI reference for ox kb describe"
-sidebar_position: 48
+sidebar_position: 53
 ---
 
 ## ox kb describe

--- a/docs/reference/kb/index.mdx
+++ b/docs/reference/kb/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb"
 description: "CLI reference for ox kb"
-sidebar_position: 47
+sidebar_position: 52
 ---
 
 ## ox kb

--- a/docs/reference/kb/list.mdx
+++ b/docs/reference/kb/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb list"
 description: "CLI reference for ox kb list"
-sidebar_position: 49
+sidebar_position: 54
 ---
 
 ## ox kb list

--- a/docs/reference/kb/query.mdx
+++ b/docs/reference/kb/query.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb query"
 description: "CLI reference for ox kb query"
-sidebar_position: 50
+sidebar_position: 55
 ---
 
 ## ox kb query

--- a/docs/reference/login.mdx
+++ b/docs/reference/login.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox login"
 description: "CLI reference for ox login"
-sidebar_position: 51
+sidebar_position: 56
 ---
 
 ## ox login

--- a/docs/reference/logout.mdx
+++ b/docs/reference/logout.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox logout"
 description: "CLI reference for ox logout"
-sidebar_position: 52
+sidebar_position: 57
 ---
 
 ## ox logout

--- a/docs/reference/murmur/delete.mdx
+++ b/docs/reference/murmur/delete.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur delete"
 description: "CLI reference for ox murmur delete"
-sidebar_position: 54
+sidebar_position: 59
 ---
 
 ## ox murmur delete

--- a/docs/reference/murmur/index.mdx
+++ b/docs/reference/murmur/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur"
 description: "CLI reference for ox murmur"
-sidebar_position: 53
+sidebar_position: 58
 ---
 
 ## ox murmur

--- a/docs/reference/murmur/list.mdx
+++ b/docs/reference/murmur/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur list"
 description: "CLI reference for ox murmur list"
-sidebar_position: 55
+sidebar_position: 60
 ---
 
 ## ox murmur list

--- a/docs/reference/murmur/pause.mdx
+++ b/docs/reference/murmur/pause.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur pause"
 description: "CLI reference for ox murmur pause"
-sidebar_position: 56
+sidebar_position: 61
 ---
 
 ## ox murmur pause

--- a/docs/reference/murmur/resume.mdx
+++ b/docs/reference/murmur/resume.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur resume"
 description: "CLI reference for ox murmur resume"
-sidebar_position: 57
+sidebar_position: 62
 ---
 
 ## ox murmur resume

--- a/docs/reference/murmur/status.mdx
+++ b/docs/reference/murmur/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur status"
 description: "CLI reference for ox murmur status"
-sidebar_position: 58
+sidebar_position: 63
 ---
 
 ## ox murmur status

--- a/docs/reference/plan/abandon.mdx
+++ b/docs/reference/plan/abandon.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan abandon"
 description: "CLI reference for ox plan abandon"
-sidebar_position: 60
+sidebar_position: 65
 ---
 
 ## ox plan abandon

--- a/docs/reference/plan/approve.mdx
+++ b/docs/reference/plan/approve.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan approve"
 description: "CLI reference for ox plan approve"
-sidebar_position: 61
+sidebar_position: 66
 ---
 
 ## ox plan approve

--- a/docs/reference/plan/enrich.mdx
+++ b/docs/reference/plan/enrich.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan enrich"
 description: "CLI reference for ox plan enrich"
-sidebar_position: 62
+sidebar_position: 67
 ---
 
 ## ox plan enrich

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan"
 description: "CLI reference for ox plan"
-sidebar_position: 59
+sidebar_position: 64
 ---
 
 ## ox plan

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan list"
 description: "CLI reference for ox plan list"
-sidebar_position: 63
+sidebar_position: 68
 ---
 
 ## ox plan list

--- a/docs/reference/plan/realize.mdx
+++ b/docs/reference/plan/realize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan realize"
 description: "CLI reference for ox plan realize"
-sidebar_position: 64
+sidebar_position: 69
 ---
 
 ## ox plan realize

--- a/docs/reference/plan/render.mdx
+++ b/docs/reference/plan/render.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan render"
 description: "CLI reference for ox plan render"
-sidebar_position: 65
+sidebar_position: 70
 ---
 
 ## ox plan render

--- a/docs/reference/plan/review/await.mdx
+++ b/docs/reference/plan/review/await.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan review await"
 description: "CLI reference for ox plan review await"
-sidebar_position: 67
+sidebar_position: 72
 ---
 
 ## ox plan review await

--- a/docs/reference/plan/review/index.mdx
+++ b/docs/reference/plan/review/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan review"
 description: "CLI reference for ox plan review"
-sidebar_position: 66
+sidebar_position: 71
 ---
 
 ## ox plan review

--- a/docs/reference/plan/status.mdx
+++ b/docs/reference/plan/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan status"
 description: "CLI reference for ox plan status"
-sidebar_position: 68
+sidebar_position: 73
 ---
 
 ## ox plan status

--- a/docs/reference/plan/supersede.mdx
+++ b/docs/reference/plan/supersede.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan supersede"
 description: "CLI reference for ox plan supersede"
-sidebar_position: 69
+sidebar_position: 74
 ---
 
 ## ox plan supersede

--- a/docs/reference/plan/view.mdx
+++ b/docs/reference/plan/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan view"
 description: "CLI reference for ox plan view"
-sidebar_position: 70
+sidebar_position: 75
 ---
 
 ## ox plan view

--- a/docs/reference/plan/work.mdx
+++ b/docs/reference/plan/work.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan work"
 description: "CLI reference for ox plan work"
-sidebar_position: 71
+sidebar_position: 76
 ---
 
 ## ox plan work

--- a/docs/reference/pr/header.mdx
+++ b/docs/reference/pr/header.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox pr header"
 description: "CLI reference for ox pr header"
-sidebar_position: 73
+sidebar_position: 78
 ---
 
 ## ox pr header

--- a/docs/reference/pr/index.mdx
+++ b/docs/reference/pr/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox pr"
 description: "CLI reference for ox pr"
-sidebar_position: 72
+sidebar_position: 77
 ---
 
 ## ox pr

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox query"
 description: "CLI reference for ox query"
-sidebar_position: 74
+sidebar_position: 79
 ---
 
 ## ox query

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -41,7 +41,7 @@ ox query [flags]
       --mode string     search mode: hybrid, knn, or bm25 (default "hybrid")
       --repo string     repo ID to search (default: from project config)
       --source string   search source: team (default), code, local, all (default "team")
-      --team string     team ID to search (default: from project config)
+      --team string     team ID to search (default: project config, else the credential's team)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/recap.mdx
+++ b/docs/reference/recap.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox recap"
 description: "CLI reference for ox recap"
-sidebar_position: 75
+sidebar_position: 80
 ---
 
 ## ox recap

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox release-notes"
 description: "CLI reference for ox release-notes"
-sidebar_position: 76
+sidebar_position: 81
 ---
 
 ## ox release-notes

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session audit"
 description: "CLI reference for ox session audit"
-sidebar_position: 78
+sidebar_position: 83
 ---
 
 ## ox session audit

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session"
 description: "CLI reference for ox session"
-sidebar_position: 77
+sidebar_position: 82
 ---
 
 ## ox session

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session lint"
 description: "CLI reference for ox session lint"
-sidebar_position: 79
+sidebar_position: 84
 ---
 
 ## ox session lint

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session list"
 description: "CLI reference for ox session list"
-sidebar_position: 80
+sidebar_position: 85
 ---
 
 ## ox session list

--- a/docs/reference/session/prune.mdx
+++ b/docs/reference/session/prune.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session prune"
 description: "CLI reference for ox session prune"
-sidebar_position: 81
+sidebar_position: 86
 ---
 
 ## ox session prune

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session redact"
 description: "CLI reference for ox session redact"
-sidebar_position: 82
+sidebar_position: 87
 ---
 
 ## ox session redact

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session regenerate"
 description: "CLI reference for ox session regenerate"
-sidebar_position: 83
+sidebar_position: 88
 ---
 
 ## ox session regenerate

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session repair-meta-summary"
 description: "CLI reference for ox session repair-meta-summary"
-sidebar_position: 84
+sidebar_position: 89
 ---
 
 ## ox session repair-meta-summary

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session score"
 description: "CLI reference for ox session score"
-sidebar_position: 85
+sidebar_position: 90
 ---
 
 ## ox session score

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session status"
 description: "CLI reference for ox session status"
-sidebar_position: 86
+sidebar_position: 91
 ---
 
 ## ox session status

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session stop"
 description: "CLI reference for ox session stop"
-sidebar_position: 87
+sidebar_position: 92
 ---
 
 ## ox session stop

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session token-optimize"
 description: "CLI reference for ox session token-optimize"
-sidebar_position: 88
+sidebar_position: 93
 ---
 
 ## ox session token-optimize

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session view"
 description: "CLI reference for ox session view"
-sidebar_position: 89
+sidebar_position: 94
 ---
 
 ## ox session view

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox status"
 description: "CLI reference for ox status"
-sidebar_position: 90
+sidebar_position: 95
 ---
 
 ## ox status

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox sync"
 description: "CLI reference for ox sync"
-sidebar_position: 91
+sidebar_position: 96
 ---
 
 ## ox sync

--- a/docs/reference/team/index.mdx
+++ b/docs/reference/team/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team"
 description: "CLI reference for ox team"
-sidebar_position: 92
+sidebar_position: 97
 ---
 
 ## ox team

--- a/docs/reference/team/invite.mdx
+++ b/docs/reference/team/invite.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team invite"
 description: "CLI reference for ox team invite"
-sidebar_position: 93
+sidebar_position: 98
 ---
 
 ## ox team invite

--- a/docs/reference/team/list.mdx
+++ b/docs/reference/team/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team list"
 description: "CLI reference for ox team list"
-sidebar_position: 94
+sidebar_position: 99
 ---
 
 ## ox team list

--- a/docs/reference/team/members.mdx
+++ b/docs/reference/team/members.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team members"
 description: "CLI reference for ox team members"
-sidebar_position: 95
+sidebar_position: 100
 ---
 
 ## ox team members

--- a/docs/reference/team/open.mdx
+++ b/docs/reference/team/open.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team open"
 description: "CLI reference for ox team open"
-sidebar_position: 96
+sidebar_position: 101
 ---
 
 ## ox team open

--- a/docs/reference/team/show.mdx
+++ b/docs/reference/team/show.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox team show"
 description: "CLI reference for ox team show"
-sidebar_position: 97
+sidebar_position: 102
 ---
 
 ## ox team show

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox uninstall"
 description: "CLI reference for ox uninstall"
-sidebar_position: 98
+sidebar_position: 103
 ---
 
 ## ox uninstall

--- a/docs/reference/upgrade.mdx
+++ b/docs/reference/upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox upgrade"
 description: "CLI reference for ox upgrade"
-sidebar_position: 99
+sidebar_position: 104
 ---
 
 ## ox upgrade

--- a/docs/reference/viz/index.mdx
+++ b/docs/reference/viz/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz"
 description: "CLI reference for ox viz"
-sidebar_position: 100
+sidebar_position: 105
 ---
 
 ## ox viz

--- a/docs/reference/viz/lint.mdx
+++ b/docs/reference/viz/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz lint"
 description: "CLI reference for ox viz lint"
-sidebar_position: 101
+sidebar_position: 106
 ---
 
 ## ox viz lint

--- a/docs/reference/viz/pr.mdx
+++ b/docs/reference/viz/pr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz pr"
 description: "CLI reference for ox viz pr"
-sidebar_position: 102
+sidebar_position: 107
 ---
 
 ## ox viz pr

--- a/docs/reference/viz/render.mdx
+++ b/docs/reference/viz/render.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz render"
 description: "CLI reference for ox viz render"
-sidebar_position: 103
+sidebar_position: 108
 ---
 
 ## ox viz render

--- a/docs/reference/viz/suggest.mdx
+++ b/docs/reference/viz/suggest.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz suggest"
 description: "CLI reference for ox viz suggest"
-sidebar_position: 104
+sidebar_position: 109
 ---
 
 ## ox viz suggest

--- a/internal/codedb/store/store_selfheal_concurrent_test.go
+++ b/internal/codedb/store/store_selfheal_concurrent_test.go
@@ -335,8 +335,9 @@ func TestConcurrentSelfHeal_MultiProcess(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			cmd := exec.Command(os.Args[0], "-test.run=^$")
-			cmd.Dir = tmp // keep the re-exec'd child out of the repo working tree
-			cmd.Env = append(os.Environ(),
+			// keep the re-exec'd child out of the repo working tree
+			cmd.Dir = tmp
+			cmd.Env = append(os.Environ(), // safe: re-execs this test binary (os.Args[0]), not the ox CLI; it needs the parent test env
 				selfHealHelperEnv+"=1",
 				selfHealRootEnv+"="+tmp,
 				selfHealPathEnv+"="+indexPath,


### PR DESCRIPTION
Fixes #840.

## What broke

`ox query` refused to run in a directory with no `.sageox/` even when the credential in `SAGEOX_TOKEN` was bound to **exactly one team** — the one fact the command needed:

```
$ cd /tmp/empty-dir
$ SAGEOX_TOKEN=… ox query "authentication"
Error: team context query failed: no team or repo ID available.
       Run 'ox init' first or pass --team/--repo flags
```

The team/repo check in `queryTeamContext` ran **above** the auth block, so the credential was never read. `ox status`, in the same directory with the same credential, printed the bound team — from `/api/v1/auth/introspect`. Two commands, one credential, opposite answers about whether we know who we are.

Neither workaround was good: `ox init` is wrong for a scratch directory or a CI checkout that only wants to *read*, and `--team <id>` demands a human already know the id that the credential exists to carry.

```mermaid
flowchart TD
    A["ox query 'authentication'"] --> B{"--team / --repo given?"}
    B -->|yes| Q["query that team"]
    B -->|no| C{"project config has team_id?"}
    C -->|yes| Q
    C -->|no| D["resolve credential<br/>(auth block — used to be BELOW the check)"]
    D --> E["GET /api/v1/auth/introspect"]
    E --> F{"bound to exactly one team?"}
    F -->|yes| Q
    F -->|"no — personal credential"| G["today's error, verbatim"]
    F -->|"endpoint unreachable"| H["name the reachability failure,<br/>drop the 'ox init' advice"]

    style D fill:#1f6feb,color:#fff
    style E fill:#1f6feb,color:#fff
    style F fill:#1f6feb,color:#fff
```

## What this PR ships

- **`cmd/ox/agent_query.go`** — deleted the early guard so the auth block runs first. When neither flags nor project config name a team or repo, the new `teamIDFromCredential()` introspects the bearer credential and uses `Team.TeamID` when one is bound.
- **Precedence, exactly as the issue specified:** `--team` → project-config `team_id` → introspection. A known team pays **no** extra round trip.
- **Flag help** updated in `query.go`, `queryUsage`, and the matching line of `docs/reference/query.mdx`.

### Failure paths

| Case | Result |
|---|---|
| Personal (user-principal) credential | today's error, **verbatim** — `ox init` / `--team` really are the remedies |
| Credential rejected, or a 200 carrying unreadable JSON | preserves the real reason via `%w`, suggests `ox login` conditionally — **not** `ox init` |
| Endpoint unreachable | names the reachability failure, wraps `auth.ErrEndpointUnreachable`, **drops** the `ox init` advice — it wouldn't have helped |

`errNoTeamOrRepoID` is reserved for the one case it names: introspection **answered**, and the answer named no single team. Every way of failing to *get* an answer keeps its own error — none of them is an initialization problem, and `ox init` cannot fix any of them (it needs a working credential itself).

### One behavior shift worth naming

In an uninitialized directory with **no** credential at all, the error is now `not authenticated. Run 'ox login' first` rather than `Run 'ox init' first`. That is the honest prerequisite — `ox init` needs a login anyway — and it falls out of moving the auth block above the check.

### Still needs server-side work

Making `ox query` *fully* usable with a team-scoped credential also needs a change owned by the API side, tracked separately by its owners. This PR is only the CLI half: the command no longer refuses to use information it already has.

## Test Plan

`cmd/ox/agent_query_test.go`, +160 lines against a real `httptest` endpoint serving both `/api/v1/auth/introspect` and `/api/v1/query`. **Every test was proven red before the fix**, and the primary one landed on exactly the claim step:

> `Received unexpected error: no team or repo ID available. Run 'ox init' first or pass --team/--repo flags`

- `DefaultsTeamFromTeamBoundCredential` — the issue's repro (bare temp dir, no flags); asserts the outgoing query request carries the credential's team.
- `PersonalCredentialKeepsInitError` — asserts the error string is **byte-identical** to today's, and that no query is sent.
- `KnownTeamSkipsIntrospection` — table over config-supplied and `--team`-supplied; asserts the introspection hit count is **zero**.
- `UnreachableEndpointIsNotAnInitProblem` — asserts `errors.Is(err, auth.ErrEndpointUnreachable)` and that `"ox init"` is absent from the message.
- `IntrospectionFailureIsNotAnInitProblem` — table over a 401 with an `error_description` and a 200 carrying unparseable JSON; asserts the real reason survives into the message, `"ox init"` is absent, and `NotErrorIs(err, errNoTeamOrRepoID)`. *(Added from CodeRabbit review.)*

Gates:

- `golangci-lint run ./...` → **0 issues**
- `go test ./cmd/ox/` (full package, 199s) → pass
- `go test ./internal/codedb/store/ ./internal/auth/` → pass

## Two notes outside the feature diff

- **One pre-existing lint failure fixed.** `make lint`'s `lint-test-env` gate was already failing on `main` at `internal/codedb/store/store_selfheal_concurrent_test.go` (unannotated `os.Environ()`, from #835). That call re-execs the *test binary* — `os.Args[0]`, not the ox CLI — so `testguard.RunOx()` doesn't apply; it needs the parent test env. Added the `// safe:` annotation.
- **`docs/reference` regenerated (`make docs`).** The committed docs had drifted from Cobra on `main`: 5 `ox code` verb subcommands (`callees`, `callers`, `defs`, `log`, `refs`) had never been generated, which shifted `sidebar_position` across 92 files. `main` never catches this — the `docs-check` gate lives in the PR `test` job — so it surfaced here. The regen is mechanical: new pages, renumbering, and refreshed `ox code` descriptions. `make docs-check` is green locally.

SageOx-Session: https://sageox.ai/c/ses_01a04be5-0730-79c7-aa3d-12ae8f24a09c

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790573742&installation_model_id=433550&pr_number=841&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F841&signature=be061d85c5a1f15193ae78d601cc30f0a3257b58f3f7c4ca07936011c7ab3597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Queries can use the team associated with credentials when no team or project configuration is provided.
  - Team-scoped credentials can search without an initialized repository.
  - Added reference documentation for code callers, callees, definitions, logs, and references.

- **Bug Fixes**
  - Improved error messages for unavailable services and invalid or unreadable credentials.

- **Documentation**
  - Expanded code search guidance, options, examples, and status output details.
  - Reorganized command reference navigation for easier browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
