### PR TITLE
feat(query): request team ledgers for a credential-derived team

### DIFF
--- a/cmd/ox/agent_query.go
+++ b/cmd/ox/agent_query.go
@@ -347,6 +347,17 @@ func queryTeamContext(qa *queryArgs, projectRoot, agentID, agentType string) (*a
 			return nil, err
 		}
 		req.Teams = []string{teamID}
+		// A credential binds to a team, not a checkout, so this branch has no
+		// repo to name. Without asking for the team's ledgers, "search team
+		// knowledge" answers from team context alone and silently omits every
+		// session, plan, and murmur.
+		//
+		// Deliberately NOT set for every teams-only request, though the server
+		// accepts it from any caller: `--team` with no repo narrows the same
+		// way, but turning it on there would change results for callers who
+		// have them today. That is a separate decision from fixing a path that
+		// returns nothing at all.
+		req.IncludeTeamRepos = true
 	}
 
 	client := api.NewRepoClientWithEndpoint(ep).WithAuthToken(token.AccessToken)

--- a/cmd/ox/agent_query_test.go
+++ b/cmd/ox/agent_query_test.go
@@ -514,6 +514,8 @@ func TestQueryTeamContext_DefaultsTeamFromTeamBoundCredential(t *testing.T) {
 	assert.Equal(t, 1, *introspectHits, "expected the credential to be introspected exactly once")
 	assert.Equal(t, []string{"team_from_credential"}, queried.Teams,
 		"query must search the team the credential is bound to")
+	assert.True(t, queried.IncludeTeamRepos,
+		"a credential-derived team has no repo to name, so the team's ledgers must be requested explicitly")
 }
 
 // TestQueryTeamContext_PersonalCredentialKeepsInitError proves a credential
@@ -577,6 +579,8 @@ func TestQueryTeamContext_KnownTeamSkipsIntrospection(t *testing.T) {
 
 			assert.Equal(t, []string{tt.wantTeam}, queried.Teams)
 			assert.Zero(t, *introspectHits, "a known team must not trigger introspection")
+			assert.False(t, queried.IncludeTeamRepos,
+				"a caller that named its team must not silently pay for team-wide fan-out")
 		})
 	}
 }
@@ -649,4 +653,22 @@ func TestQueryTeamContext_IntrospectionFailureIsNotAnInitProblem(t *testing.T) {
 			assert.Empty(t, queried.Teams, "no query should have been sent")
 		})
 	}
+}
+
+// TestQueryRequest_IncludeTeamReposWireKey pins the JSON key the server reads.
+// Every other test round-trips through the same Go struct, so a typo in the tag
+// would serialize under the wrong name, be ignored by the server, and still
+// pass all of them — the field would be dead on the wire with green tests.
+func TestQueryRequest_IncludeTeamReposWireKey(t *testing.T) {
+	t.Parallel()
+
+	on, err := json.Marshal(api.QueryRequest{Query: "q", IncludeTeamRepos: true})
+	require.NoError(t, err)
+	assert.Contains(t, string(on), `"include_team_repos":true`)
+
+	// omitempty: an ordinary repo-scoped query must not carry the field at all,
+	// so the server keeps its own default rather than being told "false".
+	off, err := json.Marshal(api.QueryRequest{Query: "q"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(off), "include_team_repos")
 }

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -27,6 +27,13 @@ type QueryRequest struct {
 	Repos     []string `json:"repos"`                // repo IDs to search ledger indexes
 	AgentID   string   `json:"agent_id,omitempty"`   // querying agent instance (e.g. "Oxa7b3")
 	AgentType string   `json:"agent_type,omitempty"` // querying agent type (e.g. "claude-code")
+
+	// IncludeTeamRepos asks the server to fold the named teams' ledger indexes
+	// into a teams-only search. Without it a request carrying no Repos reaches
+	// team context alone — never a session, plan, or murmur. Opt-in on both
+	// sides: fan-out cost grows with team size, so a caller that already names
+	// its repo must not pay for it.
+	IncludeTeamRepos bool `json:"include_team_repos,omitempty"`
 }
 
 // QueryResponse represents the POST /api/v1/query response.


### PR DESCRIPTION
Follow-up to #841.

## What's still broken after #841

#841 taught `ox query` to resolve a team from a team-scoped credential, so it stops refusing to run outside an initialized repo. But the query it then sends carries a team and **no repo** — and a teams-only request reaches team context alone.

The result is a silent narrowing: no error, no warning, just a corpus missing every session, plan, and murmur. "Search your team's knowledge" quietly answers from a fraction of that knowledge.

```mermaid
flowchart LR
    A["ox query, credential-derived team"] --> B["teams: [T]<br/>repos: []"]
    B --> C{"include_team_repos?"}
    C -->|"omitted — before"| D["team context only<br/>no sessions / plans / murmurs"]
    C -->|"true — after"| E["team context + T's ledgers"]

    style D fill:#8b1a1a,color:#fff
    style E fill:#1a7f37,color:#fff
```

## What this PR ships

- **`internal/api/query.go`** — `IncludeTeamRepos bool` on `QueryRequest`, serialized as `include_team_repos`, `omitempty`.
- **`cmd/ox/agent_query.go`** — set it in the one branch that resolves a team from the credential. That branch has no repo by construction: a credential binds to a team, not a checkout.

Scope is deliberately narrow — it changes only the path that currently returns an incomplete corpus, and touches no existing caller.

### Two things worth a reviewer's attention

- **This is opt-in on both sides, and the CLI is the side that was never opting in.** The API field defaults off; nothing in the CLI set it, so the capability was unreachable from the only client that needs it.
- **`--team` with no repo narrows the same way, and this PR does NOT change it.** The API accepts the field from any caller — it keys on request shape, not credential family. Turning it on for every teams-only query would change results for callers who get them today; that is a separate decision from fixing a path that currently returns nothing at all. Recorded in a comment beside the code so the next reader doesn't mistake the narrow rule for the whole rule.

### Forward compatibility

Safe to merge ahead of the API side. No production request-decoding path uses `DisallowUnknownFields`, so a server without the field ignores it and behavior is exactly today's. There is no flag day.

## Test Plan

Both new assertions proven red before the change:

- `DefaultsTeamFromTeamBoundCredential` — extended to assert `IncludeTeamRepos` is **true** when the team came from the credential. Red as `Should be true`.
- `KnownTeamSkipsIntrospection` — asserts it is **false** for both a config-supplied and a `--team`-supplied team, so a caller that named its team never silently pays for fan-out.
- `QueryRequest_IncludeTeamReposWireKey` — pins the JSON key and the `omitempty` behavior.

That last one earns its place: every other test round-trips through the same Go struct, so a typo'd tag would serialize under the wrong name, be ignored by the server, and still pass all of them — a field dead on the wire with a green suite. Proven by typo'ing the tag: it failed with `"includeTeamRepos":true` does not contain `"include_team_repos":true` while the behavioral tests stayed green.

Gates: `go test ./cmd/ox/` (184s) and `./internal/api/` pass; `golangci-lint` 0 issues; `make docs-check` OK (no flag added, so no reference churn).

## Not in scope

End-to-end verification needs the API-side change live; that work is owned and tracked by its owners. This PR is the client half and is inert until then.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790577191&installation_model_id=433550&pr_number=842&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F842&signature=189d1c7f9537c3460caa2832dd1d253b56d0e7aea8ec6b16699124e420d8f011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

SageOx-Session: https://sageox.ai/c/ses_01a04be5-0730-79c7-aa3d-12ae8f24a09c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team-only searches can now include repository ledger results when the team is identified through credentials.
  * Added support for requesting team repository results through the query interface.

* **Bug Fixes**
  * Improved search behavior when team or repository details are not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->