### PR TITLE
telemetry: retire dead /tevents endpoint; post only when configured

### DIFF
--- a/internal/daemon/telemetry.go
+++ b/internal/daemon/telemetry.go
@@ -36,9 +36,6 @@ const (
 	// Prevents thundering herd: without this, every Record() call above the batch
 	// threshold spawns a new flush goroutine, creating unbounded HTTP POSTs.
 	telemetryFlushCooldown = 15 * time.Minute
-
-	// telemetryEndpoint is the default telemetry API endpoint
-	telemetryEndpoint = "https://telemetry.sageox.ai/tevents"
 )
 
 // TelemetryEvent matches the spec format for telemetry events.
@@ -81,12 +78,14 @@ type TelemetryCollector struct {
 // NewTelemetryCollector creates a new telemetry collector.
 // It loads or generates a persistent client ID and checks opt-out settings.
 func NewTelemetryCollector(logger *slog.Logger) *TelemetryCollector {
-	enabled := isTelemetryEnabled()
-
+	// No baked default: the old https://telemetry.sageox.ai/tevents never
+	// existed server-side, so every event silently vanished (retired — beads
+	// desktop-yx0h.5). Post only when an endpoint is explicitly configured via
+	// SAGEOX_TELEMETRY_ENDPOINT (the telemetry migration points this at the
+	// client OTLP ingress / Sentry); with none set the collector stays inert
+	// rather than POSTing into a 404.
 	endpoint := os.Getenv("SAGEOX_TELEMETRY_ENDPOINT")
-	if endpoint == "" {
-		endpoint = telemetryEndpoint
-	}
+	enabled := isTelemetryEnabled()
 
 	return &TelemetryCollector{
 		buffer:       make([]TelemetryEvent, telemetryBufferSize),
@@ -275,6 +274,16 @@ func (c *TelemetryCollector) backgroundSender() {
 
 // flush sends buffered events to the server.
 func (c *TelemetryCollector) flush() {
+	// No endpoint configured -> do not POST. The baked default
+	// (https://telemetry.sageox.ai/tevents) never existed server-side and every
+	// send silently 404'd (retired — beads desktop-yx0h.5). Leave events in the
+	// bounded ring buffer for a later-configured endpoint (the migration points
+	// SAGEOX_TELEMETRY_ENDPOINT at the client OTLP ingress) instead of draining
+	// them into a dead URL.
+	if c.endpoint == "" {
+		return
+	}
+
 	events := c.drainBuffer()
 	if len(events) == 0 {
 		return


### PR DESCRIPTION
## Summary

Closes a silent-failure class in the daemon: telemetry has been POSTing into a
**404 since launch**. The baked-in default endpoint
`https://telemetry.sageox.ai/tevents` never existed server-side, so every daemon
event was serialized, sent, and dropped on the floor — no signal, wasted work,
and a dead URL hard-coded into shipped binaries.

**What changed (`internal/daemon/telemetry.go`):**

- **Removed the baked default** `telemetryEndpoint` constant — the dead
  `/tevents` URL is gone from the binary.
- **Endpoint is now explicit-only:** `NewTelemetryCollector` reads
  `SAGEOX_TELEMETRY_ENDPOINT` and does not fall back to any default.
- **`flush()` is gated:** with no endpoint configured it returns early and
  leaves events in the bounded ring buffer, instead of draining them into a
  dead URL. A later-configured endpoint (the telemetry migration points
  `SAGEOX_TELEMETRY_ENDPOINT` at the client OTLP ingress) can then pick them up.
- **Recording behavior is unchanged** — opt-out, buffering, and ring semantics
  are untouched. Retires beads `desktop-yx0h.5`.

```mermaid
flowchart LR
    subgraph before["Before"]
        A[Record event] --> B[flush]
        B --> C["POST https://telemetry.sageox.ai/tevents"]
        C --> D["404 — silently dropped"]
    end
    subgraph after["After"]
        E[Record event] --> F[flush]
        F --> G{"SAGEOX_TELEMETRY_ENDPOINT set?"}
        G -->|no| H[Keep in bounded ring buffer]
        G -->|yes| I[POST to configured OTLP ingress]
    end
```

## Test Plan

- Existing `internal/daemon/telemetry_test.go` suite passes; the send path is
  still exercised by `TestTelemetryCollector_SendEvents_ToServer`, which sets an
  explicit test-server endpoint.
- Opt-out / ring-overflow / drain-order behavior unchanged and covered by
  existing tests.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — N/A: existing suite covers the send path; the change removes a dead default and adds an early-return guard.
- [x] CHANGELOG entry added (if user-facing) — N/A: daemon-internal telemetry; no user-observable behavior change (recording unchanged).
- [x] Breaking change documented — none.
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: `internal/daemon/telemetry.go` is outside the auto-review trigger set.

</details>

Co-authored-by: SageOx <ox@sageox.ai>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790580982&installation_model_id=433550&pr_number=843&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F843&signature=3931b8066e9bcba8fe2a1c9ccbdc58d93a3c5944bfe42d0b4390eba1550c981d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy & Control**
  * Telemetry is now disabled unless an endpoint is explicitly configured.
  * Buffered telemetry events are retained while telemetry is inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->