### PR TITLE
fix(codedb): fail-closed source-repo config guard + ox doctor core.bare repair (#819)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.14.2"
+      "version": "0.14.3"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -175,6 +175,15 @@ func init() {
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugSourceRepoBare,
+		Name:        "Source repo work tree",
+		Category:    "Git Repository Health",
+		FixLevel:    FixLevelAuto,
+		Description: "Repairs a managed checkout whose core.bare was flipped to true (issue #819)",
+		Run:         checkSourceRepoBareFlipped,
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
 		Slug:        CheckSlugGitConnectivity,
 		Name:        "Git connectivity",
 		Category:    "Git Repository Health",

--- a/cmd/ox/doctor_source_bare.go
+++ b/cmd/ox/doctor_source_bare.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+)
+
+// CheckSlugSourceRepoBare is the slug for the flipped-core.bare repair.
+const CheckSlugSourceRepoBare = "source-repo-bare"
+
+// checkSourceRepoBareFlipped detects and repairs a managed source checkout whose
+// core.bare was flipped to true — the issue #819 failure mode. When something
+// rewrites the project's (or its shared worktree hub's) .git/config with
+// core.bare=true, every work-tree git command (git status, git pull) then fails
+// with "fatal: this operation must be run in a work tree" until the value is
+// manually reset.
+//
+// A SageOx-managed project root is a WORKING checkout — never legitimately bare —
+// so core.bare=true there is always corruption. Repair restores core.bare=false
+// (the same one-liner affected users run by hand) and logs loudly, so a still-
+// active writer stays visible instead of being silently papered over.
+//
+// This is a defense-in-depth safety net, not the #819 root-cause fix: the guard
+// in internal/codedb/gitopen prevents codedb from writing the config, while this
+// recovers a checkout that was wedged by any writer (including one we have not
+// yet pinned down). See internal/codedb/gitopen and issue #819.
+//
+// Detection deliberately uses config.FindProjectRoot (walks up for .sageox/) and
+// `git config` reads — both work even when the repo is flipped bare. findGitRoot()
+// would fail on `git rev-parse --show-toplevel` for a bare repo and skip the very
+// checkout that is broken.
+//
+// The fix parameter is ignored: restoring a managed checkout's work-tree access
+// is always safe, so this runs unconditionally under FixLevelAuto.
+//
+// Failure prevented: a flipped core.bare wedges the user's checkout until they
+// manually run `git config core.bare false` (issue #819).
+func checkSourceRepoBareFlipped(_ bool) checkResult {
+	root := config.FindProjectRoot()
+	if root == "" {
+		return SkippedCheck("Source repo work tree", "not a SageOx project", "")
+	}
+	return repairSourceRepoBare(root)
+}
+
+// repairSourceRepoBare holds the detection + repair for a single project root,
+// split out so tests can drive it with a temp repo instead of the process CWD.
+func repairSourceRepoBare(root string) checkResult {
+	if !config.IsInitialized(root) {
+		return SkippedCheck("Source repo work tree", "not initialized", "")
+	}
+
+	bare, set := gitConfigBoolAt(root, "core.bare")
+	if !set || !bare {
+		// core.bare unset, false, or unreadable — a normal working checkout.
+		return PassedCheck("Source repo work tree", "work tree intact")
+	}
+
+	// core.bare=true on a managed working checkout IS the #819 corruption.
+	if err := setGitConfigAt(root, "core.bare", "false"); err != nil {
+		return FailedCheck("Source repo work tree",
+			"core.bare=true but repair failed",
+			fmt.Sprintf("run `git -C %s config core.bare false` manually: %v", root, err))
+	}
+	slog.Warn("repaired flipped core.bare on managed source checkout",
+		"repo", root, "issue", "819")
+	return WarningCheck("Source repo work tree",
+		"repaired core.bare=true → false (was wedging work-tree git commands)",
+		"issue #819 — if this recurs, capture daemon logs around the .git/config rewrite")
+}
+
+// gitConfigBoolAt reads a boolean git config value from repoRoot. Returns
+// (value, true) when the key is set and parses as bool, (false, false)
+// otherwise. A plain config read, so it works regardless of core.bare state
+// (unlike work-tree operations, which fail on a bare repo).
+func gitConfigBoolAt(repoRoot, key string) (value bool, set bool) {
+	out, err := exec.Command("git", "-C", repoRoot, "config", "--type=bool", "--get", key).Output()
+	if err != nil {
+		return false, false
+	}
+	return strings.TrimSpace(string(out)) == "true", true
+}
+
+// setGitConfigAt sets a git config value in repoRoot.
+func setGitConfigAt(repoRoot, key, value string) error {
+	return exec.Command("git", "-C", repoRoot, "config", key, value).Run()
+}

--- a/cmd/ox/doctor_source_bare_test.go
+++ b/cmd/ox/doctor_source_bare_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runGitForBareTest runs git in dir with a deterministic identity.
+func runGitForBareTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), // safe: git CLI in a temp dir needs inherited PATH
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+	return strings.TrimSpace(string(out))
+}
+
+// newProjectRepo builds an ox-initialized git checkout (a .git repo + a minimal
+// .sageox/config.json so config.IsInitialized is satisfied). If bare != "",
+// core.bare is set to it — "true" reproduces the #819 wedged state.
+func newProjectRepo(t *testing.T, bare string) string {
+	t.Helper()
+	root := t.TempDir()
+	runGitForBareTest(t, root, "init")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".sageox"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".sageox", "config.json"), []byte("{}\n"), 0o644))
+	if bare != "" {
+		runGitForBareTest(t, root, "config", "core.bare", bare)
+	}
+	return root
+}
+
+// TestRepairSourceRepoBare_RepairsFlippedCoreBare is the #819 safety net: a
+// managed checkout whose core.bare got flipped to true must be auto-repaired
+// back to false so work-tree git commands recover. Fails if the repair is
+// removed (core.bare stays true).
+func TestRepairSourceRepoBare_RepairsFlippedCoreBare(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git config ops")
+	}
+	root := newProjectRepo(t, "true")
+
+	res := repairSourceRepoBare(root)
+
+	assert.True(t, res.warning, "a repaired corruption must surface as a warning")
+	assert.Contains(t, res.message, "repaired")
+
+	got, set := gitConfigBoolAt(root, "core.bare")
+	require.True(t, set, "core.bare should still be set (to false)")
+	assert.False(t, got, "core.bare must be repaired to false")
+}
+
+// TestRepairSourceRepoBare_LeavesHealthyRepoAlone guards against false
+// positives: a normal checkout (core.bare unset) must pass untouched.
+func TestRepairSourceRepoBare_LeavesHealthyRepoAlone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git config ops")
+	}
+	root := newProjectRepo(t, "") // core.bare not set
+
+	res := repairSourceRepoBare(root)
+
+	assert.True(t, res.passed && !res.warning, "a healthy checkout must pass cleanly")
+	// git init writes core.bare=false explicitly; the check must leave it alone.
+	got, set := gitConfigBoolAt(root, "core.bare")
+	require.True(t, set, "git init sets core.bare")
+	assert.False(t, got, "healthy repo's core.bare must remain false (untouched)")
+}
+
+// TestRepairSourceRepoBare_SkipsNonProject: a git repo with no .sageox is not
+// ours to touch — even if its core.bare is true, we must not modify it.
+func TestRepairSourceRepoBare_SkipsNonProject(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git config ops")
+	}
+	root := t.TempDir()
+	runGitForBareTest(t, root, "init")
+	runGitForBareTest(t, root, "config", "core.bare", "true")
+
+	res := repairSourceRepoBare(root)
+
+	assert.True(t, res.skipped, "non-ox repo must be skipped")
+	got, _ := gitConfigBoolAt(root, "core.bare")
+	assert.True(t, got, "non-ox repo's core.bare must NOT be touched")
+}

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.3] - 2026-08-31
+
+Code indexing stays safe on every worktree layout, a wedged checkout repairs itself, and team-scoped credentials just work with `ox query`.
+
+### Improved
+
+- **`ox query` works out of the box with a team-scoped credential** — it infers your team and searches that team's ledgers, so you no longer need to pass `--team` explicitly.
+
+### Fixed
+
+- **Code indexing can never rewrite your repo's git config** — the indexer now opens your checkout read-only across every git worktree layout, so it can't flip `core.bare` or drop your worktree settings and leave `git status` / `git pull` failing.
+- **`ox doctor` repairs a checkout wedged into a bare state** — if `core.bare` gets flipped to true (the state where every work-tree git command fails with "must be run in a work tree"), doctor now detects and restores it automatically instead of leaving you to reset it by hand.
+- **Code indexing keeps recovering from a damaged cache** — a corrupt index rebuilds safely without losing data or crash-looping `ox`.
+
 ## [0.14.2] - 2026-08-25
 
 Resumed work stays connected, stale sessions clean up after themselves, AI coworkers navigate code more directly, code indexing self-heals, team rules recover reliably, and SageOx uses one calm visual language everywhere.

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,5 +13,5 @@
     "type": "git",
     "url": "https://github.com/sageox/ox.git"
   },
-  "version": "0.14.2"
+  "version": "0.14.3"
 }

--- a/internal/codedb/gitopen/gitopen.go
+++ b/internal/codedb/gitopen/gitopen.go
@@ -2,19 +2,29 @@
 // in a way that can NEVER rewrite that repository's .git/config.
 //
 // Why this exists (issue #819): codedb opens the managed source project repo
-// in place to read objects. go-git re-marshals config through the single
-// contract Storer.SetConfig, and across go-git v6 alpha snapshots that has
-// flipped core.bare, dropped extensions.worktreeConfig, and (in some snapshots)
-// persisted config as a side effect of *opening* a worktree repo. On a linked
-// worktree that silently flipped core.bare=true on the shared main .git/config,
-// breaking every work-tree git command until it was manually reset.
+// in place to read objects. go-git persists config through exactly one contract
+// — Storer.SetConfig — reached from Init, Clone, CreateRemote, tag ops, and
+// setIsBare (which flips core.bare=true). On the pinned go-git (v6 alpha) a
+// read-only open never reaches SetConfig, but a config round-trip there flips
+// core.bare and drops extensions.worktreeConfig, so any accidental write is
+// catastrophic: on a linked worktree it silently sets core.bare=true on the
+// shared main .git/config, breaking every work-tree git command until manually
+// reset.
 //
 // The daemon must never write the managed source repo's .git/config (see
-// .claude/rules/daemon-git.md). We enforce that structurally rather than
-// trusting any particular alpha's open path to be read-only: SetConfig — the
-// only path through which go-git persists config in every version — is a no-op
-// for these read-only opens. codedb only READS objects here, so denying the
-// write is always safe.
+// .claude/rules/daemon-git.md). We enforce that STRUCTURALLY and FAIL-CLOSED,
+// rather than trusting any particular go-git version's open path to be
+// read-only: every open here goes through a storer whose SetConfig is a no-op,
+// and GuardedPlainOpen has no unguarded fallback for any layout it might hand a
+// user repo to. codedb only READS objects, so denying the write is always safe.
+//
+// The #819 recurrence (issue reopened on v0.14.2) came from the one layout that
+// slipped past the guard: a "bare hub + git worktree add" checkout, where
+// commondir points directly at the bare hub (no ".git" wrapper). ResolveGitDir
+// mis-derived the root as its parent, so GuardedPlainOpen missed every guarded
+// branch and fell through to an unguarded git.PlainOpen on the shared hub
+// config. Both are fixed here: ResolveGitDir is bare-hub aware, and the
+// fallback is guarded.
 package gitopen
 
 import (
@@ -22,6 +32,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	billy "github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
@@ -54,55 +65,85 @@ func WrapReadOnlyConfig(s *filesystem.Storage) storage.Storer {
 }
 
 // GuardedPlainOpen is a drop-in replacement for git.PlainOpen for user-owned
-// repositories. It opens with config writes denied so #819 can never recur,
-// covering three layouts:
+// repositories. Every layout is opened with config writes denied so #819 can
+// never recur — there is no unguarded fallback:
 //   - a normal checkout (.git is a directory),
-//   - a linked worktree (.git is a file with a commondir → the shared main
-//     checkout, resolved by ResolveGitDir),
-//   - a submodule (.git is a file whose self-contained gitdir has no commondir).
+//   - a linked worktree off a non-bare main (.git is a file whose commondir
+//     resolves to "<root>/.git"; ResolveGitDir returns <root>),
+//   - a linked worktree off a BARE hub (.git is a file whose commondir resolves
+//     to the hub git dir itself; ResolveGitDir returns that hub dir) — the #819
+//     recurrence layout,
+//   - a submodule (.git is a file whose self-contained gitdir has no commondir),
+//   - a bare repository (path is itself the git dir, e.g. codedb's own cache
+//     clone).
 //
-// A bare repository (e.g. codedb's own cache clone) falls back to git.PlainOpen:
-// its config legitimately carries core.bare=true and it has no worktree/
-// extensions to lose, so it is not part of the #819 surface.
+// codedb only READS objects, so a config write is never needed for any of them;
+// guarding even the bare cache clone is harmless (SetConfig is unused on the
+// read path) and keeps the open path uniformly fail-closed.
 func GuardedPlainOpen(path string) (*git.Repository, error) {
-	// Normal repo, or a linked worktree resolved to its shared main checkout —
+	// Normal repo, or a linked worktree resolved to a non-bare main checkout —
 	// either way the resolved root has a real .git directory holding objects.
 	root, _ := ResolveGitDir(path)
 	if fi, err := os.Stat(filepath.Join(root, ".git")); err == nil && fi.IsDir() {
 		return openGuarded(filepath.Join(root, ".git"), root)
 	}
+	// The resolved root IS a git directory: a bare hub (resolved from a linked
+	// worktree, no .git wrapper — the #819 recurrence) or a bare cache clone
+	// opened directly. Guard it too rather than falling through unguarded.
+	if isGitDir(root) {
+		return openGuarded(root, "")
+	}
 	// A .git FILE that ResolveGitDir did not remap: a submodule, whose gitdir
-	// (e.g. .git/modules/<name>) is self-contained. Guard it directly rather
-	// than falling through to an unguarded open.
+	// (e.g. .git/modules/<name>) is self-contained.
 	if gitDir, ok := submoduleGitDir(path); ok {
 		return openGuarded(gitDir, path)
 	}
-	// Bare repo (path is itself the git dir) or unresolvable layout.
-	return git.PlainOpen(path)
+	// Unresolvable layout: still open GUARDED (fail-closed) rather than handing
+	// go-git a config-writable handle to a user repo. Worst case this errors as
+	// "repository does not exist" — never a silent config rewrite (#819).
+	return openGuarded(path, "")
 }
 
-// openGuarded opens the repo whose git directory is dotDir and worktree is
-// wtDir, with config writes denied.
+// openGuarded opens the repo whose git directory is dotDir with config writes
+// denied. wtDir is the worktree root, or "" for a bare repo (no worktree
+// filesystem — codedb reads objects only, so no worktree is required).
 func openGuarded(dotDir, wtDir string) (*git.Repository, error) {
 	dot := osfs.New(dotDir, osfs.WithBoundOS())
-	wt := osfs.New(wtDir, osfs.WithBoundOS())
 	s := filesystem.NewStorage(dotgit.NewRepositoryFilesystem(dot, nil), cache.NewObjectLRUDefault())
+	var wt billy.Filesystem
+	if wtDir != "" {
+		wt = osfs.New(wtDir, osfs.WithBoundOS())
+	}
 	return git.Open(readOnlyConfigStorer{s}, wt)
+}
+
+// isGitDir reports whether dir is itself a git directory (a bare repo, or the
+// shared .git a worktree hub points at): it holds a HEAD file and an objects
+// directory. Used to guard the bare-hub / bare-cache open paths that would
+// otherwise fall through to an unguarded open.
+func isGitDir(dir string) bool {
+	if fi, err := os.Stat(filepath.Join(dir, "HEAD")); err != nil || fi.IsDir() {
+		return false
+	}
+	if fi, err := os.Stat(filepath.Join(dir, "objects")); err != nil || !fi.IsDir() {
+		return false
+	}
+	return true
 }
 
 // ResolveGitDir returns the path to open with go-git and whether it is a linked
 // worktree. For linked worktrees (where .git is a file containing "gitdir: ..."
-// AND the target has a commondir), it follows commondir to the main repo's root
-// so go-git can access the shared object store. For normal repos, submodules, or
-// anything unresolvable, returns the path unchanged.
+// AND the target has a commondir), it follows commondir to the shared object
+// store so go-git can read it. For normal repos, submodules, or anything
+// unresolvable, returns the path unchanged.
 func ResolveGitDir(repoPath string) (string, bool) {
 	worktreeGitDir, ok := gitdirTarget(repoPath)
 	if !ok {
 		return repoPath, false // normal repo, no .git, or unreadable .git file
 	}
 
-	// A linked worktree has a commondir pointing at the shared .git; a submodule
-	// does not (its gitdir is self-contained and is handled by GuardedPlainOpen).
+	// A linked worktree has a commondir pointing at the shared git dir; a
+	// submodule does not (its gitdir is self-contained, handled by GuardedPlainOpen).
 	commondirFile := filepath.Join(worktreeGitDir, "commondir")
 	commondirBytes, err := os.ReadFile(commondirFile)
 	if err != nil {
@@ -112,9 +153,21 @@ func ResolveGitDir(repoPath string) (string, bool) {
 	if !filepath.IsAbs(commondir) {
 		commondir = filepath.Join(worktreeGitDir, commondir)
 	}
+	commondir = filepath.Clean(commondir)
 
-	// commondir points to the main .git dir; the repo root is its parent
-	return filepath.Dir(commondir), true
+	// commondir points at the SHARED git directory. Two layouts diverge here:
+	//   - non-bare main checkout: commondir is "<root>/.git", so the repo root
+	//     (whose ".git" subdir GuardedPlainOpen opens) is its parent.
+	//   - bare hub (git init --bare + git worktree add, often with a manual
+	//     `git config core.bare false`): commondir IS the hub git dir itself
+	//     (e.g. "<name>.git"), with no ".git" wrapper — its parent is WRONG.
+	//     Taking the parent here was the #819 recurrence: GuardedPlainOpen then
+	//     missed every guarded branch and fell through to an unguarded open on
+	//     the shared hub config.
+	if filepath.Base(commondir) == ".git" {
+		return filepath.Dir(commondir), true
+	}
+	return commondir, true
 }
 
 // submoduleGitDir returns the self-contained gitdir a submodule's ".git" file

--- a/internal/codedb/index/gogit_readonly_config_test.go
+++ b/internal/codedb/index/gogit_readonly_config_test.go
@@ -305,3 +305,51 @@ func TestGuardedOpen_Submodule_PreservesConfig(t *testing.T) {
 	assert.Equal(t, string(snap), string(after),
 		"submodule .git/modules/<name>/config must be byte-identical (#819)")
 }
+
+// TestGuardedOpen_BareHubWorktree_PreservesSharedConfig covers the #819
+// RECURRENCE (issue reopened on v0.14.2): a linked worktree off a BARE hub
+// (git init --bare, core.bare manually false, worktreeConfig extension, an [lfs]
+// section) — the layout where commondir resolves directly to the hub git dir
+// with no ".git" wrapper. Before the fix, ResolveGitDir mis-derived the root as
+// the hub's parent, so GuardedPlainOpen missed every guarded branch and fell
+// through to an unguarded git.PlainOpen; a config write then flipped
+// core.bare=true and dropped extensions.worktreeConfig on the SHARED hub config,
+// breaking every work-tree git command until manually reset.
+//
+// Fails without the fail-closed guard (unguarded open lets the write land),
+// passes with it (SetConfig is a no-op) — the version-independent proof that the
+// bare-hub open is now guarded.
+func TestGuardedOpen_BareHubWorktree_PreservesSharedConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: bare-hub git worktree operations")
+	}
+	hubDir, worktreeDir := createBareHubWorktree(t)
+
+	// give the shared hub config the reported bug shape: an [lfs] section that
+	// go-git preserves while it drops worktreeConfig and flips core.bare.
+	hubCfg := filepath.Join(hubDir, "config")
+	base, err := os.ReadFile(hubCfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(hubCfg,
+		[]byte(string(base)+"[lfs]\n\trepositoryformatversion = 0\n"), 0o644))
+	snap, err := os.ReadFile(hubCfg)
+	require.NoError(t, err)
+
+	repo, err := gitopen.GuardedPlainOpen(worktreeDir)
+	require.NoError(t, err)
+	cfg, err := repo.Storer.Config()
+	require.NoError(t, err)
+	// drive the exact corruption: flip core.bare, and clear worktreeConfig so
+	// go-git writes the whole BASE hub config (its worktreeConfig=true path would
+	// instead route a delta to config.worktree). The guard must swallow it.
+	cfg.Core.IsBare = true
+	cfg.Extensions.WorktreeConfig = false
+	require.NoError(t, repo.Storer.SetConfig(cfg)) // guarded → no-op
+	require.NoError(t, repo.Close())
+
+	after, err := os.ReadFile(hubCfg)
+	require.NoError(t, err)
+	assert.Equal(t, string(snap), string(after),
+		"bare-hub shared config must be byte-identical (#819 recurrence)")
+}

--- a/internal/codedb/index/worktree_test.go
+++ b/internal/codedb/index/worktree_test.go
@@ -127,6 +127,62 @@ func TestResolveGitDir_LinkedWorktree(t *testing.T) {
 	assert.Equal(t, expectedDir, actualDir, "should resolve to main repo root")
 }
 
+// createBareHubWorktree builds the #819 recurrence layout: a BARE hub repo
+// (git init --bare) with core.bare manually set false and the worktreeConfig
+// extension, plus one linked worktree added from it. Returns the hub git dir and
+// the worktree path. In this layout commondir resolves directly to the hub (no
+// ".git" wrapper), so filepath.Dir(commondir) points one level too high — the
+// shape that slipped past the codedb config guard.
+func createBareHubWorktree(t *testing.T) (hubDir, worktreeDir string) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("short: bare-hub git worktree operations")
+	}
+	runGit := gitRunner(t)
+	base := t.TempDir()
+
+	hubDir = filepath.Join(base, "hub.git")
+	runGit(base, "init", "--bare", hubDir)
+
+	// seed a commit so `git worktree add` has a ref to check out
+	seed := filepath.Join(base, "seed")
+	runGit(base, "clone", hubDir, seed)
+	runGit(seed, "commit", "--allow-empty", "-m", "init")
+	runGit(seed, "push", "origin", "HEAD:refs/heads/main")
+
+	// add the linked worktree while the hub is still bare (main is free); a
+	// non-bare hub would "occupy" main and reject the add.
+	worktreeDir = filepath.Join(base, "wt")
+	runGit(hubDir, "worktree", "add", worktreeDir, "main")
+
+	// now apply the bare-hub-as-worktree-hub trick on the shared config:
+	// core.bare=false + worktreeConfig extension (requires format version 1).
+	runGit(hubDir, "config", "core.repositoryformatversion", "1")
+	runGit(hubDir, "config", "core.bare", "false")
+	runGit(hubDir, "config", "extensions.worktreeConfig", "true")
+	return hubDir, worktreeDir
+}
+
+// TestResolveGitDir_BareHubWorktree pins the #819 recurrence root cause: a
+// worktree off a bare hub must resolve to the hub git dir itself, not to
+// filepath.Dir(commondir). Before the fix this returned the hub's parent, which
+// dropped GuardedPlainOpen onto its unguarded fallback.
+func TestResolveGitDir_BareHubWorktree(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git worktree operations")
+	}
+	hubDir, worktreeDir := createBareHubWorktree(t)
+
+	path, isWorktree := resolveGitDir(worktreeDir)
+	assert.True(t, isWorktree, "bare-hub worktree must be detected as a linked worktree")
+
+	expected, _ := filepath.EvalSymlinks(hubDir)
+	actual, _ := filepath.EvalSymlinks(path)
+	assert.Equal(t, expected, actual,
+		"bare-hub worktree must resolve to the hub git dir, not filepath.Dir(commondir)")
+}
+
 func TestResolveGitDir_NoGit(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.14.2"
+	Version   = "0.14.3"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
Running the code indexer on a git worktree checkout can no longer corrupt your repository's `.git/config`, and if a checkout ever does get wedged into a bare state, `ox doctor` now repairs it automatically instead of leaving you to reset it by hand.

## What broke (issue #819, reopened on v0.14.2)

A customer running the daemon on a worktree checkout saw its shared `.git/config` intermittently rewritten with `core.bare = true` (and `extensions.worktreeConfig` dropped) — after which every work-tree git command (`git status`, `git pull`) failed with *"fatal: this operation must be run in a work tree"* until manually reset. PR #820 hardened the right package (`internal/codedb/gitopen`) but missed one checkout layout.

**Root cause of the recurrence:** `ResolveGitDir` derived a worktree's root as `filepath.Dir(commondir)`. That's correct for a normal `git worktree add`, but wrong for a **bare hub + worktree** layout (`git init --bare`, then `core.bare=false` + `worktreeConfig`, then `git worktree add`) — there `commondir` resolves *directly* to the bare hub, with no `.git` wrapper. The bad root made `GuardedPlainOpen` miss every guarded branch and fall through to an **unguarded `git.PlainOpen`** on the shared hub config.

```mermaid
flowchart TD
    A[daemon opens worktree checkout] --> B{ResolveGitDir}
    B -->|normal worktree<br/>commondir = root/.git| C[root = parent ✓]
    B -->|bare-hub worktree<br/>commondir = hub.git| D["root = filepath.Dir(hub.git) ✗<br/>(one level too high)"]
    C --> E[openGuarded: SetConfig no-op]
    D --> F[misses guarded branches]
    F --> G["git.PlainOpen (UNGUARDED)"]
    G --> H["shared hub config writable →<br/>core.bare flipped true, worktreeConfig dropped"]
    E --> I[config byte-identical ✓]
```

> **Note on scope (honest):** on the go-git we pin (`v6.0.0-alpha.4`), a read-only open never calls `SetConfig`, and codedb only reads objects — so we could not reproduce a codedb path that *writes* the config on this version. This PR closes a real, proven guard gap and makes the open path fail-closed; it does **not** claim to be the confirmed cause of the customer's recurrence. Issue #819 stays open pending customer diagnostics (daemon reported version vs. install time; exact repo layout). The `ox doctor` repair below protects the user regardless of which writer is at fault.

## What this PR ships

- **Fail-closed `GuardedPlainOpen`** (`internal/codedb/gitopen/gitopen.go`) — every layout (normal, worktree-off-nonbare-main, worktree-off-bare-hub, submodule, bare cache) now opens through the no-op-`SetConfig` guard. The unguarded `git.PlainOpen` fallback is gone; an unresolvable layout opens guarded (worst case: a benign "repository does not exist", never a silent config rewrite).
- **Bare-hub-aware `ResolveGitDir`** — when `commondir` is a bare hub (its base isn't `.git`), it's used directly instead of taking its parent.
- **`ox doctor` safety net** (`cmd/ox/doctor_source_bare.go`) — a `FixLevelAuto` check that detects a managed checkout whose `core.bare` was flipped to `true` and restores it to `false`, logging loudly so a still-active writer stays visible. Detection uses `.sageox/`-walk + `git config` reads, which work even when the repo is wedged bare (`findGitRoot`'s `--show-toplevel` would fail on a bare repo and skip the very repo that's broken).

## Test Plan (red-first, both proven)

- `TestGuardedOpen_BareHubWorktree_PreservesSharedConfig` + `TestResolveGitDir_BareHubWorktree` — reverting the fix reproduces the exact symptom (`bare = false` → `bare = true` on the shared hub config, whole-file re-serialized, `[lfs]` preserved); with the fix, byte-identical. Existing normal-worktree and submodule guard tests stay green.
- `TestRepairSourceRepoBare_*` — repairs a flipped `core.bare`, leaves a healthy checkout untouched, and skips non-ox repos. Neutering the repair turns the repair test red.
- `make check-codedb-guarded-open`, `go vet`, `golangci-lint` (changed files), `make verify-version` — all clean.

## Release

Bundled as **0.14.3** (version bump + CHANGELOG) alongside the pending team-ledger `ox query` improvement and continued codedb cache self-heal hardening.

Addresses #819 (hardening + auto-repair). Keeping #819 open until the customer confirms the recurrence stops.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790793000&installation_model_id=433550&pr_number=844&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F844&signature=99fa9c3bb4346b81508e44bad0e0f954c2f008e99b80af9b23868bc4b49e68b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic repair for managed repositories incorrectly configured as bare.
  * Improved support for indexing linked worktrees and bare Git repositories without changing shared configuration.
  * Added safeguards for recovering from repository configuration issues.

* **Bug Fixes**
  * Corrected Git repository path resolution for linked worktrees and bare hubs.

* **Release**
  * Updated the product version to 0.14.3 and added release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->