### PR TITLE
feat(notice): per-line update-notice ledger, daily cap, agent silence

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -42,6 +42,7 @@ import (
 	"github.com/sageox/ox/internal/tips"
 	"github.com/sageox/ox/internal/tokens"
 	"github.com/sageox/ox/internal/ui"
+	"github.com/sageox/ox/internal/updatenotice"
 	"github.com/sageox/ox/internal/useragent"
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 	"github.com/spf13/cobra"
@@ -899,19 +900,32 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	// check for version updates from daemon cache (pure file read, ~0ms)
+	// Check for version updates from the daemon cache (pure file read, ~0ms).
+	//
+	// UpdateAvailable/LatestVersion are DATA — always present, because anything
+	// parsing prime's output asked for them. UpdateHint and the UserNotices
+	// entry are the NOTICE: they instruct the AI coworker to raise the upgrade
+	// with the human out loud, so they go through the same ledger that caps the
+	// terminal tiers. Prime is where the calm tier lands when stderr belongs to
+	// an agent, so it carries the fact once per release line per day instead of
+	// on every prime.
 	if vResult := checkVersionFromCache(); vResult != nil {
 		output.UpdateAvailable = true
 		output.LatestVersion = vResult.LatestVersion
-		output.UpdateHint = fmt.Sprintf(
-			"ox v%s -> v%s is available. Offer to run 'ox upgrade' for the coworker — "+
-				"it upgrades in place for Homebrew, go install, and direct (install.sh) installs.",
-			vResult.CurrentVersion, vResult.LatestVersion,
-		)
-		output.UserNotices = append(output.UserNotices, UserNotice{
-			Type:    "upgrade",
-			Message: output.UpdateHint,
-		})
+
+		now := time.Now()
+		if line, due := updateNoticeDue(now); due {
+			output.UpdateHint = fmt.Sprintf(
+				"ox v%s -> v%s is available. Offer to run 'ox upgrade' for the coworker — "+
+					"it upgrades in place for Homebrew, go install, and direct (install.sh) installs.",
+				vResult.CurrentVersion, vResult.LatestVersion,
+			)
+			output.UserNotices = append(output.UserNotices, UserNotice{
+				Type:    "upgrade",
+				Message: output.UpdateHint,
+			})
+			updatenotice.RecordNotified(line, now)
+		}
 	}
 
 	// add support notice to user notices if present

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sageox/ox/internal/status"
 	"github.com/sageox/ox/internal/tips"
 	"github.com/sageox/ox/internal/tui"
+	"github.com/sageox/ox/internal/updatenotice"
 	"github.com/sageox/ox/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -1620,24 +1621,22 @@ daemon health, and a tree view of all SageOx directory locations.`,
 			fmt.Print(renderAgentTasksSection(gitRoot))
 		}
 
-		// show version update notice if available. refreshVersionCacheIfStale
-		// does a bounded live check so the notice reaches coworkers who never
-		// run the daemon (the daemon is otherwise the only cache writer).
+		// Calm update notice. refreshVersionCacheIfStale does a bounded live
+		// check so the notice reaches coworkers who never run the daemon (the
+		// daemon is otherwise the only cache writer).
+		//
+		// One dim line, at most once per release line per day, and only with a
+		// human watching. The old block printed a bold "Update available"
+		// banner, a hint line, AND an inline "Upgrade ox now?" prompt on every
+		// single `ox status` — three interruptions repeating forever for one
+		// fact. Dim rather than warning-colored on purpose: an available
+		// upgrade is news, not an alarm.
 		if vResult := refreshVersionCacheIfStale(6 * time.Hour); vResult != nil {
-			fmt.Printf("\n%s  %s\n",
-				statusWarningStyle.Render("Update available"),
-				fmt.Sprintf("v%s → v%s", vResult.CurrentVersion, vResult.LatestVersion),
-			)
-			// make the notice actionable rather than a dead string: offer to
-			// run the upgrade right here when we're at an interactive terminal.
-			if cli.IsInteractive() && !cfg.Quiet {
-				if cli.ConfirmYesNo("Upgrade ox now?", false) {
-					_ = runUpgrade(upgradeCmd, nil)
-				} else {
-					fmt.Printf("%s\n", cli.StyleDim.Render("Run 'ox upgrade' when you're ready."))
-				}
-			} else {
-				fmt.Printf("%s\n", cli.StyleDim.Render("Run 'ox upgrade' to update."))
+			now := time.Now()
+			if line, due := calmUpdateNoticeDue(now); due {
+				fmt.Printf("\n%s\n", cli.StyleDim.Render(
+					formatCalmUpdateNotice(vResult.LatestVersion, vResult.CurrentVersion)))
+				updatenotice.RecordNotified(line, now)
 			}
 		}
 
@@ -1837,8 +1836,12 @@ func buildStatusJSON(authenticated bool, authErr error, token *auth.StoredToken,
 		}
 	}
 
-	// version section — refresh the cache lazily (bounded live check) so
+	// Version section — refresh the cache lazily (bounded live check) so
 	// daemon-less coworkers still see update availability in JSON output.
+	//
+	// Deliberately NOT gated by the notice ledger: this is a field a caller
+	// explicitly asked for, not an interruption. Nor does it stamp the ledger —
+	// a machine reading JSON has not told the human anything.
 	currentVersion := strings.TrimPrefix(version.Version, "v")
 	vJSON := &statusVersionJSON{Current: currentVersion}
 	if vResult := refreshVersionCacheIfStale(6 * time.Hour); vResult != nil {

--- a/cmd/ox/upgrade.go
+++ b/cmd/ox/upgrade.go
@@ -124,8 +124,9 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 		return outputUpgradeResult(cmd, result, jsonOutput)
 	}
 
-	// clear version cache so next check picks up new version
-	_ = os.Remove(versionCacheFile)
+	// clear version cache (and the notice ledger with it) so the next check
+	// starts from a clean slate
+	clearVersionCacheAfterUpgrade()
 
 	result.Status = "upgraded"
 	result.Message = fmt.Sprintf("Upgraded to v%s", vResult.LatestVersion)

--- a/cmd/ox/version_cache.go
+++ b/cmd/ox/version_cache.go
@@ -1,26 +1,18 @@
 package main
 
 import (
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/updatenotice"
 	"github.com/sageox/ox/internal/version"
 )
 
-// versionCacheFile is the path to the version cache file.
-// Package-level var so tests can override with t.TempDir().
-var versionCacheFile = filepath.Join(paths.CacheDir(), "version-check.json")
-
-// versionCacheData matches the daemon's cache format for latest version info.
-type versionCacheData struct {
-	LatestVersion string    `json:"latest_version"`
-	CheckedAt     time.Time `json:"checked_at"`
-	ETag          string    `json:"etag,omitempty"`
-}
+// versionCacheData is the on-disk version cache plus the notice ledger.
+// Aliased rather than redeclared so exactly one struct describes this file — a
+// second copy is how a writer silently drops the ledger fields and restores the
+// per-command nag.
+type versionCacheData = updatenotice.Data
 
 // versionCheckResult holds the outcome of comparing cached version against current.
 type versionCheckResult struct {
@@ -29,47 +21,36 @@ type versionCheckResult struct {
 	CurrentVersion  string
 }
 
-// readVersionCache reads the daemon-written version cache file.
+// readVersionCache reads the version cache file.
 // Returns nil on any error (missing file, corrupt JSON, etc.).
 func readVersionCache() *versionCacheData {
-	data, err := os.ReadFile(versionCacheFile)
-	if err != nil {
-		return nil
-	}
-	var cache versionCacheData
-	if err := json.Unmarshal(data, &cache); err != nil {
-		return nil
-	}
-	return &cache
+	return updatenotice.Read()
 }
 
 // writeVersionCacheFromDoctor writes the version cache as a side effect of doctor's
 // live GitHub check. This warms the cache for prime even when the daemon isn't running.
 func writeVersionCacheFromDoctor(latestVersion string) {
-	cachePath := versionCacheFile
-
-	// read existing cache to preserve ETag if present
-	existing := readVersionCache()
 	data := &versionCacheData{
 		LatestVersion: latestVersion,
 		CheckedAt:     time.Now(),
 	}
-	if existing != nil {
+	// Preserve the ETag (so the next conditional request keeps its advantage)
+	// AND the notice ledger: a routine version refresh must not erase the
+	// coworker's memory of having already been told.
+	if existing := updatenotice.Read(); existing != nil {
 		data.ETag = existing.ETag
+		updatenotice.CarryLedger(data, existing)
 	}
+	_ = updatenotice.Write(data)
+}
 
-	raw, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return
-	}
-
-	dir := filepath.Dir(cachePath)
-	_ = os.MkdirAll(dir, 0700)
-	tmpPath := cachePath + ".tmp"
-	if err := os.WriteFile(tmpPath, raw, 0600); err != nil {
-		return
-	}
-	_ = os.Rename(tmpPath, cachePath)
+// clearVersionCacheAfterUpgrade drops the cache — ledger included — after a
+// successful `ox upgrade`. Both must go: the running process still reports its
+// OLD compiled-in version, so a surviving cache would keep claiming an update
+// is available, and a surviving ledger would suppress the FIRST notice about
+// the next release line.
+func clearVersionCacheAfterUpgrade() {
+	updatenotice.Reset()
 }
 
 // refreshVersionCacheIfStale ensures the version cache is reasonably fresh

--- a/cmd/ox/version_cache_test.go
+++ b/cmd/ox/version_cache_test.go
@@ -7,26 +7,27 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/updatenotice"
 	"github.com/sageox/ox/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// useTestCacheDir redirects versionCacheFile to a temp directory for the
+// useTestCacheDir redirects the version cache to a temp directory for the
 // duration of the test, preventing writes to the real ~/.cache/sageox/.
 func useTestCacheDir(t *testing.T) {
 	t.Helper()
-	old := versionCacheFile
-	versionCacheFile = filepath.Join(t.TempDir(), "version-check.json")
-	t.Cleanup(func() { versionCacheFile = old })
+	old := updatenotice.Path
+	updatenotice.Path = filepath.Join(t.TempDir(), "version-check.json")
+	t.Cleanup(func() { updatenotice.Path = old })
 }
 
 func writeTestVersionCache(t *testing.T, data *versionCacheData) {
 	t.Helper()
-	require.NoError(t, os.MkdirAll(filepath.Dir(versionCacheFile), 0700))
+	require.NoError(t, os.MkdirAll(filepath.Dir(updatenotice.Path), 0700))
 	raw, err := json.MarshalIndent(data, "", "  ")
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(versionCacheFile, raw, 0600))
+	require.NoError(t, os.WriteFile(updatenotice.Path, raw, 0600))
 }
 
 // core semver comparison logic — the double-digit case (0.12 vs 0.9) catches
@@ -150,8 +151,8 @@ func TestRefreshVersionCacheIfStale_StaleCacheRefetches(t *testing.T) {
 // corrupt cache must not crash prime — graceful degradation
 func TestCheckVersionFromCache_CorruptFile(t *testing.T) {
 	useTestCacheDir(t)
-	require.NoError(t, os.MkdirAll(filepath.Dir(versionCacheFile), 0700))
-	require.NoError(t, os.WriteFile(versionCacheFile, []byte("{{bad json"), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Dir(updatenotice.Path), 0700))
+	require.NoError(t, os.WriteFile(updatenotice.Path, []byte("{{bad json"), 0600))
 
 	assert.Nil(t, checkVersionFromCache())
 }

--- a/cmd/ox/version_notice.go
+++ b/cmd/ox/version_notice.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sageox/ox/internal/updatenotice"
+	"github.com/sageox/ox/internal/version"
+)
+
+// updateNoticeDue answers "may we bring up the available upgrade right now?"
+// and returns the release line to stamp once we have.
+//
+// Callers stamp with updatenotice.RecordNotified(line, now) only AFTER the
+// notice actually reaches someone — a notice we decided not to show must not
+// consume the day's budget.
+func updateNoticeDue(now time.Time) (line string, due bool) {
+	line = updatenotice.Line(version.Version)
+	return line, updatenotice.ShouldNotify(readVersionCache(), line, now)
+}
+
+// calmUpdateNoticeDue is updateNoticeDue plus the audience check, for the calm
+// tier (the GitHub-derived "update available" line in `ox status`).
+//
+// The calm tier is strictly for a human at a terminal. Inside a coding agent
+// both streams land in the transcript, where an upgrade nudge costs context
+// tokens on every command; `ox agent prime` carries the same fact as structured
+// data instead, which the agent can act on without it being shouted.
+func calmUpdateNoticeDue(now time.Time) (line string, due bool) {
+	if updatenotice.Suppressed() {
+		return "", false
+	}
+	return updateNoticeDue(now)
+}
+
+// formatCalmUpdateNotice renders the calm tier's one and only line. The urgent
+// tier's copy belongs to the server (it is the X-SageOx-Deprecated value,
+// printed verbatim); this is the client-owned half.
+func formatCalmUpdateNotice(latest, current string) string {
+	return fmt.Sprintf("→ ox %s available (you're on %s) — run 'ox upgrade'", latest, current)
+}

--- a/cmd/ox/version_notice_test.go
+++ b/cmd/ox/version_notice_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/updatenotice"
+	"github.com/sageox/ox/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// atTerminal puts a human at stderr and clears machine-output mode, so a test
+// exercises the cadence rather than the audience gate. Neither is true under
+// `go test`, where stderr is a pipe.
+func atTerminal(t *testing.T) {
+	t.Helper()
+	old := updatenotice.StderrIsTTY
+	updatenotice.StderrIsTTY = func() bool { return true }
+	updatenotice.SetMachineOutput(false)
+	t.Cleanup(func() { updatenotice.StderrIsTTY = old })
+}
+
+// The calm "update available" line is the surface a coworker sees dozens of
+// times a day. First sight speaks; everything inside the cap is silent.
+func TestCalmUpdateNoticeDue_SpeaksOnceThenStaysQuiet(t *testing.T) {
+	useTestCacheDir(t)
+	atTerminal(t)
+	writeTestVersionCache(t, &versionCacheData{
+		LatestVersion: "v99.0.0",
+		CheckedAt:     time.Now(),
+	})
+
+	now := time.Now()
+	line, due := calmUpdateNoticeDue(now)
+	require.True(t, due, "first sight of a release line must speak")
+	assert.Equal(t, "99.0", line)
+	updatenotice.RecordNotified(line, now)
+
+	_, due = calmUpdateNoticeDue(now.Add(1 * time.Hour))
+	assert.False(t, due, "an hour later, same line — stay quiet")
+	_, due = calmUpdateNoticeDue(now.Add(updatenotice.NotifyInterval - time.Minute))
+	assert.False(t, due, "still inside the cap — stay quiet")
+
+	_, due = calmUpdateNoticeDue(now.Add(updatenotice.NotifyInterval + time.Minute))
+	assert.True(t, due, "past the cap — speak again")
+}
+
+// A newly published release line is news; news is never capped.
+func TestCalmUpdateNoticeDue_NewReleaseLineResetsTheCap(t *testing.T) {
+	useTestCacheDir(t)
+	atTerminal(t)
+	now := time.Now()
+
+	writeTestVersionCache(t, &versionCacheData{LatestVersion: "v98.0.0", CheckedAt: now})
+	line, due := calmUpdateNoticeDue(now)
+	require.True(t, due)
+	require.Equal(t, "98.0", line)
+	updatenotice.RecordNotified(line, now)
+
+	// 99.0 ships one minute later — the cap must not swallow the announcement
+	writeTestVersionCache(t, &versionCacheData{
+		LatestVersion:  "v99.0.0",
+		CheckedAt:      now,
+		LastNaggedLine: "98.0",
+		LastNaggedAt:   now,
+	})
+	line, due = calmUpdateNoticeDue(now.Add(time.Minute))
+	assert.True(t, due, "a new release line must speak immediately")
+	assert.Equal(t, "99.0", line)
+
+	// a patch on the SAME line is not news
+	writeTestVersionCache(t, &versionCacheData{
+		LatestVersion:  "v99.0.1",
+		CheckedAt:      now,
+		LastNaggedLine: "99.0",
+		LastNaggedAt:   now,
+	})
+	_, due = calmUpdateNoticeDue(now.Add(time.Minute))
+	assert.False(t, due, "a patch release on a line we already announced is not news")
+}
+
+// The calm tier must never reach an agent transcript or a machine-output
+// stream — and a suppressed notice must not consume the day's budget, or the
+// human who runs ox at a terminal later gets told nothing.
+func TestCalmUpdateNoticeDue_SilentForAgentsAndMachineOutput(t *testing.T) {
+	useTestCacheDir(t)
+	writeTestVersionCache(t, &versionCacheData{LatestVersion: "v99.0.0", CheckedAt: time.Now()})
+	now := time.Now()
+
+	oldTTY := updatenotice.StderrIsTTY
+	t.Cleanup(func() {
+		updatenotice.StderrIsTTY = oldTTY
+		updatenotice.SetMachineOutput(false)
+	})
+
+	// stderr captured by a coding agent
+	updatenotice.StderrIsTTY = func() bool { return false }
+	updatenotice.SetMachineOutput(false)
+	_, due := calmUpdateNoticeDue(now)
+	assert.False(t, due, "an agent-captured stderr must see no calm notice")
+
+	// --json / --text
+	updatenotice.StderrIsTTY = func() bool { return true }
+	updatenotice.SetMachineOutput(true)
+	_, due = calmUpdateNoticeDue(now)
+	assert.False(t, due, "machine-output mode must see no calm notice")
+
+	// nothing was stamped, so a human at a terminal still gets told
+	assert.True(t, readVersionCache().LastNaggedAt.IsZero(), "suppression must not stamp the ledger")
+	assert.Empty(t, readVersionCache().LastNaggedLine)
+	updatenotice.SetMachineOutput(false)
+	_, due = calmUpdateNoticeDue(now)
+	assert.True(t, due, "suppressed notices must not consume the ledger")
+}
+
+// `ox agent prime` is the designated once-carrier: its structured output
+// deliberately bypasses the TTY gate (prime IS machine output) but still obeys
+// the cadence, so an agent hears about an upgrade once a day, not every prime.
+func TestUpdateNoticeDue_PrimeIgnoresTTYButObeysTheCap(t *testing.T) {
+	useTestCacheDir(t)
+	writeTestVersionCache(t, &versionCacheData{LatestVersion: "v99.0.0", CheckedAt: time.Now()})
+
+	oldTTY := updatenotice.StderrIsTTY
+	updatenotice.StderrIsTTY = func() bool { return false }
+	updatenotice.SetMachineOutput(true)
+	t.Cleanup(func() {
+		updatenotice.StderrIsTTY = oldTTY
+		updatenotice.SetMachineOutput(false)
+	})
+
+	now := time.Now()
+	line, due := updateNoticeDue(now)
+	require.True(t, due, "prime carries the fact even with no TTY and machine output on")
+	updatenotice.RecordNotified(line, now)
+
+	_, due = updateNoticeDue(now.Add(time.Hour))
+	assert.False(t, due, "the second prime an hour later must stay quiet")
+}
+
+// A routine version refresh must not erase the ledger — if it did, every
+// `ox status`/`ox doctor` GitHub check would restore the per-command nag.
+func TestWriteVersionCacheFromDoctor_PreservesLedger(t *testing.T) {
+	useTestCacheDir(t)
+	stamped := time.Now().Add(-time.Hour)
+	writeTestVersionCache(t, &versionCacheData{
+		LatestVersion:  "v0.15.0",
+		CheckedAt:      stamped,
+		ETag:           `"preserve-me"`,
+		LastNaggedLine: "0.15",
+		LastNaggedAt:   stamped,
+	})
+
+	writeVersionCacheFromDoctor("v0.15.1")
+
+	cached := readVersionCache()
+	require.NotNil(t, cached)
+	assert.Equal(t, "v0.15.1", cached.LatestVersion)
+	assert.Equal(t, `"preserve-me"`, cached.ETag)
+	assert.Equal(t, "0.15", cached.LastNaggedLine, "a version refresh must not erase the ledger")
+	assert.WithinDuration(t, stamped, cached.LastNaggedAt, time.Second)
+}
+
+// After a successful `ox upgrade` the ledger must be gone, so the FIRST notice
+// about the NEXT release line is not swallowed by a stale cap.
+func TestClearVersionCacheAfterUpgrade_ClearsLedger(t *testing.T) {
+	useTestCacheDir(t)
+	atTerminal(t)
+	now := time.Now()
+	writeTestVersionCache(t, &versionCacheData{
+		LatestVersion:  "v99.0.0",
+		CheckedAt:      now,
+		LastNaggedLine: "99.0",
+		LastNaggedAt:   now,
+	})
+	_, due := calmUpdateNoticeDue(now)
+	require.False(t, due, "precondition: capped before the upgrade")
+
+	clearVersionCacheAfterUpgrade()
+
+	assert.Nil(t, readVersionCache(), "upgrade must drop the cache, ledger included")
+	line, due := calmUpdateNoticeDue(now)
+	assert.True(t, due, "the next release line must be announceable after an upgrade")
+	assert.Equal(t, updatenotice.ReleaseLine(version.Version), line,
+		"with no cache, the ledger keys on the running binary's own line")
+}
+
+// The calm tier's copy is a client-owned contract; the urgent tier's is the
+// server's header value, printed verbatim.
+func TestFormatCalmUpdateNotice(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t,
+		"→ ox 0.16.0 available (you're on 0.14.3) — run 'ox upgrade'",
+		formatCalmUpdateNotice("0.16.0", "0.14.3"))
+}

--- a/internal/api/version_check.go
+++ b/internal/api/version_check.go
@@ -2,11 +2,15 @@ package api
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/fatih/color"
+	"github.com/sageox/ox/internal/updatenotice"
+	"github.com/sageox/ox/internal/version"
 )
 
 const (
@@ -19,6 +23,10 @@ const (
 
 var (
 	deprecationShown sync.Once // only show deprecation warning once per session
+
+	// noticeOut is where version notices are written. A var so tests can
+	// capture them without swapping the process-global os.Stderr.
+	noticeOut io.Writer = os.Stderr
 )
 
 // CheckVersionResponse inspects HTTP response for version deprecation signals.
@@ -34,12 +42,32 @@ func CheckVersionResponse(resp *http.Response) bool {
 
 	// soft warning: deprecated but still functional
 	if deprecated := resp.Header.Get(HeaderDeprecated); deprecated != "" {
-		deprecationShown.Do(func() {
-			PrintDeprecationWarning(deprecated)
-		})
+		// The Once only spares us re-reading the ledger for the dozen responses
+		// a single command produces. The cross-process cap is the ledger's job.
+		deprecationShown.Do(func() { maybeWarnDeprecated(deprecated) })
 	}
 
 	return false
+}
+
+// maybeWarnDeprecated prints the server's deprecation copy at most once per
+// release line per day, and never when nobody is watching stderr.
+//
+// This is the urgent tier: the server owns the message (it knows the floors and
+// the stakes), the client owns only the cadence. Before the ledger, the
+// sync.Once above was the ONLY dedup — and for a CLI, where one process is one
+// command, that means the warning printed on every single `ox` invocation,
+// forever. The ledger is the cross-process memory the Once could never be.
+func maybeWarnDeprecated(message string) {
+	if updatenotice.Suppressed() {
+		return
+	}
+	line, now := updatenotice.Line(version.Version), time.Now()
+	if !updatenotice.ShouldNotify(updatenotice.Read(), line, now) {
+		return
+	}
+	PrintDeprecationWarning(message)
+	updatenotice.RecordNotified(line, now)
 }
 
 // PrintUpgradeRequired displays a message indicating the CLI version is no longer supported
@@ -48,14 +76,14 @@ func PrintUpgradeRequired(minVersion string) {
 	red := color.New(color.FgRed, color.Bold)
 	redDim := color.New(color.FgRed)
 
-	fmt.Fprintln(os.Stderr)
-	red.Fprintln(os.Stderr, "  ✗ CLI Version No Longer Supported")
-	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(noticeOut)
+	red.Fprintln(noticeOut, "  ✗ CLI Version No Longer Supported")
+	fmt.Fprintln(noticeOut)
 	if minVersion != "" {
-		redDim.Fprintf(os.Stderr, "  Minimum required version: %s\n", minVersion)
+		redDim.Fprintf(noticeOut, "  Minimum required version: %s\n", minVersion)
 	}
-	redDim.Fprintln(os.Stderr, "  Please upgrade: brew upgrade sageox/tap/ox")
-	fmt.Fprintln(os.Stderr)
+	redDim.Fprintln(noticeOut, "  Please upgrade: brew upgrade sageox/tap/ox")
+	fmt.Fprintln(noticeOut)
 }
 
 // PrintDeprecationWarning displays a warning that the CLI version is deprecated
@@ -63,8 +91,8 @@ func PrintUpgradeRequired(minVersion string) {
 func PrintDeprecationWarning(message string) {
 	yellow := color.New(color.FgYellow)
 	if message != "" {
-		yellow.Fprintf(os.Stderr, "  ⚠ Deprecation warning: %s\n", message)
+		yellow.Fprintf(noticeOut, "  ⚠ Deprecation warning: %s\n", message)
 	} else {
-		yellow.Fprintln(os.Stderr, "  ⚠ This CLI version is deprecated. Please upgrade soon.")
+		yellow.Fprintln(noticeOut, "  ⚠ This CLI version is deprecated. Please upgrade soon.")
 	}
 }

--- a/internal/api/version_check_calm_test.go
+++ b/internal/api/version_check_calm_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/updatenotice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newProcess resets the process-scoped state the real CLI resets by exiting:
+// the sync.Once and the captured stderr. Every `ox` command is a fresh process,
+// so this is what the second, third, and hundredth invocation actually look
+// like — the case the sync.Once alone never covered.
+func newProcess(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	oldOut := noticeOut
+	noticeOut = &buf
+	deprecationShown = sync.Once{}
+	t.Cleanup(func() {
+		noticeOut = oldOut
+		deprecationShown = sync.Once{}
+	})
+	return &buf
+}
+
+// calmTestEnv points the ledger at a temp file and puts a human at the
+// terminal, so these tests exercise the cadence rather than the TTY gate.
+func calmTestEnv(t *testing.T) {
+	t.Helper()
+	oldPath, oldTTY := updatenotice.Path, updatenotice.StderrIsTTY
+	updatenotice.Path = filepath.Join(t.TempDir(), "version-check.json")
+	updatenotice.StderrIsTTY = func() bool { return true }
+	updatenotice.SetMachineOutput(false)
+	t.Cleanup(func() {
+		updatenotice.Path, updatenotice.StderrIsTTY = oldPath, oldTTY
+	})
+}
+
+func deprecatedResponse() *http.Response {
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
+	resp.Header.Set(HeaderDeprecated, "ox v0.5.0 no longer syncs telemetry — run 'ox upgrade' to restore it")
+	return resp
+}
+
+// THE regression this ledger exists to close: before it, the deprecation
+// warning reprinted on every single `ox` command, forever, because a sync.Once
+// scoped to one process dedupes nothing for a CLI.
+func TestDeprecationWarning_SecondInvocationStaysQuiet(t *testing.T) {
+	calmTestEnv(t)
+
+	first := newProcess(t)
+	require.False(t, CheckVersionResponse(deprecatedResponse()))
+	assert.Contains(t, first.String(), "Deprecation warning", "first sight of a release line must speak")
+
+	second := newProcess(t)
+	require.False(t, CheckVersionResponse(deprecatedResponse()))
+	assert.Empty(t, second.String(), "a second invocation inside the cap must stay silent")
+}
+
+// The value the server sends is printed verbatim after the existing prefix —
+// the server owns the stakes copy, the client owns only the cadence.
+func TestDeprecationWarning_PrintsServerCopyVerbatim(t *testing.T) {
+	calmTestEnv(t)
+
+	buf := newProcess(t)
+	CheckVersionResponse(deprecatedResponse())
+	assert.Contains(t, buf.String(),
+		"⚠ Deprecation warning: ox v0.5.0 no longer syncs telemetry — run 'ox upgrade' to restore it")
+}
+
+// Once a day, not once a command: the cap must lift after NotifyInterval.
+func TestDeprecationWarning_SpeaksAgainAfterTheCap(t *testing.T) {
+	calmTestEnv(t)
+
+	first := newProcess(t)
+	CheckVersionResponse(deprecatedResponse())
+	require.NotEmpty(t, first.String())
+
+	// backdate the stamp past the cap, as the passage of a day would
+	d := updatenotice.Read()
+	require.NotNil(t, d)
+	d.LastNaggedAt = time.Now().Add(-updatenotice.NotifyInterval - time.Minute)
+	require.NoError(t, updatenotice.Write(d))
+
+	later := newProcess(t)
+	CheckVersionResponse(deprecatedResponse())
+	assert.Contains(t, later.String(), "Deprecation warning", "the cap must lift after a day")
+}
+
+// A newly published release line is news, and news is not capped.
+func TestDeprecationWarning_NewReleaseLineSpeaksImmediately(t *testing.T) {
+	calmTestEnv(t)
+
+	require.NoError(t, updatenotice.Write(&updatenotice.Data{
+		LatestVersion: "v0.16.0", CheckedAt: time.Now(),
+	}))
+
+	first := newProcess(t)
+	CheckVersionResponse(deprecatedResponse())
+	require.NotEmpty(t, first.String())
+	require.Equal(t, "0.16", updatenotice.Read().LastNaggedLine)
+
+	// pretend a 0.17 release just landed — one minute after the 0.16 notice
+	d := updatenotice.Read()
+	d.LatestVersion = "v0.17.0"
+	d.LastNaggedAt = time.Now().Add(-time.Minute)
+	require.NoError(t, updatenotice.Write(d))
+
+	next := newProcess(t)
+	CheckVersionResponse(deprecatedResponse())
+	assert.Contains(t, next.String(), "Deprecation warning", "a new release line resets the cap")
+	assert.Equal(t, "0.17", updatenotice.Read().LastNaggedLine)
+}
+
+// Agent transcripts stay clean: nothing is printed when nobody is watching
+// stderr, and nothing is stamped either — the human who runs ox at a terminal
+// tomorrow has not been told anything.
+func TestDeprecationWarning_SilentWhenStderrIsNotATTY(t *testing.T) {
+	calmTestEnv(t)
+	updatenotice.StderrIsTTY = func() bool { return false }
+
+	buf := newProcess(t)
+	require.False(t, CheckVersionResponse(deprecatedResponse()))
+	assert.Empty(t, buf.String(), "an agent-captured stderr must see no notice")
+	assert.Nil(t, updatenotice.Read(), "suppressed notices must not consume the ledger")
+}
+
+// --json output is parsed by machines; a notice line in it is a parse error.
+func TestDeprecationWarning_SilentInMachineOutputMode(t *testing.T) {
+	calmTestEnv(t)
+	updatenotice.SetMachineOutput(true)
+	t.Cleanup(func() { updatenotice.SetMachineOutput(false) })
+
+	buf := newProcess(t)
+	require.False(t, CheckVersionResponse(deprecatedResponse()))
+	assert.Empty(t, buf.String())
+}
+
+// The 426 hard-block path is server-driven and unconditional — it is a failure,
+// not a nag, so the calm ledger must not gate it. (The server never sends 426
+// today; this pins the behavior so a future ledger change cannot mute it.)
+func TestUpgradeRequired_IgnoresTheCalmLedger(t *testing.T) {
+	calmTestEnv(t)
+	updatenotice.StderrIsTTY = func() bool { return false }
+	updatenotice.RecordNotified("0.16", time.Now())
+
+	buf := newProcess(t)
+	resp := &http.Response{StatusCode: http.StatusUpgradeRequired, Header: http.Header{}}
+	resp.Header.Set(HeaderMinVersion, "0.16.0")
+
+	assert.True(t, CheckVersionResponse(resp))
+	assert.Contains(t, buf.String(), "CLI Version No Longer Supported")
+}

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sageox/ox/internal/perf"
 	"github.com/sageox/ox/internal/signature"
 	"github.com/sageox/ox/internal/telemetry"
+	"github.com/sageox/ox/internal/updatenotice"
 	"github.com/sageox/ox/internal/useragent"
 	"github.com/sageox/ox/internal/version"
 	"github.com/spf13/cobra"
@@ -121,6 +122,10 @@ func NewContext(cmd *cobra.Command, args []string) (*Context, error) {
 	// set global output mode
 	SetJSONMode(cfg.JSON)
 	SetNoInteractive(cfg.NoInteractive)
+	// Update notices are human-facing prose; either machine-output mode turns
+	// one into a parse error for whatever is reading the stream. Wired here so
+	// every command inherits it rather than each notice site re-deriving it.
+	updatenotice.SetMachineOutput(cfg.JSON || cfg.Text)
 
 	// A long-running service process (`ox daemon start --foreground`) is not a
 	// command invocation. Cobra's post-run hooks fire at service *shutdown*, so

--- a/internal/daemon/version_cache.go
+++ b/internal/daemon/version_cache.go
@@ -13,15 +13,14 @@ import (
 
 	"github.com/sageox/ox/internal/logger"
 	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/updatenotice"
 	"github.com/sageox/ox/internal/useragent"
 )
 
-// VersionCacheData holds the cached latest release version from GitHub.
-type VersionCacheData struct {
-	LatestVersion string    `json:"latest_version"`
-	CheckedAt     time.Time `json:"checked_at"`
-	ETag          string    `json:"etag,omitempty"`
-}
+// VersionCacheData holds the cached latest release version from GitHub, plus
+// the CLI's update-notice ledger. Aliased to the canonical struct so the daemon
+// cannot drift from the CLI's view of a file they both write.
+type VersionCacheData = updatenotice.Data
 
 // VersionCache manages the GitHub release version cache on disk.
 // Thread-safe for concurrent access.
@@ -178,6 +177,16 @@ func (v *VersionCache) CheckAndUpdate(ctx context.Context) error {
 			CheckedAt:     time.Now(),
 			ETag:          resp.Header.Get("ETag"),
 		}
+
+		// The CLI stamps its update-notice ledger into this same file between
+		// daemon polls, so the in-memory copy loaded at daemon start can be
+		// hours stale. Re-read before saving: overwriting with a stale (or
+		// absent) ledger erases the coworker's "already told" memory, and the
+		// upgrade nag comes back on every command until the next notice.
+		_ = v.Load()
+		v.mu.RLock()
+		updatenotice.CarryLedger(newData, v.data)
+		v.mu.RUnlock()
 
 		v.logger.Info("version check: fetched latest", "version", release.TagName)
 		return v.Save(newData)

--- a/internal/daemon/version_cache_test.go
+++ b/internal/daemon/version_cache_test.go
@@ -204,3 +204,38 @@ func TestCheckAndUpdate_MalformedBody(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decode")
 }
+
+// The daemon rebuilds VersionCacheData from scratch on every successful poll.
+// If it saved that without carrying the CLI's update-notice ledger, each poll
+// would erase the "already told this coworker" memory and the upgrade nag would
+// come back on every command until the next notice fired.
+func TestCheckAndUpdate_200_PreservesNoticeLedger(t *testing.T) {
+	t.Parallel()
+	vc := testVersionCacheWithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", `"new-etag"`)
+		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.16.1"})
+	})
+
+	// The CLI stamped the ledger on disk after this daemon last loaded, so the
+	// daemon's in-memory copy does not know about it.
+	stamped := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	require.NoError(t, vc.Save(&VersionCacheData{
+		LatestVersion:  "v0.16.0",
+		CheckedAt:      stamped,
+		LastNaggedLine: "0.16",
+		LastNaggedAt:   stamped,
+	}))
+	vc.mu.Lock()
+	vc.data = nil // simulate a daemon that started before the stamp
+	vc.mu.Unlock()
+
+	require.NoError(t, vc.CheckAndUpdate(context.Background()))
+
+	fresh := &VersionCache{filePath: vc.filePath, logger: slog.Default()}
+	require.NoError(t, fresh.Load())
+	got := fresh.Data()
+	require.NotNil(t, got)
+	assert.Equal(t, "v0.16.1", got.LatestVersion, "poll must still record the new version")
+	assert.Equal(t, "0.16", got.LastNaggedLine, "poll must not erase the notice ledger")
+	assert.Equal(t, stamped.UTC(), got.LastNaggedAt.UTC())
+}

--- a/internal/updatenotice/notice.go
+++ b/internal/updatenotice/notice.go
@@ -1,0 +1,225 @@
+// Package updatenotice keeps ox's "you should upgrade" surfaces calm.
+//
+// ox consults a version cache and talks to the API on nearly every command, so
+// without a persisted memory both the server's deprecation header and the
+// GitHub-derived "update available" line reprint on every single invocation,
+// forever. A sync.Once cannot help: for a CLI, one process is one command, so
+// process-scoped dedup dedupes nothing. This package owns the cross-process
+// memory instead — a two-field ledger stored alongside the existing version
+// cache — plus the one question every notice site asks: may we speak now?
+//
+// One ledger serves BOTH notice tiers deliberately. The server's deprecation
+// warning and the calm "update available" line are the same fact wearing two
+// hats; a coworker who just read one should not immediately read the other.
+package updatenotice
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/mattn/go-isatty"
+	"github.com/sageox/ox/internal/paths"
+)
+
+// NotifyInterval caps how often a coworker hears about the same release line.
+//
+// 24h, tuned so the reminder lands at most once per working day: short enough
+// that an available upgrade stays top of mind, long enough that someone running
+// forty ox commands in an afternoon hears about it once rather than forty
+// times. Shortening it reintroduces exactly the alarm fatigue this ledger
+// exists to kill; lengthening it past a day lets a coworker work a full day
+// without ever learning a release shipped.
+const NotifyInterval = 24 * time.Hour
+
+// Data is the on-disk version cache. The first three fields are the GitHub
+// release check (written by the daemon, by `ox doctor`, and by `ox status`);
+// the last two are the notice ledger.
+//
+// Every writer of this file MUST round-trip the fields it does not own. A
+// writer that rebuilds this struct from a fresh GitHub check and saves it drops
+// the ledger, which silently restores the every-invocation nag — see
+// CarryLedger.
+type Data struct {
+	LatestVersion string    `json:"latest_version"`
+	CheckedAt     time.Time `json:"checked_at"`
+	ETag          string    `json:"etag,omitempty"`
+
+	// LastNaggedLine is the X.Y release line we last spoke about, e.g. "0.16".
+	// Keyed on the line rather than the exact version so a patch release does
+	// not reset the cap, while a genuinely new release line does.
+	LastNaggedLine string `json:"last_nagged_line,omitempty"`
+	// LastNaggedAt is when we last spoke about LastNaggedLine (RFC 3339).
+	LastNaggedAt time.Time `json:"last_nagged_at,omitzero"`
+}
+
+// Path is the version cache file. A var so tests redirect it to a temp dir
+// rather than writing to the real ~/.cache/sageox/.
+var Path = filepath.Join(paths.CacheDir(), "version-check.json")
+
+// Read returns the cache, or nil when it is missing or unreadable. A corrupt
+// cache is treated as absent: printing one extra notice is cheaper than
+// failing a command over a cache file.
+func Read() *Data {
+	raw, err := os.ReadFile(Path)
+	if err != nil {
+		return nil
+	}
+	var d Data
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil
+	}
+	return &d
+}
+
+// Write persists d atomically (temp file + rename, 0600).
+func Write(d *Data) error {
+	if d == nil {
+		return nil
+	}
+	raw, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(Path), 0700); err != nil {
+		return err
+	}
+	tmp := Path + ".tmp"
+	if err := os.WriteFile(tmp, raw, 0600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, Path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// Reset drops the whole cache, ledger included. Called after a successful
+// `ox upgrade`: the running process still reports its OLD compiled-in version,
+// so a surviving cache would keep claiming an update is available — and a
+// surviving ledger would then suppress the FIRST notice about the next release
+// line, which is the one notice that matters most.
+func Reset() {
+	_ = os.Remove(Path)
+}
+
+// CarryLedger copies the notice ledger from src into dst, leaving dst's version
+// fields alone. Every writer of the cache file must call this before saving a
+// freshly built Data, or a routine version refresh erases the memory.
+func CarryLedger(dst, src *Data) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.LastNaggedLine = src.LastNaggedLine
+	dst.LastNaggedAt = src.LastNaggedAt
+}
+
+// ReleaseLine reduces a version to its X.Y release line: "0.16.3" and
+// "v0.16.0-rc1+abc123" both yield "0.16".
+//
+// Pre-release and build metadata are stripped BEFORE the split so a local
+// `0.14.3-dev+<sha>` build does not read as a brand-new line on every rebuild
+// and reset the cap each time. Returns "" for anything unparseable, which
+// callers must treat as "stay quiet" rather than "always speak" — an unknown
+// line has no ledger key, so speaking would be uncappable.
+func ReleaseLine(v string) string {
+	v = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(v), "v"))
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return ""
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return ""
+	}
+	return strconv.Itoa(major) + "." + strconv.Itoa(minor)
+}
+
+// Line is the release line a notice is keyed on: the newest line we know exists
+// upstream, falling back to the running binary's own line before any cache has
+// been written. Both tiers key on the same value so one ledger caps both.
+func Line(currentVersion string) string {
+	if d := Read(); d != nil {
+		if line := ReleaseLine(d.LatestVersion); line != "" {
+			return line
+		}
+	}
+	return ReleaseLine(currentVersion)
+}
+
+// ShouldNotify reports whether a notice about line may be printed at now.
+//
+// First sight of a release line always speaks; after that the ledger caps it to
+// once per NotifyInterval. d may be nil (no cache yet).
+func ShouldNotify(d *Data, line string, now time.Time) bool {
+	if line == "" {
+		return false
+	}
+	if d == nil || d.LastNaggedLine != line {
+		return true
+	}
+	// A stamp in the future means the clock moved backwards (VM restore, NTP
+	// correction). Treat it as never-stamped rather than muting the notice
+	// until real time catches up, which could be years.
+	if d.LastNaggedAt.After(now) {
+		return true
+	}
+	return now.Sub(d.LastNaggedAt) >= NotifyInterval
+}
+
+// RecordNotified stamps the ledger for line. Best-effort: a cache we cannot
+// write means we speak again next time, which is the safe direction to fail.
+func RecordNotified(line string, now time.Time) {
+	if line == "" {
+		return
+	}
+	d := Read()
+	if d == nil {
+		d = &Data{}
+	}
+	d.LastNaggedLine = line
+	d.LastNaggedAt = now
+	_ = Write(d)
+}
+
+// machineOutput records whether this invocation emits machine-readable output.
+// Atomic because the daemon shares this package with concurrent request paths.
+var machineOutput atomic.Bool
+
+// SetMachineOutput records whether this invocation is emitting machine-readable
+// output (--json / --text). Called once from the CLI bootstrap.
+func SetMachineOutput(enabled bool) { machineOutput.Store(enabled) }
+
+// StderrIsTTY reports whether stderr is a terminal. A func var so tests can
+// simulate both a human at a terminal and an agent capturing stderr through a
+// pipe, without allocating a pty.
+var StderrIsTTY = func() bool {
+	return isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())
+}
+
+// Suppressed reports whether update notices must stay silent.
+//
+// The non-TTY rule is the load-bearing one: an ox invocation inside a coding
+// agent has stdout and stderr captured into the agent's transcript, where an
+// upgrade nag burns context tokens on every command and can pull the agent off
+// the task it was actually given. Machine-output modes are suppressed for that
+// reason plus a harder one — a stray notice line in --json output is a parse
+// error for whatever is reading it.
+//
+// Structured FIELDS are not notices. `ox agent prime` and `ox status --json`
+// still carry update availability as data, because the caller asked for it.
+func Suppressed() bool {
+	return machineOutput.Load() || !StderrIsTTY()
+}

--- a/internal/updatenotice/notice_test.go
+++ b/internal/updatenotice/notice_test.go
@@ -1,0 +1,224 @@
+package updatenotice
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// useTempCache redirects Path at a temp file so no test touches the real
+// ~/.cache/sageox/version-check.json.
+func useTempCache(t *testing.T) {
+	t.Helper()
+	old := Path
+	Path = filepath.Join(t.TempDir(), "version-check.json")
+	t.Cleanup(func() { Path = old })
+}
+
+// forceTTY makes Suppressed() behave as if a human is watching stderr, which is
+// never true under `go test`.
+func forceTTY(t *testing.T, tty bool) {
+	t.Helper()
+	old := StderrIsTTY
+	StderrIsTTY = func() bool { return tty }
+	t.Cleanup(func() { StderrIsTTY = old })
+}
+
+func TestReleaseLine(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain release", in: "0.16.3", want: "0.16"},
+		{name: "v prefix", in: "v0.16.3", want: "0.16"},
+		{name: "double digit minor", in: "0.144.0", want: "0.144"},
+		{name: "prerelease stripped", in: "0.16.0-rc1", want: "0.16"},
+		{name: "build metadata stripped", in: "0.16.2+abc123", want: "0.16"},
+		{name: "local dev build", in: "0.14.3-dev+2026-08-31T12:00:00Z", want: "0.14"},
+		{name: "major.minor only", in: "1.0", want: "1.0"},
+		{name: "leading zeros normalized", in: "0.09.0", want: "0.9"},
+		{name: "empty", in: "", want: ""},
+		{name: "dev sentinel", in: "dev", want: ""},
+		{name: "no minor", in: "1", want: ""},
+		{name: "non numeric minor", in: "0.x.1", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ReleaseLine(tt.in))
+		})
+	}
+}
+
+func TestShouldNotify(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		data *Data
+		line string
+		want bool
+	}{
+		{name: "no cache at all speaks", data: nil, line: "0.16", want: true},
+		{name: "unparseable line stays quiet", data: nil, line: "", want: false},
+		{name: "first sight of a line speaks", data: &Data{}, line: "0.16", want: true},
+		{
+			name: "same line inside the cap stays quiet",
+			data: &Data{LastNaggedLine: "0.16", LastNaggedAt: now.Add(-1 * time.Hour)},
+			line: "0.16", want: false,
+		},
+		{
+			name: "same line one minute short of the cap stays quiet",
+			data: &Data{LastNaggedLine: "0.16", LastNaggedAt: now.Add(-NotifyInterval + time.Minute)},
+			line: "0.16", want: false,
+		},
+		{
+			name: "same line exactly at the cap speaks",
+			data: &Data{LastNaggedLine: "0.16", LastNaggedAt: now.Add(-NotifyInterval)},
+			line: "0.16", want: true,
+		},
+		{
+			name: "new release line resets the cap immediately",
+			data: &Data{LastNaggedLine: "0.15", LastNaggedAt: now.Add(-1 * time.Minute)},
+			line: "0.16", want: true,
+		},
+		{
+			name: "stamp in the future is treated as never stamped",
+			data: &Data{LastNaggedLine: "0.16", LastNaggedAt: now.Add(72 * time.Hour)},
+			line: "0.16", want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ShouldNotify(tt.data, tt.line, now))
+		})
+	}
+}
+
+// The ledger has to survive the process that wrote it — that is the entire
+// point. Asserts the on-disk key names too, since they are the contract shared
+// with the daemon's writer.
+func TestLedgerPersistsAcrossProcesses(t *testing.T) {
+	useTempCache(t)
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, Write(&Data{LatestVersion: "v0.16.0", CheckedAt: now, ETag: `"e"`}))
+	RecordNotified("0.16", now)
+
+	raw, err := os.ReadFile(Path)
+	require.NoError(t, err)
+	var onDisk map[string]any
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	assert.Equal(t, "0.16", onDisk["last_nagged_line"])
+	assert.Equal(t, "2026-08-31T12:00:00Z", onDisk["last_nagged_at"], "must be RFC 3339")
+
+	// a second "process" reads the ledger back and stays quiet
+	got := Read()
+	require.NotNil(t, got)
+	assert.Equal(t, "0.16", got.LastNaggedLine)
+	assert.Equal(t, "v0.16.0", got.LatestVersion, "stamping must not clobber the version fields")
+	assert.Equal(t, `"e"`, got.ETag, "stamping must not clobber the ETag")
+	assert.False(t, ShouldNotify(got, "0.16", now.Add(time.Hour)))
+	assert.True(t, ShouldNotify(got, "0.16", now.Add(25*time.Hour)))
+}
+
+// A fresh cache has no ledger fields on disk at all — the zero time must not
+// serialize as a bogus year-1 date that a human reading the file would trip on.
+func TestWrite_OmitsEmptyLedger(t *testing.T) {
+	useTempCache(t)
+	require.NoError(t, Write(&Data{LatestVersion: "v0.16.0", CheckedAt: time.Now()}))
+
+	raw, err := os.ReadFile(Path)
+	require.NoError(t, err)
+	var onDisk map[string]any
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	assert.NotContains(t, onDisk, "last_nagged_line")
+	assert.NotContains(t, onDisk, "last_nagged_at")
+}
+
+// A successful `ox upgrade` must forget both ledger fields, so the FIRST notice
+// about the next release line is not swallowed by a stale cap.
+func TestReset_ClearsLedgerSoNextLineSpeaks(t *testing.T) {
+	useTempCache(t)
+	now := time.Now()
+	RecordNotified("0.16", now)
+	require.False(t, ShouldNotify(Read(), "0.16", now.Add(time.Hour)))
+
+	Reset()
+
+	assert.Nil(t, Read(), "upgrade must drop the cache entirely, ledger included")
+	assert.True(t, ShouldNotify(Read(), "0.16", now.Add(time.Hour)))
+}
+
+// The daemon and `ox doctor` both rebuild Data from a fresh GitHub check. If
+// they save it without carrying the ledger, every version refresh restores the
+// per-command nag.
+func TestCarryLedger(t *testing.T) {
+	t.Parallel()
+	stamped := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	src := &Data{LatestVersion: "v0.15.0", LastNaggedLine: "0.16", LastNaggedAt: stamped}
+	dst := &Data{LatestVersion: "v0.16.0", CheckedAt: stamped}
+
+	CarryLedger(dst, src)
+
+	assert.Equal(t, "0.16", dst.LastNaggedLine)
+	assert.Equal(t, stamped, dst.LastNaggedAt)
+	assert.Equal(t, "v0.16.0", dst.LatestVersion, "carrying the ledger must not touch version fields")
+
+	// nil-safe: callers pass whatever Read() gave them
+	CarryLedger(dst, nil)
+	CarryLedger(nil, src)
+	assert.Equal(t, "0.16", dst.LastNaggedLine)
+}
+
+func TestRecordNotified_IgnoresUnparseableLine(t *testing.T) {
+	useTempCache(t)
+	RecordNotified("", time.Now())
+	assert.Nil(t, Read(), "an unknown release line must not create a ledger entry")
+}
+
+func TestLine(t *testing.T) {
+	useTempCache(t)
+
+	// no cache yet: fall back to the running binary's own line
+	assert.Equal(t, "0.14", Line("0.14.3"))
+
+	// cache knows a newer line: both tiers key on it
+	require.NoError(t, Write(&Data{LatestVersion: "v0.16.0", CheckedAt: time.Now()}))
+	assert.Equal(t, "0.16", Line("0.14.3"))
+
+	// unparseable cached version falls back rather than returning ""
+	require.NoError(t, Write(&Data{LatestVersion: "garbage", CheckedAt: time.Now()}))
+	assert.Equal(t, "0.14", Line("0.14.3"))
+}
+
+// Notices must never reach an agent transcript or a machine-output stream.
+func TestSuppressed(t *testing.T) {
+	tests := []struct {
+		name          string
+		tty           bool
+		machineOutput bool
+		want          bool
+	}{
+		{name: "human at a terminal speaks", tty: true, machineOutput: false, want: false},
+		{name: "stderr captured by an agent stays silent", tty: false, machineOutput: false, want: true},
+		{name: "json mode stays silent even on a tty", tty: true, machineOutput: true, want: true},
+		{name: "json mode and no tty stays silent", tty: false, machineOutput: true, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			forceTTY(t, tt.tty)
+			SetMachineOutput(tt.machineOutput)
+			t.Cleanup(func() { SetMachineOutput(false) })
+			assert.Equal(t, tt.want, Suppressed())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
The ox CLI stops repeating itself: today the "⚠ Deprecation warning" prints on **every single invocation forever** (a 40-command day = 40 identical warnings) and "Update available" reappears on every `ox status` — and both land in AI-coworker transcripts, polluting the exact context windows the product exists to keep clean.

**Approach:** one persisted notice ledger (`~/.cache/sageox/version-check.json` gains `last_nagged_line`/`last_nagged_at`) caps both tiers at first-sight-then-daily per X.Y release line, goes silent on non-TTY stderr / machine output (agents get the fact once via `ox agent prime` structured output instead), and self-clears on `ox upgrade`.

## What changed
| File | Change |
|---|---|
| `internal/updatenotice/` (new) | Shared ledger package: release-line derivation, 24h cadence, suppression (TTY/machine-output), disk round-trip |
| `internal/api/version_check.go` | Urgent tier (server `X-SageOx-Deprecated`) routes through ledger; server still owns copy; 426 path untouched + pinned by test |
| `cmd/ox/version_notice.go` (new) + `status.go` | Calm tier: one dim line `→ ox <latest> available (you're on <cur>) — run 'ox upgrade'`, gated + stamped |
| `cmd/ox/agent_prime.go` | `UpdateAvailable`/`LatestVersion` stay unconditional data; the *notice* (`UpdateHint`, `UserNotices`) now ledger-capped once/line/day |
| `cmd/ox/upgrade.go` + `version_cache.go` | Upgrade clears the ledger; doctor-write + daemon 200-poll preserve it (without this the daemon wiped the ledger every poll) |
| `internal/daemon/version_cache.go` | `CarryLedger` on rebuild + test |

## Test Plan
- [x] Red-first (urgent): 5/7 new tests fail on HEAD — incl. `SecondInvocationStaysQuiet` reproducing the every-invocation nag — all pass after
- [x] Red-first (calm + daemon): break/restore both proven
- [x] `go test ./...` exit 0 (127 pkgs); `make test` → 20063 tests, failed=0 (race); `make lint` → 0 issues

<details><summary>Review flags</summary>

- **User-visible removal:** the inline `"Upgrade ox now?"` confirm prompt in `ox status` is gone — a prompt firing on every status run is the opposite of calm. Flagging explicitly; shout if you want it kept.
- Ledger keys on the latest-known upstream X.Y (fallback: running binary's line) so ONE ledger caps both tiers.
- "stderr not a TTY" gates the stdout status line too — agents capture both streams; stderr TTY-ness is the honest "human watching" proxy. Side effect: `ox status > file` at a terminal still writes the line.
- Pre-existing repo bug (not mine, filed separately): full `cmd/ox` suite strips the prime block from the real repo `AGENTS.md`.
- Server-side siblings in sageox-monorepo: #3732 (ADR-168 policy), #3735 (two-tier header copy — new value reads correctly behind old clients' hardcoded prefix).
</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790798563&installation_model_id=433550&pr_number=845&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F845&signature=51d3972ca842b7e009be9965cf3fd4049b0f597a269e8b47bb288e9d8e9b77d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Update notifications are now shown calmly and no more than once per release line each day.
  - Notifications remain consistent across CLI commands and background checks.
  - New release lines can trigger an immediate notification.

- **Bug Fixes**
  - Repeated upgrade and deprecation messages are suppressed.
  - Notices no longer appear in JSON, machine-readable output, or non-interactive terminals.
  - Completing an upgrade clears outdated notification state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->