### PR TITLE
feat(dist): install ox via npx @sageox/ox (+ pip wrapper skeleton)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,56 @@ jobs:
           echo "[View Release](https://github.com/sageox/ox/releases/tag/${{ env.RELEASE_TAG }})" >> $GITHUB_STEP_SUMMARY
         env:
           SAGEOX_CLI_SIGNING_KEY: ${{ secrets.SAGEOX_CLI_SIGNING_KEY }}
+
+  # Publish the @sageox/ox npm wrapper. It downloads the SAME signed release
+  # tarball that build-and-release just uploaded (verified via checksums.txt), so
+  # it MUST run after that job — `needs` guarantees the assets exist first.
+  publish-npm:
+    name: Publish @sageox/ox to npm
+    needs: build-and-release
+    if: github.repository == 'sageox/ox'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for npm provenance (SLSA build attestation)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish wrapper
+        working-directory: npm
+        env:
+          # Publishing under the public @sageox scope requires the org to own that
+          # scope on npmjs.org plus an NPM_TOKEN with publish rights. Until that is
+          # set up this step no-ops cleanly instead of failing the release.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN secret is not set; skipping public npm publish."
+            echo "Prerequisites: own the public @sageox scope on npmjs.org and add an"
+            echo "NPM_TOKEN secret with publish rights. See npm/README.md."
+            exit 0
+          fi
+          VERSION="${RELEASE_TAG#v}"
+          # Pin the wrapper's version to the release tag so its postinstall fetches
+          # the matching release assets.
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          # Prereleases (e.g. 1.2.0-rc.1) publish under the 'next' dist-tag so they
+          # never become the default `npm install @sageox/ox` for everyone.
+          if printf '%s' "$VERSION" | grep -q '-'; then
+            DIST_TAG=next
+          else
+            DIST_TAG=latest
+          fi
+          echo "Publishing @sageox/ox@$VERSION (dist-tag: $DIST_TAG)"
+          npm publish --provenance --access public --tag "$DIST_TAG"

--- a/npm/LICENSE
+++ b/npm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SageOx Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,57 @@
+# @sageox/ox
+
+The **[SageOx](https://sageox.ai) `ox` CLI** — the hivemind for agentic engineering — packaged for npm.
+
+```bash
+# one-off, no install
+npx @sageox/ox --help
+
+# or install globally
+npm install -g @sageox/ox
+ox version
+```
+
+## What this package does
+
+This is a thin wrapper. On install it downloads the **official, prebuilt `ox`
+binary** for your platform from the project's [GitHub Releases](https://github.com/sageox/ox/releases),
+**verifies its SHA-256 against the release `checksums.txt`** (the same integrity
+check the canonical `curl … | bash` installer performs), and installs it.
+
+- It does **not** bundle or vendor a copy of the binary in the npm tarball.
+- It does **not** build a second, separately-compiled binary — it fetches the
+  exact same signed release artifact you would get from Homebrew or the install
+  script.
+- If the checksum does not match, or your platform has no prebuilt binary,
+  installation **fails loudly** rather than installing something unverified.
+
+### Supported platforms
+
+| OS | Architectures |
+|----|---------------|
+| macOS (`darwin`) | Apple Silicon (`arm64`), Intel (`x64`) |
+| Linux | `x64`, `arm64` |
+| FreeBSD | `x64` |
+
+Windows is not currently published as a prebuilt binary — install from source
+(`go install github.com/sageox/ox/cmd/ox@latest`) or see the docs.
+
+### Environment variables
+
+- `OX_NPM_SKIP_DOWNLOAD=1` — skip the download during `npm install` (useful for
+  CI, offline mirrors, or `--ignore-scripts` flows). The binary is then fetched
+  and verified lazily on first `ox` invocation.
+
+## Other ways to install
+
+- **Homebrew:** `brew install sageox/tap/ox`
+- **Shell:** `curl -sSL https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh | bash`
+- **Go:** `go install github.com/sageox/ox/cmd/ox@latest`
+
+## Docs
+
+Full CLI documentation: **https://sageox.ai/docs/cli**
+
+## License
+
+MIT © SageOx Inc. See [LICENSE](./LICENSE).

--- a/npm/bin/ox.js
+++ b/npm/bin/ox.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+'use strict';
+
+// npm `bin` launcher for @sageox/ox. This thin JS shim is what `npx @sageox/ox`
+// and a global `ox` resolve to; it execs the downloaded native binary, forwarding
+// argv, stdio, and exit status. Keeping a committed JS launcher (rather than
+// pointing `bin` straight at the downloaded file) means the bin symlink is always
+// valid — even before postinstall runs or if it was skipped.
+
+const { ensure, run, isInstalled } = require('../lib/binary');
+
+async function main() {
+  if (!isInstalled()) {
+    // postinstall skipped (e.g. --ignore-scripts) or previously failed: fetch now.
+    try {
+      await ensure();
+    } catch (err) {
+      process.stderr.write(`[@sageox/ox] ${err.message}\n`);
+      process.exit(1);
+    }
+  }
+  run(process.argv.slice(2));
+}
+
+main();

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+'use strict';
+
+// postinstall entry point: download + verify + install the platform-native ox
+// binary. Fails loudly (non-zero exit) on an unsupported platform, a network
+// failure, or a checksum mismatch — we never leave an unverified or partial
+// binary in place.
+
+const { download } = require('./lib/binary');
+
+// Escape hatch for CI / offline mirrors / `npm install --ignore-scripts` flows:
+// skip the network fetch at install time. The launcher (bin/ox.js) then lazily
+// downloads and verifies on first run instead.
+if (process.env.OX_NPM_SKIP_DOWNLOAD === '1') {
+  process.stderr.write(
+    '[@sageox/ox] OX_NPM_SKIP_DOWNLOAD=1 set; skipping binary download (will fetch on first run)\n'
+  );
+  process.exit(0);
+}
+
+download().catch((err) => {
+  process.stderr.write(`\n[@sageox/ox] installation failed: ${err.message}\n`);
+  process.exit(1);
+});

--- a/npm/lib/binary.js
+++ b/npm/lib/binary.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { spawnSync } = require('node:child_process');
+
+const { target, assetName } = require('./platform');
+
+const REPO = 'sageox/ox';
+const pkg = require('../package.json');
+
+// Package version, WITHOUT a leading 'v', matches goreleaser's {{ .Version }}.
+// The release CI pins this to the tag before publishing, so the wrapper always
+// fetches the assets from its own matching release.
+const VERSION = pkg.version;
+
+const PKG_ROOT = path.join(__dirname, '..');
+// The native binary is downloaded at install time; it is NOT shipped in the npm
+// tarball (vendor/ is created post-publish and excluded from the files allowlist).
+const VENDOR_DIR = path.join(PKG_ROOT, 'vendor');
+const BINARY_PATH = path.join(VENDOR_DIR, 'ox');
+
+function releaseBaseUrl() {
+  // The git tag carries the leading 'v'; the asset filename does not.
+  return `https://github.com/${REPO}/releases/download/v${VERSION}`;
+}
+
+function log(msg) {
+  process.stderr.write(`[@sageox/ox] ${msg}\n`);
+}
+
+async function fetchBuffer(url) {
+  // Node >= 18 ships a global fetch that follows GitHub's redirect to the release
+  // CDN automatically (node:https would need manual redirect handling).
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) {
+    throw new Error(`download failed: ${url} -> HTTP ${res.status} ${res.statusText}`);
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+// goreleaser checksums.txt lines are "<sha256>  <filename>"; some tools emit
+// "<sha256> *<filename>" (binary mode). Match install.sh's tolerance for both.
+function findChecksum(text, name) {
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 2) continue;
+    const file = parts[parts.length - 1].replace(/^\*/, '');
+    if (file === name) return parts[0].toLowerCase();
+  }
+  return null;
+}
+
+function isInstalled() {
+  try {
+    fs.accessSync(BINARY_PATH, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function download({ force = false } = {}) {
+  const t = target();
+  if (!t.supported) {
+    throw new Error(
+      `unsupported platform: ${t.platform}/${t.arch}\n` +
+        '@sageox/ox ships prebuilt binaries for: darwin/x64, darwin/arm64, linux/x64, ' +
+        'linux/arm64, freebsd/x64.\n' +
+        'For other targets (including Windows) install from source:\n' +
+        `  go install github.com/${REPO}/cmd/ox@latest\n` +
+        '  or see https://sageox.ai/docs/cli'
+    );
+  }
+
+  if (!force && isInstalled()) {
+    return BINARY_PATH;
+  }
+
+  const name = assetName(VERSION, t);
+  const archiveUrl = `${releaseBaseUrl()}/${name}`;
+  const checksumsUrl = `${releaseBaseUrl()}/checksums.txt`;
+
+  log(`downloading ${name} (v${VERSION})...`);
+  const archive = await fetchBuffer(archiveUrl);
+
+  // Verify integrity BEFORE extracting or installing anything. This mirrors
+  // scripts/install.sh, which treats a missing or failing checksum as a HARD
+  // failure — the wrapper is commonly run via `npx`, so integrity is not advisory.
+  // (Note: this is the SAME check install.sh performs — SHA-256 against the
+  // release checksums.txt. The Ed25519 signatures produced by scripts/sign-manifest
+  // protect the binary's compiled-in data at runtime, not the tarball on the wire.)
+  log('verifying checksum...');
+  const checksumsText = (await fetchBuffer(checksumsUrl)).toString('utf8');
+  const expected = findChecksum(checksumsText, name);
+  if (!expected) {
+    throw new Error(
+      `release checksums.txt does not list ${name}; refusing to install an unverified binary`
+    );
+  }
+  const actual = crypto.createHash('sha256').update(archive).digest('hex').toLowerCase();
+  if (actual !== expected) {
+    throw new Error(
+      `checksum mismatch for ${name}\n` +
+        `  expected: ${expected}\n` +
+        `  actual:   ${actual}\n` +
+        'refusing to install a corrupt or tampered binary'
+    );
+  }
+
+  // Extract only the `ox` binary. Every supported platform (darwin/linux/freebsd)
+  // ships GNU/BSD tar, and this is exactly what install.sh uses (tar -xzf), so we
+  // avoid pulling a tar implementation into the dependency tree.
+  fs.mkdirSync(VENDOR_DIR, { recursive: true });
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sageox-ox-'));
+  try {
+    const archivePath = path.join(tmp, name);
+    fs.writeFileSync(archivePath, archive);
+
+    const res = spawnSync('tar', ['-xzf', archivePath, '-C', tmp, 'ox'], { stdio: 'inherit' });
+    if (res.error) throw res.error;
+    if (res.status !== 0) {
+      throw new Error(`failed to extract ox from ${name} (tar exit ${res.status})`);
+    }
+
+    const extracted = path.join(tmp, 'ox');
+    if (!fs.existsSync(extracted)) {
+      throw new Error(`archive ${name} did not contain an 'ox' binary`);
+    }
+
+    fs.copyFileSync(extracted, BINARY_PATH);
+    fs.chmodSync(BINARY_PATH, 0o755);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+
+  log(`installed ox v${VERSION} -> ${BINARY_PATH}`);
+  return BINARY_PATH;
+}
+
+// Ensure the binary exists (download+verify if the postinstall was skipped, e.g.
+// `npm install --ignore-scripts`). Used by the launcher for lazy first-run fetch.
+async function ensure() {
+  if (isInstalled()) return BINARY_PATH;
+  return download();
+}
+
+// Exec the native ox binary, forwarding stdio and exit status. Never returns.
+function run(args) {
+  const res = spawnSync(BINARY_PATH, args, { stdio: 'inherit' });
+  if (res.error) throw res.error;
+  // Terminated by a signal (e.g. Ctrl-C): exit non-zero rather than reporting 0.
+  if (res.status === null) {
+    process.exit(1);
+  }
+  process.exit(res.status);
+}
+
+module.exports = { download, ensure, run, isInstalled, BINARY_PATH, VERSION };

--- a/npm/lib/platform.js
+++ b/npm/lib/platform.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// Single source of truth for mapping the current Node runtime to an ox release
+// asset name. This MUST mirror two upstream files EXACTLY — any drift here ships
+// a wrapper that downloads a nonexistent asset:
+//
+//   scripts/install.sh          detect_platform():   uname -s -> darwin|linux|freebsd
+//                                                    uname -m -> amd64|arm64
+//                               archive_name:        ox_${version#v}_${os}_${arch}.tar.gz
+//
+//   .config/goreleaser.yml      archives.name_template:
+//                                 "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+//                               ({{ .Version }} is the tag WITHOUT the leading 'v')
+//
+// Node's process.platform values (darwin/linux/freebsd) already match goreleaser's
+// {{ .Os }}. Only the arch names differ: Node says x64/arm64, Go says amd64/arm64.
+
+// process.platform -> GOOS. Windows is intentionally absent: no ox binary is built
+// for it (install.sh tells Windows users to download manually), so npm's own `os`
+// field rejects the install before postinstall even runs.
+const PLATFORM_MAP = Object.freeze({
+  darwin: 'darwin',
+  linux: 'linux',
+  freebsd: 'freebsd',
+});
+
+// process.arch -> GOARCH.
+const ARCH_MAP = Object.freeze({
+  x64: 'amd64',
+  arm64: 'arm64',
+});
+
+// The exact GOOS_GOARCH matrix the `ox` binary is built for in .config/goreleaser.yml.
+// freebsd/arm64 is deliberately NOT built, so the coarse os/cpu OR-lists in
+// package.json cannot express it — this set is the precise gate the postinstall uses.
+const SUPPORTED = Object.freeze(
+  new Set(['darwin_amd64', 'darwin_arm64', 'linux_amd64', 'linux_arm64', 'freebsd_amd64'])
+);
+
+/**
+ * Resolve a Node platform/arch pair to the ox release target.
+ * @returns {{supported: boolean, platform: string, arch: string, os?: string, goarch?: string, key?: string}}
+ */
+function target(platform = process.platform, arch = process.arch) {
+  const os = PLATFORM_MAP[platform];
+  const goarch = ARCH_MAP[arch];
+  if (!os || !goarch) {
+    return { supported: false, platform, arch, os, goarch };
+  }
+  const key = `${os}_${goarch}`;
+  return { supported: SUPPORTED.has(key), platform, arch, os, goarch, key };
+}
+
+/**
+ * Build the release asset (tarball) filename for a version + target.
+ * @param {string} version package version WITHOUT the leading 'v' (matches goreleaser {{ .Version }})
+ */
+function assetName(version, t = target()) {
+  return `ox_${version}_${t.os}_${t.goarch}.tar.gz`;
+}
+
+module.exports = { target, assetName, SUPPORTED, PLATFORM_MAP, ARCH_MAP };

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@sageox/ox",
+  "version": "0.14.3",
+  "description": "SageOx (ox) CLI — the hivemind for agentic engineering. Downloads and runs the official signed ox binary. Try it with: npx @sageox/ox",
+  "keywords": [
+    "sageox",
+    "ox",
+    "cli",
+    "ai",
+    "agent",
+    "agentic",
+    "coding-agent",
+    "developer-tools",
+    "team-context",
+    "mcp"
+  ],
+  "homepage": "https://sageox.ai/docs/cli",
+  "bugs": {
+    "url": "https://github.com/sageox/ox/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sageox/ox.git",
+    "directory": "npm"
+  },
+  "license": "MIT",
+  "author": "SageOx Inc.",
+  "type": "commonjs",
+  "bin": {
+    "ox": "bin/ox.js"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "install.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "freebsd"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  }
+}

--- a/pip/LICENSE
+++ b/pip/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SageOx Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pip/README.md
+++ b/pip/README.md
@@ -1,0 +1,35 @@
+# sageox (PyPI wrapper) — follow-up skeleton
+
+> **Status: skeleton / not yet published.** The primary agent-installable surface
+> is the npm wrapper (`../npm`, `@sageox/ox`). This mirrors it for the Python
+> ecosystem and is provided so PyPI distribution is a small, well-scoped follow-up
+> rather than a from-scratch effort.
+
+```bash
+pip install sageox
+ox version
+```
+
+## What it does
+
+`pip install sageox` installs a console-script `ox`. On first run it downloads the
+**official signed `ox` binary** for your platform from
+[GitHub Releases](https://github.com/sageox/ox/releases), **verifies its SHA-256
+against the release `checksums.txt`** (the same check as `scripts/install.sh`),
+caches it under `~/.local/share/ox/bin/ox`, and execs it. It does not build or
+vendor a second binary.
+
+Supported platforms: macOS (arm64/x64), Linux (x64/arm64), FreeBSD (x64).
+
+## Before this can ship
+
+- [ ] Own the `sageox` project name on PyPI (or pick `sageox-cli` if taken).
+- [ ] Add a PyPI publish job to `.github/workflows/release.yml` — prefer
+      [Trusted Publishing (OIDC)](https://docs.pypi.org/trusted-publishers/) over a
+      long-lived API token.
+- [ ] Decide whether to download at install time (like npm's `postinstall`) or
+      only lazily on first run (current behavior — friendlier to `pip` sandboxes).
+
+## Docs
+
+https://sageox.ai/docs/cli

--- a/pip/pyproject.toml
+++ b/pip/pyproject.toml
@@ -1,0 +1,49 @@
+##
+## SKELETON — follow-up, not yet wired into the release pipeline.
+##
+## This mirrors the npm wrapper (../npm) for the Python ecosystem: `pip install
+## sageox` installs a console-script `ox` that downloads the official signed ox
+## binary from GitHub Releases and verifies it against the release checksums.txt
+## (same integrity check as scripts/install.sh), then execs it.
+##
+## Before this can publish to PyPI:
+##   - claim/own the `sageox` project name on PyPI
+##   - add a PyPI publish job (prefer Trusted Publishing / OIDC over a token)
+##   - decide package name if `sageox` is taken (e.g. `sageox-cli`)
+##
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sageox"
+version = "0.14.3"
+description = "SageOx (ox) CLI — downloads and runs the official signed ox binary."
+readme = "README.md"
+license = { text = "MIT" }
+authors = [{ name = "SageOx Inc." }]
+requires-python = ">=3.9"
+keywords = ["sageox", "ox", "cli", "ai", "agent", "agentic", "developer-tools"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: MacOS",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: POSIX :: BSD :: FreeBSD",
+  "Programming Language :: Python :: 3",
+]
+
+[project.urls]
+Homepage = "https://sageox.ai/docs/cli"
+Repository = "https://github.com/sageox/ox"
+Issues = "https://github.com/sageox/ox/issues"
+
+# Installs an `ox` command that shells into sageox.__main__:main, which lazily
+# downloads + verifies the native binary on first run.
+[project.scripts]
+ox = "sageox.__main__:main"
+
+[tool.setuptools]
+packages = ["sageox"]

--- a/pip/sageox/__init__.py
+++ b/pip/sageox/__init__.py
@@ -1,0 +1,10 @@
+"""SageOx (ox) CLI wrapper for the Python ecosystem.
+
+SKELETON — follow-up to the primary npm wrapper. This package does not build or
+vendor a second binary; it downloads the official signed ``ox`` release binary
+and verifies it against the release ``checksums.txt`` (the same integrity check
+as ``scripts/install.sh``).
+"""
+
+# Keep in sync with internal/version/version.go via scripts/version-bump.sh.
+__version__ = "0.14.3"

--- a/pip/sageox/__main__.py
+++ b/pip/sageox/__main__.py
@@ -1,0 +1,29 @@
+"""Console-script entry point: exec the native ox binary, forwarding argv/stdio."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from ._binary import ensure
+
+
+def main() -> int:
+    try:
+        binary = ensure()
+    except Exception as err:  # surface a clear message, non-zero exit
+        print(f"[sageox] {err}", file=sys.stderr)
+        return 1
+
+    # Replace this process with ox where possible so signals/exit codes pass
+    # through cleanly; fall back to subprocess on platforms without execv.
+    argv = [str(binary), *sys.argv[1:]]
+    if hasattr(os, "execv"):
+        os.execv(str(binary), argv)  # noqa: S606 (trusted, verified binary)
+        return 0  # unreachable
+    return subprocess.call(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pip/sageox/_binary.py
+++ b/pip/sageox/_binary.py
@@ -1,0 +1,135 @@
+"""Resolve, download, and verify the native ox binary.
+
+Mirrors ../npm/lib/platform.js + binary.js and, transitively, scripts/install.sh
+and .config/goreleaser.yml. Any change to the asset-name mapping there MUST be
+reflected here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import stat
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+from . import __version__
+
+REPO = "sageox/ox"
+
+# platform.system() -> GOOS
+_OS_MAP = {"Darwin": "darwin", "Linux": "linux", "FreeBSD": "freebsd"}
+
+# platform.machine() -> GOARCH (covers the common aliases across OSes).
+_ARCH_MAP = {
+    "x86_64": "amd64",
+    "amd64": "amd64",
+    "arm64": "arm64",
+    "aarch64": "arm64",
+}
+
+# Exact GOOS_GOARCH matrix built in .config/goreleaser.yml (freebsd/arm64 excluded).
+_SUPPORTED = {
+    "darwin_amd64",
+    "darwin_arm64",
+    "linux_amd64",
+    "linux_arm64",
+    "freebsd_amd64",
+}
+
+
+def _binary_home() -> Path:
+    # User-owned cache dir, consistent with ox's own ~/.local/share/ox layout.
+    base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return base / "ox" / "bin"
+
+
+def binary_path() -> Path:
+    return _binary_home() / "ox"
+
+
+def _target() -> tuple[str, str]:
+    goos = _OS_MAP.get(platform.system())
+    goarch = _ARCH_MAP.get(platform.machine().lower())
+    if not goos or not goarch or f"{goos}_{goarch}" not in _SUPPORTED:
+        raise RuntimeError(
+            f"unsupported platform: {platform.system()}/{platform.machine()}\n"
+            "sageox ships prebuilt binaries for: darwin/amd64, darwin/arm64, "
+            "linux/amd64, linux/arm64, freebsd/amd64.\n"
+            f"For other targets install from source: go install github.com/{REPO}/cmd/ox@latest"
+        )
+    return goos, goarch
+
+
+def _asset_name(version: str, goos: str, goarch: str) -> str:
+    return f"ox_{version}_{goos}_{goarch}.tar.gz"
+
+
+def _release_base(version: str) -> str:
+    # Tag carries the leading 'v'; asset filename does not.
+    return f"https://github.com/{REPO}/releases/download/v{version}"
+
+
+def _fetch(url: str) -> bytes:
+    with urllib.request.urlopen(url) as resp:  # noqa: S310 (trusted GitHub host)
+        return resp.read()
+
+
+def _expected_checksum(checksums_text: str, name: str) -> str | None:
+    for raw in checksums_text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        fname = parts[-1].lstrip("*")
+        if fname == name:
+            return parts[0].lower()
+    return None
+
+
+def ensure(force: bool = False) -> Path:
+    """Download + verify + install the ox binary if missing. Returns its path."""
+    dest = binary_path()
+    if dest.exists() and os.access(dest, os.X_OK) and not force:
+        return dest
+
+    version = __version__
+    goos, goarch = _target()
+    name = _asset_name(version, goos, goarch)
+    base = _release_base(version)
+
+    archive = _fetch(f"{base}/{name}")
+
+    # Verify BEFORE extracting — a missing/failed checksum is a HARD failure,
+    # exactly as scripts/install.sh treats it.
+    checksums = _fetch(f"{base}/checksums.txt").decode("utf-8")
+    expected = _expected_checksum(checksums, name)
+    if expected is None:
+        raise RuntimeError(
+            f"release checksums.txt does not list {name}; refusing to install unverified binary"
+        )
+    actual = hashlib.sha256(archive).hexdigest().lower()
+    if actual != expected:
+        raise RuntimeError(
+            f"checksum mismatch for {name}\n  expected: {expected}\n  actual:   {actual}\n"
+            "refusing to install a corrupt or tampered binary"
+        )
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="sageox-ox-") as tmp:
+        archive_path = Path(tmp) / name
+        archive_path.write_bytes(archive)
+        with tarfile.open(archive_path, "r:gz") as tf:
+            member = tf.getmember("ox")
+            extracted = tf.extractfile(member)
+            if extracted is None:
+                raise RuntimeError(f"archive {name} did not contain an 'ox' binary")
+            dest.write_bytes(extracted.read())
+
+    dest.chmod(dest.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return dest

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -56,6 +56,18 @@ if [ -f "claude-plugin/.claude-plugin/plugin.json" ]; then
     check_version "$PLUGIN_VERSION" "claude-plugin/.claude-plugin/plugin.json"
 fi
 
+# Check npm/package.json (@sageox/ox npm wrapper)
+if [ -f "npm/package.json" ]; then
+    NPM_VERSION=$(grep '"version"' npm/package.json 2>/dev/null | head -1 | sed 's/.*"\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/')
+    check_version "$NPM_VERSION" "npm/package.json"
+fi
+
+# Check pip/pyproject.toml (sageox PyPI wrapper skeleton)
+if [ -f "pip/pyproject.toml" ]; then
+    PIP_VERSION=$(grep '^version = ' pip/pyproject.toml 2>/dev/null | head -1 | sed 's/.*"\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/')
+    check_version "$PIP_VERSION" "pip/pyproject.toml"
+fi
+
 # Check CHANGELOG.md has the current version
 if [ -f "CHANGELOG.md" ]; then
     # Extract first version from CHANGELOG.md (format: ## [X.Y.Z])

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -82,7 +82,24 @@ if [ -f "claude-plugin/.claude-plugin/plugin.json" ]; then
     update_file "claude-plugin/.claude-plugin/plugin.json" "\"version\": \"$CURRENT_VERSION\"" "\"version\": \"$NEW_VERSION\""
 fi
 
-# 4. CHANGELOG.md - check if version already present
+# 4. npm/package.json (@sageox/ox npm wrapper — CI re-pins this from the tag at
+#    publish, but keep the committed default in sync so local `npm pack` is honest)
+if [ -f "npm/package.json" ]; then
+    echo "  - npm/package.json"
+    update_file "npm/package.json" "\"version\": \"$CURRENT_VERSION\"" "\"version\": \"$NEW_VERSION\""
+fi
+
+# 5. pip/ wrapper (follow-up skeleton — keep in sync so it's release-ready)
+if [ -f "pip/pyproject.toml" ]; then
+    echo "  - pip/pyproject.toml"
+    update_file "pip/pyproject.toml" "version = \"$CURRENT_VERSION\"" "version = \"$NEW_VERSION\""
+fi
+if [ -f "pip/sageox/__init__.py" ]; then
+    echo "  - pip/sageox/__init__.py"
+    update_file "pip/sageox/__init__.py" "__version__ = \"$CURRENT_VERSION\"" "__version__ = \"$NEW_VERSION\""
+fi
+
+# 6. CHANGELOG.md - check if version already present
 if [ -f "CHANGELOG.md" ]; then
     if ! grep -q "\[$NEW_VERSION\]" CHANGELOG.md; then
         echo -e "  - CHANGELOG.md ${YELLOW}(needs manual update)${NC}"


### PR DESCRIPTION
## Summary

**Developers can now install `ox` straight from the package manager they already
live in — `npx @sageox/ox` today, `pip install sageox` next — without giving up
any of the integrity guarantees of the canonical installer.** Both wrappers
download the **exact same signed release tarball** that Homebrew and
`curl … | bash` deliver and hard-gate it on a SHA-256 check against the release
`checksums.txt`; a mismatch (or an unsupported platform) fails loudly instead of
running an unverified binary. Neither wrapper vendors or recompiles a second
binary — there is still only one artifact to trust.

What this PR ships:

- **`npm/` — `@sageox/ox` (primary, publish-ready).** A thin wrapper whose
  `postinstall` (and a lazy first-run fallback for `--ignore-scripts`) downloads,
  verifies, extracts, and installs the platform-native `ox`. `bin/ox.js` execs it,
  forwarding argv/stdio/exit-status. `OX_NPM_SKIP_DOWNLOAD=1` defers the fetch for
  CI/offline mirrors.
- **`.github/workflows/release.yml` — new `publish-npm` job.** Runs
  `needs: build-and-release` (so the signed assets exist first), pins the wrapper
  version to the release tag, and runs `npm publish --provenance --access public`
  (prereleases → `next` dist-tag). **No-ops cleanly when `NPM_TOKEN` is unset**, so
  it never breaks a release before the `@sageox` npm scope + token are provisioned.
- **`pip/` — `sageox` (clearly-marked skeleton).** Same download-verify-exec model
  for PyPI, lazy on first run. Not yet wired to a publish job; the README/pyproject
  headers list the exact remaining prerequisites (own the name, add an OIDC Trusted
  Publishing job).
- **`scripts/{check-versions,version-bump}.sh`** — the version tooling now tracks
  `npm/package.json`, `pip/pyproject.toml`, and `pip/sageox/__init__.py` so every
  manifest bumps in lockstep (all currently `0.14.3`).

The asset-name mapping in each wrapper mirrors goreleaser + `scripts/install.sh`
exactly (`ox_{version}_{os}_{arch}.tar.gz`; darwin/linux amd64+arm64, freebsd
amd64; Windows and freebsd/arm64 intentionally excluded).

```mermaid
flowchart TD
    subgraph install["npx @sageox/ox  /  pip install sageox"]
        A[resolve host platform/arch] --> B{supported target?}
        B -- no --> X[fail loudly: install from source]
        B -- yes --> C[fetch ox_VER_os_arch.tar.gz + checksums.txt<br/>from GitHub Releases]
        C --> D{sha256 == checksums.txt?}
        D -- no / missing --> Y[refuse: corrupt or tampered]
        D -- yes --> E[extract ox → cache dir]
        E --> F[exec ox, forward argv/stdio/exit]
    end
```

```mermaid
flowchart LR
    R[release: published] --> BR[build-and-release<br/>sign + goreleaser + checksums.txt]
    BR -- needs --> PN[publish-npm<br/>pin version to tag<br/>npm publish --provenance]
    PN -.->|NPM_TOKEN unset| NOOP[skip cleanly, release still green]
```

## Test Plan

- `bash scripts/check-versions.sh` → green; the two new manifests report
  `Match: … 0.14.3` alongside the existing ones.
- `cd npm && npm pack --dry-run` → tarball contains only `bin/ lib/ install.js
  README.md LICENSE` (no vendored binary), matching the `files` allowlist.
- Reviewed the release job wiring: `RELEASE_TAG` is a workflow-level `env:`, so
  `publish-npm`'s `${{ env.RELEASE_TAG }}` (checkout ref + version pin) resolves;
  `needs: build-and-release` guarantees assets exist before publish.
- Runtime download/verify paths are covered by manual reading against
  `scripts/install.sh`'s checksum logic; `publish-npm` only activates on the next
  tagged release and no-ops until `NPM_TOKEN` is set. The `pip/` path is a skeleton
  and is not published by this PR.

**Supply-chain note (honest disclosure):** the new `publish-npm` job adds
`id-token: write` and consumes an `NPM_TOKEN` to publish to a public registry.
It touches none of the auto-security-reviewed paths (`internal/auth/`,
`internal/mcp/`, `go.sum`, etc.), so no auto-review is triggered — flagging the
new publish surface here for reviewer awareness.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — N/A: install-wrapper packaging; validated via `check-versions.sh` + `npm pack`.
- [x] CHANGELOG entry added (if user-facing) — N/A: no version bump in this PR; wrapper infra activates on the next tagged release.
- [x] Breaking change documented — N/A: additive (new install methods only).
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: touches none of the auto-reviewed paths; new npm-publish supply-chain surface noted above.

</details>

Co-authored-by: SageOx <ox@sageox.ai>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790801730&installation_model_id=433550&pr_number=847&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F847&signature=05ea62400516762511f8ff2fd6f03e996ceaf9ca972f5c7b4c9900eeac52c8f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added npm and PyPI wrappers for installing and running the `ox` CLI.
  * Automatically downloads the correct platform binary and verifies its checksum.
  * Added support for skipping npm downloads when needed.
  * Added platform support documentation, usage instructions, and licensing information.
  * Releases can now publish npm packages, with separate channels for stable and prerelease versions.

* **Chores**
  * Added package version validation and automated version updates for npm and PyPI packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->