### PR TITLE
Expand behavioral coverage and recovery gates

### DIFF
--- a/.config/coverage-ratchets.json
+++ b/.config/coverage-ratchets.json
@@ -3,7 +3,8 @@
   "changed_line_coverage": {
     "minimum": 90.0,
     "excluded_paths": [
-      "**/*_generated.go"
+      "**/*_generated.go",
+      "tests/**"
     ],
     "exceptions": [
       {
@@ -17,19 +18,19 @@
     {
       "path": "cmd/ox/",
       "recursive": false,
-      "minimum": 40.0,
+      "minimum": 49.0,
       "reason": "Primary CLI orchestration and user-facing failure handling"
     },
     {
       "path": "internal/daemon/",
       "recursive": false,
-      "minimum": 54.5,
+      "minimum": 63.5,
       "reason": "Sync, IPC, retry, and recovery orchestration"
     },
     {
       "path": "internal/codedb/index/",
       "recursive": false,
-      "minimum": 34.0,
+      "minimum": 68.0,
       "reason": "Repository indexing and recovery boundary"
     },
     {
@@ -47,13 +48,13 @@
     {
       "path": "internal/daemon/agentwork/",
       "recursive": false,
-      "minimum": 65.0,
+      "minimum": 72.0,
       "reason": "External AI coworker process, timeout, and output boundary"
     },
     {
       "path": "internal/session/pipeline/",
       "recursive": false,
-      "minimum": 90.0,
+      "minimum": 98.0,
       "reason": "Durable session copy and upload orchestration"
     }
   ]

--- a/.config/test-tiers.json
+++ b/.config/test-tiers.json
@@ -65,7 +65,9 @@
       "description": "Deterministic current-source compiled-binary journeys using isolated repositories and mock services.",
       "includes": [
         "Code activity behavior through a freshly built ox binary",
-        "Fresh-install init and doctor journey against a mock SageOx API with external network blocked"
+        "Fresh-install init and doctor journey against a mock SageOx API with external network blocked",
+        "Session start, incremental capture, and stop through the compiled binary, plus crash-artifact preservation through the production finalizer",
+        "Coverage fragments from the compiled binary merged with the full Go test profile"
       ],
       "excludes": [
         "Real cloud credentials and real AI coworker invocations",
@@ -78,7 +80,8 @@
       "includes": [
         "Product authentication client behavior against twin expiry, refresh, revocation, and injected API faults",
         "Ledger structural scenarios",
-        "Knowledge Bubble sync and garbage-collection scenarios against real bare Git repositories"
+        "Knowledge Bubble sync and garbage-collection scenarios against real bare Git repositories",
+        "Distinct twin coverage profiles merged into the authoritative full-suite report"
       ],
       "excludes": [
         "Real SageOx cloud infrastructure",

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.13.0
 
-      - name: Full test suite with coverage
-        run: TEST_JUNIT=junit.xml make test-all
+      - name: Full and compiled-binary suites with coverage
+        run: TEST_JUNIT=junit.xml make coverage-integration
 
       - name: Require requested test artifact
         run: |
@@ -39,17 +39,17 @@ jobs:
           python3 -c 'import xml.etree.ElementTree as ET; root = ET.parse("junit.xml").getroot(); assert any(root.iter("testcase")), "JUnit artifact has no test cases"'
 
       - name: Enforce risk-package coverage ratchets
-        run: python3 scripts/coverage_ratchet.py coverage.out
+        run: python3 scripts/coverage_ratchet.py coverage-all.out --require-provenance coverage-all.out.provenance.json
 
       - name: Enforce changed-line coverage
         if: github.event_name == 'pull_request'
-        run: python3 scripts/coverage_ratchet.py coverage.out --diff-base "${{ github.event.pull_request.base.sha }}"
+        run: python3 scripts/coverage_ratchet.py coverage-all.out --require-provenance coverage-all.out.provenance.json --diff-base "${{ github.event.pull_request.base.sha }}"
 
       - name: Upload coverage
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          files: coverage.out
+          files: coverage-all.out
           flags: ox-cli
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ docs/design/**/*.webm
 *.dylib
 *.test
 *.out
+*.out.provenance.json
 go.work
 
 # python tooling

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for ox CLI tool
 
 .PHONY: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw check-codedb-guarded-open check-test-tiers test-tiers
-.PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-timings test-all test-slow test-browser test-integration test-acceptance test-release test-agents test-preflight test-digital-twin test-cloud-api-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check coverage-ratchet coverage-ratchet-diff coverage-ratchet-test build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-check docs-publish refresh-friction-catalog bump-version verify-version check-release-drift beads-setup
+.PHONY: help build build-ox build-adapters build-acceptance install install-adapters clean dev run test test-cover test-timings test-all test-slow test-fuzz test-browser test-integration test-acceptance test-acceptance-cover test-acceptance-run test-release test-agents test-preflight test-digital-twin test-digital-twin-cover test-cloud-api-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check coverage-ratchet coverage-ratchet-diff coverage-ratchet-test build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-check docs-publish refresh-friction-catalog bump-version verify-version check-release-drift beads-setup
 
 # Variables
 GO := go
@@ -33,6 +33,20 @@ TIME_CMD = $(if $(filter 1,$(V)),time,)
 
 # Bundled adapters (shipped in release tarballs alongside ox)
 ADAPTERS := ox-adapter-claude-code ox-adapter-gemini ox-adapter-codex ox-adapter-amp ox-adapter-opencode ox-adapter-pi ox-adapter-omp ox-adapter-aider ox-adapter-droid ox-adapter-goose
+empty :=
+space := $(empty) $(empty)
+comma := ,
+ACCEPTANCE_DIR := $(abspath tmp/acceptance)
+ACCEPTANCE_OX_BIN ?= $(ACCEPTANCE_DIR)/$(BINARY_NAME)
+ACCEPTANCE_GO_COVER_DIR ?=
+ACCEPTANCE_INTEGRATION_COVER_FLAGS = $(if $(strip $(ACCEPTANCE_GO_COVER_DIR)),-coverprofile=$(ACCEPTANCE_GO_COVER_DIR)/integration-test.out -covermode=atomic,)
+ACCEPTANCE_SLOW_COVER_FLAGS = $(if $(strip $(ACCEPTANCE_GO_COVER_DIR)),-coverprofile=$(ACCEPTANCE_GO_COVER_DIR)/slow-test.out -covermode=atomic,)
+ACCEPTANCE_INTEGRATION_TESTS := TestCodeActivityE2E TestFreshInstall_MockServer_InitThenDoctor TestFreshInstall_MockServer_SyncUnavailableThenDoctorStillWorks
+ACCEPTANCE_SLOW_TESTS := TestIncrementalE2E_SingleAgent TestIncrementalE2E_CtrlC_AntiEntropy
+TWIN_COVER_DIR ?=
+CLOUD_TWIN_COVER_FLAGS = $(if $(strip $(TWIN_COVER_DIR)),-coverpkg=github.com/sageox/ox/internal/auth -coverprofile=$(TWIN_COVER_DIR)/cloud.out -covermode=atomic,)
+LEDGER_TWIN_COVER_FLAGS = $(if $(strip $(TWIN_COVER_DIR)),-coverpkg=github.com/sageox/ox/internal/glance$(comma)github.com/sageox/ox/internal/ledger$(comma)github.com/sageox/ox/internal/carts -coverprofile=$(TWIN_COVER_DIR)/ledger.out -covermode=atomic,)
+KB_TWIN_COVER_FLAGS = $(if $(strip $(TWIN_COVER_DIR)),-coverpkg=github.com/sageox/ox/internal/daemon$(comma)github.com/sageox/ox/internal/kb$(comma)github.com/sageox/ox/internal/gitserver -coverprofile=$(TWIN_COVER_DIR)/kb.out -covermode=atomic,)
 
 # Build targets
 # Targets below are agent-friendly by default (quiet). V=1 for verbose.
@@ -53,6 +67,12 @@ build-adapters: ## Build all bundled adapter binaries to bin/
 	done
 	$(call say,"Adapters built: $(ADAPTERS)")
 
+build-acceptance: ## Build the exact ox + adapter binaries used by acceptance tests
+	@rm -rf "$(ACCEPTANCE_DIR)"
+	@mkdir -p "$(ACCEPTANCE_DIR)"
+	@$(GO) build $(LDFLAGS) -o "$(ACCEPTANCE_OX_BIN)" ./cmd/ox
+	@$(GO) build $(ADAPTER_LDFLAGS) -o "$(ACCEPTANCE_DIR)/ox-adapter-claude-code" ./cmd/ox-adapter-claude-code
+
 install: install-ox install-adapters ## Install ox and adapters to $GOPATH/bin
 
 install-ox: ## Install ox to $GOPATH/bin
@@ -71,7 +91,7 @@ clean: ## Remove build artifacts
 	@echo "Cleaning build artifacts..."
 	@rm -rf bin/ dist/ tmp/
 	@rm -f $(BINARY_NAME)
-	@rm -f coverage.out coverage.html coverage-all.out .coverage-baseline.out
+	@rm -f coverage.out coverage.out.provenance.json coverage.html coverage-all.out coverage-all.out.provenance.json .coverage-baseline.out
 	@echo "Clean complete"
 
 # Development
@@ -174,6 +194,7 @@ test: check-test-tiers ## Run fast tests — unit tests <500ms, race detection, 
 test-cover: check-test-tiers ## Run fast tests with coverage collection (~15-20% slower than `make test`)
 	$(call say,"Running fast tests with coverage...")
 	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) $(GOTESTSUM_JUNIT) $(GOTESTSUM_TIMINGS) -- $(FAST_TEST_FLAGS) -coverprofile=coverage.out -covermode=atomic ./...
+	@python3 scripts/coverage_ratchet.py coverage.out --write-provenance coverage.out.provenance.json
 
 test-timings: ## Reprint metrics from the latest fast-test timing artifact
 	@test -n "$(TEST_TIMINGS)" || (echo "Set TEST_TIMINGS to an artifact printed by 'make test'." && exit 1)
@@ -183,10 +204,16 @@ test-timings: ## Reprint metrics from the latest fast-test timing artifact
 test-all: check-test-tiers ## Run all unit tests including expensive ones (git clone, SQLite, LFS) with coverage
 	$(call say,"Running all tests including expensive tests...")
 	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) $(GOTESTSUM_JUNIT) $(GOTESTSUM_TIMINGS) -- $(FULL_TEST_FLAGS) -coverprofile=coverage.out -covermode=atomic ./...
+	@python3 scripts/coverage_ratchet.py coverage.out --write-provenance coverage.out.provenance.json
 
 test-slow: check-test-tiers ## Run slow tests (build tag: slow) — requires real ox binary, no Claude needed
 	$(call say,"Running slow tests (requires built ox binary)...")
 	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- $(SLOW_TEST_FLAGS) $(SLOW_TEST_PACKAGES)
+
+test-fuzz: ## Run bounded fuzz smoke gates over untrusted parsers
+	@$(GO) test -race -run '^$$' -fuzz '^FuzzParseLayerName$$' -fuzztime=5s ./internal/conversation/format
+	@$(GO) test -race -run '^$$' -fuzz '^FuzzFolderName$$' -fuzztime=5s ./internal/conversation/read
+	@$(GO) test -race -run '^$$' -fuzz '^FuzzParseHistoryEntry$$' -fuzztime=5s ./internal/session
 
 test-browser: ## Run real-browser E2E (build tag: browser) — drives headless Chrome; skips if no Chrome installed
 	$(call say,"Running real-browser E2E (requires Chrome/Chromium)...")
@@ -197,24 +224,50 @@ test-integration: ## Integration tests live in sageox/ox-test-harness
 	@echo "For an in-repo real-agent smoke gate, run: make test-agents"
 	@exit 1
 
-test-acceptance: check-test-tiers ## Deterministic current-source compiled-binary acceptance journeys
+test-acceptance: check-test-tiers build-acceptance ## Deterministic current-source compiled-binary acceptance journeys
 	$(call say,"Running deterministic compiled-binary acceptance tests...")
+	@$(MAKE) --no-print-directory test-acceptance-run "ACCEPTANCE_OX_BIN=$(ACCEPTANCE_OX_BIN)"
+
+test-acceptance-cover: check-test-tiers build-cover ## Acceptance journeys through a coverage-instrumented current binary
+	@rm -rf $(COVERDIR)/integration
+	@mkdir -p $(COVERDIR)/integration
+	@OX_TEST_GOCOVERDIR="$(abspath $(COVERDIR)/integration)" \
+		$(MAKE) --no-print-directory test-acceptance-run \
+			"ACCEPTANCE_OX_BIN=$(abspath bin/$(BINARY_NAME)-cover)" \
+			"ACCEPTANCE_GO_COVER_DIR=$(COVERDIR)"
+	@test -s $(COVERDIR)/integration-test.out || { echo "ERROR: integration acceptance produced no Go coverage profile"; exit 1; }
+	@test -s $(COVERDIR)/slow-test.out || { echo "ERROR: session acceptance produced no Go coverage profile"; exit 1; }
+
+# Internal runner shared by ordinary and coverage-instrumented acceptance. It
+# asserts every required journey exists before execution so renames/deletions
+# cannot turn the tier green with "no tests to run".
+test-acceptance-run:
+	@test -x "$(ACCEPTANCE_OX_BIN)" || { echo "ERROR: acceptance binary missing: $(ACCEPTANCE_OX_BIN)"; exit 1; }
 	@listed=$$($(GO) test -tags=integration ./cmd/ox -list '.'); \
-	 for required in TestCodeActivityE2E TestFreshInstall_MockServer_InitThenDoctor; do \
+	 for required in $(ACCEPTANCE_INTEGRATION_TESTS); do \
 	   printf '%s\n' "$$listed" | grep -Fx "$$required" >/dev/null || { echo "ERROR: required acceptance test missing: $$required"; exit 1; }; \
 	 done
-	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- \
+	@listed=$$($(GO) test -tags=slow ./cmd/ox -list '.'); \
+	 for required in $(ACCEPTANCE_SLOW_TESTS); do \
+	   printf '%s\n' "$$listed" | grep -Fx "$$required" >/dev/null || { echo "ERROR: required acceptance test missing: $$required"; exit 1; }; \
+	 done
+	@OX_TEST_OX_BINARY="$(ACCEPTANCE_OX_BIN)" $(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- \
 		-tags=integration -race -count=1 -p 1 -parallel 1 -timeout=10m \
-		-run 'TestCodeActivityE2E|TestFreshInstall_MockServer_InitThenDoctor' \
+		$(ACCEPTANCE_INTEGRATION_COVER_FLAGS) \
+		-run '^($(subst $(space),|,$(strip $(ACCEPTANCE_INTEGRATION_TESTS))))$$' \
+		./cmd/ox
+	@OX_TEST_OX_BINARY="$(ACCEPTANCE_OX_BIN)" $(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- \
+		-tags=slow -race -count=1 -p 1 -parallel 1 -timeout=10m \
+		$(ACCEPTANCE_SLOW_COVER_FLAGS) \
+		-run '^($(subst $(space),|,$(strip $(ACCEPTANCE_SLOW_TESTS))))$$' \
 		./cmd/ox
 
 test-release: check-test-tiers ## Run every enforceable in-repo release tier sequentially
 	@$(MAKE) coverage-ratchet-test
-	@$(MAKE) test-all
-	@python3 scripts/coverage_ratchet.py coverage.out
+	@$(MAKE) coverage-integration
+	@python3 scripts/coverage_ratchet.py coverage-all.out --require-provenance coverage-all.out.provenance.json
 	@$(MAKE) test-slow
-	@$(MAKE) test-acceptance
-	@$(MAKE) test-digital-twin
+	@$(MAKE) test-fuzz
 
 test-agents: ## Drive real coding agents and read their transcripts back through ox (opt-in, costs API calls)
 	$(call say,"Driving real coding agents — requires each agent installed and authenticated...")
@@ -341,9 +394,28 @@ test-preflight: check-no-git-lfs-shell check-raw-writer-chokepoint check-session
 
 test-digital-twin: test-cloud-api-twin test-ledger-twin test-kb-twin ## Deterministic cloud-auth, ledger, and KB twins
 
+test-digital-twin-cover: ## Run every deterministic twin with distinct mergeable coverage profiles
+	@rm -rf $(COVERDIR)/twins
+	@mkdir -p $(COVERDIR)/twins
+	@$(MAKE) --no-print-directory test-digital-twin "TWIN_COVER_DIR=$(COVERDIR)/twins"
+	@for profile in cloud ledger kb; do \
+	  test -s $(COVERDIR)/twins/$$profile.out || { echo "ERROR: $$profile twin produced no coverage profile"; exit 1; }; \
+	 done
+	@grep -q '^github.com/sageox/ox/internal/auth/' $(COVERDIR)/twins/cloud.out || { echo "ERROR: cloud twin profile contains no product auth coverage"; exit 1; }
+	@grep -q '^github.com/sageox/ox/internal/glance/' $(COVERDIR)/twins/ledger.out || { echo "ERROR: ledger twin profile contains no product glance coverage"; exit 1; }
+	@grep -q '^github.com/sageox/ox/internal/daemon/' $(COVERDIR)/twins/kb.out || { echo "ERROR: KB twin profile contains no product daemon coverage"; exit 1; }
+	@if grep -q '^github.com/sageox/ox/tests/' $(COVERDIR)/twins/*.out; then \
+	  echo "ERROR: twin coverage must measure product packages, not harness packages"; exit 1; \
+	 fi
+
 test-cloud-api-twin: ## Product auth client against in-process SageOx API twin
 	@echo "Running cloud auth API digital twin tests..."
-	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -race -count=1 -timeout=2m ./internal/auth/... ./internal/twinapi/...
+	@listed=$$($(GO) test ./internal/twinapi ./internal/auth -list '^Test'); \
+	 for required in TestDeviceFlow_HappyPath TestIntrospect_FaultInjectionIsPathGeneric TestClockAdvance_JWTExpiry \
+	   TestValidateTokenServerSide_ExpiredJWT TestValidateTokenServerSide_FaultInjection TestValidateTokenServerSide_UserNotFoundError; do \
+	   printf '%s\n' "$$listed" | grep -Fx "$$required" >/dev/null || { echo "ERROR: required cloud twin test missing: $$required"; exit 1; }; \
+	 done
+	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -race -count=1 -timeout=2m $(CLOUD_TWIN_COVER_FLAGS) ./internal/auth/... ./internal/twinapi/...
 
 test-team-context-twin: ## Digital twin tests (generates fake team context for inspection)
 	@echo "Running team context digital twin tests..."
@@ -351,12 +423,20 @@ test-team-context-twin: ## Digital twin tests (generates fake team context for i
 
 test-ledger-twin: ## Digital twin ledger tests (generates fake ledger for inspection)
 	@echo "Running ledger digital twin tests..."
-	@time $(GOTESTSUM) --format pkgname-and-test-fails -- -tags=ledger_twin -v -count=1 -timeout=2m ./tests/ledger_twin/...
+	@listed=$$($(GO) test -tags=ledger_twin ./tests/ledger_twin -list '^Test'); \
+	 for required in TestCartAnalyzeWindows TestPreCrimePositive_HotZone TestSessionConflicts_MergedWithMurmurs TestFullEnrich; do \
+	   printf '%s\n' "$$listed" | grep -Fx "$$required" >/dev/null || { echo "ERROR: required ledger twin test missing: $$required"; exit 1; }; \
+	 done
+	@$(TEST_GIT_ISOLATION) time $(GOTESTSUM) --format pkgname-and-test-fails -- -tags=ledger_twin -v -count=1 -timeout=2m $(LEDGER_TWIN_COVER_FLAGS) ./tests/ledger_twin/...
 
 test-kb-twin: ## Digital twin kb tests (drives syncBubbles + GC against real bare repos)
 	@command -v git >/dev/null 2>&1 || { echo "ERROR: git is required for the KB digital twin"; exit 1; }
 	@echo "Running kb digital twin tests..."
-	@time $(GOTESTSUM) --format pkgname-and-test-fails -- -tags=kb_twin -v -count=1 -timeout=5m ./tests/kb_twin/...
+	@listed=$$($(GO) test -tags=kb_twin ./tests/kb_twin -list '^Test'); \
+	 for required in TestKBTwin TestKBTwin_MultiEndpoint TestKBTwin_APIUnavailable_NoSideEffects TestKBTwin_MetaJSONShape; do \
+	   printf '%s\n' "$$listed" | grep -Fx "$$required" >/dev/null || { echo "ERROR: required KB twin test missing: $$required"; exit 1; }; \
+	 done
+	@$(TEST_GIT_ISOLATION) time $(GOTESTSUM) --format pkgname-and-test-fails -- -tags=kb_twin -v -count=1 -timeout=5m $(KB_TWIN_COVER_FLAGS) ./tests/kb_twin/...
 
 test-benchmark: ## Run prime efficiency benchmarks (requires claude CLI) - ~80 min, ~40 API calls
 	@echo "Running prime efficiency benchmarks..."
@@ -419,10 +499,10 @@ coverage-check: ## Fail if coverage is below threshold (default: 50%)
 	 fi
 
 coverage-ratchet: test-all ## Fail if protected risk-package coverage regresses
-	@python3 scripts/coverage_ratchet.py coverage.out
+	@python3 scripts/coverage_ratchet.py coverage.out --require-provenance coverage.out.provenance.json
 
 coverage-ratchet-diff: test-all ## Enforce package + changed-line coverage vs COVERAGE_BASE
-	@python3 scripts/coverage_ratchet.py coverage.out --diff-base $(COVERAGE_BASE)
+	@python3 scripts/coverage_ratchet.py coverage.out --require-provenance coverage.out.provenance.json --diff-base $(COVERAGE_BASE)
 
 coverage-ratchet-test: ## Test the coverage ratchet parser and failure semantics
 	@cd scripts && PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v coverage_ratchet_test.py test_tiers_test.py test_metrics_test.py
@@ -431,13 +511,15 @@ build-cover: ## Build ox binary with coverage instrumentation
 	@rm -rf $(COVERDIR)/integration $(COVERDIR)/merged
 	@mkdir -p bin $(COVERDIR)/integration
 	@$(GO) build -cover -covermode=atomic $(LDFLAGS) -o bin/$(BINARY_NAME)-cover ./cmd/ox
+	@$(GO) build $(ADAPTER_LDFLAGS) -o bin/ox-adapter-claude-code ./cmd/ox-adapter-claude-code
 	@echo "Instrumented binary: bin/$(BINARY_NAME)-cover"
 	@echo "Run with: GOCOVERDIR=$(COVERDIR)/integration bin/$(BINARY_NAME)-cover ..."
 
-coverage-integration: test-cover build-cover ## Run instrumented ox and merge unit + integration coverage
-	@echo "Running deterministic instrumented-binary scenarios..."
-	@GOCOVERDIR=$(abspath $(COVERDIR)/integration) bin/$(BINARY_NAME)-cover version >/dev/null
-	@GOCOVERDIR=$(abspath $(COVERDIR)/integration) bin/$(BINARY_NAME)-cover help >/dev/null
+coverage-integration: ## Run acceptance through instrumented ox and merge full + binary coverage
+	@rm -f coverage-all.out coverage-all.out.provenance.json
+	@$(MAKE) --no-print-directory test-all
+	@$(MAKE) --no-print-directory test-acceptance-cover
+	@$(MAKE) --no-print-directory test-digital-twin-cover
 	@count=$$(find $(COVERDIR)/integration -type f -name 'covcounters.*' | wc -l | tr -d ' '); \
 	 if [ "$$count" -eq 0 ]; then \
 	   echo "ERROR: instrumented ox produced no fresh coverage counters"; exit 1; \
@@ -446,9 +528,12 @@ coverage-integration: test-cover build-cover ## Run instrumented ox and merge un
 	@echo "Converting integration profile..."
 	@$(GO) tool covdata textfmt -i=$(COVERDIR)/integration -o=$(COVERDIR)/integration.out
 	@echo "Merging profiles..."
-	@awk 'FNR == 1 { next } { counts[$$1 " " $$2] += $$3 } END { for (block in counts) print block, counts[block] }' \
-	  coverage.out $(COVERDIR)/integration.out | LC_ALL=C sort > $(COVERDIR)/merged-body.out
+	@awk 'FNR == 1 { next } /\/kb_twin_export\.go:/ { next } { counts[$$1 " " $$2] += $$3 } END { for (block in counts) print block, counts[block] }' \
+	  coverage.out $(COVERDIR)/integration.out $(COVERDIR)/integration-test.out $(COVERDIR)/slow-test.out \
+	  $(COVERDIR)/twins/cloud.out $(COVERDIR)/twins/ledger.out $(COVERDIR)/twins/kb.out \
+	  | LC_ALL=C sort > $(COVERDIR)/merged-body.out
 	@{ echo 'mode: atomic'; sed -n '1,$$p' $(COVERDIR)/merged-body.out; } > coverage-all.out
+	@python3 scripts/coverage_ratchet.py coverage-all.out --write-provenance coverage-all.out.provenance.json
 	@$(GO) tool cover -func=coverage-all.out | tail -1
 	@echo "Combined profile: coverage-all.out"
 

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1309,6 +1309,10 @@ func finalizeModeForSessionStop(userPrefersAsync bool) session.FinalizeDispatchM
 // If this fails, the session data is safe in the local cache and doctor can retry.
 // ledgerPath and sessionName are pre-computed by the caller.
 func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state *session.RecordingState, ledgerPath, sessionName string) error {
+	return uploadSessionToLedgerWithEffects(projectRoot, result, state, ledgerPath, sessionName, productionSessionUploadEffects())
+}
+
+func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionResult, state *session.RecordingState, ledgerPath, sessionName string, effects sessionUploadEffects) error {
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	sessionDir := filepath.Join(sessionsDir, sessionName)
 
@@ -1381,7 +1385,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	}
 
 	// upload content files to LFS blob storage
-	fileRefs, err := uploadSessionLFS(projectRoot, sessionDir)
+	fileRefs, err := effects.uploadLFS(projectRoot, sessionDir)
 	if err != nil {
 		if errors.Is(err, api.ErrReadOnly) {
 			return err // don't wrap, don't set doctor marker
@@ -1403,7 +1407,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	}
 
 	// commit meta.json + .gitignore and push
-	if err := commitAndPushLedger(ledgerPath, sessionName); err != nil {
+	if err := effects.commitInitial(ledgerPath, sessionName); err != nil {
 		// set marker - session saved locally but not synced to remote
 		_ = doctor.SetNeedsDoctorAgent(projectRoot)
 		return fmt.Errorf("commit and push: %w", err)
@@ -1413,7 +1417,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	// is committed, so backfill it + outcome=stopped onto every plan this
 	// session produced (slugs in hand — no directory scan), then commit those
 	// plan dirs. Best-effort; any miss falls to `ox doctor`.
-	reconcileProducedPlansAtStop(projectRoot, state.ProducedPlans, sessionName, meta.EffectiveSessionID())
+	effects.reconcilePlans(projectRoot, state.ProducedPlans, sessionName, meta.EffectiveSessionID())
 
 	// push succeeded — now safe to replace content files with LFS pointer stubs
 	if len(meta.Files) > 0 {
@@ -1433,7 +1437,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 			// the stash-pop yields conflict markers that ox doctor's auto-commit
 			// will eventually freeze into a permanent commit on main.
 			// (Tactical fix; pointer-first commit ordering is a separate discussion.)
-			if err := commitPointerRewriteAndPush(ledgerPath, sessionName, written); err != nil {
+			if err := effects.commitPointerRewrite(ledgerPath, sessionName, written); err != nil {
 				slog.Warn("LFS pointer rewrite commit failed", "error", err, "session", sessionName)
 			}
 		}
@@ -1450,7 +1454,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	// already-successful upload. Server-reported PR-link misses become
 	// repair tasks in the stop output — the agent still holds the session
 	// context and can fix the PR bodies with its own tooling.
-	for _, miss := range finalizeLinkageAfterPush(projectRoot, sessionDir, meta, sessionName) {
+	for _, miss := range effects.finalizeLinkage(projectRoot, sessionDir, meta, sessionName) {
 		result.PRLinkMisses = append(result.PRLinkMisses, fmt.Sprintf(
 			"PR %s is missing its session link — append this exact final line to its body: %s",
 			miss.PRURL, miss.ExpectedLine))

--- a/cmd/ox/agent_session_upload_lifecycle_test.go
+++ b/cmd/ox/agent_session_upload_lifecycle_test.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type sessionUploadFixture struct {
+	projectRoot string
+	ledgerPath  string
+	sessionName string
+	rawContent  []byte
+	result      *agentSessionResult
+	state       *session.RecordingState
+	refs        map[string]lfs.FileRef
+}
+
+func newSessionUploadFixture(t *testing.T) sessionUploadFixture {
+	t.Helper()
+	t.Setenv("OX_XDG_DISABLE", "")
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	projectRoot := t.TempDir()
+	ledgerPath := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "2026-09-01T03-00-testuser-OxLifecycle")
+	require.NoError(t, os.MkdirAll(cachePath, 0o755))
+	rawContent := []byte("{\"type\":\"header\",\"metadata\":{\"agent_id\":\"OxLifecycle\"}}\n" +
+		"{\"type\":\"user\",\"content\":\"preserve me\"}\n" +
+		"{\"type\":\"assistant\",\"content\":\"preserved\"}\n" +
+		"{\"type\":\"footer\",\"entry_count\":2}\n")
+	rawPath := filepath.Join(cachePath, ledgerFileRaw)
+	require.NoError(t, os.WriteFile(rawPath, rawContent, 0o600))
+
+	sessionName := filepath.Base(cachePath)
+	return sessionUploadFixture{
+		projectRoot: projectRoot,
+		ledgerPath:  ledgerPath,
+		sessionName: sessionName,
+		rawContent:  rawContent,
+		result: &agentSessionResult{
+			RawPath:     rawPath,
+			EntryCount:  2,
+			SessionName: sessionName,
+			Summary:     "A durable local summary",
+		},
+		state: &session.RecordingState{
+			AgentID:     "OxLifecycle",
+			AdapterName: "claude-code",
+			SessionID:   "ses_019d0000-0000-7000-8000-000000000007",
+			SessionPath: cachePath,
+			StartedAt:   time.Date(2026, 9, 1, 3, 0, 0, 0, time.UTC),
+			Title:       "Lifecycle recovery",
+		},
+		refs: map[string]lfs.FileRef{ledgerFileRaw: lfs.NewFileRef(rawContent)},
+	}
+}
+
+func scriptedSessionUploadEffects(calls *[]string, refs map[string]lfs.FileRef, failAt string) sessionUploadEffects {
+	mark := func(name string) error {
+		*calls = append(*calls, name)
+		if failAt == name {
+			return errors.New(name + " failed")
+		}
+		return nil
+	}
+	return sessionUploadEffects{
+		uploadLFS: func(_, _ string) (map[string]lfs.FileRef, error) {
+			if err := mark("upload_lfs"); err != nil {
+				return nil, err
+			}
+			return refs, nil
+		},
+		commitInitial: func(_, _ string) error { return mark("commit_initial") },
+		commitRetry: func(_, _ string, _ bool) error {
+			return mark("commit_retry")
+		},
+		commitPointerRewrite: func(_, _ string, paths []string) error {
+			if len(paths) == 0 {
+				return errors.New("pointer commit received no paths")
+			}
+			return mark("commit_pointers")
+		},
+		reconcilePlans: func(_ string, _ []string, _, _ string) {
+			_ = mark("reconcile_plans")
+		},
+		finalizeLinkage: func(_, _ string, _ *lfs.SessionMeta, _ string) []api.PRLinkMiss {
+			_ = mark("finalize_linkage")
+			return nil
+		},
+	}
+}
+
+func assertSessionBytesPreserved(t *testing.T, fixture sessionUploadFixture) {
+	t.Helper()
+	cacheBytes, err := os.ReadFile(fixture.result.RawPath)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.rawContent, cacheBytes, "the cache remains the authoritative retry source")
+
+	ledgerRaw := filepath.Join(fixture.ledgerPath, "sessions", fixture.sessionName, ledgerFileRaw)
+	ledgerBytes, err := os.ReadFile(ledgerRaw)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.rawContent, ledgerBytes, "pre-push failures must leave real bytes, never a pointer")
+	assert.False(t, lfs.IsPointerFile(ledgerRaw))
+}
+
+func TestUploadSessionToLedger_PreservesPriorStateAtFallibleBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		failAt    string
+		wantCalls []string
+		wantRefs  bool
+	}{
+		{
+			name:      "LFS upload failure",
+			failAt:    "upload_lfs",
+			wantCalls: []string{"upload_lfs"},
+		},
+		{
+			name:      "git sync failure after durable manifest",
+			failAt:    "commit_initial",
+			wantCalls: []string{"upload_lfs", "commit_initial"},
+			wantRefs:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newSessionUploadFixture(t)
+			var calls []string
+			effects := scriptedSessionUploadEffects(&calls, fixture.refs, tc.failAt)
+
+			err := uploadSessionToLedgerWithEffects(
+				fixture.projectRoot, fixture.result, fixture.state,
+				fixture.ledgerPath, fixture.sessionName, effects,
+			)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.failAt+" failed")
+			assert.Equal(t, tc.wantCalls, calls, "no later phase may run after a failed boundary")
+			assertSessionBytesPreserved(t, fixture)
+
+			meta, readErr := lfs.ReadSessionMeta(filepath.Join(fixture.ledgerPath, "sessions", fixture.sessionName))
+			require.NoError(t, readErr, "metadata must be durable before external publication")
+			assert.Equal(t, fixture.state.SessionID, meta.SessionID)
+			assert.Equal(t, lfs.LinkageStatusStaged, meta.LinkageStatus)
+			if tc.wantRefs {
+				assert.Equal(t, fixture.refs, meta.Files)
+			} else {
+				assert.Empty(t, meta.Files)
+			}
+		})
+	}
+}
+
+func TestUploadSessionToLedger_FullSuccessRunsOnlyPostPushEffects(t *testing.T) {
+	fixture := newSessionUploadFixture(t)
+	var calls []string
+	effects := scriptedSessionUploadEffects(&calls, fixture.refs, "")
+	effects.finalizeLinkage = func(_, _ string, _ *lfs.SessionMeta, _ string) []api.PRLinkMiss {
+		calls = append(calls, "finalize_linkage")
+		return []api.PRLinkMiss{{
+			PRURL:        "https://github.com/sageox/ox/pull/999",
+			ExpectedLine: "SageOx-Session: https://sageox.ai/c/ses_test",
+		}}
+	}
+
+	err := uploadSessionToLedgerWithEffects(
+		fixture.projectRoot, fixture.result, fixture.state,
+		fixture.ledgerPath, fixture.sessionName, effects,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"upload_lfs", "commit_initial", "reconcile_plans", "commit_pointers", "finalize_linkage",
+	}, calls)
+	ledgerRaw := filepath.Join(fixture.ledgerPath, "sessions", fixture.sessionName, ledgerFileRaw)
+	assert.True(t, lfs.IsPointerFile(ledgerRaw), "real bytes become pointers only after the durable push")
+	cacheBytes, readErr := os.ReadFile(fixture.result.RawPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, fixture.rawContent, cacheBytes, "the local source survives through post-push processing")
+	require.Len(t, fixture.result.PRLinkMisses, 1)
+	assert.Contains(t, fixture.result.PRLinkMisses[0], "pull/999")
+}
+
+func TestUploadSessionToLedger_GitignoreFailureStopsBeforePush(t *testing.T) {
+	fixture := newSessionUploadFixture(t)
+	gitignorePath := filepath.Join(fixture.ledgerPath, "sessions", ".gitignore")
+	require.NoError(t, os.MkdirAll(gitignorePath, 0o755))
+	var calls []string
+	effects := scriptedSessionUploadEffects(&calls, fixture.refs, "")
+
+	err := uploadSessionToLedgerWithEffects(
+		fixture.projectRoot, fixture.result, fixture.state,
+		fixture.ledgerPath, fixture.sessionName, effects,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ensure .gitignore")
+	assert.Equal(t, []string{"upload_lfs"}, calls, "push and all post-push effects must remain unreachable")
+	assertSessionBytesPreserved(t, fixture)
+	meta, readErr := lfs.ReadSessionMeta(filepath.Join(fixture.ledgerPath, "sessions", fixture.sessionName))
+	require.NoError(t, readErr)
+	assert.Equal(t, fixture.refs, meta.Files, "the uploaded manifest remains durable for doctor retry")
+}
+
+func TestUploadSessionToLedger_ReadOnlyIsNotHiddenByRecoveryWrapping(t *testing.T) {
+	fixture := newSessionUploadFixture(t)
+	var calls []string
+	effects := scriptedSessionUploadEffects(&calls, fixture.refs, "")
+	effects.uploadLFS = func(_, _ string) (map[string]lfs.FileRef, error) {
+		calls = append(calls, "upload_lfs")
+		return nil, api.ErrReadOnly
+	}
+
+	err := uploadSessionToLedgerWithEffects(
+		fixture.projectRoot, fixture.result, fixture.state,
+		fixture.ledgerPath, fixture.sessionName, effects,
+	)
+
+	assert.ErrorIs(t, err, api.ErrReadOnly)
+	assert.Equal(t, api.ErrReadOnly, err, "the caller relies on the sentinel for membership guidance")
+	assert.Equal(t, []string{"upload_lfs"}, calls)
+	assertSessionBytesPreserved(t, fixture)
+}
+
+func TestSessionUploadOrchestration_FailedUploadThenRetryIsIdempotent(t *testing.T) {
+	fixture := newSessionUploadFixture(t)
+	var failedCalls []string
+	failedEffects := scriptedSessionUploadEffects(&failedCalls, fixture.refs, "commit_initial")
+	require.Error(t, uploadSessionToLedgerWithEffects(
+		fixture.projectRoot, fixture.result, fixture.state,
+		fixture.ledgerPath, fixture.sessionName, failedEffects,
+	))
+	assertSessionBytesPreserved(t, fixture)
+
+	orphan := orphanedSession{
+		SessionName: fixture.sessionName,
+		CachePath:   fixture.state.SessionPath,
+		Meta: &session.StoreMeta{
+			SessionID: fixture.state.SessionID,
+			AgentID:   fixture.state.AgentID,
+			AgentType: fixture.state.AdapterName,
+			Username:  "testuser",
+			CreatedAt: fixture.state.StartedAt,
+		},
+		EntryCount: fixture.result.EntryCount,
+	}
+
+	var retryCalls []string
+	retryEffects := scriptedSessionUploadEffects(&retryCalls, fixture.refs, "")
+	require.NoError(t, retrySessionUploadWithEffects(
+		fixture.projectRoot, fixture.ledgerPath, orphan, retryEffects,
+	))
+	assert.Equal(t, []string{"upload_lfs", "commit_retry", "commit_pointers"}, retryCalls)
+
+	sessionDir := filepath.Join(fixture.ledgerPath, "sessions", fixture.sessionName)
+	firstMeta, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.state.SessionID, firstMeta.SessionID,
+		"recovery must preserve the ID already made durable by the failed stop")
+	assert.True(t, lfs.IsPointerFile(filepath.Join(sessionDir, ledgerFileRaw)))
+	cacheBytes, err := os.ReadFile(fixture.result.RawPath)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.rawContent, cacheBytes)
+
+	// A second doctor pass after a crash between remote push and cache pruning
+	// is safe: it replays from cache, retains identity, and converges again.
+	retryCalls = nil
+	require.NoError(t, retrySessionUploadWithEffects(
+		fixture.projectRoot, fixture.ledgerPath, orphan, retryEffects,
+	))
+	assert.Equal(t, []string{"upload_lfs", "commit_retry", "commit_pointers"}, retryCalls)
+	secondMeta, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, firstMeta.SessionID, secondMeta.SessionID)
+	assert.Equal(t, firstMeta.Files, secondMeta.Files)
+	assert.True(t, lfs.IsPointerFile(filepath.Join(sessionDir, ledgerFileRaw)))
+}
+
+func TestRetrySessionUpload_PointerCommitFailureRemainsIncomplete(t *testing.T) {
+	fixture := newSessionUploadFixture(t)
+	orphan := orphanedSession{
+		SessionName: fixture.sessionName,
+		CachePath:   fixture.state.SessionPath,
+		Meta: &session.StoreMeta{
+			SessionID: fixture.state.SessionID,
+			AgentID:   fixture.state.AgentID,
+			AgentType: fixture.state.AdapterName,
+			Username:  "testuser",
+			CreatedAt: fixture.state.StartedAt,
+		},
+		EntryCount: fixture.result.EntryCount,
+	}
+
+	var calls []string
+	effects := scriptedSessionUploadEffects(&calls, fixture.refs, "commit_pointers")
+	err := retrySessionUploadWithEffects(
+		fixture.projectRoot, fixture.ledgerPath, orphan, effects,
+	)
+
+	require.ErrorContains(t, err, "commit LFS pointer rewrite")
+	assert.Equal(t, []string{"upload_lfs", "commit_retry", "commit_pointers"}, calls)
+	_, statErr := os.Stat(fixture.state.SessionPath)
+	assert.NoError(t, statErr, "failed retry must leave authoritative cache available")
+}

--- a/cmd/ox/agent_session_upload_lifecycle_test.go
+++ b/cmd/ox/agent_session_upload_lifecycle_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +25,21 @@ type sessionUploadFixture struct {
 	result      *agentSessionResult
 	state       *session.RecordingState
 	refs        map[string]lfs.FileRef
+}
+
+func (f sessionUploadFixture) orphan() orphanedSession {
+	return orphanedSession{
+		SessionName: f.sessionName,
+		CachePath:   f.state.SessionPath,
+		Meta: &session.StoreMeta{
+			SessionID: f.state.SessionID,
+			AgentID:   f.state.AgentID,
+			AgentType: f.state.AdapterName,
+			Username:  "testuser",
+			CreatedAt: f.state.StartedAt,
+		},
+		EntryCount: f.result.EntryCount,
+	}
 }
 
 func newSessionUploadFixture(t *testing.T) sessionUploadFixture {
@@ -240,18 +258,7 @@ func TestSessionUploadOrchestration_FailedUploadThenRetryIsIdempotent(t *testing
 	))
 	assertSessionBytesPreserved(t, fixture)
 
-	orphan := orphanedSession{
-		SessionName: fixture.sessionName,
-		CachePath:   fixture.state.SessionPath,
-		Meta: &session.StoreMeta{
-			SessionID: fixture.state.SessionID,
-			AgentID:   fixture.state.AgentID,
-			AgentType: fixture.state.AdapterName,
-			Username:  "testuser",
-			CreatedAt: fixture.state.StartedAt,
-		},
-		EntryCount: fixture.result.EntryCount,
-	}
+	orphan := fixture.orphan()
 
 	var retryCalls []string
 	retryEffects := scriptedSessionUploadEffects(&retryCalls, fixture.refs, "")
@@ -286,18 +293,7 @@ func TestSessionUploadOrchestration_FailedUploadThenRetryIsIdempotent(t *testing
 
 func TestRetrySessionUpload_PointerCommitFailureRemainsIncomplete(t *testing.T) {
 	fixture := newSessionUploadFixture(t)
-	orphan := orphanedSession{
-		SessionName: fixture.sessionName,
-		CachePath:   fixture.state.SessionPath,
-		Meta: &session.StoreMeta{
-			SessionID: fixture.state.SessionID,
-			AgentID:   fixture.state.AgentID,
-			AgentType: fixture.state.AdapterName,
-			Username:  "testuser",
-			CreatedAt: fixture.state.StartedAt,
-		},
-		EntryCount: fixture.result.EntryCount,
-	}
+	orphan := fixture.orphan()
 
 	var calls []string
 	effects := scriptedSessionUploadEffects(&calls, fixture.refs, "commit_pointers")
@@ -309,4 +305,82 @@ func TestRetrySessionUpload_PointerCommitFailureRemainsIncomplete(t *testing.T) 
 	assert.Equal(t, []string{"upload_lfs", "commit_retry", "commit_pointers"}, calls)
 	_, statErr := os.Stat(fixture.state.SessionPath)
 	assert.NoError(t, statErr, "failed retry must leave authoritative cache available")
+	require.FileExists(t, filepath.Join(fixture.state.SessionPath, sessionUploadRetryPendingFile))
+
+	// The committed final metadata used to make the next doctor pass skip this
+	// cache directory forever. The pending marker must keep it discoverable.
+	orphans, scanErr := findOrphanedSessionsInDir(filepath.Dir(fixture.state.SessionPath), fixture.ledgerPath)
+	require.NoError(t, scanErr)
+	require.Len(t, orphans, 1)
+	assert.Equal(t, fixture.sessionName, orphans[0].SessionName)
+
+	calls = nil
+	successEffects := scriptedSessionUploadEffects(&calls, fixture.refs, "")
+	require.NoError(t, retrySessionUploadWithEffects(
+		fixture.projectRoot, fixture.ledgerPath, orphans[0], successEffects,
+	))
+	assert.Equal(t, []string{"upload_lfs", "commit_retry", "commit_pointers"}, calls)
+	assert.True(t, lfs.IsPointerFile(filepath.Join(
+		fixture.ledgerPath, "sessions", fixture.sessionName, ledgerFileRaw,
+	)))
+
+	require.NoError(t, os.RemoveAll(orphans[0].CachePath), "doctor prunes cache only after full success")
+	orphans, scanErr = findOrphanedSessionsInDir(filepath.Dir(fixture.state.SessionPath), fixture.ledgerPath)
+	require.NoError(t, scanErr)
+	assert.Empty(t, orphans)
+}
+
+func TestRetrySessionUpload_AcceptsLargeValidHeader(t *testing.T) {
+	fixture := newSessionUploadFixture(t)
+
+	var raw bytes.Buffer
+	enc := json.NewEncoder(&raw)
+	require.NoError(t, enc.Encode(map[string]any{
+		"type": "header",
+		"metadata": map[string]any{
+			"agent_id":   fixture.state.AgentID,
+			"agent_type": fixture.state.AdapterName,
+			"session_id": fixture.state.SessionID,
+			"model":      strings.Repeat("m", 70*1024),
+		},
+	}))
+	require.NoError(t, enc.Encode(map[string]any{"type": "user", "content": "preserve me"}))
+	require.NoError(t, enc.Encode(map[string]any{"type": "footer", "entry_count": 1}))
+	require.Greater(t, bytes.IndexByte(raw.Bytes(), '\n'), 64*1024)
+
+	fixture.rawContent = raw.Bytes()
+	require.NoError(t, os.WriteFile(fixture.result.RawPath, fixture.rawContent, 0o600))
+	fixture.result.EntryCount = 1
+	fixture.refs = map[string]lfs.FileRef{ledgerFileRaw: lfs.NewFileRef(fixture.rawContent)}
+
+	require.NoError(t, validateRawJSONLHeader(fixture.result.RawPath))
+	var calls []string
+	effects := scriptedSessionUploadEffects(&calls, fixture.refs, "")
+	require.NoError(t, retrySessionUploadWithEffects(
+		fixture.projectRoot, fixture.ledgerPath, fixture.orphan(), effects,
+	))
+	assert.Equal(t, []string{"upload_lfs", "commit_retry", "commit_pointers"}, calls)
+}
+
+func TestWriteSessionUploadRetryPending_RequiresExistingCache(t *testing.T) {
+	err := writeSessionUploadRetryPending(filepath.Join(t.TempDir(), "missing"))
+	require.Error(t, err)
+}
+
+func TestRetrySessionUpload_PendingMarkerFailureStopsBeforeMutation(t *testing.T) {
+	fixture := newSessionUploadFixture(t)
+	require.NoError(t, os.Mkdir(
+		filepath.Join(fixture.state.SessionPath, sessionUploadRetryPendingFile),
+		0o700,
+	))
+
+	var calls []string
+	err := retrySessionUploadWithEffects(
+		fixture.projectRoot,
+		fixture.ledgerPath,
+		fixture.orphan(),
+		scriptedSessionUploadEffects(&calls, fixture.refs, ""),
+	)
+	require.ErrorContains(t, err, "record pending session upload retry")
+	assert.Empty(t, calls, "ledger mutation must not begin without durable retry ownership")
 }

--- a/cmd/ox/agent_session_upload_lifecycle_test.go
+++ b/cmd/ox/agent_session_upload_lifecycle_test.go
@@ -384,3 +384,18 @@ func TestRetrySessionUpload_PendingMarkerFailureStopsBeforeMutation(t *testing.T
 	require.ErrorContains(t, err, "record pending session upload retry")
 	assert.Empty(t, calls, "ledger mutation must not begin without durable retry ownership")
 }
+
+func TestRetrySessionUpload_UnsafePointerPathRemainsRetryable(t *testing.T) {
+	fixture := newSessionUploadFixture(t)
+	fixture.refs["../escape.jsonl"] = lfs.NewFileRef([]byte("must not escape"))
+
+	var calls []string
+	err := retrySessionUploadWithEffects(
+		fixture.projectRoot,
+		fixture.ledgerPath,
+		fixture.orphan(),
+		scriptedSessionUploadEffects(&calls, fixture.refs, ""),
+	)
+	require.ErrorContains(t, err, "write LFS pointer files")
+	require.FileExists(t, filepath.Join(fixture.state.SessionPath, sessionUploadRetryPendingFile))
+}

--- a/cmd/ox/doctor_e2e_test.go
+++ b/cmd/ox/doctor_e2e_test.go
@@ -222,11 +222,12 @@ func TestFreshInstall_RealRepo_InitThenDoctor(t *testing.T) {
 	}
 }
 
-// TestFreshInstall_MockServer_InitThenSyncThenDoctor is a comparison test.
-// It runs the same flow but WITH ox sync between init and doctor.
-// By comparing reports from this test vs the no-sync test, we can see
-// exactly which issues are caused by missing sync.
-func TestFreshInstall_MockServer_InitThenSyncThenDoctor(t *testing.T) {
+// TestFreshInstall_MockServer_SyncUnavailableThenDoctorStillWorks proves an
+// unavailable sync prerequisite fails closed without preventing the next
+// diagnostic command from working. This is a survivability check, not a claim
+// that partial sync state was repaired; stateful retry coverage lives in the
+// daemon and session lifecycle suites.
+func TestFreshInstall_MockServer_SyncUnavailableThenDoctorStillWorks(t *testing.T) {
 	oxBin := buildOxBinary(t)
 	mockServer := startMockSageoxAPI(t)
 	repoDir := testGitRepo(t)
@@ -239,17 +240,25 @@ func TestFreshInstall_MockServer_InitThenSyncThenDoctor(t *testing.T) {
 		"init", "--quiet", "--team", "team_test123")
 
 	t.Logf("ox init: exit=%d duration=%s", initExit, initDuration)
-	if initExit != 0 {
-		t.Logf("WARNING: ox init exited with code %d\nOutput:\n%s", initExit, initOutput)
-	}
+	require.Equal(t, 0, initExit, "init must succeed before recovery evidence is meaningful; output:\n%s", initOutput)
+	gitAdd := testguard.OxCmd(t, "git", repoDir, nil, "add", "-A")
+	require.NoError(t, gitAdd.Run())
+	gitCommit := testguard.OxCmd(t, "git", repoDir, nil,
+		"-c", "commit.gpgsign=false", "commit", "-m", "initialize SageOx")
+	require.NoError(t, gitCommit.Run())
 
-	// step 2: ox sync (this is what users SHOULD do but often don't)
+	// step 2: sync fails at the unavailable daemon boundary
 	syncOutput, syncExit, syncDuration := testguard.RunOx(t, oxBin, repoDir, envVars, "sync")
 	t.Logf("ox sync: exit=%d duration=%s output:\n%s", syncExit, syncDuration, syncOutput)
+	require.NotEqual(t, 0, syncExit, "sync must fail when daemon startup is explicitly disabled")
+	assert.Contains(t, syncOutput, "daemon start disabled",
+		"failure must identify the unavailable boundary rather than reporting false success")
 
-	// step 3: doctor
+	// step 3: doctor remains independently usable
 	doctorOutput, doctorExit, doctorDuration := testguard.RunOx(t, oxBin, repoDir, envVars,
 		"doctor", "--json", "--verbose")
+	require.Equal(t, 0, doctorExit,
+		"doctor must recover after the failed sync without requiring repository repair; output:\n%s", doctorOutput)
 
 	doctorJSON := parseDoctorJSON(t, doctorOutput)
 	report := catalogReport(doctorJSON)
@@ -264,6 +273,16 @@ func TestFreshInstall_MockServer_InitThenSyncThenDoctor(t *testing.T) {
 	logReport(t, report)
 
 	require.NotNil(t, doctorJSON, "doctor must produce parseable JSON; output:\n%s", doctorOutput)
+	assert.Greater(t, mockServer.cloudDoctorAuthedCalls.Load(), int32(0),
+		"recovery must reach the current authenticated cloud doctor route")
+	assert.Zero(t, mockServer.cloudDoctorLegacyCalls.Load(),
+		"recovery must not hide a current-route regression behind the legacy fallback")
+	assert.Zero(t, mockServer.cloudDoctorSingularCalls.Load(),
+		"recovery must not use the obsolete singular route")
+	require.Empty(t, filterExpectedE2EIssues(report.Failures),
+		"unavailable sync must not leave an unexpected doctor failure: %+v", report.Failures)
+	require.Empty(t, filterExpectedE2EIssues(report.Warnings),
+		"unavailable sync must not leave an unexpected doctor warning: %+v", report.Warnings)
 	t.Logf("With-sync summary: passed=%d warnings=%d failed=%d skipped=%d",
 		doctorJSON.Summary.Passed, doctorJSON.Summary.Warnings,
 		doctorJSON.Summary.Failed, doctorJSON.Summary.Skipped)

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -34,7 +34,7 @@ type orphanedSession struct {
 	SessionName string
 	CachePath   string             // full path to cache session dir
 	Meta        *session.StoreMeta // from raw.jsonl header
-	EntryCount  int                // from raw.jsonl footer
+	EntryCount  int                // footer count, or recovered valid turns after a crash
 }
 
 // checkSessionUploadRetry finds sessions in cache that failed to upload and retries them.
@@ -207,8 +207,11 @@ func findOrphanedSessions(projectRoot, ledgerPath string) ([]orphanedSession, er
 	return orphans, nil
 }
 
-// readCacheSessionMeta reads the header and footer from a raw.jsonl file.
-// Returns the StoreMeta from the header and entry_count from the footer.
+// readCacheSessionMeta reads durable metadata and counts recoverable entries
+// from raw.jsonl. A clean stop writes a footer with entry_count, but a crashed
+// process may leave a perfectly usable stream without one. In that case the
+// valid entry lines are authoritative; treating the missing footer as zero
+// made doctor discard the only copy instead of recovering it.
 func readCacheSessionMeta(rawPath string) (*session.StoreMeta, int, error) {
 	f, err := os.Open(rawPath)
 	if err != nil {
@@ -225,10 +228,11 @@ func readCacheSessionMeta(rawPath string) (*session.StoreMeta, int, error) {
 	}
 
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 256*1024), 256*1024) // 256KB line buffer
-
-	// read first line (header)
+	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
 	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return nil, 0, fmt.Errorf("read header: %w", err)
+		}
 		return nil, 0, fmt.Errorf("empty file")
 	}
 
@@ -236,36 +240,35 @@ func readCacheSessionMeta(rawPath string) (*session.StoreMeta, int, error) {
 	if err := json.Unmarshal(scanner.Bytes(), &header); err != nil {
 		return nil, 0, fmt.Errorf("parse header: %w", err)
 	}
-
-	// extract metadata from header
-	metaRaw, ok := header["metadata"]
+	metaMap, ok := header["metadata"].(map[string]any)
 	if !ok {
 		return nil, 0, fmt.Errorf("no metadata in header")
 	}
-
-	metaMap, ok := metaRaw.(map[string]any)
-	if !ok {
-		return nil, 0, fmt.Errorf("metadata is not a map")
-	}
-
 	meta := session.ParseStoreMeta(metaMap)
 
-	// read to last line for footer entry_count
-	var lastLine []byte
-	for scanner.Scan() {
-		lastLine = scanner.Bytes()
-	}
-
 	entryCount := 0
-	if len(lastLine) > 0 {
-		var footer map[string]any
-		if json.Unmarshal(lastLine, &footer) == nil {
-			if v, ok := footer["entry_count"].(float64); ok {
-				entryCount = int(v)
-			}
+	footerCount := -1
+	for scanner.Scan() {
+		var line map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			// Crash recovery follows ReadSessionFromPath semantics: an incomplete
+			// trailing append must not hide the valid turns already fsynced.
+			continue
+		}
+		if v, ok := line["entry_count"].(float64); ok && v >= 0 {
+			footerCount = int(v)
+			continue
+		}
+		if entryType, _ := line["type"].(string); entryType != "" && entryType != "footer" && entryType != "header" {
+			entryCount++
 		}
 	}
-
+	if err := scanner.Err(); err != nil {
+		return nil, 0, fmt.Errorf("read session: %w", err)
+	}
+	if footerCount > entryCount {
+		entryCount = footerCount
+	}
 	return meta, entryCount, nil
 }
 
@@ -316,6 +319,10 @@ func resolveOrphanSessionID(sessionDir string, orphan orphanedSession, draftPres
 // the authoritative copy; raw.jsonl is the critical file from which all others
 // can be regenerated.
 func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) error {
+	return retrySessionUploadWithEffects(projectRoot, ledgerPath, orphan, productionSessionUploadEffects())
+}
+
+func retrySessionUploadWithEffects(projectRoot, ledgerPath string, orphan orphanedSession, effects sessionUploadEffects) error {
 	// guard: never upload a session with zero substantive entries
 	if orphan.EntryCount == 0 {
 		slog.Info("skipping retry upload: zero entries", "session", orphan.SessionName)
@@ -378,7 +385,7 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 	}
 
 	// upload to LFS
-	fileRefs, err := uploadSessionLFS(projectRoot, sessionDir)
+	fileRefs, err := effects.uploadLFS(projectRoot, sessionDir)
 	if err != nil {
 		return fmt.Errorf("LFS upload: %w", err)
 	}
@@ -401,15 +408,25 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 	}
 
 	// commit and push (meta.json + optional summary.json)
-	if err := commitAndPushLedgerWithExtras(ledgerPath, orphan.SessionName, hasSummary); err != nil {
+	if err := effects.commitRetry(ledgerPath, orphan.SessionName, hasSummary); err != nil {
 		return fmt.Errorf("commit and push: %w", err)
 	}
 
 	// push succeeded — now safe to replace content files with LFS pointer stubs.
 	// AssertUploaded: this retry path uploaded meta.Files' blobs before the push.
 	if len(meta.Files) > 0 {
-		if _, err := lfs.WritePointerFiles(sessionDir, lfs.AssertUploadedManifest(meta.Files)); err != nil {
-			slog.Warn("LFS pointer file write failed after push", "error", err, "session", orphan.SessionName)
+		written, writeErr := lfs.WritePointerFiles(sessionDir, lfs.AssertUploadedManifest(meta.Files))
+		if len(written) > 0 {
+			// Mirror the primary stop path: leaving freshly written pointers dirty
+			// lets a daemon pull autostash them and can freeze a stash conflict into
+			// a later unrelated commit. Commit every pointer that landed, even when
+			// another file in the same batch failed to rewrite.
+			if err := effects.commitPointerRewrite(ledgerPath, orphan.SessionName, written); err != nil {
+				return fmt.Errorf("commit LFS pointer rewrite: %w", err)
+			}
+		}
+		if writeErr != nil {
+			return fmt.Errorf("write LFS pointer files: %w", writeErr)
 		}
 	}
 

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -37,6 +37,12 @@ type orphanedSession struct {
 	EntryCount  int                // footer count, or recovered valid turns after a crash
 }
 
+const (
+	rawJSONLInitialScanBuffer     = 1024 * 1024
+	rawJSONLMaxLineBytes          = 10 * 1024 * 1024
+	sessionUploadRetryPendingFile = ".upload-retry-pending"
+)
+
 // checkSessionUploadRetry finds sessions in cache that failed to upload and retries them.
 func checkSessionUploadRetry() checkResult {
 	const name = "session upload retry"
@@ -104,6 +110,13 @@ func findOrphanedSessions(projectRoot, ledgerPath string) ([]orphanedSession, er
 	}
 
 	cacheSessionsDir := filepath.Join(contextPath, "sessions")
+	return findOrphanedSessionsInDir(cacheSessionsDir, ledgerPath)
+}
+
+// findOrphanedSessionsInDir contains the filesystem scan after project path
+// resolution. Keeping this as production code lets tests exercise the exact
+// stale-recording and uploaded-session decisions used by doctor.
+func findOrphanedSessionsInDir(cacheSessionsDir, ledgerPath string) ([]orphanedSession, error) {
 	entries, err := os.ReadDir(cacheSessionsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -167,7 +180,8 @@ func findOrphanedSessions(projectRoot, ledgerPath string) ([]orphanedSession, er
 			continue
 		}
 
-		// skip if already uploaded (meta.json exists in ledger).
+		// Skip if already uploaded (meta.json exists in ledger), unless this
+		// retry recorded that post-publication work is still pending.
 		//
 		// A DRAFT placeholder does not count as uploaded. It is a
 		// meta.json-only marker published mid-recording (ADR-029) and carries
@@ -184,7 +198,9 @@ func findOrphanedSessions(projectRoot, ledgerPath string) ([]orphanedSession, er
 		ledgerSessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
 		if _, err := os.Stat(filepath.Join(ledgerSessionDir, "meta.json")); err == nil {
 			ledgerMeta, metaErr := lfs.ReadSessionMeta(ledgerSessionDir)
-			if metaErr != nil || !ledgerMeta.IsDraft() {
+			_, pendingErr := os.Stat(filepath.Join(sessionDir, sessionUploadRetryPendingFile))
+			pendingRetry := pendingErr == nil
+			if metaErr != nil || (!ledgerMeta.IsDraft() && !pendingRetry) {
 				continue
 			}
 		}
@@ -227,8 +243,7 @@ func readCacheSessionMeta(rawPath string) (*session.StoreMeta, int, error) {
 		return nil, 0, fmt.Errorf("not a regular file: %s", rawPath)
 	}
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+	scanner := newRawJSONLScanner(f)
 	if !scanner.Scan() {
 		if err := scanner.Err(); err != nil {
 			return nil, 0, fmt.Errorf("read header: %w", err)
@@ -339,6 +354,15 @@ func retrySessionUploadWithEffects(projectRoot, ledgerPath string, orphan orphan
 	rawSrc := filepath.Join(orphan.CachePath, ledgerFileRaw)
 	if err := validateRawJSONLHeader(rawSrc); err != nil {
 		return fmt.Errorf("%s validation failed (skipping corrupt session): %w", ledgerFileRaw, err)
+	}
+
+	// Record retry ownership before mutating the ledger. Once meta.json becomes
+	// final, ordinary orphan discovery skips it to avoid replaying an already
+	// published session. This cache-side marker is what keeps failures from any
+	// later phase (including the post-push pointer commit) discoverable on the
+	// next doctor pass. A successful pass prunes the cache and marker together.
+	if err := writeSessionUploadRetryPending(orphan.CachePath); err != nil {
+		return fmt.Errorf("record pending session upload retry: %w", err)
 	}
 
 	// Supersede a draft placeholder if one was published before the agent died,
@@ -531,10 +555,12 @@ func validateRawJSONLHeader(rawPath string) error {
 		return fmt.Errorf("not a regular file: %s", rawPath)
 	}
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 64*1024), 64*1024)
+	scanner := newRawJSONLScanner(f)
 
 	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("read header: %w", err)
+		}
 		return fmt.Errorf("empty file")
 	}
 
@@ -548,6 +574,29 @@ func validateRawJSONLHeader(rawPath string) error {
 	}
 
 	return nil
+}
+
+func newRawJSONLScanner(r io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, rawJSONLInitialScanBuffer), rawJSONLMaxLineBytes)
+	return scanner
+}
+
+func writeSessionUploadRetryPending(cachePath string) error {
+	markerPath := filepath.Join(cachePath, sessionUploadRetryPendingFile)
+	f, err := os.OpenFile(markerPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.WriteString("pending\n"); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 // copyFile copies a file from src to dst.

--- a/cmd/ox/doctor_session_upload_retry_test.go
+++ b/cmd/ox/doctor_session_upload_retry_test.go
@@ -164,6 +164,21 @@ func TestReadCacheSessionMeta(t *testing.T) {
 	})
 }
 
+func TestRawJSONLReadersRejectOverlongHeader(t *testing.T) {
+	rawPath := filepath.Join(t.TempDir(), ledgerFileRaw)
+	require.NoError(t, os.WriteFile(
+		rawPath,
+		[]byte(strings.Repeat("x", rawJSONLMaxLineBytes+1)),
+		0o600,
+	))
+
+	_, _, err := readCacheSessionMeta(rawPath)
+	require.ErrorContains(t, err, "read header")
+
+	err = validateRawJSONLHeader(rawPath)
+	require.ErrorContains(t, err, "read header")
+}
+
 func findTestOrphans(t *testing.T, cacheSessionsDir, ledgerPath string) []orphanedSession {
 	t.Helper()
 	orphans, err := findOrphanedSessionsInDir(cacheSessionsDir, ledgerPath)

--- a/cmd/ox/doctor_session_upload_retry_test.go
+++ b/cmd/ox/doctor_session_upload_retry_test.go
@@ -493,7 +493,7 @@ func TestReadCacheSessionMeta_EntriesButNoFooter(t *testing.T) {
 			"created_at": time.Now().Format(time.RFC3339),
 		},
 	})
-	// entries but no footer
+	// entries but no footer: valid turns remain recoverable after a crash
 	for i := 0; i < 3; i++ {
 		enc.Encode(map[string]any{"type": "assistant", "content": "entry"})
 	}
@@ -502,8 +502,39 @@ func TestReadCacheSessionMeta_EntriesButNoFooter(t *testing.T) {
 	meta, count, err := readCacheSessionMeta(rawPath)
 	require.NoError(t, err)
 	assert.Equal(t, "OxCrash", meta.AgentID)
-	// last line is an entry, not a footer — entry_count should be 0
-	assert.Equal(t, 0, count, "entries without footer should yield entry_count=0")
+	assert.Equal(t, 3, count,
+		"doctor must recover valid entries without a footer instead of treating the only copy as empty")
+}
+
+func TestReadCacheSessionMeta_RecoversValidEntriesBeforeTornTail(t *testing.T) {
+	tmpDir := t.TempDir()
+	rawPath := filepath.Join(tmpDir, ledgerFileRaw)
+	content := `{"type":"header","metadata":{"agent_id":"OxTorn","agent_type":"codex"}}` + "\n" +
+		`{"type":"user","content":"durable one"}` + "\n" +
+		`{"type":"assistant","content":"durable two"}` + "\n" +
+		`{"type":"assistant","content":"torn`
+	require.NoError(t, os.WriteFile(rawPath, []byte(content), 0o600))
+
+	meta, count, err := readCacheSessionMeta(rawPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, "OxTorn", meta.AgentID)
+	assert.Equal(t, 2, count, "a torn final append must not hide prior fsynced turns")
+}
+
+func TestReadCacheSessionMeta_NeverTrustsStaleFooterBelowDurableTurns(t *testing.T) {
+	tmpDir := t.TempDir()
+	rawPath := filepath.Join(tmpDir, ledgerFileRaw)
+	content := `{"type":"header","metadata":{"agent_id":"OxStale","agent_type":"codex"}}` + "\n" +
+		`{"type":"user","content":"one"}` + "\n" +
+		`{"type":"assistant","content":"two"}` + "\n" +
+		`{"type":"footer","entry_count":0}` + "\n"
+	require.NoError(t, os.WriteFile(rawPath, []byte(content), 0o600))
+
+	_, count, err := readCacheSessionMeta(rawPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "a stale footer must not turn durable content into a zero-entry prune")
 }
 
 func TestReadCacheSessionMeta_HeaderWithNoMetadataKey(t *testing.T) {

--- a/cmd/ox/doctor_session_upload_retry_test.go
+++ b/cmd/ox/doctor_session_upload_retry_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -101,10 +102,7 @@ func TestFindOrphanedSessions(t *testing.T) {
 
 			tt.setup(t, cacheDir, ledgerDir)
 
-			// call findOrphanedSessions with a shim: we can't easily use the real
-			// function because it calls getRepoIDOrDefault + GetContextPath.
-			// Instead, test the core scanning logic directly.
-			orphans := scanCacheDirForOrphans(cacheDir, ledgerDir)
+			orphans := findTestOrphans(t, cacheDir, ledgerDir)
 
 			if len(orphans) != tt.expected {
 				t.Errorf("expected %d orphans, got %d", tt.expected, len(orphans))
@@ -166,78 +164,10 @@ func TestReadCacheSessionMeta(t *testing.T) {
 	})
 }
 
-// scanCacheDirForOrphans is a test-friendly version of the core scanning logic
-// extracted from findOrphanedSessions, without the config/path resolution.
-// This MUST stay in sync with findOrphanedSessions — especially StopIncomplete handling.
-//
-// Known divergences from production findOrphanedSessions:
-// - Production uses session.RecordingState struct instead of anonymous struct
-// - Production has stale recording detection (time-based threshold)
-// - Production cleans up .lock files
-// These divergences are intentional to keep the test helper simple.
-func scanCacheDirForOrphans(cacheSessionsDir, ledgerPath string) []orphanedSession {
-	entries, err := os.ReadDir(cacheSessionsDir)
-	if err != nil {
-		return nil
-	}
-
-	var orphans []orphanedSession
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		sessionName := entry.Name()
-		sessionDir := filepath.Join(cacheSessionsDir, sessionName)
-
-		if sessionName == "raw" || sessionName == "events" {
-			continue
-		}
-
-		// check if still recording (.recording.json present)
-		recordingPath := filepath.Join(sessionDir, ".recording.json")
-		if _, err := os.Stat(recordingPath); err == nil {
-			// read recording state to check for StopIncomplete
-			recData, readErr := os.ReadFile(recordingPath)
-			if readErr != nil {
-				continue
-			}
-			var recState struct {
-				StopIncomplete bool `json:"stop_incomplete"`
-			}
-			if json.Unmarshal(recData, &recState) != nil {
-				continue // corrupt, skip
-			}
-			if !recState.StopIncomplete {
-				continue // genuinely active recording, skip
-			}
-			// StopIncomplete: clear the recording state so session can be recovered
-			_ = os.Remove(recordingPath)
-		}
-
-		rawPath := filepath.Join(sessionDir, ledgerFileRaw)
-		if _, err := os.Stat(rawPath); os.IsNotExist(err) {
-			continue
-		}
-
-		ledgerSessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
-		if _, err := os.Stat(filepath.Join(ledgerSessionDir, "meta.json")); err == nil {
-			continue
-		}
-
-		meta, entryCount, err := readCacheSessionMeta(rawPath)
-		if err != nil {
-			continue
-		}
-
-		orphans = append(orphans, orphanedSession{
-			SessionName: sessionName,
-			CachePath:   sessionDir,
-			Meta:        meta,
-			EntryCount:  entryCount,
-		})
-	}
-
+func findTestOrphans(t *testing.T, cacheSessionsDir, ledgerPath string) []orphanedSession {
+	t.Helper()
+	orphans, err := findOrphanedSessionsInDir(cacheSessionsDir, ledgerPath)
+	require.NoError(t, err)
 	return orphans
 }
 
@@ -310,7 +240,7 @@ func TestFindOrphanedSessions_CorruptRawJSONL(t *testing.T) {
 	require.NoError(t, os.MkdirAll(dir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ledgerFileRaw), []byte("this is not json\n"), 0644))
 
-	orphans := scanCacheDirForOrphans(cacheDir, ledgerDir)
+	orphans := findTestOrphans(t, cacheDir, ledgerDir)
 	assert.Empty(t, orphans, "corrupt raw.jsonl should be excluded from orphan list")
 }
 
@@ -361,7 +291,7 @@ func TestFindOrphanedSessions_ActiveRecordingWithRawJSONL(t *testing.T) {
 	writeTestRawJSONL(t, filepath.Join(dir, ledgerFileRaw))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".recording.json"), []byte(`{"agent_id":"OxActv"}`), 0644))
 
-	orphans := scanCacheDirForOrphans(cacheDir, ledgerDir)
+	orphans := findTestOrphans(t, cacheDir, ledgerDir)
 	assert.Empty(t, orphans,
 		"session with .recording.json should be excluded even if raw.jsonl exists")
 }
@@ -380,7 +310,7 @@ func TestFindOrphanedSessions_StopIncompleteRecovery(t *testing.T) {
 	recState := `{"agent_id":"OxStop","stop_incomplete":true}`
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".recording.json"), []byte(recState), 0644))
 
-	orphans := scanCacheDirForOrphans(cacheDir, ledgerDir)
+	orphans := findTestOrphans(t, cacheDir, ledgerDir)
 	assert.Len(t, orphans, 1, "stop_incomplete session should be treated as orphan")
 	assert.Equal(t, "2026-01-15T10-30-ryan-OxStop", orphans[0].SessionName)
 
@@ -403,7 +333,7 @@ func TestFindOrphanedSessions_StopIncompleteActiveNotRecovered(t *testing.T) {
 	recState := `{"agent_id":"OxLive","stop_incomplete":false}`
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".recording.json"), []byte(recState), 0644))
 
-	orphans := scanCacheDirForOrphans(cacheDir, ledgerDir)
+	orphans := findTestOrphans(t, cacheDir, ledgerDir)
 	assert.Empty(t, orphans, "active recording (stop_incomplete=false) should not be treated as orphan")
 
 	// .recording.json should still exist
@@ -424,7 +354,7 @@ func TestFindOrphanedSessions_CorruptRecordingJSON(t *testing.T) {
 	writeTestRawJSONL(t, filepath.Join(dir, ledgerFileRaw))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".recording.json"), []byte("not json{{{"), 0644))
 
-	orphans := scanCacheDirForOrphans(cacheDir, ledgerDir)
+	orphans := findTestOrphans(t, cacheDir, ledgerDir)
 	assert.Empty(t, orphans, "corrupt .recording.json should be skipped, not crash")
 }
 
@@ -464,7 +394,7 @@ func TestFindOrphanedSessions_MixedStates(t *testing.T) {
 	emptyDir := filepath.Join(cacheDir, "2026-01-15T10-40-ryan-Ox0005")
 	require.NoError(t, os.MkdirAll(emptyDir, 0755))
 
-	orphans := scanCacheDirForOrphans(cacheDir, ledgerDir)
+	orphans := findTestOrphans(t, cacheDir, ledgerDir)
 	assert.Len(t, orphans, 2, "should find exactly 2 orphans: plain orphan + stop_incomplete")
 
 	names := make(map[string]bool)
@@ -506,35 +436,40 @@ func TestReadCacheSessionMeta_EntriesButNoFooter(t *testing.T) {
 		"doctor must recover valid entries without a footer instead of treating the only copy as empty")
 }
 
-func TestReadCacheSessionMeta_RecoversValidEntriesBeforeTornTail(t *testing.T) {
-	tmpDir := t.TempDir()
-	rawPath := filepath.Join(tmpDir, ledgerFileRaw)
-	content := `{"type":"header","metadata":{"agent_id":"OxTorn","agent_type":"codex"}}` + "\n" +
-		`{"type":"user","content":"durable one"}` + "\n" +
-		`{"type":"assistant","content":"durable two"}` + "\n" +
-		`{"type":"assistant","content":"torn`
-	require.NoError(t, os.WriteFile(rawPath, []byte(content), 0o600))
+func TestReadCacheSessionMeta_RecoversDurableEntries(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		agentID   string
+		tail      string
+		assertion string
+	}{
+		{
+			name:      "torn final append",
+			agentID:   "OxTorn",
+			tail:      `{"type":"assistant","content":"torn`,
+			assertion: "a torn final append must not hide prior fsynced turns",
+		},
+		{
+			name:      "stale footer below durable turns",
+			agentID:   "OxStale",
+			tail:      `{"type":"footer","entry_count":0}` + "\n",
+			assertion: "a stale footer must not turn durable content into a zero-entry prune",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rawPath := filepath.Join(t.TempDir(), ledgerFileRaw)
+			content := fmt.Sprintf(`{"type":"header","metadata":{"agent_id":%q,"agent_type":"codex"}}`, tc.agentID) + "\n" +
+				`{"type":"user","content":"durable one"}` + "\n" +
+				`{"type":"assistant","content":"durable two"}` + "\n" + tc.tail
+			require.NoError(t, os.WriteFile(rawPath, []byte(content), 0o600))
 
-	meta, count, err := readCacheSessionMeta(rawPath)
+			meta, count, err := readCacheSessionMeta(rawPath)
 
-	require.NoError(t, err)
-	assert.Equal(t, "OxTorn", meta.AgentID)
-	assert.Equal(t, 2, count, "a torn final append must not hide prior fsynced turns")
-}
-
-func TestReadCacheSessionMeta_NeverTrustsStaleFooterBelowDurableTurns(t *testing.T) {
-	tmpDir := t.TempDir()
-	rawPath := filepath.Join(tmpDir, ledgerFileRaw)
-	content := `{"type":"header","metadata":{"agent_id":"OxStale","agent_type":"codex"}}` + "\n" +
-		`{"type":"user","content":"one"}` + "\n" +
-		`{"type":"assistant","content":"two"}` + "\n" +
-		`{"type":"footer","entry_count":0}` + "\n"
-	require.NoError(t, os.WriteFile(rawPath, []byte(content), 0o600))
-
-	_, count, err := readCacheSessionMeta(rawPath)
-
-	require.NoError(t, err)
-	assert.Equal(t, 2, count, "a stale footer must not turn durable content into a zero-entry prune")
+			require.NoError(t, err)
+			assert.Equal(t, tc.agentID, meta.AgentID)
+			assert.Equal(t, 2, count, tc.assertion)
+		})
+	}
 }
 
 func TestReadCacheSessionMeta_HeaderWithNoMetadataKey(t *testing.T) {

--- a/cmd/ox/incremental_e2e_test.go
+++ b/cmd/ox/incremental_e2e_test.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/daemon/agentwork"
+	"github.com/sageox/ox/internal/session/pipeline"
+	"github.com/sageox/ox/internal/testguard"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,9 +68,8 @@ func TestIncrementalE2E_SingleAgent(t *testing.T) {
 
 	// find the raw.jsonl path from recording state
 	rawPath := findRawJSONL(t, env)
-	if rawPath != "" {
-		t.Logf("raw.jsonl at: %s", rawPath)
-	}
+	require.NotEmpty(t, rawPath, "session start must create a durable raw.jsonl")
+	t.Logf("raw.jsonl at: %s", rawPath)
 
 	// timestamps must be AFTER session start for the filter to pass
 	now := time.Now().Add(1 * time.Second)
@@ -81,11 +82,9 @@ func TestIncrementalE2E_SingleAgent(t *testing.T) {
 	t.Logf("hook 1 output: %s", truncateStr(hookOut, 500))
 
 	// check raw.jsonl has entries now
-	if rawPath != "" {
-		lines := e2eCountLines(t, rawPath)
-		t.Logf("after hook 1: %d lines in raw.jsonl", lines)
-		assert.GreaterOrEqual(t, lines, 2, "should have header + entries after first hook")
-	}
+	lines := e2eCountLines(t, rawPath)
+	t.Logf("after hook 1: %d lines in raw.jsonl", lines)
+	assert.GreaterOrEqual(t, lines, 2, "should have header + entries after first hook")
 
 	// --- simulate turn 2: more conversation ---
 	now2 := now.Add(2 * time.Second)
@@ -97,20 +96,29 @@ func TestIncrementalE2E_SingleAgent(t *testing.T) {
 	hookOut2 := runOxHook(t, oxBin, env, agentID, "PostToolUse", claudeSessionID)
 	t.Logf("hook 2 output: %s", truncateStr(hookOut2, 2000))
 
-	if rawPath != "" {
-		lines := e2eCountLines(t, rawPath)
-		t.Logf("after hook 2: %d lines in raw.jsonl", lines)
-		assert.GreaterOrEqual(t, lines, 4, "should have more entries after second hook")
-	}
+	lines = e2eCountLines(t, rawPath)
+	t.Logf("after hook 2: %d lines in raw.jsonl", lines)
+	assert.GreaterOrEqual(t, lines, 4, "should have more entries after second hook")
 
 	// --- session stop ---
 	stopOut := runOx(t, oxBin, env, agentID, "session", "stop")
 	t.Logf("session stop output: %s", truncateStr(stopOut, 500))
 
-	// verify stop completed (may have upload warnings, that's ok)
-	if !strings.Contains(stopOut, `"success"`) {
-		t.Logf("stop output (no success field): %s", stopOut)
-	}
+	// Upload may be deferred while offline, but local finalization must return a
+	// valid structured result and preserve the captured conversation for retry.
+	var stop pipeline.StopOutput
+	jsonStart := strings.Index(stopOut, "{")
+	require.NotEqual(t, -1, jsonStart, "session stop must contain a JSON result: %s", stopOut)
+	require.NoError(t, json.Unmarshal([]byte(stopOut[jsonStart:]), &stop), "session stop must emit valid JSON: %s", stopOut)
+	require.True(t, stop.Success, "session stop must report success: %+v", stop)
+	require.Equal(t, "session_stop", stop.Type)
+	require.Greater(t, stop.EntryCount, 0)
+	require.NotEmpty(t, stop.RawPath)
+	require.Contains(t, stop.UploadWarning, "ledger", "offline finalization must explain deferred upload")
+	finalRaw, err := os.ReadFile(rawPath)
+	require.NoError(t, err, "session stop must preserve raw capture until upload succeeds")
+	assert.Contains(t, string(finalRaw), "Now add tests", "finalized capture must retain the user turn")
+	assert.Contains(t, string(finalRaw), "I'll add tests", "finalized capture must retain the assistant turn")
 }
 
 // TestIncrementalE2E_MultiAgent tests Conductor scenario with 2 agents
@@ -403,13 +411,8 @@ func buildOxBinary(t *testing.T) string {
 		dir = parent
 	}
 
-	binDir := t.TempDir()
-	oxBin := filepath.Join(binDir, "ox")
-
-	cmd := exec.Command("go", "build", "-o", oxBin, "./cmd/ox")
-	cmd.Dir = dir
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, "failed to build ox: %s", output)
+	oxBin := testguard.BuildOxBinary(t, dir)
+	binDir := filepath.Dir(oxBin)
 
 	// Also build the claude-code adapter binary next to ox so adapter
 	// discovery (AdapterDirs() includes filepath.Dir(exe)) finds it.
@@ -417,10 +420,12 @@ func buildOxBinary(t *testing.T) string {
 	// falls through to the generic adapter, and PostToolUse hooks never
 	// parse the fake Claude JSONL source file.
 	adapterBin := filepath.Join(binDir, "ox-adapter-claude-code")
-	adapterCmd := exec.Command("go", "build", "-o", adapterBin, "./cmd/ox-adapter-claude-code")
-	adapterCmd.Dir = dir
-	adapterOut, adapterErr := adapterCmd.CombinedOutput()
-	require.NoError(t, adapterErr, "failed to build ox-adapter-claude-code: %s", adapterOut)
+	if _, err := os.Stat(adapterBin); err != nil {
+		adapterCmd := exec.Command("go", "build", "-o", adapterBin, "./cmd/ox-adapter-claude-code")
+		adapterCmd.Dir = dir
+		adapterOut, adapterErr := adapterCmd.CombinedOutput()
+		require.NoError(t, adapterErr, "failed to build ox-adapter-claude-code: %s", adapterOut)
+	}
 
 	return oxBin
 }
@@ -460,14 +465,15 @@ func setupE2EWorkspace(t *testing.T, oxBin string) e2eEnv {
 	// create .sageox/config.json
 	sageoxDir := filepath.Join(workspace, ".sageox")
 	require.NoError(t, os.MkdirAll(sageoxDir, 0755))
-	cfg := `{"config_version":"2","repo_id":"e2e-test-repo","endpoint":"https://sageox.ai"}`
+	const endpointURL = "http://127.0.0.1:1"
+	cfg := `{"config_version":"2","repo_id":"e2e-test-repo","endpoint":"` + endpointURL + `"}`
 	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), []byte(cfg), 0644))
 
 	// create fake auth so session start doesn't fail on auth check
 	authDir := filepath.Join(home, ".config", "sageox")
 	require.NoError(t, os.MkdirAll(authDir, 0700))
-	authJSON := fmt.Sprintf(`{"tokens":{"sageox.ai":{"access_token":"fake-pat-for-e2e-test","token_type":"bearer","expires_at":"%s"}}}`,
-		time.Now().Add(24*time.Hour).Format(time.RFC3339))
+	authJSON := fmt.Sprintf(`{"tokens":{%q:{"access_token":"fake-pat-for-e2e-test","token_type":"bearer","expires_at":"%s"}}}`,
+		endpointURL, time.Now().Add(24*time.Hour).Format(time.RFC3339))
 	require.NoError(t, os.WriteFile(filepath.Join(authDir, "auth.json"), []byte(authJSON), 0644))
 
 	// synthetic username prevents colliding with developer's real session markers
@@ -482,7 +488,7 @@ func setupE2EWorkspace(t *testing.T, oxBin string) e2eEnv {
 }
 
 func oxEnv(env e2eEnv) []string {
-	return []string{
+	result := []string{
 		"HOME=" + env.home,
 		"XDG_CACHE_HOME=" + env.cacheDir,
 		"XDG_CONFIG_HOME=" + filepath.Join(env.home, ".config"),
@@ -495,24 +501,20 @@ func oxEnv(env e2eEnv) []string {
 		// prevent real network calls
 		"OX_OFFLINE=1",
 	}
+	return result
 }
 
 func runOx(t *testing.T, oxBin string, env e2eEnv, agentID string, args ...string) string {
 	t.Helper()
 	fullArgs := append([]string{"agent", agentID}, args...)
-	cmd := exec.Command(oxBin, fullArgs...)
-	cmd.Dir = env.workspace
-	cmd.Env = oxEnv(env)
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "ox agent %s %v failed:\n%s", agentID, args, string(out))
-	return string(out)
+	out, exitCode, _ := testguard.RunOx(t, oxBin, env.workspace, oxEnv(env), fullArgs...)
+	require.Equal(t, 0, exitCode, "ox agent %s %v failed:\n%s", agentID, args, out)
+	return out
 }
 
 func runOxHook(t *testing.T, oxBin string, env e2eEnv, agentID, event, sessionID string) string {
 	t.Helper()
-	cmd := exec.Command(oxBin, "agent", agentID, "hook", event)
-	cmd.Dir = env.workspace
-	cmd.Env = oxEnv(env)
+	cmd := testguard.OxCmd(t, oxBin, env.workspace, oxEnv(env), "agent", agentID, "hook", event)
 
 	// pipe hook input via stdin
 	hookInput := fmt.Sprintf(`{"session_id":"%s","hook_event_name":"%s"}`, sessionID, event)

--- a/cmd/ox/incremental_e2e_test.go
+++ b/cmd/ox/incremental_e2e_test.go
@@ -43,8 +43,8 @@ import (
 //
 // Run with: go test -tags=slow -timeout=5m -run TestIncrementalE2E ./cmd/ox/ -v
 func TestIncrementalE2E_SingleAgent(t *testing.T) {
-	oxBin := buildOxBinary(t)
-	env := setupE2EWorkspace(t, oxBin)
+	oxBin, adapterDir := buildIncrementalE2EBinaries(t)
+	env := setupE2EWorkspace(t, adapterDir)
 
 	agentID := "OxE2E1"
 	claudeSessionID := "test-e2e-session-001"
@@ -125,8 +125,8 @@ func TestIncrementalE2E_SingleAgent(t *testing.T) {
 // on the same worktree, verifying no cross-contamination.
 // Component test with simulated data — not a real Claude E2E test.
 func TestIncrementalE2E_MultiAgent(t *testing.T) {
-	oxBin := buildOxBinary(t)
-	env := setupE2EWorkspace(t, oxBin)
+	oxBin, adapterDir := buildIncrementalE2EBinaries(t)
+	env := setupE2EWorkspace(t, adapterDir)
 
 	agentA := "OxCdA1"
 	agentB := "OxCdB2"
@@ -221,8 +221,8 @@ func TestIncrementalE2E_MultiAgent(t *testing.T) {
 // This is the core anti-entropy guarantee: no session data is lost even if the
 // CLI crashes or the user interrupts the process.
 func TestIncrementalE2E_CtrlC_AntiEntropy(t *testing.T) {
-	oxBin := buildOxBinary(t)
-	env := setupE2EWorkspace(t, oxBin)
+	oxBin, adapterDir := buildIncrementalE2EBinaries(t)
+	env := setupE2EWorkspace(t, adapterDir)
 
 	agentID := "OxCtC1"
 	claudeSessionID := "test-ctrlc-session-001"
@@ -387,13 +387,40 @@ func findFilesRecursive(root, name string) []string {
 // --- E2E test infrastructure ---
 
 type e2eEnv struct {
-	workspace string // git repo with .sageox/
-	home      string // fake HOME for isolation
-	cacheDir  string // XDG_CACHE_HOME
-	username  string // synthetic username for test isolation
+	workspace  string // git repo with .sageox/
+	home       string // fake HOME for isolation
+	cacheDir   string // XDG_CACHE_HOME
+	username   string // synthetic username for test isolation
+	adapterDir string // test-owned external adapter directory
 }
 
 func buildOxBinary(t *testing.T) string {
+	t.Helper()
+	return testguard.BuildOxBinary(t, slowTestProjectRoot(t))
+}
+
+func buildIncrementalE2EBinaries(t *testing.T) (string, string) {
+	t.Helper()
+	dir := slowTestProjectRoot(t)
+	oxBin := testguard.BuildOxBinary(t, dir)
+	adapterDir := t.TempDir()
+
+	// Also build the claude-code adapter binary in a test-owned directory and
+	// expose that directory through OX_ADAPTER_PATH.
+	// Without this the deep adapter detect fails silently, the session
+	// falls through to the generic adapter, and PostToolUse hooks never
+	// parse the fake Claude JSONL source file. In particular, do not write
+	// beside OX_TEST_OX_BINARY: callers may provide a read-only shared artifact.
+	adapterBin := filepath.Join(adapterDir, "ox-adapter-claude-code")
+	adapterCmd := exec.Command("go", "build", "-o", adapterBin, "./cmd/ox-adapter-claude-code")
+	adapterCmd.Dir = dir
+	adapterOut, adapterErr := adapterCmd.CombinedOutput()
+	require.NoError(t, adapterErr, "failed to build ox-adapter-claude-code: %s", adapterOut)
+
+	return oxBin, adapterDir
+}
+
+func slowTestProjectRoot(t *testing.T) string {
 	t.Helper()
 
 	// find project root
@@ -410,27 +437,10 @@ func buildOxBinary(t *testing.T) string {
 		require.NotEqual(t, parent, dir, "could not find project root")
 		dir = parent
 	}
-
-	oxBin := testguard.BuildOxBinary(t, dir)
-	binDir := filepath.Dir(oxBin)
-
-	// Also build the claude-code adapter binary next to ox so adapter
-	// discovery (AdapterDirs() includes filepath.Dir(exe)) finds it.
-	// Without this the deep adapter detect fails silently, the session
-	// falls through to the generic adapter, and PostToolUse hooks never
-	// parse the fake Claude JSONL source file.
-	adapterBin := filepath.Join(binDir, "ox-adapter-claude-code")
-	if _, err := os.Stat(adapterBin); err != nil {
-		adapterCmd := exec.Command("go", "build", "-o", adapterBin, "./cmd/ox-adapter-claude-code")
-		adapterCmd.Dir = dir
-		adapterOut, adapterErr := adapterCmd.CombinedOutput()
-		require.NoError(t, adapterErr, "failed to build ox-adapter-claude-code: %s", adapterOut)
-	}
-
-	return oxBin
+	return dir
 }
 
-func setupE2EWorkspace(t *testing.T, oxBin string) e2eEnv {
+func setupE2EWorkspace(t *testing.T, adapterDir string) e2eEnv {
 	t.Helper()
 
 	workspace := t.TempDir()
@@ -480,10 +490,11 @@ func setupE2EWorkspace(t *testing.T, oxBin string) e2eEnv {
 	username := "oxtest-" + strings.ReplaceAll(t.Name(), "/", "-")
 
 	return e2eEnv{
-		workspace: workspace,
-		home:      home,
-		cacheDir:  cacheDir,
-		username:  username,
+		workspace:  workspace,
+		home:       home,
+		cacheDir:   cacheDir,
+		username:   username,
+		adapterDir: adapterDir,
 	}
 }
 
@@ -495,6 +506,7 @@ func oxEnv(env e2eEnv) []string {
 		"OX_XDG_ENABLE=1",
 		"PATH=" + os.Getenv("PATH"),
 		"AGENT_ENV=claude-code",
+		"OX_ADAPTER_PATH=" + env.adapterDir,
 		"USER=" + env.username,
 		// prevent real daemon IPC
 		"OX_NO_DAEMON=1",

--- a/cmd/ox/session_upload_effects.go
+++ b/cmd/ox/session_upload_effects.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// sessionUploadEffects is the narrow orchestration boundary between durable
+// local session state and the fallible external effects used to publish it.
+// Filesystem preparation and metadata writes deliberately remain real: tests
+// exercise the same cache/ledger artifacts production writes while replacing
+// only network and git effects that cannot be made deterministic in-process.
+//
+// Keep this value explicit (rather than a package global) so parallel tests do
+// not race by swapping process-wide hooks.
+type sessionUploadEffects struct {
+	uploadLFS            func(projectRoot, sessionDir string) (map[string]lfs.FileRef, error)
+	commitInitial        func(ledgerPath, sessionName string) error
+	commitRetry          func(ledgerPath, sessionName string, includeSummary bool) error
+	commitPointerRewrite func(ledgerPath, sessionName string, paths []string) error
+	reconcilePlans       func(projectRoot string, slugs []string, sessionName, sessionID string)
+	finalizeLinkage      func(projectRoot, sessionDir string, meta *lfs.SessionMeta, sessionName string) []api.PRLinkMiss
+}
+
+func productionSessionUploadEffects() sessionUploadEffects {
+	return sessionUploadEffects{
+		uploadLFS:            uploadSessionLFS,
+		commitInitial:        commitAndPushLedger,
+		commitRetry:          commitAndPushLedgerWithExtras,
+		commitPointerRewrite: commitPointerRewriteAndPush,
+		reconcilePlans:       reconcileProducedPlansAtStop,
+		finalizeLinkage:      finalizeLinkageAfterPush,
+	}
+}

--- a/internal/daemon/agentwork/claude_runner_test.go
+++ b/internal/daemon/agentwork/claude_runner_test.go
@@ -194,14 +194,15 @@ func TestProcessCancellationKillsDescendants(t *testing.T) {
 	cmd := exec.CommandContext(ctx, script)
 	setProcAttr(cmd)
 	require.NoError(t, cmd.Start())
+	var childPID int
 	require.Eventually(t, func() bool {
-		_, err := os.Stat(childPIDFile)
-		return err == nil
+		rawPID, err := os.ReadFile(childPIDFile)
+		if err != nil {
+			return false
+		}
+		childPID, err = strconv.Atoi(strings.TrimSpace(string(rawPID)))
+		return err == nil && childPID > 0
 	}, 5*time.Second, 10*time.Millisecond, "process tree must become ready")
-	rawPID, err := os.ReadFile(childPIDFile)
-	require.NoError(t, err)
-	childPID, err := strconv.Atoi(strings.TrimSpace(string(rawPID)))
-	require.NoError(t, err)
 
 	cancel()
 	require.Error(t, cmd.Wait())

--- a/internal/daemon/codedb_freshness_test.go
+++ b/internal/daemon/codedb_freshness_test.go
@@ -200,7 +200,9 @@ func TestCheckFreshness_NonENOENT_NoIssue(t *testing.T) {
 // recovery path: sparse-checkout is fixed, codedb rebuilds, and the warning
 // disappears from ox status.
 func TestCheckFreshness_IssueCleared_AfterRecovery(t *testing.T) {
-	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: exercises a real git + SQLite + Bleve recovery pass")
+	}
 
 	tracker := NewIssueTracker()
 	// pre-set the issue as if a prior cache wipe occurred
@@ -212,22 +214,34 @@ func TestCheckFreshness_IssueCleared_AfterRecovery(t *testing.T) {
 	})
 	require.Equal(t, 1, tracker.Count(), "precondition: issue must be set")
 
-	// doIndex clears the issue only on err == nil. We can't easily make doIndex
-	// succeed without a real git repo, but we CAN verify the complementary
-	// invariant: non-ENOENT failure does NOT clear the issue.
-	// This ensures stale issues persist until genuine recovery.
+	// First pass: a real failure. The directory exists but is not a git repo,
+	// so the stale issue must remain and the indexing claim must be released.
 	dir := t.TempDir()
 	mgr := NewCodeDBManager(dir, codedbTestLogger(), nil)
+	mgr.dataDir = t.TempDir()
 	mgr.SetIssueTracker(tracker)
 
 	ctx := context.Background()
 	mgr.CheckFreshness(ctx)
 	waitForIndexingDone(t, mgr)
 
-	// issue persists: doIndex failed (no git repo) but NOT with ENOENT,
-	// so the issue is neither re-emitted nor cleared
 	assert.Equal(t, 1, tracker.Count(),
 		"cache-wipe issue must persist until a successful index — non-ENOENT failure must not clear it")
+	failedStats := mgr.Stats()
+	require.NotEmpty(t, failedStats.LastError, "failed pass must remain visible in status")
+
+	// Repair the boundary and retry using the same manager. This is the
+	// lifecycle the daemon runs after a transient checkout/configuration fault.
+	seedGitRepo(t, dir)
+	mgr.CheckFreshness(ctx)
+	require.Eventually(t, func() bool { return !mgr.IsIndexing() },
+		30*time.Second, 20*time.Millisecond, "recovery index did not finish")
+
+	assert.Zero(t, tracker.Count(), "successful retry must clear the stale cache-wipe issue")
+	recoveredStats := mgr.Stats()
+	assert.True(t, recoveredStats.IndexExists)
+	assert.Greater(t, recoveredStats.Commits, 0, "successful retry must make indexing progress")
+	assert.Empty(t, recoveredStats.LastError, "successful retry must clear the prior error")
 }
 
 // --- B. CheckFreshness worktree guard ---

--- a/internal/daemon/codedb_selfheal_test.go
+++ b/internal/daemon/codedb_selfheal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sageox/ox/internal/codedb"
 	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
 )
@@ -200,6 +201,42 @@ func TestDoIndex_RestoresMarkersWhenMarkerForcedReindexFails(t *testing.T) {
 	// Marker must still be present so the NEXT freshness pass re-forces --full.
 	require.True(t, store.HasNeedsReindexMarker(dataDir, "code"),
 		"self-heal marker must be restored after failed marker-forced reindex")
+}
+
+// TestDoIndex_MarkerRecoverySurvivesManagerRestart closes the other half of
+// marker restoration: a failed full rebuild is not useful unless a fresh daemon
+// instance can consume the restored marker, repopulate the index, and clear it.
+// A canceled context is the deterministic stand-in for shutdown/network loss
+// during the first pass; the second manager models daemon restart.
+func TestDoIndex_MarkerRecoverySurvivesManagerRestart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: exercises two real git + SQLite + Bleve indexing passes")
+	}
+
+	repoDir := t.TempDir()
+	seedGitRepo(t, repoDir)
+	dataDir := t.TempDir()
+	require.NoError(t, writeMarkerForTest(dataDir, "code"))
+
+	first := NewCodeDBManager(repoDir, codedbTestLogger(), nil)
+	first.dataDir = dataDir
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := first.Index(canceled, CodeIndexPayload{}, nil)
+	require.Error(t, err, "canceled rebuild must not report success")
+	require.True(t, store.HasNeedsReindexMarker(dataDir, "code"),
+		"failed pass must restore the durable retry marker")
+
+	second := NewCodeDBManager(repoDir, codedbTestLogger(), nil)
+	second.dataDir = dataDir
+	ctx, stop := context.WithTimeout(context.Background(), 60*time.Second)
+	defer stop()
+	_, err = second.Index(ctx, CodeIndexPayload{}, nil)
+	require.NoError(t, err, "fresh manager must recover on retry")
+	require.False(t, store.HasNeedsReindexMarker(dataDir, "code"),
+		"successful recovery must consume the retry marker")
+	assert.Greater(t, countCommits(t, dataDir), 0,
+		"restarted manager must repopulate the index, not merely clear the marker")
 }
 
 // TestIsIndexing_ReflectsFlag verifies the IsIndexing accessor used by

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -28,6 +28,13 @@ const maxIPCMessageSize = 1 * 1024 * 1024 // 1MB
 // Prevents file descriptor or memory exhaustion from connection floods.
 const maxConcurrentConnections = 100
 
+// finalResponseWriteTimeout bounds delivery of the authoritative response after
+// a long-running handler. ProgressWriter deliberately installs a very short
+// best-effort deadline; sendResponse must replace that stale deadline or a
+// handler that does work after its last progress update can complete
+// successfully while the client sees an EOF/timeout instead of the result.
+const finalResponseWriteTimeout = 5 * time.Second
+
 // Message types for IPC communication.
 const (
 	MsgTypeStatus            = "status"
@@ -1561,7 +1568,7 @@ func (s *Server) handleConnection(_ context.Context, conn net.Conn) {
 	// Tests can opt out via DisablePeerCred (set during test setup) — real
 	// production code paths never set this.
 	if !s.peerCredDisabled {
-		ownerUID := uint32(os.Geteuid())
+		ownerUID := currentProcessUID()
 		peer, err := peerUID(conn)
 		if err != nil {
 			s.logger.Warn("ipc: rejecting connection — peercred lookup failed",
@@ -1622,6 +1629,12 @@ func (s *Server) handleConnection(_ context.Context, conn net.Conn) {
 
 // sendResponse sends a response to the client.
 func (s *Server) sendResponse(conn net.Conn, resp Response) {
+	// A progress write leaves a 100ms deadline on the shared connection. Reset
+	// it for the final response, which is authoritative rather than best-effort.
+	// This also keeps a disconnected/non-reading client from blocking shutdown.
+	if err := conn.SetWriteDeadline(time.Now().Add(finalResponseWriteTimeout)); err != nil {
+		s.logger.Debug("failed to set IPC response write deadline", "error", err)
+	}
 	data, err := json.Marshal(resp)
 	if err != nil {
 		s.logger.Error("failed to marshal IPC response", "error", err)

--- a/internal/daemon/ipc_owner_unix.go
+++ b/internal/daemon/ipc_owner_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package daemon
+
+import "os"
+
+func currentProcessUID() uint32 { return uint32(os.Geteuid()) }

--- a/internal/daemon/ipc_peercred_windows.go
+++ b/internal/daemon/ipc_peercred_windows.go
@@ -19,3 +19,7 @@ func peerUID(conn net.Conn) (uint32, error) {
 	_ = conn
 	return 0, nil
 }
+
+// currentProcessUID uses the sentinel returned by peerUID on Windows. Named
+// pipe ACLs, not Unix numeric UIDs, are the same-user trust boundary here.
+func currentProcessUID() uint32 { return 0 }

--- a/internal/daemon/ipc_pipe_name.go
+++ b/internal/daemon/ipc_pipe_name.go
@@ -1,0 +1,14 @@
+package daemon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// pipeName maps the logical socket path to a Windows-safe named pipe. Basing
+// the name on the path keeps XDG-isolated test/ephemeral daemons from sharing
+// the production pipe while remaining deterministic for clients.
+func pipeName(path string) string {
+	digest := sha256.Sum256([]byte(path))
+	return "sageox-daemon-" + hex.EncodeToString(digest[:8])
+}

--- a/internal/daemon/ipc_pipe_name_test.go
+++ b/internal/daemon/ipc_pipe_name_test.go
@@ -1,0 +1,16 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipeNameIsStableAndPathScoped(t *testing.T) {
+	first := pipeName(`/runtime/one/daemon.sock`)
+	assert.Equal(t, first, pipeName(`/runtime/one/daemon.sock`))
+	assert.NotEqual(t, first, pipeName(`/runtime/two/daemon.sock`))
+	assert.True(t, strings.HasPrefix(first, "sageox-daemon-"))
+	assert.Len(t, first, len("sageox-daemon-")+16)
+}

--- a/internal/daemon/ipc_recovery_test.go
+++ b/internal/daemon/ipc_recovery_test.go
@@ -1,0 +1,144 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func startRecoveryTestServer(t *testing.T, server *Server) (stop func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- server.Start(ctx) }()
+
+	client := &Client{socketPath: SocketPath(), timeout: time.Second}
+	require.Eventually(t, func() bool { return client.Ping() == nil },
+		2*time.Second, 10*time.Millisecond, "server socket was not ready")
+
+	return func() {
+		cancel()
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(2 * time.Second):
+			t.Fatal("server did not stop after cancellation")
+		}
+	}
+}
+
+func recoveryRuntimeDir(t *testing.T, pattern string) string {
+	t.Helper()
+	root := os.TempDir()
+	if runtime.GOOS != "windows" {
+		root = "/tmp" // keep Unix socket paths below macOS's small limit
+	}
+	dir, err := os.MkdirTemp(root, pattern)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// TestSyncFinalResponseReplacesProgressDeadline protects the distinction
+// between best-effort progress and the authoritative final response. A progress
+// update installs a 100ms write deadline. Real sync work can continue longer
+// than that after its last update, so the server must replace the expired
+// deadline before writing success or failure.
+func TestSyncFinalResponseReplacesProgressDeadline(t *testing.T) {
+	runtimeDir := recoveryRuntimeDir(t, "ox-ipc-final-")
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	server := NewServer(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	server.SetHandlers(func() error { return nil }, func() {}, func() *StatusData {
+		return &StatusData{Running: true}
+	})
+	server.SetSyncHandler(func(progress *ProgressWriter) error {
+		if err := progress.WriteStage("fetching", "remote contacted"); err != nil {
+			return err
+		}
+		// Expire ProgressWriter's short deadline before returning the final
+		// result. Without sendResponse resetting it, the client never sees OK.
+		time.Sleep(150 * time.Millisecond)
+		return nil
+	})
+	stop := startRecoveryTestServer(t, server)
+	defer stop()
+
+	client := &Client{socketPath: SocketPath(), timeout: 2 * time.Second}
+	var stages []string
+	err := client.SyncWithProgress(func(stage string, _ *int, _ string) {
+		stages = append(stages, stage)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"fetching"}, stages)
+}
+
+// TestSyncDroppedConnectionRestartAndRetry is the real socket boundary for a
+// CLI disappearing mid-sync. The abandoned handler must finish without
+// poisoning server shutdown, and a replacement daemon must accept a retry and
+// report progress normally.
+func TestSyncDroppedConnectionRestartAndRetry(t *testing.T) {
+	runtimeDir := recoveryRuntimeDir(t, "ox-ipc-retry-")
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	first := NewServer(logger)
+	first.SetHandlers(func() error { return nil }, func() {}, func() *StatusData {
+		return &StatusData{Running: true}
+	})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	first.SetSyncHandler(func(progress *ProgressWriter) error {
+		_ = progress.WriteStage("fetching", "first attempt")
+		<-release
+		close(finished)
+		return nil
+	})
+	stopFirst := startRecoveryTestServer(t, first)
+
+	client := &Client{socketPath: SocketPath(), timeout: 75 * time.Millisecond}
+	err := client.SyncWithProgress(nil)
+	require.Error(t, err, "client should disconnect when progress stops")
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+
+	close(release)
+	require.Eventually(t, func() bool {
+		select {
+		case <-finished:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond, "abandoned handler did not finish")
+	stopFirst()
+
+	second := NewServer(logger)
+	second.SetHandlers(func() error { return nil }, func() {}, func() *StatusData {
+		return &StatusData{Running: true}
+	})
+	var calls atomic.Int32
+	second.SetSyncHandler(func(progress *ProgressWriter) error {
+		calls.Add(1)
+		_ = progress.WriteStage("complete", "retry succeeded")
+		return nil
+	})
+	stopSecond := startRecoveryTestServer(t, second)
+	defer stopSecond()
+
+	client = &Client{socketPath: SocketPath(), timeout: time.Second}
+	var stages []string
+	require.NoError(t, client.SyncWithProgress(func(stage string, _ *int, _ string) {
+		stages = append(stages, stage)
+	}))
+	assert.Equal(t, int32(1), calls.Load())
+	assert.Equal(t, []string{"complete"}, stages)
+}

--- a/internal/daemon/ipc_windows.go
+++ b/internal/daemon/ipc_windows.go
@@ -60,9 +60,3 @@ func dial(path string) (net.Conn, error) {
 func cleanupSocket(path string) {
 	// no-op: Windows named pipes are automatically cleaned up when closed
 }
-
-// pipeName converts a socket path to a pipe name.
-func pipeName(path string) string {
-	// use a fixed name for simplicity
-	return "sageox-daemon"
-}

--- a/internal/daemon/sync_failure_recovery_test.go
+++ b/internal/daemon/sync_failure_recovery_test.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoPull_NetworkFailurePreservesStateAndRetryProgresses exercises the
+// complete offline-to-online transition against real git repositories. The
+// failed fetch must preserve both user work and the last-known-good sync
+// checkpoint. Restoring connectivity must then fetch remote content and reset
+// failure state without requiring a scheduler restart.
+func TestDoPull_NetworkFailurePreservesStateAndRetryProgresses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: exercises real git failure and recovery")
+	}
+
+	root := t.TempDir()
+	ledgerDir := filepath.Join(root, "ledger")
+	require.NoError(t, os.MkdirAll(ledgerDir, 0o755))
+	setupGitRepo(t, ledgerDir)
+	remote := bareRepoPath(ledgerDir)
+	scheduler := newPullTestScheduler(t, ledgerDir)
+
+	// Establish a durable last-known-good checkpoint before connectivity fails.
+	require.NoError(t, scheduler.doPull(context.Background(), nil, true, true))
+	before := LoadSyncState(ledgerDir)
+	require.False(t, before.LastSync.IsZero())
+	require.NotEmpty(t, before.LastSyncCommit)
+
+	// User work exists only in the worktree while the remote becomes
+	// unreachable. A failed pull must not reset/overwrite either kind of state.
+	const localEdit = "# Test\n\nlocal uncommitted work\n"
+	require.NoError(t, os.WriteFile(filepath.Join(ledgerDir, "README.md"), []byte(localEdit), 0o644))
+	gitCmd(t, ledgerDir, "remote", "set-url", "origin", "http://127.0.0.1:1/unreachable.git")
+
+	err := scheduler.doPull(context.Background(), nil, true, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch failed")
+	afterFailure := LoadSyncState(ledgerDir)
+	assert.Equal(t, before.LastSync, afterFailure.LastSync,
+		"failure must preserve the last successful sync time")
+	assert.Equal(t, before.LastSyncCommit, afterFailure.LastSyncCommit,
+		"failure must preserve the last known-good commit")
+	assert.Equal(t, 1, afterFailure.ConsecutiveFailures)
+	body, readErr := os.ReadFile(filepath.Join(ledgerDir, "README.md"))
+	require.NoError(t, readErr)
+	assert.Equal(t, localEdit, string(body), "network failure must preserve uncommitted user work")
+
+	// Connectivity returns and the remote has moved. Backdate FETCH_HEAD to
+	// model the next scheduled retry (a failed fetch may still touch the file,
+	// and the cross-daemon dedup window intentionally suppresses immediate
+	// refetches). Force bypasses failure backoff, proving retry makes progress.
+	pushFromSeparateClone(t, remote, "remote-recovery.txt", "remote is back\n")
+	gitCmd(t, ledgerDir, "remote", "set-url", "origin", remote)
+	oldFetch := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(filepath.Join(ledgerDir, ".git", "FETCH_HEAD"), oldFetch, oldFetch))
+	require.NoError(t, scheduler.doPull(context.Background(), nil, true, true))
+
+	afterRecovery := LoadSyncState(ledgerDir)
+	assert.Zero(t, afterRecovery.ConsecutiveFailures)
+	assert.True(t, afterRecovery.LastSync.After(before.LastSync))
+	assert.NotEqual(t, before.LastSyncCommit, afterRecovery.LastSyncCommit,
+		"successful retry must advance the durable checkpoint")
+	require.FileExists(t, filepath.Join(ledgerDir, "remote-recovery.txt"),
+		"successful retry must materialize remote progress")
+	body, readErr = os.ReadFile(filepath.Join(ledgerDir, "README.md"))
+	require.NoError(t, readErr)
+	assert.Equal(t, localEdit, string(body), "successful autostash retry must restore user work")
+
+	metrics := scheduler.Metrics().Snapshot()
+	assert.Equal(t, int64(1), metrics.PullFailureCount)
+	assert.Equal(t, int64(1), metrics.PullSuccessCount,
+		"the recovery pull, unlike the initial remote-unchanged checkpoint, must record success")
+}

--- a/internal/dashboard/app/keys.go
+++ b/internal/dashboard/app/keys.go
@@ -69,6 +69,6 @@ func DefaultPaneKeys() PaneKeyMap {
 		Up:     key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),
 		Down:   key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
 		Select: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-		Expand: key.NewBinding(key.WithKeys(" "), key.WithHelp("space", "expand")),
+		Expand: key.NewBinding(key.WithKeys("space"), key.WithHelp("space", "expand")),
 	}
 }

--- a/internal/dashboard/app/update.go
+++ b/internal/dashboard/app/update.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"sort"
+
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
@@ -201,8 +203,14 @@ func (m Model) syncTargetAtCursor(cursor int) *domain.InspectorTarget {
 	if ds == nil {
 		return nil
 	}
+	repoIDs := make([]string, 0, len(ds.Workspaces))
+	for repoID := range ds.Workspaces {
+		repoIDs = append(repoIDs, repoID)
+	}
+	sort.Strings(repoIDs)
 	idx := 0
-	for _, wsList := range ds.Workspaces {
+	for _, repoID := range repoIDs {
+		wsList := ds.Workspaces[repoID]
 		for i := range wsList {
 			if idx == cursor {
 				ws := wsList[i]

--- a/internal/dashboard/app/update_test.go
+++ b/internal/dashboard/app/update_test.go
@@ -193,8 +193,9 @@ func TestOpenInspectorForCursorRejectsOutOfRangeSelection(t *testing.T) {
 	assert.Equal(t, "one.jsonl", got.store.Selected.Session.Filename)
 }
 
-func TestAsyncResultsFromSupersededRefreshAreAllDiscarded(t *testing.T) {
+func TestUpdateDiscardsAllAsyncResultsFromSupersededRefresh(t *testing.T) {
 	m := Model{effectGen: 9}
+	m.listLens = &[int(sectionCount)]int{}
 	m.store = state.Store{
 		DaemonStatus:   &daemon.StatusData{Pid: 1},
 		Sessions:       []session.SessionInfo{{Filename: "kept.jsonl"}},
@@ -220,53 +221,102 @@ func TestAsyncResultsFromSupersededRefreshAreAllDiscarded(t *testing.T) {
 	}
 
 	for _, msg := range stale {
-		got, cmd := m.reduceEffects(msg)
+		updated, cmd := m.Update(msg)
+		got := updated.(Model)
 		assert.Nil(t, cmd)
 		assert.Equal(t, m.store, got.store, "%T escaped generation cancellation", msg)
 	}
 }
 
-func TestRefreshIssuesLoadsAndSupersedesOlderWork(t *testing.T) {
+func TestUpdateRoutesRefreshAndSupersedesOlderWork(t *testing.T) {
 	m := Model{effectGen: 4}
+	m.listLens = &[int(sectionCount)]int{}
 	m.store.Generation = 4
 
-	got, cmd := m.reduceGlobal(RefreshMsg{})
+	updated, cmd := m.Update(RefreshMsg{})
+	got := updated.(Model)
 	require.NotNil(t, cmd)
 	assert.Equal(t, 5, got.effectGen)
 	assert.Equal(t, 5, got.store.Generation)
 
-	outer, ok := cmd().(tea.BatchMsg)
+	refresh, ok := cmd().(tea.BatchMsg)
 	require.True(t, ok, "refresh must issue both loads and a replacement tick")
-	require.Len(t, outer, 2)
-	loads, ok := outer[0]().(tea.BatchMsg)
+	require.Len(t, refresh, 2)
+	loads, ok := refresh[0]().(tea.BatchMsg)
 	require.True(t, ok)
 	assert.Len(t, loads, 9, "every dashboard data source must be refreshed")
 }
 
-func TestGlobalNavigationClampsAndInspectorOwnsKeys(t *testing.T) {
+func TestUpdateRoutesPaletteInputSelectionThroughOverlayStack(t *testing.T) {
+	m := NewModel(nil, nil, nil)
+	m.store.Sessions = []session.SessionInfo{
+		{Filename: "alpha.jsonl", Username: "Alpha"},
+		{Filename: "beta.jsonl", Username: "Beta"},
+	}
+	updated, cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+
+	updated, cmd = m.Update(keyPress("ctrl+k"))
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+	require.NotNil(t, m.overlays.Top())
+	assert.Equal(t, overlays.OverlayPalette, m.overlays.Top().ID())
+	assert.Contains(t, m.View().Content, "Quick Search", "the active overlay must own the composed view")
+
+	for _, r := range "Beta" {
+		updated, cmd = m.Update(keyPress(string(r)))
+		m = updated.(Model)
+		assert.Nil(t, cmd)
+	}
+	assert.Contains(t, m.View().Content, "Beta")
+	assert.NotContains(t, m.View().Content, "Alpha")
+
+	updated, cmd = m.Update(keyPress("enter"))
+	m = updated.(Model)
+	assert.True(t, m.overlays.IsEmpty(), "selection must close the palette")
+	require.NotNil(t, cmd)
+
+	selection, ok := cmd().(SelectionChangedMsg)
+	require.True(t, ok)
+
+	updated, cmd = m.Update(selection)
+	m = updated.(Model)
+	assert.Nil(t, cmd)
+	require.NotNil(t, m.store.Selected)
+	require.NotNil(t, m.store.Selected.Session)
+	assert.Equal(t, "beta.jsonl", m.store.Selected.Session.Filename)
+}
+
+func TestUpdateRoutesNavigationAndInspectorOwnsFocus(t *testing.T) {
 	m := NewModel(nil, nil, nil)
 	m.section = SectionSessions
 	m.listLens[SectionSessions] = 2
+	update := func(msg tea.Msg) {
+		updated, cmd := m.Update(msg)
+		m = updated.(Model)
+		assert.Nil(t, cmd)
+	}
 
-	m, _ = m.reduceGlobal(keyPress("j"))
+	update(keyPress("j"))
 	assert.Equal(t, 1, m.cursors[SectionSessions])
-	m, _ = m.reduceGlobal(keyPress("j"))
+	update(keyPress("j"))
 	assert.Equal(t, 1, m.cursors[SectionSessions], "cursor must not run past the list")
-	m, _ = m.reduceGlobal(keyPress("k"))
+	update(keyPress("k"))
 	assert.Zero(t, m.cursors[SectionSessions])
 
 	m.inspectorOpen = true
 	m.inspectorScroll = 0
-	m, _ = m.reduceGlobal(keyPress("j"))
+	update(keyPress("j"))
 	assert.Equal(t, 1, m.inspectorScroll)
 	assert.Zero(t, m.cursors[SectionSessions], "inspector scrolling must not move list selection")
-	m, _ = m.reduceGlobal(keyPress("tab"))
+	update(keyPress("tab"))
 	assert.Equal(t, SectionSessions, m.section, "section navigation is disabled while inspecting")
-	m, _ = m.reduceGlobal(keyPress("esc"))
+	update(keyPress("esc"))
 	assert.False(t, m.inspectorOpen)
 	assert.Zero(t, m.inspectorScroll)
 
-	m, _ = m.reduceGlobal(keyPress("tab"))
+	update(keyPress("tab"))
 	assert.Equal(t, SectionFeed, m.section)
 }
 
@@ -318,6 +368,8 @@ func TestFeedSelectionPreservesMurmurDiscussionWhisperOrder(t *testing.T) {
 
 func keyPress(name string) tea.KeyPressMsg {
 	switch name {
+	case "ctrl+k":
+		return tea.KeyPressMsg(tea.Key{Code: 'k', Mod: tea.ModCtrl})
 	case "tab":
 		return tea.KeyPressMsg(tea.Key{Code: tea.KeyTab})
 	case "esc":

--- a/internal/dashboard/app/update_test.go
+++ b/internal/dashboard/app/update_test.go
@@ -6,9 +6,11 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/dashboard/domain"
 	"github.com/sageox/ox/internal/dashboard/effects"
 	"github.com/sageox/ox/internal/dashboard/overlays"
+	"github.com/sageox/ox/internal/dashboard/state"
 	"github.com/sageox/ox/internal/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -189,4 +191,141 @@ func TestOpenInspectorForCursorRejectsOutOfRangeSelection(t *testing.T) {
 	require.NotNil(t, got.store.Selected)
 	assert.Equal(t, domain.TargetSession, got.store.Selected.Kind)
 	assert.Equal(t, "one.jsonl", got.store.Selected.Session.Filename)
+}
+
+func TestAsyncResultsFromSupersededRefreshAreAllDiscarded(t *testing.T) {
+	m := Model{effectGen: 9}
+	m.store = state.Store{
+		DaemonStatus:   &daemon.StatusData{Pid: 1},
+		Sessions:       []session.SessionInfo{{Filename: "kept.jsonl"}},
+		Murmurs:        []domain.MurmurEntry{{Content: "kept"}},
+		Discussions:    []domain.TeamDiscussion{{Title: "kept"}},
+		Instances:      []daemon.InstanceInfo{{AgentID: "kept"}},
+		StoredErrors:   []daemon.StoredError{{Message: "kept"}},
+		TeamContexts:   []domain.TeamContextEntry{{TeamName: "kept"}},
+		CodeIndexStats: &daemon.CodeDBStats{Symbols: 1},
+		WhisperHistory: []domain.WhisperHistoryEntry{{Content: "kept"}},
+	}
+
+	stale := []tea.Msg{
+		effects.DaemonStatusLoadedMsg{Gen: 8, Data: &daemon.StatusData{Pid: 2}},
+		effects.SessionsLoadedMsg{Gen: 8, Sessions: []session.SessionInfo{{Filename: "stale"}}},
+		effects.MurmursLoadedMsg{Gen: 8, Murmurs: []domain.MurmurEntry{{Content: "stale"}}},
+		effects.TeamDiscussionsLoadedMsg{Gen: 8, Discussions: []domain.TeamDiscussion{{Title: "stale"}}},
+		effects.InstancesLoadedMsg{Gen: 8, Instances: []daemon.InstanceInfo{{AgentID: "stale"}}},
+		effects.StoredErrorsLoadedMsg{Gen: 8, Errors: []daemon.StoredError{{Message: "stale"}}},
+		effects.TeamContextsLoadedMsg{Gen: 8, TeamContexts: []domain.TeamContextEntry{{TeamName: "stale"}}},
+		effects.CodeIndexStatsLoadedMsg{Gen: 8, Stats: &daemon.CodeDBStats{Symbols: 2}},
+		effects.WhisperHistoryLoadedMsg{Gen: 8, Entries: []domain.WhisperHistoryEntry{{Content: "stale"}}},
+	}
+
+	for _, msg := range stale {
+		got, cmd := m.reduceEffects(msg)
+		assert.Nil(t, cmd)
+		assert.Equal(t, m.store, got.store, "%T escaped generation cancellation", msg)
+	}
+}
+
+func TestRefreshIssuesLoadsAndSupersedesOlderWork(t *testing.T) {
+	m := Model{effectGen: 4}
+	m.store.Generation = 4
+
+	got, cmd := m.reduceGlobal(RefreshMsg{})
+	require.NotNil(t, cmd)
+	assert.Equal(t, 5, got.effectGen)
+	assert.Equal(t, 5, got.store.Generation)
+
+	outer, ok := cmd().(tea.BatchMsg)
+	require.True(t, ok, "refresh must issue both loads and a replacement tick")
+	require.Len(t, outer, 2)
+	loads, ok := outer[0]().(tea.BatchMsg)
+	require.True(t, ok)
+	assert.Len(t, loads, 9, "every dashboard data source must be refreshed")
+}
+
+func TestGlobalNavigationClampsAndInspectorOwnsKeys(t *testing.T) {
+	m := NewModel(nil, nil, nil)
+	m.section = SectionSessions
+	m.listLens[SectionSessions] = 2
+
+	m, _ = m.reduceGlobal(keyPress("j"))
+	assert.Equal(t, 1, m.cursors[SectionSessions])
+	m, _ = m.reduceGlobal(keyPress("j"))
+	assert.Equal(t, 1, m.cursors[SectionSessions], "cursor must not run past the list")
+	m, _ = m.reduceGlobal(keyPress("k"))
+	assert.Zero(t, m.cursors[SectionSessions])
+
+	m.inspectorOpen = true
+	m.inspectorScroll = 0
+	m, _ = m.reduceGlobal(keyPress("j"))
+	assert.Equal(t, 1, m.inspectorScroll)
+	assert.Zero(t, m.cursors[SectionSessions], "inspector scrolling must not move list selection")
+	m, _ = m.reduceGlobal(keyPress("tab"))
+	assert.Equal(t, SectionSessions, m.section, "section navigation is disabled while inspecting")
+	m, _ = m.reduceGlobal(keyPress("esc"))
+	assert.False(t, m.inspectorOpen)
+	assert.Zero(t, m.inspectorScroll)
+
+	m, _ = m.reduceGlobal(keyPress("tab"))
+	assert.Equal(t, SectionFeed, m.section)
+}
+
+func TestInspectorSelectionMatchesRenderedSyncOrder(t *testing.T) {
+	m := NewModel(nil, nil, nil)
+	m.section = SectionSync
+	m.store.DaemonStatus = &daemon.StatusData{Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+		"z-repo": {{Path: "/z"}},
+		"a-repo": {{Path: "/a"}},
+	}}
+	m.listLens[SectionSync] = 2
+
+	m.cursors[SectionSync] = 0
+	first := m.openInspectorForCursor()
+	require.NotNil(t, first.store.Selected)
+	assert.Equal(t, "/a", first.store.Selected.Workspace.Path)
+
+	m.inspectorOpen = false
+	m.cursors[SectionSync] = 1
+	second := m.openInspectorForCursor()
+	require.NotNil(t, second.store.Selected)
+	assert.Equal(t, "/z", second.store.Selected.Workspace.Path)
+}
+
+func TestDefaultPaneKeysUseBubbleTeaSpaceName(t *testing.T) {
+	keys := DefaultPaneKeys()
+	assert.Equal(t, []string{"space"}, keys.Expand.Keys())
+}
+
+func TestFeedSelectionPreservesMurmurDiscussionWhisperOrder(t *testing.T) {
+	m := Model{}
+	m.store.Murmurs = []domain.MurmurEntry{{Content: "murmur"}}
+	m.store.Discussions = []domain.TeamDiscussion{{Title: "discussion"}}
+	m.store.WhisperHistory = []domain.WhisperHistoryEntry{{Content: "whisper"}}
+
+	wantKinds := []domain.InspectorTargetKind{
+		domain.TargetMurmur,
+		domain.TargetTeamDiscussion,
+		domain.TargetWhisperHistory,
+	}
+	for cursor, want := range wantKinds {
+		target := m.feedTargetAtCursor(cursor)
+		require.NotNil(t, target)
+		assert.Equal(t, want, target.Kind)
+	}
+	assert.Nil(t, m.feedTargetAtCursor(-1))
+	assert.Nil(t, m.feedTargetAtCursor(len(wantKinds)))
+}
+
+func keyPress(name string) tea.KeyPressMsg {
+	switch name {
+	case "tab":
+		return tea.KeyPressMsg(tea.Key{Code: tea.KeyTab})
+	case "esc":
+		return tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape})
+	case "enter":
+		return tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter})
+	default:
+		r := []rune(name)
+		return tea.KeyPressMsg(tea.Key{Text: name, Code: r[0]})
+	}
 }

--- a/internal/dashboard/overlays/palette/palette_test.go
+++ b/internal/dashboard/overlays/palette/palette_test.go
@@ -1,0 +1,80 @@
+package palette
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type selectedMsg struct{ label string }
+
+func TestOverlayFiltersNavigatesAndSelectsVisibleItem(t *testing.T) {
+	o := New([]Item{
+		{Label: "Alpha session", Sub: "sessions", Cmd: func() tea.Msg { return selectedMsg{"alpha"} }},
+		{Label: "Beta workspace", Sub: "workspaces", Cmd: func() tea.Msg { return selectedMsg{"beta"} }},
+		{Label: "Gamma session", Sub: "sessions", Cmd: func() tea.Msg { return selectedMsg{"gamma"} }},
+	})
+
+	for _, r := range "session" {
+		updated, _, consumed := o.Update(keyPress(string(r)))
+		require.True(t, consumed)
+		o = updated.(*Overlay)
+	}
+	assert.Len(t, o.filtered(), 2, "filtering by category must retain both sessions")
+
+	updated, _, consumed := o.Update(keyPress("j"))
+	require.True(t, consumed)
+	o = updated.(*Overlay)
+	assert.Equal(t, 1, o.cursor)
+
+	closed, cmd, consumed := o.Update(keyPress("enter"))
+	assert.True(t, consumed)
+	assert.Nil(t, closed, "selection closes the palette")
+	require.NotNil(t, cmd)
+	assert.Equal(t, selectedMsg{"gamma"}, cmd())
+}
+
+func TestOverlayQueryChangesResetCursorAndCancellationRunsNoCommand(t *testing.T) {
+	o := New([]Item{{Label: "one"}, {Label: "two"}})
+	o.cursor = 1
+
+	updated, cmd, consumed := o.Update(keyPress("x"))
+	require.True(t, consumed)
+	assert.Nil(t, cmd)
+	o = updated.(*Overlay)
+	assert.Zero(t, o.cursor)
+	assert.Equal(t, "x", o.query)
+
+	updated, _, _ = o.Update(keyPress("backspace"))
+	o = updated.(*Overlay)
+	assert.Empty(t, o.query)
+
+	closed, cmd, consumed := o.Update(keyPress("esc"))
+	assert.True(t, consumed)
+	assert.Nil(t, closed)
+	assert.Nil(t, cmd, "cancel must never execute the highlighted action")
+}
+
+func TestOverlayDeclinesNonKeyboardMessages(t *testing.T) {
+	o := New(nil)
+	updated, cmd, consumed := o.Update(struct{}{})
+	assert.False(t, consumed)
+	assert.Same(t, o, updated)
+	assert.Nil(t, cmd)
+}
+
+func keyPress(name string) tea.KeyPressMsg {
+	switch name {
+	case "enter":
+		return tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter})
+	case "esc":
+		return tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape})
+	case "backspace":
+		return tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace})
+	default:
+		r := []rune(name)
+		return tea.KeyPressMsg(tea.Key{Text: name, Code: r[0]})
+	}
+}

--- a/internal/dashboard/panes/nav/nav_test.go
+++ b/internal/dashboard/panes/nav/nav_test.go
@@ -1,0 +1,106 @@
+package nav
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/sageox/ox/internal/dashboard/app"
+	"github.com/sageox/ox/internal/dashboard/domain"
+	"github.com/sageox/ox/internal/dashboard/panes"
+	"github.com/sageox/ox/internal/dashboard/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaneIssuesNavigationIntentsOnlyWhenFocused(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want tea.Msg
+	}{
+		{"up", "k", app.NavCursorUpMsg{}},
+		{"down", "j", app.NavCursorDownMsg{}},
+		{"expand", " ", app.NavExpandMsg{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := New()
+			store := &state.Store{}
+			ctx := panes.Context{Store: store, Focused: true}
+			_, cmd := p.Update(keyPress(tc.key), ctx)
+			require.NotNil(t, cmd)
+			assert.IsType(t, tc.want, cmd())
+
+			ctx.Focused = false
+			_, cmd = p.Update(keyPress(tc.key), ctx)
+			assert.Nil(t, cmd, "unfocused panes must not consume global navigation")
+		})
+	}
+}
+
+func TestPaneSelectionUsesCursorAndRejectsNonSelectableRows(t *testing.T) {
+	target := &domain.InspectorTarget{Kind: domain.TargetSession}
+	nodes := []domain.NavNode{
+		{Kind: domain.NavNodeSection, Label: "Sessions"},
+		{Kind: domain.NavNodeSession, Label: "one", Target: target},
+		{Kind: domain.NavNodeHint, Label: "none"},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		cursor  int
+		wantCmd bool
+	}{
+		{"section", 0, false},
+		{"target", 1, true},
+		{"hint", 2, false},
+		{"past end", 3, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := New()
+			store := &state.Store{NavCursorPos: tc.cursor}
+			ctx := panes.Context{Store: store, Focused: true, NavNodes: nodes}
+			_, cmd := p.Update(keyPress("enter"), ctx)
+			if !tc.wantCmd {
+				assert.Nil(t, cmd)
+				return
+			}
+			require.NotNil(t, cmd)
+			msg, ok := cmd().(app.SelectionChangedMsg)
+			require.True(t, ok)
+			assert.Same(t, target, msg.Target)
+		})
+	}
+}
+
+func TestPaneScrollKeepsCursorInsideViewport(t *testing.T) {
+	p := New()
+	p.SetSize(panes.Rect{Height: 6}) // three visible rows after chrome
+	store := &state.Store{NavCursorPos: 5}
+	ctx := panes.Context{Store: store}
+
+	p.adjustScroll(ctx)
+	assert.Equal(t, 3, p.scrollTop)
+
+	store.NavCursorPos = 1
+	p.adjustScroll(ctx)
+	assert.Equal(t, 1, p.scrollTop)
+
+	store.NavCursorPos = -1
+	p.adjustScroll(ctx)
+	assert.Zero(t, p.scrollTop)
+}
+
+func keyPress(name string) tea.KeyPressMsg {
+	switch name {
+	case "enter":
+		return tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter})
+	case " ":
+		return tea.KeyPressMsg(tea.Key{Text: " ", Code: tea.KeySpace})
+	default:
+		r := []rune(name)
+		return tea.KeyPressMsg(tea.Key{Text: name, Code: r[0]})
+	}
+}

--- a/internal/session/adapters/external.go
+++ b/internal/session/adapters/external.go
@@ -602,7 +602,6 @@ func (ea *ExternalAdapter) execOneShot(subcommand string, args ...string) ([]byt
 
 	cmd := exec.CommandContext(ctx, ea.binaryPath, cmdArgs...)
 	cmd.Env = ea.buildEnv()
-	configureOneShotCommand(cmd)
 	cmd.WaitDelay = oneShotPipeDrainDelay
 
 	limit := ea.oneShotOutputLimit
@@ -615,7 +614,7 @@ func (ea *ExternalAdapter) execOneShot(subcommand string, args ...string) ([]byt
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err := runOneShotCommand(cmd)
 	if timeoutCtx.Err() == context.DeadlineExceeded {
 		return nil, fmt.Errorf("%w: %s %s", ErrAdapterTimeout, ea.binaryPath, subcommand)
 	}

--- a/internal/session/adapters/external.go
+++ b/internal/session/adapters/external.go
@@ -31,7 +31,14 @@ var (
 
 	// ErrProtocolMismatch is returned when an adapter's protocol version is incompatible.
 	ErrProtocolMismatch = errors.New("adapter protocol version mismatch")
+
+	// ErrAdapterOutputLimit is returned when an adapter writes more output than
+	// the runtime will retain. A misbehaving adapter must not be able to grow the
+	// daemon without bound before its subprocess timeout expires.
+	ErrAdapterOutputLimit = errors.New("adapter output exceeded limit")
 )
+
+const defaultOneShotOutputLimit = 64 * 1024 * 1024
 
 // ExternalAdapter implements Adapter and IncrementalReader by calling an
 // external adapter binary via subprocess (one-shot) or serve-mode pipe.
@@ -47,17 +54,19 @@ type ExternalAdapter struct {
 	serveSeq int
 
 	// timeouts
-	oneShotTimeout time.Duration
-	serveTimeout   time.Duration
+	oneShotTimeout     time.Duration
+	serveTimeout       time.Duration
+	oneShotOutputLimit int
 }
 
 // NewExternalAdapter creates an ExternalAdapter wrapping the binary at the given path.
 // It calls `info` to populate adapter metadata.
 func NewExternalAdapter(binaryPath string) (*ExternalAdapter, error) {
 	ea := &ExternalAdapter{
-		binaryPath:     binaryPath,
-		oneShotTimeout: 10 * time.Second,
-		serveTimeout:   100 * time.Millisecond,
+		binaryPath:         binaryPath,
+		oneShotTimeout:     10 * time.Second,
+		serveTimeout:       100 * time.Millisecond,
+		oneShotOutputLimit: defaultOneShotOutputLimit,
 	}
 
 	// call info to get adapter metadata
@@ -74,10 +83,11 @@ func NewExternalAdapter(binaryPath string) (*ExternalAdapter, error) {
 // Used when info has already been called (e.g., during discovery).
 func NewExternalAdapterWithInfo(binaryPath string, info *adapterprotocol.InfoResponse) *ExternalAdapter {
 	return &ExternalAdapter{
-		binaryPath:     binaryPath,
-		info:           info,
-		oneShotTimeout: 10 * time.Second,
-		serveTimeout:   100 * time.Millisecond,
+		binaryPath:         binaryPath,
+		info:               info,
+		oneShotTimeout:     10 * time.Second,
+		serveTimeout:       100 * time.Millisecond,
+		oneShotOutputLimit: defaultOneShotOutputLimit,
 	}
 }
 
@@ -579,19 +589,30 @@ func (ea *ExternalAdapter) execOneShot(subcommand string, args ...string) ([]byt
 	}
 
 	cmdArgs := append([]string{subcommand}, args...)
-	ctx, cancel := context.WithTimeout(context.Background(), ea.oneShotTimeout)
-	defer cancel()
+	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), ea.oneShotTimeout)
+	defer timeoutCancel()
+	ctx, outputCancel := context.WithCancel(timeoutCtx)
+	defer outputCancel()
 
 	cmd := exec.CommandContext(ctx, ea.binaryPath, cmdArgs...)
 	cmd.Env = ea.buildEnv()
 
-	var stdout, stderr bytes.Buffer
+	limit := ea.oneShotOutputLimit
+	if limit <= 0 {
+		limit = defaultOneShotOutputLimit
+	}
+	budget := newOutputBudget(limit, outputCancel)
+	stdout := newBoundedBuffer(budget)
+	stderr := newBoundedBuffer(budget)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
-	if ctx.Err() == context.DeadlineExceeded {
+	if timeoutCtx.Err() == context.DeadlineExceeded {
 		return nil, fmt.Errorf("%w: %s %s", ErrAdapterTimeout, ea.binaryPath, subcommand)
+	}
+	if budget.wasExceeded() {
+		return nil, fmt.Errorf("%w (%d bytes): %s %s", ErrAdapterOutputLimit, limit, ea.binaryPath, subcommand)
 	}
 	if err != nil {
 		// check for error response in stdout (adapter may exit non-zero with a JSON error)
@@ -609,6 +630,69 @@ func (ea *ExternalAdapter) execOneShot(subcommand string, args ...string) ([]byt
 
 	return bytes.TrimSpace(stdout.Bytes()), nil
 }
+
+// outputBudget bounds stdout and stderr together. The first overflow cancels
+// the subprocess so an adapter that ignores a broken pipe cannot continue
+// consuming CPU until the ordinary timeout.
+type outputBudget struct {
+	mu        sync.Mutex
+	remaining int
+	exceeded  bool
+	cancel    context.CancelFunc
+}
+
+func newOutputBudget(limit int, cancel context.CancelFunc) *outputBudget {
+	return &outputBudget{remaining: limit, cancel: cancel}
+}
+
+func (b *outputBudget) claim(want int) (allowed int, exceeded bool) {
+	b.mu.Lock()
+	allowed = min(want, b.remaining)
+	b.remaining -= allowed
+	if allowed < want {
+		exceeded = true
+		b.exceeded = true
+	}
+	cancel := b.cancel
+	b.mu.Unlock()
+
+	if exceeded && cancel != nil {
+		cancel()
+	}
+	return allowed, exceeded
+}
+
+func (b *outputBudget) wasExceeded() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.exceeded
+}
+
+// boundedBuffer implements io.Writer while retaining only bytes granted by a
+// shared output budget.
+type boundedBuffer struct {
+	buf    bytes.Buffer
+	budget *outputBudget
+}
+
+func newBoundedBuffer(budget *outputBudget) boundedBuffer {
+	return boundedBuffer{budget: budget}
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	allowed, exceeded := b.budget.claim(len(p))
+	if allowed > 0 {
+		_, _ = b.buf.Write(p[:allowed])
+	}
+	if exceeded {
+		return allowed, ErrAdapterOutputLimit
+	}
+	return allowed, nil
+}
+
+func (b *boundedBuffer) Len() int       { return b.buf.Len() }
+func (b *boundedBuffer) Bytes() []byte  { return b.buf.Bytes() }
+func (b *boundedBuffer) String() string { return b.buf.String() }
 
 // validateRepoRootArg scans CLI args for --repo-root and validates the value
 // before spawning the subprocess. Delegates path validation to

--- a/internal/session/adapters/external.go
+++ b/internal/session/adapters/external.go
@@ -38,7 +38,13 @@ var (
 	ErrAdapterOutputLimit = errors.New("adapter output exceeded limit")
 )
 
-const defaultOneShotOutputLimit = 64 * 1024 * 1024
+const (
+	defaultOneShotOutputLimit = 64 * 1024 * 1024
+	// After cancellation, a descendant may keep the adapter's inherited output
+	// pipes open even though the direct process has exited. Bound pipe draining
+	// so a timed-out one-shot call returns promptly on every platform.
+	oneShotPipeDrainDelay = 100 * time.Millisecond
+)
 
 // ExternalAdapter implements Adapter and IncrementalReader by calling an
 // external adapter binary via subprocess (one-shot) or serve-mode pipe.
@@ -596,6 +602,8 @@ func (ea *ExternalAdapter) execOneShot(subcommand string, args ...string) ([]byt
 
 	cmd := exec.CommandContext(ctx, ea.binaryPath, cmdArgs...)
 	cmd.Env = ea.buildEnv()
+	configureOneShotCommand(cmd)
+	cmd.WaitDelay = oneShotPipeDrainDelay
 
 	limit := ea.oneShotOutputLimit
 	if limit <= 0 {

--- a/internal/session/adapters/external_process_unix.go
+++ b/internal/session/adapters/external_process_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package adapters
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// configureOneShotCommand isolates an adapter in its own process group so a
+// timeout or output-limit cancellation terminates descendants as well as the
+// adapter process itself. Adapter wrappers are commonly shell scripts, and a
+// child inheriting their output pipes would otherwise outlive the canceled
+// command.
+func configureOneShotCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+}

--- a/internal/session/adapters/external_process_unix.go
+++ b/internal/session/adapters/external_process_unix.go
@@ -29,3 +29,8 @@ func configureOneShotCommand(cmd *exec.Cmd) {
 		return nil
 	}
 }
+
+func runOneShotCommand(cmd *exec.Cmd) error {
+	configureOneShotCommand(cmd)
+	return cmd.Run()
+}

--- a/internal/session/adapters/external_process_unix_test.go
+++ b/internal/session/adapters/external_process_unix_test.go
@@ -1,0 +1,79 @@
+//go:build !windows
+
+package adapters
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+func TestExternalAdapter_TimeoutKillsDescendants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: drives an external adapter subprocess")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "ox-adapter-descendant")
+	contents := "#!/bin/sh\nsleep 30 &\nchild=$!\nprintf '%s\\n' \"$child\" > \"${0%/*}/child.pid\"\nwait\n"
+	if err := os.WriteFile(script, []byte(contents), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ea := NewExternalAdapterWithInfo(script, &adapterprotocol.InfoResponse{Name: "descendant"})
+	ea.oneShotTimeout = 500 * time.Millisecond
+	_, err := ea.Read("session")
+	if !errors.Is(err, ErrAdapterTimeout) {
+		t.Fatalf("error = %v, want ErrAdapterTimeout", err)
+	}
+
+	pidBytes, err := os.ReadFile(filepath.Join(dir, "child.pid"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		err = syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("adapter descendant pid %d remained alive after cancellation: %v", pid, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestConfigureOneShotCommand_CancelLifecycle(t *testing.T) {
+	t.Run("before start", func(t *testing.T) {
+		cmd := exec.CommandContext(context.Background(), "true")
+		configureOneShotCommand(cmd)
+		if err := cmd.Cancel(); !errors.Is(err, os.ErrProcessDone) {
+			t.Fatalf("Cancel error = %v, want os.ErrProcessDone", err)
+		}
+	})
+
+	t.Run("after exit", func(t *testing.T) {
+		cmd := exec.CommandContext(context.Background(), "true")
+		configureOneShotCommand(cmd)
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+		if err := cmd.Cancel(); !errors.Is(err, os.ErrProcessDone) {
+			t.Fatalf("Cancel error = %v, want os.ErrProcessDone", err)
+		}
+	})
+}

--- a/internal/session/adapters/external_process_windows.go
+++ b/internal/session/adapters/external_process_windows.go
@@ -2,8 +2,68 @@
 
 package adapters
 
-import "os/exec"
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+	"unsafe"
 
-// configureOneShotCommand leaves Windows cancellation to CommandContext.
-// WaitDelay remains the cross-platform backstop for inherited output pipes.
-func configureOneShotCommand(_ *exec.Cmd) {}
+	"golang.org/x/sys/windows"
+)
+
+// configureOneShotCommand gives the direct adapter process its own console
+// process group. Descendant lifetime is enforced by runOneShotCommand's Job
+// Object; the group also keeps console control events scoped away from ox.
+func configureOneShotCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+}
+
+// runOneShotCommand assigns the adapter to a kill-on-close Job Object. Windows
+// Job membership is inherited by descendants, so closing the job after a
+// timeout, output-limit cancellation, or ordinary adapter exit terminates the
+// entire subprocess tree rather than only the direct adapter process.
+func runOneShotCommand(cmd *exec.Cmd) error {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return fmt.Errorf("create adapter job object: %w", err)
+	}
+	defer windows.CloseHandle(job) //nolint:errcheck // closing is the kill-on-close action
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		return fmt.Errorf("configure adapter job object: %w", err)
+	}
+
+	configureOneShotCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	process, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	if err != nil {
+		killAndWait(cmd)
+		return fmt.Errorf("open adapter process for job assignment: %w", err)
+	}
+	defer windows.CloseHandle(process) //nolint:errcheck // process exit owns lifecycle
+	if err := windows.AssignProcessToJobObject(job, process); err != nil {
+		killAndWait(cmd)
+		return fmt.Errorf("assign adapter process to job object: %w", err)
+	}
+
+	return cmd.Wait()
+}
+
+func killAndWait(cmd *exec.Cmd) {
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+}

--- a/internal/session/adapters/external_process_windows.go
+++ b/internal/session/adapters/external_process_windows.go
@@ -3,6 +3,7 @@
 package adapters
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"syscall"
@@ -15,7 +16,9 @@ import (
 // process group. Descendant lifetime is enforced by runOneShotCommand's Job
 // Object; the group also keeps console control events scoped away from ox.
 func configureOneShotCommand(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_SUSPENDED,
+	}
 }
 
 // runOneShotCommand assigns the adapter to a kill-on-close Job Object. Windows
@@ -59,8 +62,42 @@ func runOneShotCommand(cmd *exec.Cmd) error {
 		killAndWait(cmd)
 		return fmt.Errorf("assign adapter process to job object: %w", err)
 	}
+	if err := resumeProcess(uint32(cmd.Process.Pid)); err != nil {
+		killAndWait(cmd)
+		return fmt.Errorf("resume adapter process after job assignment: %w", err)
+	}
 
 	return cmd.Wait()
+}
+
+func resumeProcess(processID uint32) error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(snapshot) //nolint:errcheck // snapshot is read-only
+
+	entry := windows.ThreadEntry32{Size: uint32(unsafe.Sizeof(windows.ThreadEntry32{}))}
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		return err
+	}
+	for {
+		if entry.OwnerProcessID == processID {
+			thread, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, entry.ThreadID)
+			if err != nil {
+				return err
+			}
+			defer windows.CloseHandle(thread) //nolint:errcheck // resumed thread owns lifecycle
+			_, err = windows.ResumeThread(thread)
+			return err
+		}
+		if err := windows.Thread32Next(snapshot, &entry); err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				return fmt.Errorf("primary thread not found for process %d", processID)
+			}
+			return err
+		}
+	}
 }
 
 func killAndWait(cmd *exec.Cmd) {

--- a/internal/session/adapters/external_process_windows.go
+++ b/internal/session/adapters/external_process_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package adapters
+
+import "os/exec"
+
+// configureOneShotCommand leaves Windows cancellation to CommandContext.
+// WaitDelay remains the cross-platform backstop for inherited output pipes.
+func configureOneShotCommand(_ *exec.Cmd) {}

--- a/internal/session/adapters/external_process_windows_test.go
+++ b/internal/session/adapters/external_process_windows_test.go
@@ -1,0 +1,61 @@
+//go:build windows
+
+package adapters
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const windowsJobHelperEnv = "OX_TEST_WINDOWS_JOB_HELPER"
+
+func TestRunOneShotCommand_WindowsJobKillsDescendants(t *testing.T) {
+	if mode := os.Getenv(windowsJobHelperEnv); mode != "" {
+		runWindowsJobHelper(t, mode)
+		return
+	}
+
+	dir := t.TempDir()
+	survivedPath := filepath.Join(dir, "descendant-survived")
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRunOneShotCommand_WindowsJobKillsDescendants$")
+	cmd.Env = append(os.Environ(), windowsJobHelperEnv+"=parent", "OX_TEST_SURVIVED_PATH="+survivedPath) // safe: re-executes this test binary only
+	cmd.WaitDelay = 100 * time.Millisecond
+
+	err := runOneShotCommand(cmd)
+	if err == nil || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("run error = %v, context error = %v; want deadline cancellation", err, ctx.Err())
+	}
+	time.Sleep(2 * time.Second)
+	if _, err := os.Stat(survivedPath); !os.IsNotExist(err) {
+		t.Fatalf("adapter descendant survived Job Object cancellation: %v", err)
+	}
+}
+
+func runWindowsJobHelper(t *testing.T, mode string) {
+	t.Helper()
+	switch mode {
+	case "parent":
+		time.Sleep(100 * time.Millisecond)
+		child := exec.Command(os.Args[0], "-test.run=^TestRunOneShotCommand_WindowsJobKillsDescendants$")
+		child.Env = append(os.Environ(), windowsJobHelperEnv+"=child") // safe: re-executes this test binary only
+		if err := child.Start(); err != nil {
+			os.Exit(2)
+		}
+		time.Sleep(30 * time.Second)
+	case "child":
+		time.Sleep(time.Second)
+		if err := os.WriteFile(os.Getenv("OX_TEST_SURVIVED_PATH"), []byte("alive"), 0o600); err != nil {
+			os.Exit(3)
+		}
+		os.Exit(0)
+	default:
+		os.Exit(4)
+	}
+}

--- a/internal/session/adapters/external_process_windows_test.go
+++ b/internal/session/adapters/external_process_windows_test.go
@@ -42,7 +42,6 @@ func runWindowsJobHelper(t *testing.T, mode string) {
 	t.Helper()
 	switch mode {
 	case "parent":
-		time.Sleep(100 * time.Millisecond)
 		child := exec.Command(os.Args[0], "-test.run=^TestRunOneShotCommand_WindowsJobKillsDescendants$")
 		child.Env = append(os.Environ(), windowsJobHelperEnv+"=child") // safe: re-executes this test binary only
 		if err := child.Start(); err != nil {

--- a/internal/session/adapters/external_process_windows_test.go
+++ b/internal/session/adapters/external_process_windows_test.go
@@ -12,7 +12,11 @@ import (
 	"time"
 )
 
-const windowsJobHelperEnv = "OX_TEST_WINDOWS_JOB_HELPER"
+const (
+	windowsJobHelperEnv   = "OX_TEST_WINDOWS_JOB_HELPER"
+	windowsJobStartedEnv  = "OX_TEST_WINDOWS_JOB_STARTED"
+	windowsJobSurvivedEnv = "OX_TEST_WINDOWS_JOB_SURVIVED"
+)
 
 func TestRunOneShotCommand_WindowsJobKillsDescendants(t *testing.T) {
 	if mode := os.Getenv(windowsJobHelperEnv); mode != "" {
@@ -21,16 +25,25 @@ func TestRunOneShotCommand_WindowsJobKillsDescendants(t *testing.T) {
 	}
 
 	dir := t.TempDir()
+	startedPath := filepath.Join(dir, "descendant-started")
 	survivedPath := filepath.Join(dir, "descendant-survived")
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRunOneShotCommand_WindowsJobKillsDescendants$")
-	cmd.Env = append(os.Environ(), windowsJobHelperEnv+"=parent", "OX_TEST_SURVIVED_PATH="+survivedPath) // safe: re-executes this test binary only
+	cmd.Env = append(
+		os.Environ(), // safe: re-executes this test binary only
+		windowsJobHelperEnv+"=parent",
+		windowsJobStartedEnv+"="+startedPath,
+		windowsJobSurvivedEnv+"="+survivedPath,
+	)
 	cmd.WaitDelay = 100 * time.Millisecond
 
 	err := runOneShotCommand(cmd)
 	if err == nil || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		t.Fatalf("run error = %v, context error = %v; want deadline cancellation", err, ctx.Err())
+	}
+	if _, err := os.Stat(startedPath); err != nil {
+		t.Fatalf("adapter parent never started its immediate descendant: %v", err)
 	}
 	time.Sleep(2 * time.Second)
 	if _, err := os.Stat(survivedPath); !os.IsNotExist(err) {
@@ -47,14 +60,17 @@ func runWindowsJobHelper(t *testing.T, mode string) {
 		if err := child.Start(); err != nil {
 			os.Exit(2)
 		}
+		if err := os.WriteFile(os.Getenv(windowsJobStartedEnv), []byte("started"), 0o600); err != nil {
+			os.Exit(3)
+		}
 		time.Sleep(30 * time.Second)
 	case "child":
-		time.Sleep(time.Second)
-		if err := os.WriteFile(os.Getenv("OX_TEST_SURVIVED_PATH"), []byte("alive"), 0o600); err != nil {
-			os.Exit(3)
+		time.Sleep(3 * time.Second)
+		if err := os.WriteFile(os.Getenv(windowsJobSurvivedEnv), []byte("alive"), 0o600); err != nil {
+			os.Exit(4)
 		}
 		os.Exit(0)
 	default:
-		os.Exit(4)
+		os.Exit(5)
 	}
 }

--- a/internal/session/adapters/external_test.go
+++ b/internal/session/adapters/external_test.go
@@ -2,10 +2,14 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
 )
 
 // fakeBinary creates a shell script that echoes canned responses.
@@ -173,6 +177,109 @@ func TestExternalAdapter_InvalidJSON(t *testing.T) {
 	_, err := NewExternalAdapter(script)
 	if err == nil {
 		t.Error("expected error for invalid JSON response")
+	}
+}
+
+func TestExternalAdapter_MalformedCommandResponsesFailClosed(t *testing.T) {
+	binary := fakeBinary(t, map[string]string{
+		"read":             `not-json`,
+		"read-metadata":    `not-json`,
+		"read-from-offset": `not-json`,
+		"diagnose":         `not-json`,
+	})
+	ea := NewExternalAdapterWithInfo(binary, &adapterprotocol.InfoResponse{Name: "test"})
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"read", func() error { _, err := ea.Read("session"); return err }},
+		{"metadata", func() error { _, err := ea.ReadMetadata("session"); return err }},
+		{"incremental read", func() error { _, _, err := ea.ReadFromOffset("session", 4); return err }},
+		{"diagnose", func() error { _, err := ea.Diagnose("/repo", "project", ""); return err }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); !errors.Is(err, ErrInvalidResponse) {
+				t.Fatalf("error = %v, want ErrInvalidResponse", err)
+			}
+		})
+	}
+}
+
+func TestExternalAdapter_OneShotTimeoutCancelsProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: drives an external adapter subprocess")
+	}
+	script := filepath.Join(t.TempDir(), "ox-adapter-slow")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nsleep 2\nprintf '{\"entries\":[]}'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ea := NewExternalAdapterWithInfo(script, &adapterprotocol.InfoResponse{Name: "slow"})
+	ea.oneShotTimeout = 20 * time.Millisecond
+
+	started := time.Now()
+	_, err := ea.Read("session")
+	if !errors.Is(err, ErrAdapterTimeout) {
+		t.Fatalf("error = %v, want ErrAdapterTimeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("timed-out adapter returned after %v; subprocess was not canceled promptly", elapsed)
+	}
+}
+
+func TestExternalAdapter_OneShotOutputIsBounded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: drives an external adapter subprocess")
+	}
+	script := filepath.Join(t.TempDir(), "ox-adapter-noisy")
+	output := strings.Repeat("x", 512)
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nwhile :; do printf '%s' '"+output+"'; done\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ea := NewExternalAdapterWithInfo(script, &adapterprotocol.InfoResponse{Name: "noisy"})
+	ea.oneShotOutputLimit = 64
+	ea.oneShotTimeout = 5 * time.Second
+
+	started := time.Now()
+	_, err := ea.Read("session")
+	if !errors.Is(err, ErrAdapterOutputLimit) {
+		t.Fatalf("error = %v, want ErrAdapterOutputLimit", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("output-limited adapter returned after %v; subprocess was not canceled promptly", elapsed)
+	}
+}
+
+func TestBoundedBufferNeverRetainsPastLimit(t *testing.T) {
+	budget := newOutputBudget(4, nil)
+	b := newBoundedBuffer(budget)
+	n, err := b.Write([]byte("abcdef"))
+	if n != 4 || !errors.Is(err, ErrAdapterOutputLimit) {
+		t.Fatalf("Write = (%d, %v), want (4, ErrAdapterOutputLimit)", n, err)
+	}
+	if got := b.String(); got != "abcd" {
+		t.Fatalf("retained %q, want exactly the bounded prefix", got)
+	}
+	if !budget.wasExceeded() {
+		t.Fatal("buffer did not record that its limit was exceeded")
+	}
+}
+
+func TestBoundedBuffersShareOneOutputBudget(t *testing.T) {
+	budget := newOutputBudget(6, nil)
+	stdout := newBoundedBuffer(budget)
+	stderr := newBoundedBuffer(budget)
+
+	if n, err := stdout.Write([]byte("abcd")); n != 4 || err != nil {
+		t.Fatalf("stdout Write = (%d, %v), want (4, nil)", n, err)
+	}
+	if n, err := stderr.Write([]byte("wxyz")); n != 2 || !errors.Is(err, ErrAdapterOutputLimit) {
+		t.Fatalf("stderr Write = (%d, %v), want (2, ErrAdapterOutputLimit)", n, err)
+	}
+	if got := stdout.Len() + stderr.Len(); got != 6 {
+		t.Fatalf("combined retained bytes = %d, want 6", got)
 	}
 }
 

--- a/internal/session/adapters/external_test.go
+++ b/internal/session/adapters/external_test.go
@@ -252,6 +252,22 @@ func TestExternalAdapter_OneShotOutputIsBounded(t *testing.T) {
 	}
 }
 
+func TestExternalAdapter_OneShotZeroLimitUsesDefault(t *testing.T) {
+	binary := fakeBinary(t, map[string]string{
+		"read": `{"entries":[]}`,
+	})
+	ea := NewExternalAdapterWithInfo(binary, &adapterprotocol.InfoResponse{Name: "default-limit"})
+	ea.oneShotOutputLimit = 0
+
+	entries, err := ea.Read("session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("entries = %v, want empty response", entries)
+	}
+}
+
 func TestBoundedBufferNeverRetainsPastLimit(t *testing.T) {
 	budget := newOutputBudget(4, nil)
 	b := newBoundedBuffer(budget)

--- a/internal/session/history_schema_fuzz_test.go
+++ b/internal/session/history_schema_fuzz_test.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// FuzzParseHistoryEntry exercises the untrusted JSONL boundary shared by
+// imported planning history and reconstructed AI coworker sessions. Successful
+// parses must classify a line as exactly one shape, and that classification
+// must survive a JSON round trip.
+func FuzzParseHistoryEntry(f *testing.F) {
+	for _, seed := range [][]byte{
+		[]byte(`{"_meta":{"schema_version":"1","agent_id":"OxTest","source":"agent_reconstruction"}}`),
+		[]byte(`{"type":"user","content":"hello","seq":1}`),
+		[]byte(`{"type":"tool","tool_name":"Read","seq":2}`),
+		[]byte(`null`),
+		[]byte(`{"_meta":`),
+		{0xff, 0xfe, 0xfd},
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, line []byte) {
+		meta, entry, err := ParseHistoryEntry(line)
+		if err != nil {
+			return
+		}
+		if (meta == nil) == (entry == nil) {
+			t.Fatalf("successful parse classified as meta=%t entry=%t", meta != nil, entry != nil)
+		}
+
+		var encoded []byte
+		if meta != nil {
+			var marshalErr error
+			encoded, marshalErr = json.Marshal(map[string]any{"_meta": meta})
+			if marshalErr != nil {
+				t.Fatalf("marshal parsed metadata: %v", marshalErr)
+			}
+		} else {
+			_ = ValidateHistoryEntry(entry) // validation must remain panic-free for any parsed shape
+			var marshalErr error
+			encoded, marshalErr = json.Marshal(entry)
+			if marshalErr != nil {
+				t.Fatalf("marshal parsed entry: %v", marshalErr)
+			}
+		}
+
+		roundMeta, roundEntry, roundErr := ParseHistoryEntry(encoded)
+		if roundErr != nil {
+			t.Fatalf("round-trip parse: %v", roundErr)
+		}
+		if (meta != nil) != (roundMeta != nil) || (entry != nil) != (roundEntry != nil) {
+			t.Fatalf("classification changed after round trip")
+		}
+	})
+}

--- a/internal/testguard/testguard.go
+++ b/internal/testguard/testguard.go
@@ -17,6 +17,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -31,6 +33,16 @@ var allowedBaseEnv = []string{
 	"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
 	"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
 }
+
+// TestOxBinaryEnv selects a prebuilt ox binary for compiled-binary tests.
+// It is intentionally test-only: Make builds the binary from the current
+// checkout immediately before invoking the acceptance suite.
+const TestOxBinaryEnv = "OX_TEST_OX_BINARY"
+
+// TestGoCoverDirEnv selects where a spawned instrumented ox binary flushes
+// counters. It must be distinct from GOCOVERDIR: go test -coverprofile replaces
+// GOCOVERDIR with an internal $WORK path before tests execute.
+const TestGoCoverDirEnv = "OX_TEST_GOCOVERDIR"
 
 // productionHostPatterns are substrings that must NEVER appear in test
 // env values or mock server responses unless exempted by allowedTestHostPatterns.
@@ -104,6 +116,9 @@ func MinimalEnv(testVars []string) []string {
 	}
 	env = append(env, "OX_NO_DAEMON=1")
 	env = append(env, "DO_NOT_TRACK=1") // prevent friction telemetry hitting production
+	if coverDir := os.Getenv(TestGoCoverDirEnv); coverDir != "" {
+		env = append(env, "GOCOVERDIR="+coverDir)
+	}
 	env = append(env, testVars...)
 	return env
 }
@@ -217,6 +232,14 @@ func StopDaemonCleanup(t *testing.T, oxBin, repoDir string, envVars []string) {
 func BuildOxBinary(t *testing.T, projectRoot string) string {
 	t.Helper()
 
+	if configured := os.Getenv(TestOxBinaryEnv); configured != "" {
+		binPath, err := resolveTestOxBinary(configured)
+		if err != nil {
+			t.Fatalf("invalid %s: %v", TestOxBinaryEnv, err)
+		}
+		return binPath
+	}
+
 	binDir := t.TempDir()
 	binPath := fmt.Sprintf("%s/ox", binDir)
 
@@ -229,4 +252,22 @@ func BuildOxBinary(t *testing.T, projectRoot string) string {
 	}
 
 	return binPath
+}
+
+func resolveTestOxBinary(configured string) (string, error) {
+	binPath, err := filepath.Abs(configured)
+	if err != nil {
+		return "", fmt.Errorf("resolve %q: %w", configured, err)
+	}
+	info, err := os.Stat(binPath)
+	if err != nil {
+		return "", fmt.Errorf("stat %q: %w", binPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%q is not a regular file", binPath)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0111 == 0 {
+		return "", fmt.Errorf("%q is not executable", binPath)
+	}
+	return binPath, nil
 }

--- a/internal/testguard/testguard_test.go
+++ b/internal/testguard/testguard_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,12 +27,38 @@ func TestMinimalEnv_InheritsAllowlistedVars(t *testing.T) {
 	// set a known allowlisted var and confirm it's inherited
 	t.Setenv("GOPATH", "/tmp/testgopath")
 	t.Setenv("HOME", "/tmp/testhome")
+	t.Setenv(TestGoCoverDirEnv, "/tmp/test-coverdir")
 
 	env := MinimalEnv(nil)
 	envMap := envToMap(env)
 
 	assert.Equal(t, "/tmp/testgopath", envMap["GOPATH"])
 	assert.Equal(t, "/tmp/testhome", envMap["HOME"])
+	assert.Equal(t, "/tmp/test-coverdir", envMap["GOCOVERDIR"])
+}
+
+func TestMinimalEnv_DoesNotInheritGoTestInternalCoverDir(t *testing.T) {
+	t.Setenv("GOCOVERDIR", "/tmp/go-test-workdir")
+	t.Setenv(TestGoCoverDirEnv, "")
+
+	env := envToMap(MinimalEnv(nil))
+	assert.NotContains(t, env, "GOCOVERDIR")
+}
+
+func TestResolveTestOxBinary(t *testing.T) {
+	binPath := filepath.Join(t.TempDir(), "ox")
+	require.NoError(t, os.WriteFile(binPath, []byte("test binary"), 0755))
+
+	resolved, err := resolveTestOxBinary(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, binPath, resolved)
+
+	_, err = resolveTestOxBinary(filepath.Join(t.TempDir(), "missing"))
+	assert.ErrorContains(t, err, "stat")
+
+	directory := t.TempDir()
+	_, err = resolveTestOxBinary(directory)
+	assert.ErrorContains(t, err, "not a regular file")
 }
 
 func TestMinimalEnv_BlocksNonAllowlistedVars(t *testing.T) {

--- a/internal/testguard/testguard_test.go
+++ b/internal/testguard/testguard_test.go
@@ -46,19 +46,47 @@ func TestMinimalEnv_DoesNotInheritGoTestInternalCoverDir(t *testing.T) {
 }
 
 func TestResolveTestOxBinary(t *testing.T) {
-	binPath := filepath.Join(t.TempDir(), "ox")
-	require.NoError(t, os.WriteFile(binPath, []byte("test binary"), 0755))
+	tests := []struct {
+		name    string
+		setup   func(*testing.T) string
+		wantErr string
+	}{
+		{
+			name: "regular executable",
+			setup: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "ox")
+				require.NoError(t, os.WriteFile(path, []byte("test binary"), 0o755))
+				return path
+			},
+		},
+		{
+			name: "missing path",
+			setup: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing")
+			},
+			wantErr: "stat",
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			wantErr: "not a regular file",
+		},
+	}
 
-	resolved, err := resolveTestOxBinary(binPath)
-	require.NoError(t, err)
-	assert.Equal(t, binPath, resolved)
-
-	_, err = resolveTestOxBinary(filepath.Join(t.TempDir(), "missing"))
-	assert.ErrorContains(t, err, "stat")
-
-	directory := t.TempDir()
-	_, err = resolveTestOxBinary(directory)
-	assert.ErrorContains(t, err, "not a regular file")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.setup(t)
+			resolved, err := resolveTestOxBinary(path)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, path, resolved)
+		})
+	}
 }
 
 func TestMinimalEnv_BlocksNonAllowlistedVars(t *testing.T) {

--- a/scripts/coverage_ratchet.py
+++ b/scripts/coverage_ratchet.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import hashlib
 import json
 import math
 import re
@@ -49,6 +50,118 @@ class ChangedLineException:
     path: str
     reason: str
     expires: date
+
+
+PROVENANCE_VERSION = 2
+EVIDENCE_PREFIXES = (
+    "cmd/",
+    "internal/",
+    "pkg/",
+    "tests/",
+    "scripts/",
+    ".config/",
+    ".github/workflows/",
+)
+EVIDENCE_ROOT_FILES = {"Makefile", "go.mod", "go.sum"}
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def evidence_paths(root: Path) -> list[Path]:
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    paths = []
+    for raw_path in completed.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        relative = raw_path.decode("utf-8")
+        if not (
+            relative in EVIDENCE_ROOT_FILES
+            or relative.startswith(EVIDENCE_PREFIXES)
+        ):
+            continue
+        path = root / relative
+        if path.is_file():
+            paths.append(path)
+    return sorted(paths, key=lambda path: path.relative_to(root).as_posix())
+
+
+def evidence_sha256(root: Path, paths: list[Path] | None = None) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    inputs = evidence_paths(root) if paths is None else paths
+    for path in inputs:
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        digest.update(relative)
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest(), len(inputs)
+
+
+def write_provenance(profile: Path, destination: Path, root: Path) -> None:
+    evidence_digest, evidence_files = evidence_sha256(root)
+    head = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    payload = {
+        "version": PROVENANCE_VERSION,
+        "profile_sha256": file_sha256(profile),
+        "evidence_sha256": evidence_digest,
+        "evidence_files": evidence_files,
+        "git_head": head,
+    }
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(destination.name + ".tmp")
+    temporary.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(destination)
+
+
+def verify_provenance(profile: Path, provenance: Path, root: Path) -> None:
+    payload = json.loads(provenance.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("version") != PROVENANCE_VERSION:
+        raise ValueError(f"{provenance}: unsupported coverage provenance version")
+    expected_profile = payload.get("profile_sha256")
+    if expected_profile != file_sha256(profile):
+        raise ValueError(f"{profile}: content does not match coverage provenance")
+    current_head = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    if payload.get("git_head") != current_head:
+        raise ValueError(f"{profile}: git HEAD changed after coverage was generated")
+    expected_evidence = payload.get("evidence_sha256")
+    current_evidence, evidence_files = evidence_sha256(root)
+    if (
+        payload.get("evidence_files") != evidence_files
+        or expected_evidence != current_evidence
+    ):
+        raise ValueError(
+            f"{profile}: code, tests, dependencies, or harness changed after coverage was generated"
+        )
 
 
 def validate_percentage(name: str, value: object) -> float:
@@ -387,9 +500,31 @@ def main() -> int:
         "--diff-base",
         help="also enforce changed-line coverage against BASE and the working tree",
     )
+    provenance = parser.add_mutually_exclusive_group()
+    provenance.add_argument(
+        "--write-provenance",
+        type=Path,
+        metavar="PATH",
+        help="bind this profile to the current production Go source contents",
+    )
+    provenance.add_argument(
+        "--require-provenance",
+        type=Path,
+        metavar="PATH",
+        help="fail unless this profile matches its recorded source contents",
+    )
     args = parser.parse_args()
 
     try:
+        root = Path.cwd()
+        if args.write_provenance:
+            write_provenance(args.profile, args.write_provenance, root)
+            print(f"Coverage provenance: {args.write_provenance}")
+            return 0
+        required_provenance = args.require_provenance or args.profile.with_name(
+            args.profile.name + ".provenance.json"
+        )
+        verify_provenance(args.profile, required_provenance, root)
         failures = check(args.profile, args.config)
         if args.diff_base:
             failures.extend(

--- a/scripts/coverage_ratchet_test.py
+++ b/scripts/coverage_ratchet_test.py
@@ -259,6 +259,87 @@ diff --git a/deleted.go b/deleted.go
             with self.assertRaisesRegex(ValueError, "invalid Go coverage mode"):
                 coverage_ratchet.load_profile(profile, "example.com/project/")
 
+    def test_provenance_binds_profile_to_production_source_contents(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            source = root / "internal" / "risk" / "risk.go"
+            source.parent.mkdir(parents=True)
+            source.write_text("package risk\n\nfunc Risk() {}\n", encoding="utf-8")
+            profile = self.write_profile(
+                root,
+                "example.com/project/internal/risk/risk.go:3.1,3.15 1 1\n",
+            )
+            provenance = root / "coverage.provenance.json"
+
+            with mock.patch(
+                "coverage_ratchet.evidence_paths", return_value=[source]
+            ), mock.patch("coverage_ratchet.subprocess.run") as run:
+                run.return_value = mock.Mock(stdout="abc123\n")
+                coverage_ratchet.write_provenance(profile, provenance, root)
+                coverage_ratchet.verify_provenance(profile, provenance, root)
+
+                source.write_text(
+                    "package risk\n\nfunc Risk() { panic(\"changed\") }\n",
+                    encoding="utf-8",
+                )
+                with self.assertRaisesRegex(ValueError, "code, tests, dependencies"):
+                    coverage_ratchet.verify_provenance(profile, provenance, root)
+
+    def test_provenance_rejects_substituted_profile(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            source = root / "risk.go"
+            source.write_text("package risk\n", encoding="utf-8")
+            profile = self.write_profile(
+                root,
+                "example.com/project/risk.go:1.1,1.13 1 1\n",
+            )
+            provenance = root / "coverage.provenance.json"
+
+            with mock.patch(
+                "coverage_ratchet.evidence_paths", return_value=[source]
+            ), mock.patch("coverage_ratchet.subprocess.run") as run:
+                run.return_value = mock.Mock(stdout="abc123\n")
+                coverage_ratchet.write_provenance(profile, provenance, root)
+                profile.write_text(
+                    "mode: atomic\nexample.com/project/risk.go:1.1,1.13 1 0\n",
+                    encoding="utf-8",
+                )
+                with self.assertRaisesRegex(ValueError, "content does not match"):
+                    coverage_ratchet.verify_provenance(profile, provenance, root)
+
+    def test_provenance_rejects_changed_commit_identity(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            source = root / "risk.go"
+            source.write_text("package risk\n", encoding="utf-8")
+            profile = self.write_profile(
+                root,
+                "example.com/project/risk.go:1.1,1.13 1 1\n",
+            )
+            provenance = root / "coverage.provenance.json"
+
+            with mock.patch(
+                "coverage_ratchet.evidence_paths", return_value=[source]
+            ), mock.patch("coverage_ratchet.subprocess.run") as run:
+                run.return_value = mock.Mock(stdout="first\n")
+                coverage_ratchet.write_provenance(profile, provenance, root)
+                run.return_value = mock.Mock(stdout="second\n")
+                with self.assertRaisesRegex(ValueError, "git HEAD changed"):
+                    coverage_ratchet.verify_provenance(profile, provenance, root)
+
+    def test_missing_provenance_fails_closed(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            profile = self.write_profile(
+                root,
+                "example.com/project/risk.go:1.1,1.13 1 1\n",
+            )
+            with self.assertRaises(FileNotFoundError):
+                coverage_ratchet.verify_provenance(
+                    profile, root / "missing.provenance.json", root
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/kb_twin/generate.go
+++ b/tests/kb_twin/generate.go
@@ -142,7 +142,7 @@ func isolatedGitEnv() []string {
 	env := make([]string, 0, len(os.Environ())+3)
 	for _, entry := range os.Environ() {
 		name, _, ok := strings.Cut(entry, "=")
-		if ok && (name == "GIT_CONFIG_GLOBAL" || name == "GIT_CONFIG_SYSTEM" || name == "GIT_CONFIG_NOSYSTEM" || name == "GIT_TERMINAL_PROMPT") {
+		if ok && (name == "GIT_CONFIG" || strings.HasPrefix(name, "GIT_CONFIG_") || name == "GIT_TERMINAL_PROMPT") {
 			continue
 		}
 		env = append(env, entry)

--- a/tests/kb_twin/generate.go
+++ b/tests/kb_twin/generate.go
@@ -13,10 +13,13 @@ package kb_twin
 // behavior has its own coverage in internal/lfs.
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/sageox/ox/internal/api"
 )
@@ -116,13 +119,39 @@ func configGitIdentity(dir string) error {
 // surface the combined output (git's error messages are notoriously
 // terse without it).
 func runGit(cwd string, args ...string) error {
-	cmd := exec.Command("git", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = cwd
+	cmd.Env = isolatedGitEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("git %v timed out: %w", args, ctx.Err())
+		}
 		return fmt.Errorf("git %v failed: %s: %w", args, string(out), err)
 	}
 	return nil
+}
+
+// isolatedGitEnv prevents a coworker's signing, hooks, credentials, or prompt
+// settings from changing deterministic twin behavior. Keep PATH and other
+// ordinary process state, but replace Git's configuration trust boundaries.
+func isolatedGitEnv() []string {
+	env := make([]string, 0, len(os.Environ())+3)
+	for _, entry := range os.Environ() {
+		name, _, ok := strings.Cut(entry, "=")
+		if ok && (name == "GIT_CONFIG_GLOBAL" || name == "GIT_CONFIG_SYSTEM" || name == "GIT_CONFIG_NOSYSTEM" || name == "GIT_TERMINAL_PROMPT") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env,
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_TERMINAL_PROMPT=0",
+	)
 }
 
 // resolveRepoURLs walks a scenario's bubbles, materializes a bare

--- a/tests/kb_twin/generate_test.go
+++ b/tests/kb_twin/generate_test.go
@@ -1,0 +1,79 @@
+//go:build kb_twin
+
+package kb_twin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigGitIdentityIgnoresInheritedConfigOverrides(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+
+	alternateConfig := filepath.Join(t.TempDir(), "inherited.gitconfig")
+	originalConfig := []byte("[user]\n\temail = inherited@test.invalid\n")
+	if err := os.WriteFile(alternateConfig, originalConfig, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG", alternateConfig)
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "user.name")
+	t.Setenv("GIT_CONFIG_VALUE_0", "Inherited Identity")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/nonexistent/inherited-system-config")
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(repoDir, "init"); err != nil {
+		t.Fatal(err)
+	}
+	if err := configGitIdentity(repoDir); err != nil {
+		t.Fatal(err)
+	}
+
+	localConfig, err := os.ReadFile(filepath.Join(repoDir, ".git", "config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{"kb-twin@test.invalid", "KB Twin"} {
+		if !strings.Contains(string(localConfig), expected) {
+			t.Errorf("local config missing %q:\n%s", expected, localConfig)
+		}
+	}
+	alternateAfter, err := os.ReadFile(alternateConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(alternateAfter) != string(originalConfig) {
+		t.Errorf("inherited GIT_CONFIG was modified:\n%s", alternateAfter)
+	}
+
+	values := make(map[string][]string)
+	for _, entry := range isolatedGitEnv() {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[name] = append(values[name], value)
+		}
+	}
+	for _, name := range []string{"GIT_CONFIG", "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0", "GIT_CONFIG_SYSTEM"} {
+		if got := values[name]; len(got) != 0 {
+			t.Errorf("%s leaked into isolated Git environment: %v", name, got)
+		}
+	}
+	if got := values["GIT_CONFIG_GLOBAL"]; len(got) != 1 || got[0] != os.DevNull {
+		t.Errorf("GIT_CONFIG_GLOBAL = %v, want [%q]", got, os.DevNull)
+	}
+	if got := values["GIT_CONFIG_NOSYSTEM"]; len(got) != 1 || got[0] != "1" {
+		t.Errorf("GIT_CONFIG_NOSYSTEM = %v, want [1]", got)
+	}
+	if got := values["GIT_TERMINAL_PROMPT"]; len(got) != 1 || got[0] != "0" {
+		t.Errorf("GIT_TERMINAL_PROMPT = %v, want [0]", got)
+	}
+}

--- a/tests/kb_twin/twin_test.go
+++ b/tests/kb_twin/twin_test.go
@@ -138,6 +138,9 @@ func buildScheduler(t *testing.T, projectDir string) *daemon.SyncScheduler {
 // subtest and its own XDG isolation. The multi-endpoint scenario has
 // dedicated drive logic in TestKBTwin_MultiEndpoint below.
 func TestKBTwin(t *testing.T) {
+	if len(kbTwinManifest.Scenarios) < 9 {
+		t.Fatalf("KB twin manifest has %d scenarios, want at least 9 required lifecycle scenarios", len(kbTwinManifest.Scenarios))
+	}
 	if testing.Short() {
 		t.Skip("short: kb_twin runs real git clones across multiple scenarios")
 	}


### PR DESCRIPTION
## What broke

- **Coverage was too shallow in critical orchestration:** the prior full-suite baseline was 64.6%, with the largest gaps in `cmd/ox`, daemon recovery, dashboard behavior, and adapter boundaries.
- **Coverage evidence could drift from the code and harness:** profiles were not bound to the current commit, test inputs, workflows, or dependency manifests.
- **High-value journeys were fragmented:** compiled CLI acceptance and cloud/ledger/KB twins were not merged into the product coverage signal.
- **Several failure modes were under-tested:** session upload retries, daemon IPC deadlines/reconnects, Git/CodeDB recovery, runaway adapter output, and Windows IPC isolation.

## What this PR ships

- **A product-only combined coverage pipeline**
  - runs the complete Go suite, compiled current-source acceptance, and cloud/ledger/KB twins;
  - instruments the spawned `ox` binary through a dedicated coverage directory;
  - scopes twin coverage to production packages and rejects harness-only profiles;
  - requires named journeys/scenario floors so zero-test runs fail closed;
  - merges profiles without double-counting blocks and excludes build-tag-only twin seams.

- **Coverage provenance v2**
  - binds profile bytes, Git HEAD, production source, tests, harness scripts, workflows, tier configuration, `Makefile`, and Go dependency manifests;
  - rejects missing, stale, substituted, or cross-commit evidence;
  - raises protected Linux-safe floors for `cmd/ox`, daemon, CodeDB index, agentwork, and session pipeline.

- **Session lifecycle and retry hardening**
  - extracts a narrow, non-global Git/LFS effect boundary;
  - tests failure ordering, preserved cache/state, durable session identity, retry, and idempotency;
  - counts durable turns in footerless crash recovery;
  - propagates pointer-write/commit failures so doctor does not prune the only retry source;
  - parses compiled session-stop output structurally and requires durable artifacts.

- **Daemon and CodeDB recovery evidence**
  - resets the stale progress deadline before authoritative IPC responses;
  - covers dropped connections, replacement daemon retry, offline Git preservation/recovery, and marker-driven CodeDB rebuild across a fresh manager;
  - makes Windows peer ownership use the named-pipe ACL trust boundary and scopes pipe names to the logical socket path.

- **Behavioral dashboard and adapter coverage**
  - covers reducer generations, selection order, navigation, palette state, and Bubble Tea space-key semantics without snapshots;
  - caps combined adapter stdout/stderr at 64 MiB and immediately cancels runaway subprocesses;
  - exercises malformed responses and timeout/output-limit cancellation under race.

- **Adversarial parser coverage**
  - adds meaningful history-schema fuzz invariants;
  - runs fuzz targets in the release gate;
  - validates coverage/tier mutation cases, including malformed config and zero evidence.

```mermaid
flowchart LR
  Full[Full Go suite] --> Merge[Product profile merge]
  Binary[Compiled ox journeys] --> Merge
  Cloud[Cloud auth twin] --> Merge
  Ledger[Ledger twin] --> Merge
  KB[KB twin] --> Merge
  Merge --> Provenance[Profile + HEAD + harness provenance]
  Provenance --> Floors[Package and changed-line ratchets]
  Floors --> Release[Release gate]
```

## Coverage result

- **Combined Go statement coverage:** 66.2%, up from 64.6% (+1.6 percentage points).
- **Full suite:** 20,481 tests, 28 skips.
- **Changed executable statements:** 90.4% (122/135), meeting the 90% floor.
- **Protected packages:** `cmd/ox` 55.1%, daemon 67.0%, CodeDB index 70.8%, dashboard state 57.2%, session 85.1%, agentwork 77.9%, pipeline 98.5%.
- **Digital twins:** 552 cloud auth/API tests, 41 ledger tests, 14 KB tests.

## Test plan

- `make coverage-integration`
- `python3 scripts/coverage_ratchet.py coverage-all.out --require-provenance coverage-all.out.provenance.json --diff-base origin/main`
- `make lint`
- `make test-fuzz`
- `make test-digital-twin-cover`
- `make test-acceptance-cover`
- focused `go test -race` runs for session retry, daemon IPC/recovery, dashboard, adapters, and testguard
- `actionlint .github/workflows/coverage.yml`
- Windows daemon cross-compilation
- adversarial and behavioral review agents independently re-attacked fail-open paths

## Explicit follow-up

- The epic remains open. This PR does **not** claim the complete compiled init → prime → record → finalize → sync → recover cloud/Git/LFS journey.
- Beads retain the remaining work for the full doctor/LFS remote-convergence test, shared cross-adapter conformance, physical dashboard effect cancellation, mutation governance, external-harness provenance, and human release documentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790830870&installation_model_id=433550&pr_number=849&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F849&signature=433c36cb8c773570aca555da7e9ce798872af0579978b58c7ca8b3976b107a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session upload recovery after interrupted commits, preserving captured data for retry.
  * Increased support for large session records and improved handling of malformed or incomplete uploads.
  * Improved daemon recovery after disconnected syncs, network failures, and interrupted indexing.
  * External adapters now stop descendant processes reliably and report timeouts or excessive output clearly.
  * Improved dashboard navigation consistency and palette interactions.
  * Improved fresh-install diagnostics when synchronization is unavailable.

* **Quality Improvements**
  * Expanded acceptance, recovery, fuzz, and integration coverage for more dependable releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

SageOx-Session: https://sageox.ai/c/ses_01a05b1b-a77e-7a68-9202-958c49da92c2
