### PR TITLE
fix(init): name the team on the success line, not just the ID

### DIFF
--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -880,7 +880,7 @@ func runInit() error {
 		if err := config.SaveProjectConfig(gitRoot, cfg); err != nil {
 			cli.PrintWarning(fmt.Sprintf("Could not save config: %v", err))
 		} else if !initQuiet {
-			cli.PrintSuccess(fmt.Sprintf("Registered with SageOx (team: %s)", resp.TeamID))
+			cli.PrintSuccess(fmt.Sprintf("Registered with SageOx (team: %s)", formatTeamLabel(selectedTeamName, resp.TeamID)))
 		}
 
 		// update README.md with SageOx links now that we have repo_id and team_id
@@ -1130,6 +1130,18 @@ func createRepoMarker(sageoxDir, repoID, repoSalt string, gitIdentity *repotools
 // Example: "repo_01jfk3mab..." -> "01jfk3mab..."
 func extractUUIDSuffix(repoID string) string {
 	return strings.TrimPrefix(repoID, "repo_")
+}
+
+// formatTeamLabel renders the team this repo was just bound to. init already holds
+// the team's name whenever the user picked it from the selector, so lead with that
+// and keep the ID alongside — the ID is what --team accepts and what the dashboard
+// URL uses. Falls back to the bare ID when no name is available, which is the --team
+// path: passing a team ID skips the team fetch, so no name is ever retrieved.
+func formatTeamLabel(name, id string) string {
+	if strings.TrimSpace(name) == "" {
+		return id
+	}
+	return fmt.Sprintf("%s (%s)", name, id)
 }
 
 // stringSlicesEqual compares two string slices for equality

--- a/cmd/ox/init_pure_test.go
+++ b/cmd/ox/init_pure_test.go
@@ -323,3 +323,47 @@ func TestStringSlicesEqual_TableDriven(t *testing.T) {
 		})
 	}
 }
+
+// TestFormatTeamLabel_Pure covers the team label shown on init's success line.
+// Failure prevented: the outcome line reports an opaque team ID, so a user with
+// more than one team cannot tell which team the repo was just bound to.
+func TestFormatTeamLabel_Pure(t *testing.T) {
+	tests := []struct {
+		name     string
+		teamName string
+		teamID   string
+		want     string
+	}{
+		{
+			name:     "named team leads with the name",
+			teamName: "Platform",
+			teamID:   "team_abc123",
+			want:     "Platform (team_abc123)",
+		},
+		{
+			name:     "no name falls back to the bare id",
+			teamName: "",
+			teamID:   "team_abc123",
+			want:     "team_abc123",
+		},
+		{
+			name:     "whitespace-only name is treated as absent",
+			teamName: "   ",
+			teamID:   "team_abc123",
+			want:     "team_abc123",
+		},
+		{
+			name:     "name containing spaces is preserved",
+			teamName: "Developer Experience",
+			teamID:   "team_xyz789",
+			want:     "Developer Experience (team_xyz789)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatTeamLabel(tt.teamName, tt.teamID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Addresses the first symptom in #852.

## What broke

`ox init` ends its run with the line that reports the binding it just made:

```
✓ Registered with SageOx (team: team_aaa111)
```

Binding a repo to a team is the decision `ox init` exists to make, and the outcome line
names it with an opaque ID. Three lines further down, the next-steps block names a team
in plain language — so a single run shows the user two different renderings of the same
concept, and the authoritative one is the unreadable one.

- **Where:** `cmd/ox/init.go:883`
- **Who hits it:** anyone on more than one team, where "which team did that just bind to?" is a real question
- **Why it matters most when confirmation is weakest:** with no TTY the selector falls back to a numbered prompt whose read hits EOF and returns the default, so the binding can be made without a visible choice. Naming the team in the outcome is the cheapest way to make that binding legible after the fact.

The name is not missing — it is already in hand on the picker path:

```mermaid
flowchart TD
    A[ox init] --> B{--team passed?}
    B -->|yes| C[selectedTeamID = flag<br/>selectedTeamName stays empty]
    B -->|no| D[selectTeam picker]
    D --> E[selectedTeamID + selectedTeamName]
    C --> F[register with API]
    E --> F
    F --> G["success line prints resp.TeamID"]
    G --> H["team_aaa111 — name discarded"]
    style H fill:#f8d7da,stroke:#b02a37
    style G fill:#f8d7da,stroke:#b02a37
```

## What this PR ships

- **Adds** `formatTeamLabel(name, id)` in `cmd/ox/init.go`, beside `extractUUIDSuffix`.
- **Changes** the success line to `Platform (team_abc123)` when a name is known, and to the bare `team_abc123` when it is not.
- **Adds** `TestFormatTeamLabel_Pure` — table-driven, 4 cases.

Scope is output only. No behavioral change to team selection, registration, or config.

**Reads `selectedTeamName`, not `cfg.TeamName` — deliberately.** `cfg` can carry a team
name written by a *previous* `ox init`. Pairing that stale name with a newly supplied
`--team` ID would print a team the repo is not bound to — turning a merely opaque line
into a confidently wrong one. Reading the value this run actually selected cannot do that.

That staleness is real and reproducible, but it lives in the config write at
`init.go:872-877`, not on this line. It is written up as symptom 2 of #852 and left for a
separate change rather than widened into this one.

**Keeps the ID alongside the name** rather than replacing it: the ID is what `--team`
accepts and what the dashboard URL uses, so dropping it would break copy-paste workflows.

**Falls back to the bare ID on the `--team` path**, where passing an ID short-circuits the
team fetch (`init.go:410-415`) and no name is ever retrieved. Preserving today's output
there keeps this PR to one idea.

## Test Plan

| Check | Command | Result |
|---|---|---|
| New unit test | `go test ./cmd/ox/ -run TestFormatTeamLabel_Pure` | 4/4 pass |
| **Red-first proof** | Stubbed the helper to `return id` | **2/4 fail** with exact diffs |
| Restore | Reverted the stub | 4/4 pass |
| Full suite | `make test` | 19,111 tests, 999 skipped, **0 failed** |
| Lint | `make lint` | **0 issues** |
| Formatting | `gofmt -l` | clean |

Verified end to end with a local build against a real multi-team account:

```
picker path:   ✓ Registered with SageOx (team: Platform (team_abc123))
--team path:   ✓ Registered with SageOx (team: team_abc123)
```

A control run with the released `0.14.3` binary in the same repo printed the bare ID on
both paths, confirming the difference comes from this change and not the environment.

**On `make test-preflight`:** it is red on my machine, in `internal/ledger`
(`TestCloneWithSparseCheckout_*`) and intermittently `internal/codedb/store`
(`TestConcurrentSelfHeal_MultiProcess`). These are **pre-existing and unrelated** — a
control run on a clean `origin/main` @ `19fac267` with this change absent reproduces the
same 8 `internal/ledger` failures, they pass in isolation, and two preflight runs produced
disjoint failure sets. This change is confined to `package main`, which nothing imports,
so it cannot affect `internal/*` tests. Flagging it rather than hiding it; happy to open a
separate issue if these are not already known.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790911314&installation_model_id=433550&pr_number=853&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F853&signature=90714809ca882b27f6b9d01578cc8c028c267a126516ee7705cba5e187bcd66b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Registration success messages now display a readable team name alongside its ID when available.
  - When no team name is available, the message continues to show the team ID בלבד.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->