### PR TITLE
fix(session): stop go test recursively re-invoking itself via inline prime

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/sageox/agentx"
@@ -357,6 +358,18 @@ func ensurePrimeBeforeSession(agentID string) {
 	}
 
 	// prime hasn't run — execute it inline
+	//
+	// Guard against test binaries: os.Executable() below resolves to the
+	// compiled `go test` binary when this runs inside a test process, not
+	// the real ox CLI. exec'ing it with args "agent prime" doesn't hit any
+	// -test.* flag, so the test binary just reruns its entire suite from
+	// scratch — which reaches this same code path again, recursing without
+	// bound until the package's test deadline kills it. See #846.
+	if testing.Testing() {
+		slog.Debug("session start: skipping inline prime (running under go test)")
+		return
+	}
+
 	slog.Info("session start: prime not detected, running inline", "agent_session_id", agentSessionID)
 
 	oxPath, err := os.Executable()
@@ -1029,17 +1042,16 @@ func processAgentSession(projectRoot string, state *session.RecordingState) (*ag
 	// carrier of the start-minted ID on the reconstruct path too (daemon
 	// orphan-finalize recovers it from here when meta.json was never written)
 	meta := &session.StoreMeta{
-		Version:                "1.0",
-		SessionID:              state.SessionID,
-		ContinuedFromSessionID: state.ContinuedFromSessionID,
-		CreatedAt:              state.StartedAt,
-		AgentID:                state.AgentID,
-		AgentType:              agentTypeForMeta,
-		AgentVersion:           result.AgentVersion,
-		Model:                  result.Model,
-		Username:               identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
-		RepoID:                 repoID,
-		OxVersion:              version.Version,
+		Version:      "1.0",
+		SessionID:    state.SessionID,
+		CreatedAt:    state.StartedAt,
+		AgentID:      state.AgentID,
+		AgentType:    agentTypeForMeta,
+		AgentVersion: result.AgentVersion,
+		Model:        result.Model,
+		Username:     identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
+		RepoID:       repoID,
+		OxVersion:    version.Version,
 	}
 	if err := rawWriter.WriteHeader(meta); err != nil {
 		rawWriter.Close()
@@ -1309,10 +1321,6 @@ func finalizeModeForSessionStop(userPrefersAsync bool) session.FinalizeDispatchM
 // If this fails, the session data is safe in the local cache and doctor can retry.
 // ledgerPath and sessionName are pre-computed by the caller.
 func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state *session.RecordingState, ledgerPath, sessionName string) error {
-	return uploadSessionToLedgerWithEffects(projectRoot, result, state, ledgerPath, sessionName, productionSessionUploadEffects())
-}
-
-func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionResult, state *session.RecordingState, ledgerPath, sessionName string, effects sessionUploadEffects) error {
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	sessionDir := filepath.Join(sessionsDir, sessionName)
 
@@ -1367,7 +1375,6 @@ func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionRe
 		EntryCount(result.EntryCount).
 		Summary(result.Summary).
 		StopReason(session.StopReasonStopped).
-		ContinuedFromSessionID(state.ContinuedFromSessionID).
 		ProducedCommits(state.ProducedCommits).
 		ProducedPlans(state.ProducedPlans).
 		LinkedPRs(state.LinkedPRs).
@@ -1379,13 +1386,20 @@ func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionRe
 		// session that may never reach the remote.
 		LinkageStatus(lfs.LinkageStatusStaged)
 
-	meta, err := writeInitialSessionMeta(sessionDir, state.AgentID, metaBuilder)
-	if err != nil {
+	// inject sageox contribution score from cache file into meta.json,
+	// then clean up the score file to prevent stale scores leaking into future sessions
+	if scoreFile, _ := session.ReadSageoxScore(state.AgentID); scoreFile != nil {
+		metaBuilder.SageoxScore(scoreFile.Score, string(scoreFile.Category), scoreFile.Reason)
+	}
+	_ = session.CleanupSageoxScore(state.AgentID)
+
+	meta := metaBuilder.Build()
+	if err := lfs.WriteSessionMeta(sessionDir, meta); err != nil {
 		return fmt.Errorf("write meta.json: %w", err)
 	}
 
 	// upload content files to LFS blob storage
-	fileRefs, err := effects.uploadLFS(projectRoot, sessionDir)
+	fileRefs, err := uploadSessionLFS(projectRoot, sessionDir)
 	if err != nil {
 		if errors.Is(err, api.ErrReadOnly) {
 			return err // don't wrap, don't set doctor marker
@@ -1407,7 +1421,7 @@ func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionRe
 	}
 
 	// commit meta.json + .gitignore and push
-	if err := effects.commitInitial(ledgerPath, sessionName); err != nil {
+	if err := commitAndPushLedger(ledgerPath, sessionName); err != nil {
 		// set marker - session saved locally but not synced to remote
 		_ = doctor.SetNeedsDoctorAgent(projectRoot)
 		return fmt.Errorf("commit and push: %w", err)
@@ -1417,7 +1431,7 @@ func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionRe
 	// is committed, so backfill it + outcome=stopped onto every plan this
 	// session produced (slugs in hand — no directory scan), then commit those
 	// plan dirs. Best-effort; any miss falls to `ox doctor`.
-	effects.reconcilePlans(projectRoot, state.ProducedPlans, sessionName, meta.EffectiveSessionID())
+	reconcileProducedPlansAtStop(projectRoot, state.ProducedPlans, sessionName, meta.EffectiveSessionID())
 
 	// push succeeded — now safe to replace content files with LFS pointer stubs
 	if len(meta.Files) > 0 {
@@ -1426,9 +1440,7 @@ func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionRe
 		// the first failure). Always commit whatever pointers DID land — any
 		// rewritten pointer left uncommitted re-opens the autostash race for
 		// that file, even if other files in the same call failed.
-		// AssertUploaded: meta.Files is the persisted manifest whose blobs were
-		// uploaded before the push that just succeeded above.
-		written, writeErr := lfs.WritePointerFiles(sessionDir, lfs.AssertUploadedManifest(meta.Files))
+		written, writeErr := lfs.WritePointerFiles(sessionDir, meta.Files)
 		if len(written) > 0 {
 			// Commit the pointer rewrite so it doesn't sit dirty in the worktree.
 			// A dirty worktree here races against the daemon's sync-timer pull:
@@ -1437,7 +1449,7 @@ func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionRe
 			// the stash-pop yields conflict markers that ox doctor's auto-commit
 			// will eventually freeze into a permanent commit on main.
 			// (Tactical fix; pointer-first commit ordering is a separate discussion.)
-			if err := effects.commitPointerRewrite(ledgerPath, sessionName, written); err != nil {
+			if err := commitPointerRewriteAndPush(ledgerPath, sessionName, written); err != nil {
 				slog.Warn("LFS pointer rewrite commit failed", "error", err, "session", sessionName)
 			}
 		}
@@ -1454,50 +1466,13 @@ func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionRe
 	// already-successful upload. Server-reported PR-link misses become
 	// repair tasks in the stop output — the agent still holds the session
 	// context and can fix the PR bodies with its own tooling.
-	for _, miss := range effects.finalizeLinkage(projectRoot, sessionDir, meta, sessionName) {
+	for _, miss := range finalizeLinkageAfterPush(projectRoot, sessionDir, meta, sessionName) {
 		result.PRLinkMisses = append(result.PRLinkMisses, fmt.Sprintf(
 			"PR %s is missing its session link — append this exact final line to its body: %s",
 			miss.PRURL, miss.ExpectedLine))
 	}
 
 	return nil
-}
-
-// writeInitialSessionMeta persists the first durable metadata snapshot before
-// consuming the per-agent contribution score. If the write fails, the score
-// remains available for a retry instead of being silently lost alongside the
-// failed meta.json write.
-func writeInitialSessionMeta(sessionDir, agentID string, builder *lfs.SessionMetaBuilder) (*lfs.SessionMeta, error) {
-	scoreFile, err := session.ReadSageoxScore(agentID)
-	if err != nil {
-		return nil, fmt.Errorf("read SageOx score: %w", err)
-	}
-	if scoreFile != nil {
-		builder.SageoxScore(scoreFile.Score, string(scoreFile.Category), scoreFile.Reason)
-	} else {
-		// A prior attempt may have persisted metadata and consumed the score
-		// carrier before a later LFS/push failure. Preserve that durable score on
-		// retry instead of overwriting meta.json with an unscored rebuild.
-		existing, readErr := lfs.ReadSessionMeta(sessionDir)
-		if readErr == nil && existing.SageoxScore != nil {
-			builder.SageoxScore(*existing.SageoxScore, existing.SageoxScoreCategory, existing.SageoxScoreReason)
-		} else if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
-			return nil, fmt.Errorf("read existing session metadata: %w", readErr)
-		}
-	}
-
-	meta := builder.Build()
-	if err := lfs.WriteSessionMeta(sessionDir, meta); err != nil {
-		return nil, err
-	}
-
-	// Cleanup remains best-effort, but only after a successfully read score has
-	// a durable carrier. Missing scores need no cleanup; unreadable scores are
-	// preserved above for diagnosis and retry rather than silently discarded.
-	if scoreFile != nil {
-		_ = session.CleanupSageoxScore(agentID)
-	}
-	return meta, nil
 }
 
 // reconcileProducedPlansAtStop backfills the canonical session id + a

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1042,16 +1042,17 @@ func processAgentSession(projectRoot string, state *session.RecordingState) (*ag
 	// carrier of the start-minted ID on the reconstruct path too (daemon
 	// orphan-finalize recovers it from here when meta.json was never written)
 	meta := &session.StoreMeta{
-		Version:      "1.0",
-		SessionID:    state.SessionID,
-		CreatedAt:    state.StartedAt,
-		AgentID:      state.AgentID,
-		AgentType:    agentTypeForMeta,
-		AgentVersion: result.AgentVersion,
-		Model:        result.Model,
-		Username:     identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
-		RepoID:       repoID,
-		OxVersion:    version.Version,
+		Version:                "1.0",
+		SessionID:              state.SessionID,
+		ContinuedFromSessionID: state.ContinuedFromSessionID,
+		CreatedAt:              state.StartedAt,
+		AgentID:                state.AgentID,
+		AgentType:              agentTypeForMeta,
+		AgentVersion:           result.AgentVersion,
+		Model:                  result.Model,
+		Username:               identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName()),
+		RepoID:                 repoID,
+		OxVersion:              version.Version,
 	}
 	if err := rawWriter.WriteHeader(meta); err != nil {
 		rawWriter.Close()
@@ -1321,6 +1322,10 @@ func finalizeModeForSessionStop(userPrefersAsync bool) session.FinalizeDispatchM
 // If this fails, the session data is safe in the local cache and doctor can retry.
 // ledgerPath and sessionName are pre-computed by the caller.
 func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state *session.RecordingState, ledgerPath, sessionName string) error {
+	return uploadSessionToLedgerWithEffects(projectRoot, result, state, ledgerPath, sessionName, productionSessionUploadEffects())
+}
+
+func uploadSessionToLedgerWithEffects(projectRoot string, result *agentSessionResult, state *session.RecordingState, ledgerPath, sessionName string, effects sessionUploadEffects) error {
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	sessionDir := filepath.Join(sessionsDir, sessionName)
 
@@ -1375,6 +1380,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		EntryCount(result.EntryCount).
 		Summary(result.Summary).
 		StopReason(session.StopReasonStopped).
+		ContinuedFromSessionID(state.ContinuedFromSessionID).
 		ProducedCommits(state.ProducedCommits).
 		ProducedPlans(state.ProducedPlans).
 		LinkedPRs(state.LinkedPRs).
@@ -1386,20 +1392,13 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		// session that may never reach the remote.
 		LinkageStatus(lfs.LinkageStatusStaged)
 
-	// inject sageox contribution score from cache file into meta.json,
-	// then clean up the score file to prevent stale scores leaking into future sessions
-	if scoreFile, _ := session.ReadSageoxScore(state.AgentID); scoreFile != nil {
-		metaBuilder.SageoxScore(scoreFile.Score, string(scoreFile.Category), scoreFile.Reason)
-	}
-	_ = session.CleanupSageoxScore(state.AgentID)
-
-	meta := metaBuilder.Build()
-	if err := lfs.WriteSessionMeta(sessionDir, meta); err != nil {
+	meta, err := writeInitialSessionMeta(sessionDir, state.AgentID, metaBuilder)
+	if err != nil {
 		return fmt.Errorf("write meta.json: %w", err)
 	}
 
 	// upload content files to LFS blob storage
-	fileRefs, err := uploadSessionLFS(projectRoot, sessionDir)
+	fileRefs, err := effects.uploadLFS(projectRoot, sessionDir)
 	if err != nil {
 		if errors.Is(err, api.ErrReadOnly) {
 			return err // don't wrap, don't set doctor marker
@@ -1421,7 +1420,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	}
 
 	// commit meta.json + .gitignore and push
-	if err := commitAndPushLedger(ledgerPath, sessionName); err != nil {
+	if err := effects.commitInitial(ledgerPath, sessionName); err != nil {
 		// set marker - session saved locally but not synced to remote
 		_ = doctor.SetNeedsDoctorAgent(projectRoot)
 		return fmt.Errorf("commit and push: %w", err)
@@ -1431,7 +1430,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	// is committed, so backfill it + outcome=stopped onto every plan this
 	// session produced (slugs in hand — no directory scan), then commit those
 	// plan dirs. Best-effort; any miss falls to `ox doctor`.
-	reconcileProducedPlansAtStop(projectRoot, state.ProducedPlans, sessionName, meta.EffectiveSessionID())
+	effects.reconcilePlans(projectRoot, state.ProducedPlans, sessionName, meta.EffectiveSessionID())
 
 	// push succeeded — now safe to replace content files with LFS pointer stubs
 	if len(meta.Files) > 0 {
@@ -1440,7 +1439,9 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		// the first failure). Always commit whatever pointers DID land — any
 		// rewritten pointer left uncommitted re-opens the autostash race for
 		// that file, even if other files in the same call failed.
-		written, writeErr := lfs.WritePointerFiles(sessionDir, meta.Files)
+		// AssertUploaded: meta.Files is the persisted manifest whose blobs were
+		// uploaded before the push that just succeeded above.
+		written, writeErr := lfs.WritePointerFiles(sessionDir, lfs.AssertUploadedManifest(meta.Files))
 		if len(written) > 0 {
 			// Commit the pointer rewrite so it doesn't sit dirty in the worktree.
 			// A dirty worktree here races against the daemon's sync-timer pull:
@@ -1449,7 +1450,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 			// the stash-pop yields conflict markers that ox doctor's auto-commit
 			// will eventually freeze into a permanent commit on main.
 			// (Tactical fix; pointer-first commit ordering is a separate discussion.)
-			if err := commitPointerRewriteAndPush(ledgerPath, sessionName, written); err != nil {
+			if err := effects.commitPointerRewrite(ledgerPath, sessionName, written); err != nil {
 				slog.Warn("LFS pointer rewrite commit failed", "error", err, "session", sessionName)
 			}
 		}
@@ -1466,13 +1467,50 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	// already-successful upload. Server-reported PR-link misses become
 	// repair tasks in the stop output — the agent still holds the session
 	// context and can fix the PR bodies with its own tooling.
-	for _, miss := range finalizeLinkageAfterPush(projectRoot, sessionDir, meta, sessionName) {
+	for _, miss := range effects.finalizeLinkage(projectRoot, sessionDir, meta, sessionName) {
 		result.PRLinkMisses = append(result.PRLinkMisses, fmt.Sprintf(
 			"PR %s is missing its session link — append this exact final line to its body: %s",
 			miss.PRURL, miss.ExpectedLine))
 	}
 
 	return nil
+}
+
+// writeInitialSessionMeta persists the first durable metadata snapshot before
+// consuming the per-agent contribution score. If the write fails, the score
+// remains available for a retry instead of being silently lost alongside the
+// failed meta.json write.
+func writeInitialSessionMeta(sessionDir, agentID string, builder *lfs.SessionMetaBuilder) (*lfs.SessionMeta, error) {
+	scoreFile, err := session.ReadSageoxScore(agentID)
+	if err != nil {
+		return nil, fmt.Errorf("read SageOx score: %w", err)
+	}
+	if scoreFile != nil {
+		builder.SageoxScore(scoreFile.Score, string(scoreFile.Category), scoreFile.Reason)
+	} else {
+		// A prior attempt may have persisted metadata and consumed the score
+		// carrier before a later LFS/push failure. Preserve that durable score on
+		// retry instead of overwriting meta.json with an unscored rebuild.
+		existing, readErr := lfs.ReadSessionMeta(sessionDir)
+		if readErr == nil && existing.SageoxScore != nil {
+			builder.SageoxScore(*existing.SageoxScore, existing.SageoxScoreCategory, existing.SageoxScoreReason)
+		} else if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+			return nil, fmt.Errorf("read existing session metadata: %w", readErr)
+		}
+	}
+
+	meta := builder.Build()
+	if err := lfs.WriteSessionMeta(sessionDir, meta); err != nil {
+		return nil, err
+	}
+
+	// Cleanup remains best-effort, but only after a successfully read score has
+	// a durable carrier. Missing scores need no cleanup; unreadable scores are
+	// preserved above for diagnosis and retry rather than silently discarded.
+	if scoreFile != nil {
+		_ = session.CleanupSageoxScore(agentID)
+	}
+	return meta, nil
 }
 
 // reconcileProducedPlansAtStop backfills the canonical session id + a

--- a/cmd/ox/agent_session_prime_guard_test.go
+++ b/cmd/ox/agent_session_prime_guard_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/sageox/agentx"
 )
 
 // TestEnsurePrimeBeforeSession_DoesNotRecurseUnderGoTest is the regression
@@ -26,6 +28,24 @@ func TestEnsurePrimeBeforeSession_DoesNotRecurseUnderGoTest(t *testing.T) {
 	// yet" state that used to trigger the exec.Command call.
 	agentSessionID := fmt.Sprintf("test-guard-%d", time.Now().UnixNano())
 	t.Setenv("CLAUDE_CODE_SESSION_ID", agentSessionID)
+
+	// Confirm the test actually reaches the branch it means to exercise.
+	// agentx.CurrentAgent() returns whichever agent it detects first — if a
+	// different signal in the test environment won the detection, or that
+	// agent doesn't support sessions, or reports a different session ID,
+	// ensurePrimeBeforeSession would return early via its "no session ID"
+	// path instead of the testing.Testing() guard, and this test would pass
+	// for the wrong reason.
+	agent := agentx.CurrentAgent()
+	if agent == nil {
+		t.Fatal("agentx.CurrentAgent() returned nil — CLAUDE_CODE_SESSION_ID should have made ClaudeCodeAgent detectable")
+	}
+	if !agent.SupportsSession() {
+		t.Fatalf("detected agent %q does not support sessions", agent.Name())
+	}
+	if got := agent.SessionID(agentx.NewSystemEnvironment()); got != agentSessionID {
+		t.Fatalf("detected agent %q reports SessionID() = %q, want %q — some other env signal is interfering", agent.Name(), got, agentSessionID)
+	}
 
 	if marker, err := ReadSessionMarker(agentSessionID); err != nil || marker != nil {
 		t.Fatalf("test session id %q unexpectedly already has a marker (marker=%+v err=%v)", agentSessionID, marker, err)

--- a/cmd/ox/agent_session_prime_guard_test.go
+++ b/cmd/ox/agent_session_prime_guard_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestEnsurePrimeBeforeSession_DoesNotRecurseUnderGoTest is the regression
+// test for #846: the full `go test ./cmd/ox/...` run deterministically hung
+// for ~10 minutes and then failed, because ensurePrimeBeforeSession used
+// os.Executable() to find the ox binary to shell out to for inline priming.
+// Under `go test`, os.Executable() resolves to the compiled test binary, not
+// the real ox CLI. Exec'ing that binary with args "agent prime" doesn't match
+// any -test.* flag, so the test binary just reran its entire suite from
+// scratch — which reaches this same code path again, recursing without bound
+// until the package's test deadline killed the whole run.
+//
+// Failure prevented: any test that exercises runAgentSessionStart on an
+// agent session with no prime marker yet (matching real agent env vars, e.g.
+// CLAUDE_CODE_SESSION_ID) triggers an unbounded recursive self-invocation of
+// the whole test binary instead of returning.
+func TestEnsurePrimeBeforeSession_DoesNotRecurseUnderGoTest(t *testing.T) {
+	// A session ID agentx's ClaudeCodeAgent will report via SessionID(), with
+	// no corresponding marker on disk — this is exactly the "prime hasn't run
+	// yet" state that used to trigger the exec.Command call.
+	agentSessionID := fmt.Sprintf("test-guard-%d", time.Now().UnixNano())
+	t.Setenv("CLAUDE_CODE_SESSION_ID", agentSessionID)
+
+	if marker, err := ReadSessionMarker(agentSessionID); err != nil || marker != nil {
+		t.Fatalf("test session id %q unexpectedly already has a marker (marker=%+v err=%v)", agentSessionID, marker, err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ensurePrimeBeforeSession("test-agent-id")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// good: returned without shelling out
+	case <-time.After(5 * time.Second):
+		t.Fatal("ensurePrimeBeforeSession did not return within 5s — it is " +
+			"almost certainly shelling out via os.Executable(), which under " +
+			"go test recursively re-invokes the whole test suite (see #846)")
+	}
+
+	// A real inline prime run would have written a session marker on success.
+	// If one appeared, the exec branch fired for real — the guard failed to
+	// stop it, and we got lucky it also happened to complete before the
+	// timeout above rather than recursing.
+	if marker, _ := ReadSessionMarker(agentSessionID); marker != nil {
+		t.Fatalf("ensurePrimeBeforeSession wrote a session marker under go test — "+
+			"it exec'd something instead of skipping: %+v", marker)
+	}
+}


### PR DESCRIPTION
## What broke

- `go test ./cmd/ox/...` hung for ~10 minutes on every run and then failed with a goroutine-dump panic. Traced to #846.
- Root cause: `ensurePrimeBeforeSession` (`cmd/ox/agent_session.go`) calls `os.Executable()` to locate the `ox` binary before shelling out to `ox agent prime` inline. Under `go test`, `os.Executable()` resolves to the **compiled test binary**, not the real CLI.
- Exec'ing the test binary with args `agent prime` matches no `-test.*` flag, so the binary just reruns its **entire suite from scratch** — which reaches `ensurePrimeBeforeSession` again, recursing without bound until Go's 10-minute per-package deadline kills it.

| | Before | After |
|---|---|---|
| `go test ./cmd/ox/...` | ~601s, FAIL (goroutine-dump panic) | ~205s, PASS |
| `TestManualPublishingSessionCapture_Matrix` | hangs indefinitely (killed by deadline) | 0.24s |

## What this PR ships

- **Guard**: `ensurePrimeBeforeSession` now checks `testing.Testing()` and returns immediately when running inside a test binary, before ever calling `os.Executable()` / `exec.Command`.
- **Regression test**: `TestEnsurePrimeBeforeSession_DoesNotRecurseUnderGoTest` (`cmd/ox/agent_session_prime_guard_test.go`) — drives the exact "no marker yet" state that used to trigger the exec, and asserts the function returns within 5s and never writes a marker.

## Test Plan

- [x] `go build ./...` clean
- [x] `go vet ./cmd/ox/...` clean
- [x] `go test ./cmd/ox/...`: was ~601s + FAIL, now ~205s + PASS (0 failures)
- [x] Regression test verified **red** with the guard neutered — failed at the 5s bound, and the recursive child visibly ran unrelated tests while ignoring `-run`, confirming the fork-bomb was real
- [x] Regression test verified **green** with the guard restored

## Follow-up (not in scope here)

There is currently no test coverage verifying the inline-prime **fallback path itself** works correctly in production (i.e. that `ensurePrimeBeforeSession` correctly execs `ox agent prime` when no marker exists). This fix removes an uncontrolled side effect tests were accidentally triggering — it does not add coverage for the fallback's real behavior, since that would need a mocked command runner rather than a real subprocess. Worth a separate issue if that path should be verified going forward.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790924924&installation_model_id=433550&pr_number=859&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F859&signature=4d92b86e61d27a47ef49f7c625aa12444d36f8bf6aee8144e20f9afdf18a44ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented session startup from recursively launching the test suite when running under `go test`.
  * Preserved contribution scores when retrying session uploads.
  * Improved reliability during session metadata saving, uploads, synchronization, and finalization.
  * Recorded the originating session when continuing an existing session.

* **Tests**
  * Added regression coverage confirming session initialization completes without recursion during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->