### PR TITLE
fix(status): resolve the project from the git root, not the working directory

### DIFF
--- a/cmd/ox/agent_prime_context_trace_test.go
+++ b/cmd/ox/agent_prime_context_trace_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -97,10 +98,36 @@ func TestEmitProvidedContextTrace_NilTeamCtx(t *testing.T) {
 	}
 }
 
+// TestEmitProvidedContextTrace_EmptySessionDir verifies an absent session
+// directory writes nothing anywhere, checked from an empty working directory.
+//
+// Failure prevented: the writer joins paths onto sessionDir. Without the empty
+// guard, "" makes every path relative, so the trace lands in whatever directory
+// the agent happened to be run from — inside the user's repo.
 func TestEmitProvidedContextTrace_EmptySessionDir(t *testing.T) {
-	// should return immediately without error
-	emitProvidedContextTrace("", &prime.TeamContextInfo{TeamName: "test"}, nil)
-	// no file created, nothing to verify — just ensures no panic
+	cwd := t.TempDir()
+	restore := changeToDir(t, cwd)
+	defer restore()
+
+	// MemoryContent must be non-empty: it is what makes the writer append an
+	// event at all. With an empty struct nothing is ever written and the test
+	// passes even with the sessionDir guard removed.
+	emitProvidedContextTrace("", &prime.TeamContextInfo{
+		TeamName:      "test",
+		MemoryContent: "some memory content",
+	}, nil)
+
+	entries, err := os.ReadDir(cwd)
+	if err != nil {
+		t.Fatalf("read working directory: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("empty sessionDir wrote %v into the working directory, want nothing", names)
+	}
 }
 
 func TestEmitProvidedContextTrace_NoInstructions(t *testing.T) {

--- a/cmd/ox/agent_prime_coverage_test.go
+++ b/cmd/ox/agent_prime_coverage_test.go
@@ -404,10 +404,33 @@ func TestLoadProjectGuidance_ReturnsNil(t *testing.T) {
 	}
 }
 
+// TestCheckTeamContextStaleness_NilTeamContext pairs the nil guard with a case
+// that proves the function still marks staleness, so the nil test cannot pass
+// against a body that does nothing at all.
+//
+// Failure prevented: the function reports its answer by mutating the struct it
+// is handed. A no-op body satisfies "does not panic on nil" perfectly while
+// silently reporting every team context as fresh.
 func TestCheckTeamContextStaleness_NilTeamContext(t *testing.T) {
 	t.Parallel()
-	// should not panic on nil input
-	checkTeamContextStaleness(nil, "")
+
+	t.Run("nil is ignored", func(t *testing.T) {
+		t.Parallel()
+		checkTeamContextStaleness(nil, "") // must not panic
+	})
+
+	t.Run("a context with no sync state is stale with an unknown age", func(t *testing.T) {
+		t.Parallel()
+		tc := &teamContextInfo{Path: t.TempDir()} // no sync state on disk
+		checkTeamContextStaleness(tc, "")
+
+		if !tc.Stale {
+			t.Error("Stale = false for a context that has never synced, want true")
+		}
+		if tc.StaleSince != "unknown" {
+			t.Errorf("StaleSince = %q, want %q", tc.StaleSince, "unknown")
+		}
+	})
 }
 
 func TestTeamContextAge_EmptyPath(t *testing.T) {

--- a/cmd/ox/doctor_git_repos_test.go
+++ b/cmd/ox/doctor_git_repos_test.go
@@ -812,7 +812,10 @@ func TestCheckSSHAuth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			home := t.TempDir()
+			// os.UserHomeDir reads HOME on unix and USERPROFILE on Windows;
+			// set both so the check cannot fall through to the real profile.
 			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
 			if tt.setup != nil {
 				tt.setup(t, home)
 			}

--- a/cmd/ox/doctor_git_repos_test.go
+++ b/cmd/ox/doctor_git_repos_test.go
@@ -764,12 +764,63 @@ func TestNormalizeGitURLForCompare(t *testing.T) {
 	}
 }
 
+// TestCheckSSHAuth drives the key lookup off a controlled HOME so the result is
+// determined by the fixture rather than by the developer's own ~/.ssh.
+//
+// Failure prevented: doctor reports SSH auth as available. Reading the real
+// home directory made the outcome differ between a laptop with keys and CI
+// without them, so neither answer was ever asserted.
 func TestCheckSSHAuth(t *testing.T) {
-	// this test just verifies the function doesn't panic
-	// actual SSH key presence depends on the test environment
-	result := checkSSHAuth()
-	// result can be true or false depending on environment
-	_ = result
+	// plantKey writes a stand-in private key at the given name under ~/.ssh.
+	plantKey := func(t *testing.T, home, name string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
+			t.Fatalf("create .ssh: %v", err)
+		}
+		key := filepath.Join(home, ".ssh", name)
+		if err := os.WriteFile(key, []byte("not-a-real-key\n"), 0o600); err != nil {
+			t.Fatalf("write %q: %v", key, err)
+		}
+	}
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, home string)
+		want  bool
+	}{
+		{
+			name: "no keys present",
+			want: false,
+		},
+		{
+			name:  "an ed25519 key is found",
+			setup: func(t *testing.T, home string) { plantKey(t, home, "id_ed25519") },
+			want:  true,
+		},
+		{
+			name:  "an rsa key is found",
+			setup: func(t *testing.T, home string) { plantKey(t, home, "id_rsa") },
+			want:  true,
+		},
+		{
+			name:  "an unrelated file in .ssh is not a key",
+			setup: func(t *testing.T, home string) { plantKey(t, home, "known_hosts") },
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			if tt.setup != nil {
+				tt.setup(t, home)
+			}
+			if got := checkSSHAuth(); got != tt.want {
+				t.Errorf("checkSSHAuth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 // TestClassifyFsckOutput covers the checkGitFsck false-positive fix: git

--- a/cmd/ox/doctor_integration_claude_test.go
+++ b/cmd/ox/doctor_integration_claude_test.go
@@ -86,11 +86,19 @@ func TestDetectClaudeCode_ProjectCLAUDEMd(t *testing.T) {
 	}
 }
 
+// TestDetectClaudeCode_NotDetected pins the negative case by controlling both
+// inputs the detector reads: the working directory and HOME.
+//
+// Failure prevented: the test asserted nothing because the real HOME decided
+// the answer — on any machine that has ever run Claude Code, the user-level
+// config makes detection true no matter what the project contains, so a
+// detector that always returned true would have passed.
 func TestDetectClaudeCode_NotDetected(t *testing.T) {
-	tmpDir := t.TempDir()
-	restoreCwd := changeToDir(t, tmpDir)
+	t.Setenv("HOME", t.TempDir())
+	restoreCwd := changeToDir(t, t.TempDir())
 	defer restoreCwd()
 
-	// just verify function doesn't panic (result depends on user environment)
-	_ = detectClaudeCode()
+	if detectClaudeCode() {
+		t.Error("detectClaudeCode() = true with no project markers and an empty home, want false")
+	}
 }

--- a/cmd/ox/doctor_integration_editors_test.go
+++ b/cmd/ox/doctor_integration_editors_test.go
@@ -183,15 +183,34 @@ func TestDetectOtherAIEditors_MultipleEditors(t *testing.T) {
 	}
 }
 
+// TestDetectOtherAIEditors_NoEditors verifies a project-level editor directory
+// is what gets detected, distinguishing it from the empty case above.
 func TestDetectOtherAIEditors_NoEditors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	gitRoot, cleanup := setupTempGitRepo(t)
 	defer cleanup()
 
 	restoreCwd := changeToDir(t, gitRoot)
 	defer restoreCwd()
 
-	// just verify function doesn't panic (may detect user-level editors)
-	_ = detectOtherAIEditors()
+	before := detectOtherAIEditors()
+	if len(before) != 0 {
+		t.Fatalf("precondition: expected no editors, got %v", before)
+	}
+
+	// Planting one known editor's project path must move the result, otherwise
+	// the empty answer above is indistinguishable from a detector that is off.
+	if len(knownEditors) == 0 || len(knownEditors[0].paths) == 0 {
+		t.Skip("no known editors compiled in")
+	}
+	plant := filepath.Join(gitRoot, knownEditors[0].paths[0])
+	if err := os.MkdirAll(plant, 0o755); err != nil {
+		t.Fatalf("plant %q: %v", plant, err)
+	}
+	if after := detectOtherAIEditors(); len(after) == 0 {
+		t.Errorf("detectOtherAIEditors() found nothing after planting %q", plant)
+	}
 }
 
 // TestCheckCodexIntegration_ProjectWithHooks verifies passed when hooks installed
@@ -513,17 +532,22 @@ func TestDetectOtherAIEditors_NoDuplicates(t *testing.T) {
 	}
 }
 
+// TestDetectOtherAIEditors_EmptyRepo pins the empty result with HOME controlled,
+// so the assertion holds on a developer machine that has editors installed.
+//
+// Failure prevented: the detector scans project-relative AND user-level paths.
+// Without pinning HOME the expected value was unknowable, so the result was
+// discarded and a detector reporting every known editor would have passed.
 func TestDetectOtherAIEditors_EmptyRepo(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	gitRoot, cleanup := setupTempGitRepo(t)
 	defer cleanup()
 
 	restoreCwd := changeToDir(t, gitRoot)
 	defer restoreCwd()
 
-	// no editor directories
-	detected := detectOtherAIEditors()
-
-	// should return empty or only user-level editors (not error)
-	// just verify it doesn't panic
-	_ = detected
+	if detected := detectOtherAIEditors(); len(detected) != 0 {
+		t.Errorf("detectOtherAIEditors() = %v, want none in an empty repo with an empty home", detected)
+	}
 }

--- a/cmd/ox/friction_coverage_test.go
+++ b/cmd/ox/friction_coverage_test.go
@@ -47,17 +47,6 @@ func TestOxActorDetector_ImplementsInterface(t *testing.T) {
 	} = oxActorDetector{}
 }
 
-func TestSendFrictionEvent_DisabledViaSAGEOX_FRICTION_Env(t *testing.T) {
-	t.Setenv("SAGEOX_FRICTION", "false")
-
-	event := &friction.FrictionEvent{
-		Kind:    "test",
-		Command: "ox test",
-	}
-	// should return early without panic or error
-	sendFrictionEvent(event)
-}
-
 func TestGetCatalogCachePath_WithFallback(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/cmd/ox/friction_test.go
+++ b/cmd/ox/friction_test.go
@@ -91,46 +91,71 @@ func TestFrictionIPC_CalledFromRecoveryPath(t *testing.T) {
 			"removing this breaks CLI→daemon friction telemetry")
 }
 
-// TestSendFrictionEvent_NilEvent verifies nil events are safely ignored.
-func TestSendFrictionEvent_NilEvent(t *testing.T) {
-	// should not panic
-	sendFrictionEvent(nil)
-}
+// TestSendFrictionEvent_Suppressed verifies every path that must NOT reach the
+// daemon, using an injected socket so "suppressed" means "nothing arrived"
+// rather than "the call returned".
+//
+// Failure prevented: two of these are telemetry opt-outs. Asserting only that
+// the call does not panic passes against a build that ignores them entirely and
+// sends the event anyway.
+func TestSendFrictionEvent_Suppressed(t *testing.T) {
+	sample := &friction.FrictionEvent{Kind: "unknown-command", Input: "ox bad"}
 
-// TestSendFrictionEvent_DoNotTrack verifies telemetry opt-out is respected.
-func TestSendFrictionEvent_DoNotTrack(t *testing.T) {
-	t.Setenv("DO_NOT_TRACK", "1")
-
-	// set up socket that should NOT receive anything
-	socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("ox-fdnt-%d.sock", time.Now().UnixNano()%100000))
-	t.Cleanup(func() { os.Remove(socketPath) })
-
-	listener, err := net.Listen("unix", socketPath)
-	require.NoError(t, err)
-	defer listener.Close()
-
-	received := make(chan struct{}, 1)
-	go func() {
-		conn, err := listener.Accept()
-		if err != nil {
-			return
-		}
-		defer conn.Close()
-		received <- struct{}{}
-	}()
-
-	event := &friction.FrictionEvent{
-		Kind:  "unknown-command",
-		Input: "ox bad",
+	tests := []struct {
+		name  string
+		env   map[string]string
+		event *friction.FrictionEvent
+	}{
+		{
+			// The nil guard is the first line of sendFrictionEventTo. Without
+			// it a nil event either panics or serializes to a null payload and
+			// is delivered as a real event.
+			name:  "a nil event",
+			event: nil,
+		},
+		{
+			name:  "DO_NOT_TRACK=1",
+			env:   map[string]string{"DO_NOT_TRACK": "1"},
+			event: sample,
+		},
+		{
+			name:  "SAGEOX_FRICTION=false",
+			env:   map[string]string{"SAGEOX_FRICTION": "false"},
+			event: sample,
+		},
 	}
 
-	// exercise the real sendFrictionEventTo — should be blocked by DO_NOT_TRACK
-	sendFrictionEventTo(event, socketPath)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
 
-	select {
-	case <-received:
-		t.Fatal("friction event should NOT be sent when DO_NOT_TRACK=1")
-	case <-time.After(50 * time.Millisecond):
-		// good — no IPC sent
+			socketPath := filepath.Join(os.TempDir(), fmt.Sprintf("ox-fsup-%d.sock", time.Now().UnixNano()%100000))
+			t.Cleanup(func() { os.Remove(socketPath) })
+
+			listener, err := net.Listen("unix", socketPath)
+			require.NoError(t, err)
+			defer listener.Close()
+
+			received := make(chan struct{}, 1)
+			go func() {
+				conn, err := listener.Accept()
+				if err != nil {
+					return
+				}
+				defer conn.Close()
+				received <- struct{}{}
+			}()
+
+			sendFrictionEventTo(tt.event, socketPath)
+
+			select {
+			case <-received:
+				t.Fatal("event reached the daemon but delivery should have been suppressed")
+			case <-time.After(50 * time.Millisecond):
+				// good — nothing sent
+			}
+		})
 	}
 }

--- a/cmd/ox/friction_test.go
+++ b/cmd/ox/friction_test.go
@@ -127,6 +127,12 @@ func TestSendFrictionEvent_Suppressed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Neutralize both opt-outs before applying the case's own. An
+			// inherited DO_NOT_TRACK=1 would suppress the SAGEOX_FRICTION case
+			// for the wrong reason, and vice versa, so each case would pass
+			// against a build that ignores the variable it is meant to prove.
+			t.Setenv("DO_NOT_TRACK", "")
+			t.Setenv("SAGEOX_FRICTION", "true")
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}

--- a/cmd/ox/helpers_coverage_test.go
+++ b/cmd/ox/helpers_coverage_test.go
@@ -641,13 +641,42 @@ func TestCheckSessionCompleteness_SomeMissing(t *testing.T) {
 
 // --- resolvePhase ---
 
+// TestResolvePhase_UnknownAgent pins the cross-agent fallback.
+//
+// Failure prevented: an agent type ox does not know must still resolve a hook
+// event that every known agent shares, or hooks from a new or renamed agent
+// silently resolve to no phase and the event is dropped.
 func TestResolvePhase_UnknownAgent(t *testing.T) {
-	// unknown agent type should try all maps as fallback
-	phase := resolvePhase("totally-unknown-agent", "session_start")
-	// session_start maps to "start" for claude-code; fallback should find it
-	// (or return empty if event doesn't match any agent)
-	// the point: it shouldn't panic
-	_ = phase
+	tests := []struct {
+		name  string
+		agent string
+		event string
+		want  string
+	}{
+		{
+			// session_start is mapped by claude-code; the fallback sweeps every map.
+			name:  "an event some known agent maps resolves through the fallback",
+			agent: "totally-unknown-agent",
+			event: "session_start",
+			want:  "start",
+		},
+		{
+			// Must resolve to nothing rather than to an arbitrary phase picked
+			// out of whichever map happened to iterate first.
+			name:  "an event no agent maps resolves to no phase",
+			agent: "totally-unknown-agent",
+			event: "bogus_event",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolvePhase(tt.agent, tt.event); got != tt.want {
+				t.Errorf("resolvePhase(%q, %q) = %q, want %q", tt.agent, tt.event, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestResolvePhase_UnknownEvent(t *testing.T) {

--- a/cmd/ox/init_helpers_coverage_test.go
+++ b/cmd/ox/init_helpers_coverage_test.go
@@ -188,15 +188,31 @@ func TestInitTracker_TrackForceStage(t *testing.T) {
 	assert.Len(t, tracker.forceStage, 2)
 }
 
+// TestInitTracker_RollbackEmpty verifies a rollback that tracked nothing removes
+// nothing, including on a fresh init where directory removal is armed.
+//
+// Failure prevented: rollback deletes createdDirs when isFreshInit is set. If
+// an empty tracker fell through to removing its root, a failed init would take
+// the user's existing directory contents with it.
 func TestInitTracker_RollbackEmpty(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "pre-existing.txt")
+	if err := os.WriteFile(sentinel, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
 	tracker := newInitTracker(dir)
 	tracker.isFreshInit = true
-
-	// rollback with nothing tracked should not panic
 	tracker.rollback(true)
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("rollback removed an untracked file: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("rollback removed the tracker root: %v", err)
+	}
 }
 
 func TestDetectRepoMarkersForEndpoint_Coverage_NonexistentDir(t *testing.T) {

--- a/cmd/ox/init_rollback_test.go
+++ b/cmd/ox/init_rollback_test.go
@@ -114,25 +114,79 @@ func TestRollbackInit_OnlyFilesNoDirectory(t *testing.T) {
 	assert.DirExists(t, sageoxDir, "directory should be preserved when not a fresh init")
 }
 
-func TestRollbackInit_EmptyTracker(t *testing.T) {
-	// should not panic with empty tracker
-	tracker := newInitTracker(t.TempDir())
-	tracker.rollback(true)
-}
-
-func TestRollbackInit_NonexistentFiles(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// files that don't exist
-	files := []string{
-		filepath.Join(tmpDir, "nonexistent1.txt"),
-		filepath.Join(tmpDir, "nonexistent2.txt"),
+// TestRollbackInit_SkipsMissingAndSparesUntracked verifies rollback removes only
+// what it tracked, and is not derailed by tracked paths that were never created.
+//
+// Failure prevented: a tracked file may never exist if init failed early.
+// Aborting on the first missing path leaves the files that DID get created
+// behind; deleting beyond the tracked set destroys the user's own files.
+func TestRollbackInit_SkipsMissingAndSparesUntracked(t *testing.T) {
+	tests := []struct {
+		name string
+		// tracked returns the paths to record as created, given the temp dir
+		// and the path of a real file that exists on disk.
+		tracked      func(dir, real string) []string
+		isFreshInit  bool
+		wantRealGone bool
+	}{
+		{
+			name:         "an empty tracker removes nothing",
+			tracked:      func(dir, real string) []string { return nil },
+			wantRealGone: false,
+		},
+		{
+			name:         "an empty tracker on a fresh init still removes nothing",
+			tracked:      func(dir, real string) []string { return nil },
+			isFreshInit:  true,
+			wantRealGone: false,
+		},
+		{
+			name: "missing tracked paths are skipped and the real one still goes",
+			tracked: func(dir, real string) []string {
+				return []string{
+					filepath.Join(dir, "nonexistent1.txt"),
+					filepath.Join(dir, "nonexistent2.txt"),
+					real,
+				}
+			},
+			wantRealGone: true,
+		},
 	}
 
-	// should not panic, just skip missing files
-	tracker := newInitTracker(tmpDir)
-	tracker.createdFiles = files
-	tracker.rollback(true)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			sentinel := filepath.Join(dir, "pre-existing.txt")
+			if err := os.WriteFile(sentinel, []byte("keep me\n"), 0o644); err != nil {
+				t.Fatalf("write sentinel: %v", err)
+			}
+			real := filepath.Join(dir, "created.txt")
+			if err := os.WriteFile(real, []byte("remove me\n"), 0o644); err != nil {
+				t.Fatalf("write tracked file: %v", err)
+			}
+
+			tracker := newInitTracker(dir)
+			tracker.isFreshInit = tt.isFreshInit
+			tracker.createdFiles = tt.tracked(dir, real)
+			tracker.rollback(true)
+
+			_, err := os.Stat(real)
+			if tt.wantRealGone && !os.IsNotExist(err) {
+				t.Error("rollback stopped at the first missing file and left a tracked file behind")
+			}
+			if !tt.wantRealGone && err != nil {
+				t.Errorf("rollback removed an untracked file: %v", err)
+			}
+			// The sentinel is never tracked in any case.
+			if _, err := os.Stat(sentinel); err != nil {
+				t.Errorf("rollback removed an untracked file: %v", err)
+			}
+			if _, err := os.Stat(dir); err != nil {
+				t.Errorf("rollback removed the tracker root: %v", err)
+			}
+		})
+	}
 }
 
 func TestRollbackInit_ReInitScenario(t *testing.T) {

--- a/cmd/ox/init_rollback_test.go
+++ b/cmd/ox/init_rollback_test.go
@@ -143,10 +143,14 @@ func TestRollbackInit_SkipsMissingAndSparesUntracked(t *testing.T) {
 		{
 			name: "missing tracked paths are skipped and the real one still goes",
 			tracked: func(dir, real string) []string {
+				// rollback walks createdFiles in reverse, so `real` must be
+				// first for the missing paths to be reached before it. With
+				// `real` last it is removed first and a rollback that aborts
+				// on the first os.Remove error still passes.
 				return []string{
+					real,
 					filepath.Join(dir, "nonexistent1.txt"),
 					filepath.Join(dir, "nonexistent2.txt"),
-					real,
 				}
 			},
 			wantRealGone: true,

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -1408,6 +1408,24 @@ func countReadyAgentTasks(gitRoot, agentType string) int {
 	return len(ready)
 }
 
+// resolveStatusProject returns the directory whose .sageox/ describes the
+// repository status is reporting on, and whether that project is initialized.
+//
+// The project root is the git root, not the working directory. gitRoot is
+// already resolved by walking up, so it is correct from any subdirectory,
+// while statting cwd/.sageox reports an initialized project as uninitialized
+// from every subdirectory and then recommends `ox init` on a healthy repo.
+//
+// Outside a git repo there is nothing to walk up to, so status describes the
+// directory the user is standing in, as it always has.
+func resolveStatusProject(cwd, gitRoot string) (root string, initialized bool) {
+	root = gitRoot
+	if root == "" {
+		root = cwd
+	}
+	return root, config.IsInitialized(root)
+}
+
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Display SageOx status and directory locations",
@@ -1472,13 +1490,12 @@ daemon health, and a tree view of all SageOx directory locations.`,
 			return fmt.Errorf("failed to get working directory: %w", err)
 		}
 
-		sageoxDir := filepath.Join(cwd, ".sageox")
+		projectRoot, projectInitialized := resolveStatusProject(cwd, gitRoot)
+
+		sageoxDir := filepath.Join(projectRoot, ".sageox")
 		var localCfg *config.LocalConfig
-		var projectInitialized bool
 
-		if stat, err := os.Stat(sageoxDir); err == nil && stat.IsDir() {
-			projectInitialized = true
-
+		if projectInitialized {
 			if gitRoot != "" {
 				// load local config for git repos section
 				localCfg, _ = config.LoadLocalConfig(gitRoot)
@@ -1559,7 +1576,7 @@ daemon health, and a tree view of all SageOx directory locations.`,
 		// JSON output mode
 		if statusJSONFlag {
 			output := buildStatusJSON(authenticated, authErr, token, endpointSlug, authFile, authFileExists,
-				userConfigDir, cwd, sageoxDir, projectInitialized, localCfg, gitRoot, repoDetail, codeStats,
+				userConfigDir, projectRoot, sageoxDir, projectInitialized, localCfg, gitRoot, repoDetail, codeStats,
 				daemonStatus, client, bubblesSummary)
 			jsonBytes, err := json.MarshalIndent(output, "", "  ")
 			if err != nil {
@@ -1666,7 +1683,7 @@ daemon health, and a tree view of all SageOx directory locations.`,
 // fields are permanent, first-class output — conversation stores are not
 // bubbles (ox ADR-028) and never fold into the bubbles field.
 func buildStatusJSON(authenticated bool, authErr error, token *auth.StoredToken, endpointSlug, authFile string, authFileExists bool,
-	userConfigDir, cwd, sageoxDir string, projectInitialized bool, localCfg *config.LocalConfig, gitRoot string,
+	userConfigDir, projectRoot, sageoxDir string, projectInitialized bool, localCfg *config.LocalConfig, gitRoot string,
 	repoDetail *api.RepoDetailResponse, codeStats *daemon.CodeDBStats,
 	daemonStatus *daemon.StatusData, daemonClient *daemon.Client,
 	bubblesSummary statusBubblesSummary) statusJSONOutput {
@@ -1721,7 +1738,7 @@ func buildStatusJSON(authenticated bool, authErr error, token *auth.StoredToken,
 	// project section
 	output.Project = &statusProjectJSON{
 		Initialized: projectInitialized,
-		Directory:   cwd,
+		Directory:   projectRoot,
 	}
 	if projectInitialized {
 		output.Project.ConfigPath = sageoxDir

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -953,6 +953,12 @@ func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, dae
 // daemonSyncWarningThreshold is the uptime duration after which we expect syncs to have occurred
 const daemonSyncWarningThreshold = time.Minute
 
+// daemonGetState indirects daemon.GetState so tests can drive the branches
+// below. The real function probes a live socket, so without this seam the
+// stopped-daemon wording is only reachable on a machine that happens to have
+// no daemon running — which is not the usual developer state.
+var daemonGetState = daemon.GetState
+
 // renderDaemonSyncSection renders daemon sync statistics
 func renderDaemonSyncSection(ds *daemon.StatusData, syncHistory []daemon.SyncEvent, localCfg *config.LocalConfig, noProject bool, projectInitialized bool) string {
 	var b strings.Builder
@@ -974,7 +980,7 @@ func renderDaemonSyncSection(ds *daemon.StatusData, syncHistory []daemon.SyncEve
 	// handle nil status (daemon not connected)
 	if ds == nil {
 		b.WriteString(statusLabelStyle.Render("Status"))
-		switch daemon.GetState() {
+		switch daemonGetState() {
 		case daemon.DaemonStateStarting:
 			b.WriteString(statusMutedStyle.Render("◐ starting — process is running but not yet accepting connections"))
 		case daemon.DaemonStateStuck:

--- a/cmd/ox/status_project_root_test.go
+++ b/cmd/ox/status_project_root_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- Project resolution for `ox status` ---
+
+// TestResolveStatusProject verifies that status describes the repository it is
+// standing in, from anywhere inside it.
+//
+// Failure prevented: run from a subdirectory, status reported an initialized
+// repo as "not initialized", suppressed the ledger and code-index rows, and
+// printed `ox init` as the starred next action — on a healthy project, where
+// re-running init is the one command that can delete agent hook files.
+//
+// The nested cases guard the opposite error: resolving by walking up without a
+// boundary makes an uninitialized repo adopt an ancestor's project, which hides
+// the `ox init` it genuinely needs and attributes another repo's ledger and team
+// to it.
+func TestResolveStatusProject(t *testing.T) {
+	// initProject writes the marker config.IsInitialized actually requires.
+	initProject := func(t *testing.T, dir string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(dir, ".sageox"), 0o755); err != nil {
+			t.Fatalf("create .sageox in %q: %v", dir, err)
+		}
+		cfg := filepath.Join(dir, ".sageox", "config.json")
+		if err := os.WriteFile(cfg, []byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("write %q: %v", cfg, err)
+		}
+	}
+
+	// bareSageoxDir creates .sageox/ with no config inside it — the state
+	// CLAUDE.md calls out as "directory exists != initialized".
+	bareSageoxDir := func(t *testing.T, dir string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(dir, ".sageox"), 0o755); err != nil {
+			t.Fatalf("create .sageox in %q: %v", dir, err)
+		}
+	}
+
+	// initProjectYAML uses the other config filename IsInitialized accepts.
+	initProjectYAML := func(t *testing.T, dir string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(dir, ".sageox"), 0o755); err != nil {
+			t.Fatalf("create .sageox in %q: %v", dir, err)
+		}
+		cfg := filepath.Join(dir, ".sageox", "config.yaml")
+		if err := os.WriteFile(cfg, []byte("version: \"1\"\n"), 0o644); err != nil {
+			t.Fatalf("write %q: %v", cfg, err)
+		}
+	}
+
+	mkdirs := func(t *testing.T, dir string) {
+		t.Helper()
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %q: %v", dir, err)
+		}
+	}
+
+	tests := []struct {
+		name string
+		// setup builds the tree and returns the arguments to resolve with,
+		// plus the project root expected back.
+		setup           func(t *testing.T, tmp string) (cwd, gitRoot, wantRoot string)
+		wantInitialized bool
+	}{
+		{
+			name: "from the project root",
+			setup: func(t *testing.T, tmp string) (string, string, string) {
+				initProject(t, tmp)
+				return tmp, tmp, tmp
+			},
+			wantInitialized: true,
+		},
+		{
+			name: "from an immediate subdirectory",
+			setup: func(t *testing.T, tmp string) (string, string, string) {
+				initProject(t, tmp)
+				sub := filepath.Join(tmp, "pkg")
+				mkdirs(t, sub)
+				return sub, tmp, tmp
+			},
+			wantInitialized: true,
+		},
+		{
+			name: "from a deeply nested subdirectory",
+			setup: func(t *testing.T, tmp string) (string, string, string) {
+				initProject(t, tmp)
+				deep := filepath.Join(tmp, "services", "api", "internal")
+				mkdirs(t, deep)
+				return deep, tmp, tmp
+			},
+			wantInitialized: true,
+		},
+		{
+			name: "a config.yaml project resolves from a subdirectory",
+			setup: func(t *testing.T, tmp string) (string, string, string) {
+				initProjectYAML(t, tmp)
+				sub := filepath.Join(tmp, "pkg")
+				mkdirs(t, sub)
+				return sub, tmp, tmp
+			},
+			wantInitialized: true,
+		},
+		{
+			name: "a bare .sageox directory is not an initialized project",
+			setup: func(t *testing.T, tmp string) (string, string, string) {
+				bareSageoxDir(t, tmp)
+				sub := filepath.Join(tmp, "pkg")
+				mkdirs(t, sub)
+				return sub, tmp, tmp
+			},
+			wantInitialized: false,
+		},
+		{
+			name: "uninitialized repo does not adopt an initialized ancestor",
+			setup: func(t *testing.T, tmp string) (string, string, string) {
+				initProject(t, tmp) // the ancestor — e.g. a stray ~/.sageox
+				repo := filepath.Join(tmp, "repo")
+				sub := filepath.Join(repo, "sub")
+				mkdirs(t, sub)
+				return sub, repo, repo
+			},
+			wantInitialized: false,
+		},
+		{
+			name: "outside a git repo, an initialized cwd still reports",
+			setup: func(t *testing.T, tmp string) (string, string, string) {
+				initProject(t, tmp)
+				return tmp, "", tmp
+			},
+			wantInitialized: true,
+		},
+		{
+			name: "outside a git repo, an uninitialized cwd reports itself",
+			setup: func(t *testing.T, tmp string) (string, string, string) {
+				return tmp, "", tmp
+			},
+			wantInitialized: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cwd, gitRoot, wantRoot := tt.setup(t, t.TempDir())
+
+			gotRoot, gotInitialized := resolveStatusProject(cwd, gitRoot)
+
+			if gotRoot != wantRoot {
+				t.Errorf("root = %q, want %q", gotRoot, wantRoot)
+			}
+			if gotInitialized != tt.wantInitialized {
+				t.Errorf("initialized = %v, want %v", gotInitialized, tt.wantInitialized)
+			}
+		})
+	}
+}

--- a/cmd/ox/status_sections_test.go
+++ b/cmd/ox/status_sections_test.go
@@ -148,31 +148,77 @@ func TestRenderDaemonSyncSection(t *testing.T) {
 	}
 }
 
-// TestRenderDaemonSyncSection_UninitializedProjectIsNotAlarming checks that a
-// stopped daemon reads as expected in a repo that was never initialized, and as
-// actionable in one that was.
+// TestRenderDaemonSyncSection_StoppedDaemonWording drives daemonGetState
+// directly so every branch of the nil-status switch is reachable regardless of
+// whether a daemon happens to be running on the machine under test.
 //
 // Failure prevented: the same "daemon not running" fact means different things
 // either side of `ox init`. Showing the initialized wording in an uninitialized
-// repo tells the reader to start a daemon for a project that does not exist yet.
-func TestRenderDaemonSyncSection_UninitializedProjectIsNotAlarming(t *testing.T) {
-	if state := daemon.GetState(); state != daemon.DaemonStateStopped {
-		// Starting/stuck/running states short-circuit before the branch under
-		// test, so the comparison below would be vacuous.
-		t.Skipf("daemon state is %v, not stopped; this branch is unreachable", state)
+// repo tells the reader to start a daemon for a project that does not exist
+// yet. Reading the real daemon state instead made this assertion vacuous on any
+// machine with a daemon up, which is the normal developer state.
+func TestRenderDaemonSyncSection_StoppedDaemonWording(t *testing.T) {
+	stubDaemonState := func(t *testing.T, state daemon.DaemonState) {
+		t.Helper()
+		prev := daemonGetState
+		daemonGetState = func() daemon.DaemonState { return state }
+		t.Cleanup(func() { daemonGetState = prev })
 	}
 
-	uninit := renderDaemonSyncSection(nil, nil, nil, false, false)
-	inited := renderDaemonSyncSection(nil, nil, nil, false, true)
+	tests := []struct {
+		name               string
+		state              daemon.DaemonState
+		projectInitialized bool
+		wantContains       []string
+		wantOmits          []string
+	}{
+		{
+			name:               "stopped in an uninitialized project blames init, not the daemon",
+			state:              daemon.DaemonStateStopped,
+			projectInitialized: false,
+			wantContains:       []string{"ox init"},
+			wantOmits:          []string{"ox daemon start"},
+		},
+		{
+			name:               "stopped in an initialized project points at the daemon",
+			state:              daemon.DaemonStateStopped,
+			projectInitialized: true,
+			wantContains:       []string{"ox daemon start"},
+			wantOmits:          []string{"ox init"},
+		},
+		{
+			name:               "starting short-circuits both wordings",
+			state:              daemon.DaemonStateStarting,
+			projectInitialized: false,
+			wantContains:       []string{"starting"},
+			wantOmits:          []string{"ox init", "ox daemon start"},
+		},
+		{
+			name:               "stuck recommends a restart, not init",
+			state:              daemon.DaemonStateStuck,
+			projectInitialized: false,
+			wantContains:       []string{"stuck", "ox daemon restart"},
+			wantOmits:          []string{"ox init"},
+		},
+	}
 
-	if !strings.Contains(uninit, "ox init") {
-		t.Errorf("uninitialized output %q should attribute the stopped daemon to init not having run", uninit)
-	}
-	if strings.Contains(inited, "ox init") {
-		t.Errorf("initialized output %q must not suggest init on an already-initialized project", inited)
-	}
-	if uninit == inited {
-		t.Error("initialized and uninitialized projects render the same daemon message")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubDaemonState(t, tt.state)
+
+			got := renderDaemonSyncSection(nil, nil, nil, false, tt.projectInitialized)
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output %q should contain %q", got, want)
+				}
+			}
+			for _, omit := range tt.wantOmits {
+				if strings.Contains(got, omit) {
+					t.Errorf("output %q unexpectedly contains %q", got, omit)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/ox/status_sections_test.go
+++ b/cmd/ox/status_sections_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon"
+)
+
+// writeUserConfig points OX_USER_CONFIG at a config file holding the given
+// body. OX_USER_CONFIG overrides all path discovery, so the agent-worker
+// readers below resolve against this file instead of the developer's real
+// ~/.config/sageox — the seam that makes these two functions testable at all.
+func writeUserConfig(t *testing.T, body string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write user config: %v", err)
+	}
+	t.Setenv(config.EnvUserConfig, path)
+}
+
+// --- Agent worker (`Summarizer` row, and .daemon.agent_worker in --json) ---
+
+// TestAgentWorkerResolution covers the agent-worker states that resolve
+// identically on every machine, in both output forms.
+//
+// Failure prevented: source is the only field separating a deliberate opt-out
+// or an explicit pin from ox picking an agent by scanning PATH. Collapsing
+// those hides a pin, which matters wherever a build and its review must not
+// land on the same model.
+func TestAgentWorkerResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		userConfig string
+		wantAgent  string
+		wantSource string
+		wantInLine string // substring the rendered Summarizer row must contain
+	}{
+		{
+			name:       "explicitly disabled",
+			userConfig: "agent_worker:\n  agent: none\n",
+			wantAgent:  "none",
+			wantSource: "disabled",
+			wantInLine: "disabled",
+		},
+		{
+			name:       "explicitly pinned to an agent",
+			userConfig: "agent_worker:\n  agent: codex\n",
+			wantAgent:  "codex",
+			wantSource: "configured",
+			wantInLine: "codex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeUserConfig(t, tt.userConfig)
+
+			got := buildAgentWorkerJSON()
+			if got == nil {
+				t.Fatal("buildAgentWorkerJSON() = nil, want a value")
+			}
+			if got.Agent != tt.wantAgent {
+				t.Errorf("Agent = %q, want %q", got.Agent, tt.wantAgent)
+			}
+			if got.Source != tt.wantSource {
+				t.Errorf("Source = %q, want %q", got.Source, tt.wantSource)
+			}
+
+			line := renderAgentWorkerLine()
+			if !strings.Contains(line, "Summarizer") {
+				t.Errorf("line %q missing the Summarizer label", line)
+			}
+			if !strings.Contains(line, tt.wantInLine) {
+				t.Errorf("line %q does not contain %q", line, tt.wantInLine)
+			}
+			if !strings.HasSuffix(line, "\n") {
+				t.Errorf("line %q must end in a newline or it runs into the next row", line)
+			}
+		})
+	}
+}
+
+// --- Daemon Sync section ---
+
+// TestRenderDaemonSyncSection covers the branches that do not depend on whether
+// a daemon happens to be running on the machine executing the test.
+func TestRenderDaemonSyncSection(t *testing.T) {
+	syncedLedger := &config.LocalConfig{
+		Ledger: &config.LedgerConfig{
+			Path:     "/tmp/ledger",
+			LastSync: time.Now().Add(-2 * time.Hour),
+		},
+	}
+	neverSynced := &config.LocalConfig{
+		Ledger: &config.LedgerConfig{Path: "/tmp/ledger"}, // LastSync zero
+	}
+
+	tests := []struct {
+		name               string
+		localCfg           *config.LocalConfig
+		noProject          bool
+		projectInitialized bool
+		wantContains       []string
+		wantOmits          []string
+	}{
+		{
+			name:         "outside a git repo the section reports n/a",
+			noProject:    true,
+			wantContains: []string{"Daemon Sync", "not in a git repo"},
+		},
+		{
+			// The point of persisting last_sync is that it still answers
+			// "when did this last sync?" once the daemon is gone.
+			name:               "last known ledger sync survives a stopped daemon",
+			localCfg:           syncedLedger,
+			projectInitialized: true,
+			wantContains:       []string{"Last ledger sync"},
+		},
+		{
+			name:               "a zero last-sync is not rendered as a real time",
+			localCfg:           neverSynced,
+			projectInitialized: true,
+			wantOmits:          []string{"Last ledger sync"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderDaemonSyncSection(nil, nil, tt.localCfg, tt.noProject, tt.projectInitialized)
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output %q missing %q", got, want)
+				}
+			}
+			for _, omit := range tt.wantOmits {
+				if strings.Contains(got, omit) {
+					t.Errorf("output %q unexpectedly contains %q", got, omit)
+				}
+			}
+		})
+	}
+}
+
+// TestRenderDaemonSyncSection_UninitializedProjectIsNotAlarming checks that a
+// stopped daemon reads as expected in a repo that was never initialized, and as
+// actionable in one that was.
+//
+// Failure prevented: the same "daemon not running" fact means different things
+// either side of `ox init`. Showing the initialized wording in an uninitialized
+// repo tells the reader to start a daemon for a project that does not exist yet.
+func TestRenderDaemonSyncSection_UninitializedProjectIsNotAlarming(t *testing.T) {
+	if state := daemon.GetState(); state != daemon.DaemonStateStopped {
+		// Starting/stuck/running states short-circuit before the branch under
+		// test, so the comparison below would be vacuous.
+		t.Skipf("daemon state is %v, not stopped; this branch is unreachable", state)
+	}
+
+	uninit := renderDaemonSyncSection(nil, nil, nil, false, false)
+	inited := renderDaemonSyncSection(nil, nil, nil, false, true)
+
+	if !strings.Contains(uninit, "ox init") {
+		t.Errorf("uninitialized output %q should attribute the stopped daemon to init not having run", uninit)
+	}
+	if strings.Contains(inited, "ox init") {
+		t.Errorf("initialized output %q must not suggest init on an already-initialized project", inited)
+	}
+	if uninit == inited {
+		t.Error("initialized and uninitialized projects render the same daemon message")
+	}
+}
+
+// --- AI Coworkers section ---
+
+// TestRenderAICoworkersSection_NoDaemonRendersNothing verifies the section stays
+// silent rather than reporting zero.
+//
+// Failure prevented: this row is suppressed by design when there is nothing to
+// say. Emitting a header or "0 active" with no daemon adds a line to every
+// status run on every machine without a daemon.
+func TestRenderAICoworkersSection_NoDaemonRendersNothing(t *testing.T) {
+	if got := renderAICoworkersSection(nil); got != "" {
+		t.Errorf("renderAICoworkersSection(nil) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Problem

`ox status` decides whether a project is initialized by statting `<cwd>/.sageox`, while the
`Repo directory` row directly above it resolves through `findGitRoot()`. From any subdirectory
the two disagree.

Reproduces in this repo:

```console
$ cd internal && ox status
Repo directory      /path/to/ox
  SageOx state      └── .sageox/ dir (not initialized)
★ ox init  Initialize project for AI agent context (Step 2)
```

The consequences compound:

- a healthy, ledger-connected project reports as **not initialized**
- the ledger and code-index rows are **suppressed**
- the daemon line prints `not running (expected until 'ox init' completed)`, which is a false excuse
- **`ox init` is starred as the next action on an already-initialized repo**

That last one is the reason this is more than cosmetic: re-running `init` on a healthy project is
not a no-op.

## Fix

Resolve the project from the git root, which `findGitRoot()` has already walked up to, and ask the
canonical helper whether it is initialized:

```go
func resolveStatusProject(cwd, gitRoot string) (root string, initialized bool) {
	root = gitRoot
	if root == "" {
		root = cwd
	}
	return root, config.IsInitialized(root)
}
```

Outside a git repo there is nothing to walk up to, so status describes the directory the user is
standing in, as it always has.

`CLAUDE.md` is explicit that `config.IsInitialized(gitRoot)` is the canonical check and that
`os.Stat(filepath.Join(root, ".sageox"))` is wrong ("Directory exists ≠ initialized"). Routing
through the helper also means the resolver *cannot* walk out of the repo — an earlier draft of this
fix used an unbounded `config.FindProjectRoot()`, which found a stray `~/.sageox` and reported every
repo under `$HOME` as initialized at `/home/<user>`. The test below pins that regression shut.

## Two deliberate behavior changes

1. **A bare `.sageox/` with no `config.json`/`config.yaml` now reports uninitialized.** Previously
   the directory alone was enough. This makes `ox init` correct advice in the one case where it
   genuinely applies. `ox init` writes `config.json`, so real projects are unaffected.
2. **`project.directory` in `--json` is now the project root.** Under a symlinked path the released
   binary printed a resolved `Repo directory` but an unresolved `project.directory`; these now agree.

## Tests

`TestResolveStatusProject` — table-driven, 8 cases: project root, immediate and deeply nested
subdirectories, `config.yaml` projects, bare `.sageox/`, non-git directories, and an uninitialized
repo nested inside an initialized ancestor (the regression guard). Five of the eight fail against
the previous behavior.

The second commit is separable and covers pre-existing gaps found while working here: the untested
`status` render paths, plus several tests that ran code without asserting on it. Each new assertion
was mutation-tested — the defect planted, the failure confirmed, then reverted.

## Testing notes

`cmd/ox` passes under `-race` on the full tier, before and after (coverage 52.6% → 52.9%).

Three unrelated packages are flaky on my machine under `make test-all`, and I could not get a green
baseline on `origin/main` either — `internal/codedb/store`, `internal/ledger`, and `internal/daemon`
failed across runs in **disjoint** sets. `internal/ledger`'s `TestBackfillPRCommits` is
GitHub-API-quota dependent and, when it fails, `t.Errorf` at `github_sync_test.go:546` is followed by
an unguarded index at `:548`, turning one assertion failure into a package-wide panic. Flagging in
case it is useful; none of it is touched by this change.

Happy to split, rename, or drop the second commit if you would rather keep this to the one-function fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790998523&installation_model_id=433550&pr_number=864&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F864&signature=1ac71271c42dcca6eb8e209d5bc07b67e97018d0369201e2f65a71349958e1dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Status now correctly identifies initialized projects and reports the project root when run from a nested directory.
  - Rollback preserves untracked files and safely skips missing paths.
  - Status displays more reliable daemon and synchronization information across project states.

- **Tests**
  - Expanded coverage for status displays, project-root detection, editor and integration detection, friction-event suppression, context tracing, and rollback behavior.
  - Tests now use isolated environments and verify expected results deterministically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->