### PR TITLE
fix(daemon): serialize git ops per clone to close the FETCH_HEAD race

### DIFF
--- a/.config/coverage-ratchets.json
+++ b/.config/coverage-ratchets.json
@@ -11,6 +11,16 @@
         "path": "cmd/ox/agent_session.go",
         "reason": "Durable score write and retry preservation are directly tested; the orchestration call site awaits the ox-ilrr.7 lifecycle seam",
         "expires": "2026-09-30"
+      },
+      {
+        "path": "cmd/ox/doctor_ledger_git.go",
+        "reason": "PR #868 (ADR-030 per-clone git locking): the new WithRepoLock wrapper and D3 own-rebase guard in fixLedgerBranchBehind are directly tested (TestFixLedgerBranchBehind_LockBusy_FailsFastInsteadOfRacing, TestFixLedgerBranchBehind_ForeignRebase_NeverTouched). The remaining uncovered lines are the pre-existing LLM-resolver/AuditAndAbort conflict-resolution ladder, unchanged in behavior but re-indented into the diff by the new wrapper. Covering it needs a mock for automerge's external-binary resolver contract, tracked as bd ox-baz5.7.",
+        "expires": "2026-10-17"
+      },
+      {
+        "path": "internal/daemon/sync_managed.go",
+        "reason": "PR #868 (ADR-030 per-clone git locking): the new lock/retry/D3-guard logic in pullManagedRepo and fetchAndPullLocked is directly tested (TestPullManagedRepo_ConcurrentFetchDoesNotCorruptFETCH_HEAD, -race clean). The remaining uncovered lines are the pre-existing auto-resolve/LLM-resolver/AuditAndAbort conflict ladder, extracted verbatim (unchanged in behavior) out of the old pullManagedRepo body. Same automerge mocking gap as doctor_ledger_git.go, tracked together under bd ox-baz5.7.",
+        "expires": "2026-10-17"
       }
     ]
   },

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -400,9 +400,24 @@ func unbornLedgerFailure(ledgerPath, branch string, fix bool) checkResult {
 			return PassedCheck(name, fmt.Sprintf("restored branch %q from local objects", branch))
 		}
 		// Objects genuinely missing — one narrow fetch is the only way back, and
-		// a ledger that has never synced is worth it.
-		if fetchOut, fetchErr := exec.Command("git", "-C", ledgerPath, "fetch", "origin", branch).CombinedOutput(); fetchErr != nil {
-			return critical(FailedCheck(name, "fetch failed", gitutil.SanitizeOutput(strings.TrimSpace(string(fetchOut)))))
+		// a ledger that has never synced is worth it. Locked (ADR-030 D1): the
+		// daemon may be mid-fetch on this same clone; without the per-clone
+		// lock the two could interleave FETCH_HEAD exactly as in the
+		// 2026-09-02 incident.
+		var fetchOut []byte
+		fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		fetchErr := gitutil.WithRepoLock(fetchCtx, ledgerPath, func() error {
+			var err error
+			fetchOut, err = exec.Command("git", "-C", ledgerPath, "fetch", "origin", branch).CombinedOutput()
+			return err
+		})
+		fetchCancel()
+		if fetchErr != nil {
+			detail := strings.TrimSpace(string(fetchOut))
+			if detail == "" {
+				detail = fetchErr.Error() // lock could not be acquired — no CombinedOutput to show
+			}
+			return critical(FailedCheck(name, "fetch failed", gitutil.SanitizeOutput(detail)))
 		}
 		if out, err := exec.Command("git", "-C", ledgerPath, "checkout", branch).CombinedOutput(); err != nil {
 			return critical(FailedCheck(name, "checkout failed", gitutil.SanitizeOutput(strings.TrimSpace(string(out)))))
@@ -472,11 +487,17 @@ func fixLedgerBranchBehind(ledgerPath string, behindCount int) checkResult {
 // ox doctor --fix the divergence may already be resolved. Re-check before
 // attempting the heavier PushWithRetry path.
 func fixLedgerBranchDiverged(ledgerPath string, aheadCount, behindCount int) checkResult {
-	// re-fetch so we compare against the latest remote state
-	fetchCmd := exec.Command("git", "-C", ledgerPath, "fetch", "--quiet")
-	if err := fetchCmd.Run(); err != nil {
+	// re-fetch so we compare against the latest remote state. Locked
+	// (ADR-030 D1): serializes against a concurrent daemon fetch on the same
+	// clone. Best-effort either way — a stale re-check just falls through to
+	// the ahead/behind counts the caller already has.
+	fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if err := gitutil.WithRepoLock(fetchCtx, ledgerPath, func() error {
+		return exec.Command("git", "-C", ledgerPath, "fetch", "--quiet").Run()
+	}); err != nil {
 		slog.Debug("fetch before diverged re-check failed", "error", err)
 	}
+	fetchCancel()
 
 	// re-check ahead/behind — daemon may have already reconciled
 	revCmd := exec.Command("git", "-C", ledgerPath, "rev-list", "--left-right", "--count", "origin/main...HEAD")

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -408,7 +408,12 @@ func unbornLedgerFailure(ledgerPath, branch string, fix bool) checkResult {
 		fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		fetchErr := gitutil.WithRepoLock(fetchCtx, ledgerPath, func() error {
 			var err error
-			fetchOut, err = exec.Command("git", "-C", ledgerPath, "fetch", "origin", branch).CombinedOutput()
+			// NewNetworkCmd, not a bare exec.Command: binds the fetch itself
+			// to fetchCtx (a stalled network fetch would otherwise run
+			// unbounded once the lock is held — fetchCtx only bounded the
+			// wait to ACQUIRE it) and disables the interactive credential
+			// prompt the daemon/doctor have no TTY to answer.
+			fetchOut, err = gitutil.NewNetworkCmd(fetchCtx, "-C", ledgerPath, "fetch", "origin", branch).CombinedOutput()
 			return err
 		})
 		fetchCancel()
@@ -450,36 +455,62 @@ func fixLedgerBranchAhead(ledgerPath string, aheadCount int) checkResult {
 
 // fixLedgerBranchBehind pulls remote changes into local ledger.
 func fixLedgerBranchBehind(ledgerPath string, behindCount int) checkResult {
-	// --autostash: uncommitted local changes must not block the pull
-	pullCmd := exec.Command("git", "-C", ledgerPath, "pull", "--rebase", "--autostash")
-	output, err := pullCmd.CombinedOutput()
-	if err != nil {
-		errStr := strings.TrimSpace(string(output))
-		// Route through automerge, not the bare accept-theirs call. This was the
-		// one reconcile path that skipped the tiered resolver, so it got no union
-		// tier and no LLM tier while every other path (CLI push, daemon pull,
-		// diverged fix) went through ledgerLLMResolveHook. Behind-only pulls hit
-		// exactly the same sessions/ conflicts as the others.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		_, resolveErr := ledgerLLMResolveHook()(ctx, ledgerPath, nil)
-		cancel()
-		if resolveErr != nil {
-			slog.Debug("rebase auto-resolve failed", "error", resolveErr)
-			// AuditAndAbort: log HEAD SHA, unmerged files, and stash count
-			// before discarding rebase state so silent recovery is not
-			// invisible. See ox-ooy3 and .claude/rules/daemon-git.md.
-			abortCtx, abortCancel := context.WithTimeout(context.Background(), 15*time.Second)
-			_ = gitutil.AuditAndAbort(abortCtx, ledgerPath, gitutil.AuditOpRebase, "doctor --fix auto-resolve failed", slog.Default())
-			abortCancel()
-			return FailedCheck("Ledger branch status",
-				"pull --rebase failed (aborted)",
-				fmt.Sprintf("Conflict during rebase (aborted to restore clean state): %s", errStr))
+	// Locked (ADR-030 D1): the whole pull + conflict-resolution + abort
+	// sequence runs under the per-clone lock. A concurrent daemon sync
+	// cycle fetching or rebasing the same clone mid-sequence is exactly
+	// the 2026-09-02 incident's shape. 30s to ACQUIRE the lock, matching
+	// this file's other fetch sites (fixLedgerBranchDiverged, the
+	// unborn-branch repair) — this bounds only the wait to get the lock,
+	// not the work once inside it, which has its own budgets below.
+	var result checkResult
+	lockCtx, lockCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer lockCancel()
+	lockErr := gitutil.WithRepoLock(lockCtx, ledgerPath, func() error {
+		// --autostash: uncommitted local changes must not block the pull.
+		// Bounded so a hung network pull can't hold the lock forever.
+		pullCtx, pullCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		pullCmd := gitutil.NewNetworkCmd(pullCtx, "-C", ledgerPath, "pull", "--rebase", "--autostash")
+		output, err := pullCmd.CombinedOutput()
+		pullCancel()
+		if err != nil {
+			errStr := strings.TrimSpace(string(output))
+			// Route through automerge, not the bare accept-theirs call. This was the
+			// one reconcile path that skipped the tiered resolver, so it got no union
+			// tier and no LLM tier while every other path (CLI push, daemon pull,
+			// diverged fix) went through ledgerLLMResolveHook. Behind-only pulls hit
+			// exactly the same sessions/ conflicts as the others.
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			_, resolveErr := ledgerLLMResolveHook()(ctx, ledgerPath, nil)
+			cancel()
+			if resolveErr != nil {
+				slog.Debug("rebase auto-resolve failed", "error", resolveErr)
+				// AuditAndAbort: log HEAD SHA, unmerged files, and stash count
+				// before discarding rebase state so silent recovery is not
+				// invisible. See ox-ooy3 and .claude/rules/daemon-git.md.
+				abortCtx, abortCancel := context.WithTimeout(context.Background(), 15*time.Second)
+				_ = gitutil.AuditAndAbort(abortCtx, ledgerPath, gitutil.AuditOpRebase, "doctor --fix auto-resolve failed", slog.Default())
+				abortCancel()
+				result = FailedCheck("Ledger branch status",
+					"pull --rebase failed (aborted)",
+					fmt.Sprintf("Conflict during rebase (aborted to restore clean state): %s", errStr))
+				return nil
+			}
+			result = PassedCheck("Ledger branch status",
+				fmt.Sprintf("pulled %d commit(s) (auto-resolved conflicts)", behindCount))
+			return nil
 		}
-		return PassedCheck("Ledger branch status",
-			fmt.Sprintf("pulled %d commit(s) (auto-resolved conflicts)", behindCount))
+		result = PassedCheck("Ledger branch status",
+			fmt.Sprintf("pulled %d commit(s)", behindCount))
+		return nil
+	})
+	if lockErr != nil {
+		detail := lockErr.Error()
+		if gitutil.IsRepoLockBusy(lockErr) {
+			detail = "a concurrent ox process (daemon sync, another doctor run) held the ledger; try again"
+		}
+		return FailedCheck("Ledger branch status", "could not acquire ledger lock", detail)
 	}
-	return PassedCheck("Ledger branch status",
-		fmt.Sprintf("pulled %d commit(s)", behindCount))
+	return result
 }
 
 // fixLedgerBranchDiverged reconciles a diverged ledger by rebasing then pushing.
@@ -493,7 +524,10 @@ func fixLedgerBranchDiverged(ledgerPath string, aheadCount, behindCount int) che
 	// the ahead/behind counts the caller already has.
 	fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	if err := gitutil.WithRepoLock(fetchCtx, ledgerPath, func() error {
-		return exec.Command("git", "-C", ledgerPath, "fetch", "--quiet").Run()
+		// NewNetworkCmd binds the fetch to fetchCtx too, not just the lock
+		// wait — see the matching comment in the unborn-branch repair above.
+		_, err := gitutil.NewNetworkCmd(fetchCtx, "-C", ledgerPath, "fetch", "--quiet").CombinedOutput()
+		return err
 	}); err != nil {
 		slog.Debug("fetch before diverged re-check failed", "error", err)
 	}

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -466,6 +466,13 @@ func fixLedgerBranchBehind(ledgerPath string, behindCount int) checkResult {
 	lockCtx, lockCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer lockCancel()
 	lockErr := gitutil.WithRepoLock(lockCtx, ledgerPath, func() error {
+		// ADR-030 D3, applied here too: a rebase that already existed
+		// before this call's own pull is not this call's to resolve or
+		// abort — it belongs to whoever started it (a human running raw
+		// git is the one realistic case once the lock is held). Only a
+		// rebase this specific pull created is safe to touch below.
+		hadRebaseBefore := gitutil.IsRebaseInProgress(ledgerPath)
+
 		// --autostash: uncommitted local changes must not block the pull.
 		// Bounded so a hung network pull can't hold the lock forever.
 		pullCtx, pullCancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -474,6 +481,12 @@ func fixLedgerBranchBehind(ledgerPath string, behindCount int) checkResult {
 		pullCancel()
 		if err != nil {
 			errStr := strings.TrimSpace(string(output))
+			if hadRebaseBefore {
+				result = FailedCheck("Ledger branch status",
+					"pull --rebase failed",
+					fmt.Sprintf("A rebase was already in progress before this pull (not started by ox doctor --fix) — not touching it: %s", errStr))
+				return nil
+			}
 			// Route through automerge, not the bare accept-theirs call. This was the
 			// one reconcile path that skipped the tiered resolver, so it got no union
 			// tier and no LLM tier while every other path (CLI push, daemon pull,

--- a/cmd/ox/doctor_ledger_git_test.go
+++ b/cmd/ox/doctor_ledger_git_test.go
@@ -511,3 +511,40 @@ func TestFixLedgerBranchBehind_LockBusy_FailsFastInsteadOfRacing(t *testing.T) {
 	assert.Less(t, elapsed, 35*time.Second,
 		"must fail within the lock's own acquire budget (30s), not hang past it")
 }
+
+// TestFixLedgerBranchBehind_ForeignRebase_NeverTouched proves the ADR-030 D3
+// guard applies here too, not just in the daemon's pull path: a rebase that
+// already existed before this call's own `git pull --rebase` — a human
+// running raw git, since nothing else can be mid-rebase against this clone
+// once the lock is held — is not this call's to resolve or abort.
+func TestFixLedgerBranchBehind_ForeignRebase_NeverTouched(t *testing.T) {
+	barePath, machineA := createBareAndClone(t)
+	machineB := cloneBare(t, barePath)
+
+	// machineA pushes, AND machineB has an unpushed local commit: a pure
+	// fast-forward (behind but not diverged) never invokes the rebase
+	// machinery at all, so an empty rebase-merge/ would go unnoticed — git
+	// only refuses on it once there's a real rebase to attempt.
+	require.NoError(t, os.WriteFile(filepath.Join(machineA, "notes.txt"), []byte("from A"), 0644))
+	runGit(t, machineA, "add", "notes.txt")
+	runGit(t, machineA, "commit", "--no-verify", "-m", "notes from A")
+	runGit(t, machineA, "push")
+	runGit(t, machineB, "fetch")
+	require.NoError(t, os.WriteFile(filepath.Join(machineB, "local.txt"), []byte("from B"), 0644))
+	runGit(t, machineB, "add", "local.txt")
+	runGit(t, machineB, "commit", "--no-verify", "-m", "local change on B")
+
+	// Fake a foreign rebase-in-progress: enough for gitutil.IsRebaseInProgress
+	// to see it, and for git itself to refuse the pull with its own
+	// "already a rebase-merge directory" error — no real conflict needed.
+	require.NoError(t, os.MkdirAll(filepath.Join(machineB, ".git", "rebase-merge"), 0o755))
+
+	result := fixLedgerBranchBehind(machineB, 1)
+
+	assert.False(t, result.passed, "must not report success while a foreign rebase sits untouched")
+	assert.Contains(t, result.detail, "not touching it",
+		"failure must say the rebase predates this call, not read like a real conflict")
+
+	_, err := os.Stat(filepath.Join(machineB, ".git", "rebase-merge"))
+	assert.NoError(t, err, "the foreign rebase-merge directory must survive untouched — proves neither resolve nor AuditAndAbort ran")
+}

--- a/cmd/ox/doctor_ledger_git_test.go
+++ b/cmd/ox/doctor_ledger_git_test.go
@@ -3,12 +3,15 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -474,4 +477,37 @@ func TestUnbornLedger_FailedRepairStaysCritical(t *testing.T) {
 		"a failed repair must stay critical, not be demoted to the attention bucket")
 	assert.Equal(t, CheckSlugLedgerBranchStatus, res.slug,
 		"slug must survive so the failure correlates with the original check")
+}
+
+// TestFixLedgerBranchBehind_LockBusy_FailsFastInsteadOfRacing proves the
+// bd ox-baz5.1/CodeRabbit finding is fixed: fixLedgerBranchBehind used to run
+// `git pull --rebase --autostash` (plus LLM conflict resolution and abort)
+// completely outside gitutil.WithRepoLock, so it could interleave FETCH_HEAD
+// writes with a concurrent daemon sync cycle on the same clone — the exact
+// 2026-09-02 incident shape. With the lock in place, a peer holding it makes
+// this fail fast and cleanly instead of racing the peer's git operations.
+func TestFixLedgerBranchBehind_LockBusy_FailsFastInsteadOfRacing(t *testing.T) {
+	_, machineB := createBareAndClone(t)
+
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = gitutil.WithRepoLock(context.Background(), machineB, func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held
+	defer close(release)
+
+	start := time.Now()
+	result := fixLedgerBranchBehind(machineB, 1)
+	elapsed := time.Since(start)
+
+	assert.False(t, result.passed, "must not report success when the pull never ran")
+	assert.Contains(t, result.detail, "concurrent ox process",
+		"failure must explain it's lock contention, not a real git error, so a user isn't sent chasing a phantom conflict")
+	assert.Less(t, elapsed, 35*time.Second,
+		"must fail within the lock's own acquire budget (30s), not hang past it")
 }

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1474,6 +1474,14 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 		s.issues.ClearIssue(IssueTypeSyncBackoff, "ledger")
 		s.issues.ClearIssue(IssueTypeDiverged, "ledger")
 		s.issues.ClearIssue(IssueTypeSessionConflictWedge, "ledger")
+		// bd ox-baz5.3 / COE 2026-09-02: IssueTypeRebaseStuck was raised by a
+		// prior failed cycle's recovery ladder and had NO clear path — a
+		// ledger that recovered on its own next cycle kept showing `ox
+		// status` a confirm-required "stuck in a broken rebase state" error,
+		// with instructions (`git rebase --abort`) that did nothing, until
+		// the daemon was restarted. A successful pull is proof the clone is
+		// not stuck, the same evidence the other issue types above rely on.
+		s.issues.ClearIssue(IssueTypeRebaseStuck, "ledger")
 	}
 
 	duration := time.Since(startTime)

--- a/internal/daemon/sync_concurrency_test.go
+++ b/internal/daemon/sync_concurrency_test.go
@@ -103,15 +103,31 @@ func TestPullManagedRepo_ConcurrentFetchDoesNotCorruptFETCH_HEAD(t *testing.T) {
 	s := newTestScheduler(t.TempDir())
 	const iterations = 15
 	var failures []string
+	lastSkipped := false
 	for i := 0; i < iterations; i++ {
 		advanceRemote(t, writer, i)
-		res := s.pullManagedRepo(ctx, ManagedRepoPullOpts{
+		pullCtx := ctx
+		if i == iterations-1 {
+			// flock grants no fairness guarantee — the peer could in
+			// principle win the whole RepoLockTimeout window on this last
+			// call, which would report Skipped (not a failure) while
+			// leaving local genuinely behind and failing the catch-up
+			// assertions below for a reason this test doesn't intend to
+			// detect. Stop racing before the call the assertions depend on.
+			cancel()
+			<-peerDone
+			pullCtx = context.Background()
+		}
+		res := s.pullManagedRepo(pullCtx, ManagedRepoPullOpts{
 			RepoPath:     local,
 			RepoName:     "ledger",
 			SyncInterval: 0,
 			MinFetchAge:  time.Nanosecond, // the peer keeps FETCH_HEAD fresh; do not let dedup skip the pull
 			Logger:       s.logger,
 		})
+		if i == iterations-1 {
+			lastSkipped = res.Skipped
+		}
 		if res.Err != nil {
 			failures = append(failures, res.Err.Error())
 		}
@@ -119,8 +135,8 @@ func TestPullManagedRepo_ConcurrentFetchDoesNotCorruptFETCH_HEAD(t *testing.T) {
 			failures = append(failures, "issue: "+res.Issue.Summary)
 		}
 	}
-	cancel()
-	<-peerDone
+
+	assert.False(t, lastSkipped, "the final iteration must actually pull (peer is stopped by then), not skip — the catch-up assertions below only mean something if it ran")
 
 	for _, f := range failures {
 		assert.NotContains(t, f, "multiple branches", "FETCH_HEAD race reached git pull")

--- a/internal/daemon/sync_concurrency_test.go
+++ b/internal/daemon/sync_concurrency_test.go
@@ -1,0 +1,172 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// COE 2026-09-02 / ADR-030 / bd ox-baz5.1 — the FETCH_HEAD race.
+//
+// git rewrites .git/FETCH_HEAD on every fetch with no lock of its own. When
+// two fetches on one clone overlap, their appends interleave and `main`
+// appears twice as a merge-eligible head; the daemon's next
+// `git pull --rebase` then refuses with "Cannot rebase onto multiple
+// branches." Before ADR-030 D1 four ox code paths fetched the same clone
+// with nothing serializing them (daemon pull cycle, daemon wedge probe, CLI
+// status, doctor --fix). Reproduced on the real monorepo ledger: 5/5 for the
+// corrupted FETCH_HEAD, 2/6 for the failed pull.
+//
+// The failure this prevents: `ox status` run near a daemon sync cycle makes
+// ledger sync fail with an error that reads like corruption, and (bugs .2/.3)
+// leaves a red confirm-required issue on `ox status` until daemon restart.
+
+// setupRacingLedger returns a bare remote, a local clone (the ledger under
+// test) and a writer clone that advances the remote so every pull has work.
+func setupRacingLedger(t *testing.T) (bare, local, writer string) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	bare = filepath.Join(t.TempDir(), "bare.git")
+	out, err := runGitOut(t, t.TempDir(), "init", "--bare", "--initial-branch=main", bare)
+	require.NoError(t, err, out)
+
+	writer = filepath.Join(t.TempDir(), "writer")
+	out, err = runGitOut(t, t.TempDir(), "clone", "--quiet", bare, writer)
+	require.NoError(t, err, out)
+	require.NoError(t, os.WriteFile(filepath.Join(writer, "seed.txt"), []byte("seed\n"), 0o644))
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-q", "-m", "seed"}, {"push", "-q", "-u", "origin", "main"}} {
+		out, err = runGitOut(t, writer, args...)
+		require.NoError(t, err, out)
+	}
+	// a couple of extra remote branches so FETCH_HEAD carries not-for-merge
+	// lines too — the exact shape observed in production.
+	for _, b := range []string{"ryan/regen-summaries", "ryan/summary-push"} {
+		out, err = runGitOut(t, writer, "push", "-q", "origin", "main:refs/heads/"+b)
+		require.NoError(t, err, out)
+	}
+
+	local = filepath.Join(t.TempDir(), "ledger")
+	out, err = runGitOut(t, t.TempDir(), "clone", "--quiet", bare, local)
+	require.NoError(t, err, out)
+	return bare, local, writer
+}
+
+func advanceRemote(t *testing.T, writer string, n int) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(writer, fmt.Sprintf("c%03d.txt", n)), []byte("x\n"), 0o644))
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-q", "-m", fmt.Sprintf("remote %d", n)}, {"push", "-q", "origin", "main"}} {
+		out, err := runGitOut(t, writer, args...)
+		require.NoError(t, err, out)
+	}
+}
+
+// TestPullManagedRepo_ConcurrentFetchDoesNotCorruptFETCH_HEAD drives the
+// production pull pipeline while a cooperating peer (the shape of `ox status`
+// or the wedge probe after ADR-030) fetches the same clone as fast as it can.
+// Red on main: pullManagedRepo does not take the repo lock, so its internal
+// fetch races the peer's and some iteration fails with "multiple branches".
+// Green once every fetch/pull site goes through gitutil.WithRepoLock.
+func TestPullManagedRepo_ConcurrentFetchDoesNotCorruptFETCH_HEAD(t *testing.T) {
+	_, local, writer := setupRacingLedger(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// peer fetcher: the post-ADR-030 shape of every other ox fetch site.
+	peerDone := make(chan struct{})
+	go func() {
+		defer close(peerDone)
+		for ctx.Err() == nil {
+			_ = gitutil.WithRepoLock(ctx, local, func() error {
+				cmd := exec.CommandContext(ctx, "git", "-C", local, "fetch", "--quiet") // safe: git in a temp dir
+				cmd.Env = gitEnv()
+				_, _ = cmd.CombinedOutput()
+				return nil
+			})
+		}
+	}()
+
+	s := newTestScheduler(t.TempDir())
+	const iterations = 15
+	var failures []string
+	for i := 0; i < iterations; i++ {
+		advanceRemote(t, writer, i)
+		res := s.pullManagedRepo(ctx, ManagedRepoPullOpts{
+			RepoPath:     local,
+			RepoName:     "ledger",
+			SyncInterval: 0,
+			MinFetchAge:  time.Nanosecond, // the peer keeps FETCH_HEAD fresh; do not let dedup skip the pull
+			Logger:       s.logger,
+		})
+		if res.Err != nil {
+			failures = append(failures, res.Err.Error())
+		}
+		if res.Issue != nil && res.Issue.Type == IssueTypeRebaseStuck {
+			failures = append(failures, "issue: "+res.Issue.Summary)
+		}
+	}
+	cancel()
+	<-peerDone
+
+	for _, f := range failures {
+		assert.NotContains(t, f, "multiple branches", "FETCH_HEAD race reached git pull")
+		assert.NotContains(t, f, "stuck in a broken rebase", "transient race latched as a stuck rebase")
+	}
+	assert.Empty(t, failures, "pull failures under concurrent fetch: %s", strings.Join(failures, " | "))
+
+	// the clone must actually have kept up — this is not a test that passes by skipping.
+	out, err := runGitOut(t, local, "rev-list", "--count", "origin/main..main")
+	require.NoError(t, err, out)
+	assert.Equal(t, "0", strings.TrimSpace(out), "local should have no unpushed commits")
+	out, err = runGitOut(t, local, "rev-list", "--count", "main..origin/main")
+	require.NoError(t, err, out)
+	assert.Equal(t, "0", strings.TrimSpace(out), "local should be caught up with the remote after the last pull")
+}
+
+// TestDoPull_ClearsRebaseStuckOnSuccess — bd ox-baz5.3. IssueTypeRebaseStuck
+// was raised on a failed cycle and never cleared: the ledger recovered on the
+// next cycle while `ox status` kept telling the user to run `git rebase
+// --abort` until the daemon restarted. A successful pull must clear it, the
+// same way it already clears MergeConflict / SyncBackoff / Diverged.
+func TestDoPull_ClearsRebaseStuckOnSuccess(t *testing.T) {
+	// Fixture must leave the local clone genuinely BEHIND origin: doPull's
+	// success path (where the clearing lives) is only reached past
+	// pullManagedRepo's remoteRefCheck dedup, which short-circuits to a
+	// no-op "Skipped" result — and skips clearing — whenever local HEAD
+	// already matches the remote (setupGitRepo's fixture, used as-is,
+	// always does).
+	_, ledgerDir, writer := setupRacingLedger(t)
+	advanceRemote(t, writer, 0)
+
+	cfg := DefaultConfig()
+	cfg.LedgerPath = ledgerDir
+	cfg.SyncIntervalRead = time.Second
+	scheduler := NewSyncScheduler(cfg, newTestScheduler(t.TempDir()).logger)
+	tracker := NewIssueTracker()
+	scheduler.SetIssueTracker(tracker)
+
+	// the latched state from a previous, failed cycle
+	tracker.SetIssue(DaemonIssue{Type: IssueTypeRebaseStuck, Severity: SeverityError, Repo: "ledger", Summary: "ledger is stuck in a broken rebase state", RequiresConfirm: true})
+	tracker.SetIssue(DaemonIssue{Type: IssueTypeSyncBackoff, Severity: SeverityWarning, Repo: "ledger", Summary: "Sync suspended after 1 consecutive failures"})
+
+	require.NoError(t, scheduler.doPull(context.Background(), nil, false, true))
+
+	_, stuck := tracker.GetIssue(IssueTypeRebaseStuck, "ledger")
+	assert.False(t, stuck, "a successful pull must clear the stale rebase-stuck error")
+	_, backoff := tracker.GetIssue(IssueTypeSyncBackoff, "ledger")
+	assert.False(t, backoff, "a successful pull must clear the stale sync-suspended warning")
+}

--- a/internal/daemon/sync_gc.go
+++ b/internal/daemon/sync_gc.go
@@ -136,10 +136,16 @@ func (s *SyncScheduler) checkAndRunGC(ctx context.Context) {
 			wedged := false
 			var wedgeAge time.Duration
 			if !intervalExceeded && !fullClone && wedgeCooldownElapsed {
-				wedged, wedgeAge, _ = s.ledgerSyncWedged(ctx, l.Path)
-				s.mu.Lock()
-				s.lastWedgeCheck = time.Now()
-				s.mu.Unlock()
+				var lockBusy bool
+				wedged, wedgeAge, _, lockBusy = s.ledgerSyncWedged(ctx, l.Path)
+				// A lock-busy result means no check actually ran — spending
+				// the cooldown on it would let frequent contention from the
+				// daemon's own sync cycle silently disable wedge detection.
+				if !lockBusy {
+					s.mu.Lock()
+					s.lastWedgeCheck = time.Now()
+					s.mu.Unlock()
+				}
 			}
 
 			if intervalExceeded || fullClone || wedged {
@@ -254,10 +260,10 @@ const ledgerGCWedgeCooldown = 6 * time.Hour
 // multi-hour incident. Confirmed via a live fetch so a merely-offline
 // machine, an explicitly supported normal state, is never mistaken for
 // wedged.
-func (s *SyncScheduler) ledgerSyncWedged(ctx context.Context, path string) (wedged bool, oldestUnpushedAge time.Duration, unpushedCount int) {
+func (s *SyncScheduler) ledgerSyncWedged(ctx context.Context, path string) (wedged bool, oldestUnpushedAge time.Duration, unpushedCount int, lockBusy bool) {
 	ahead, err := revListCount(ctx, path, "@{upstream}..HEAD", "origin/main..HEAD")
 	if err != nil || ahead <= 0 {
-		return false, 0, 0
+		return false, 0, 0, false
 	}
 
 	// bounded fetch to confirm we're actually online before concluding
@@ -273,14 +279,19 @@ func (s *SyncScheduler) ledgerSyncWedged(ctx context.Context, path string) (wedg
 		return err
 	})
 	if fetchErr != nil {
-		return false, 0, ahead
+		// A lock held by a concurrent ox process (the sync scheduler's own
+		// pull cycle, most likely, since this probe now shares its lock)
+		// is NOT the same signal as offline: the caller must not spend the
+		// 6h cooldown on a cycle where no check actually happened, or
+		// frequent lock contention could starve this detector indefinitely.
+		return false, 0, ahead, gitutil.IsRepoLockBusy(fetchErr)
 	}
 
 	behind, err := revListCount(ctx, path, "HEAD..@{upstream}", "HEAD..origin/main")
 	if err != nil || behind <= 0 {
 		// ahead only, not behind — a plain push (gcPushUnpushedCommits)
 		// resolves this; not wedged.
-		return false, 0, ahead
+		return false, 0, ahead, false
 	}
 
 	oldestOutput, err := gitutil.RunGit(ctx, path, "log", "@{upstream}..HEAD", "--format=%ct")
@@ -288,20 +299,20 @@ func (s *SyncScheduler) ledgerSyncWedged(ctx context.Context, path string) (wedg
 		oldestOutput, err = gitutil.RunGit(ctx, path, "log", "origin/main..HEAD", "--format=%ct")
 	}
 	if err != nil {
-		return false, 0, ahead
+		return false, 0, ahead, false
 	}
 	timestamps := strings.Fields(strings.TrimSpace(oldestOutput))
 	if len(timestamps) == 0 {
-		return false, 0, ahead
+		return false, 0, ahead, false
 	}
 	// git log lists newest-first; the last line is the oldest unpushed commit.
 	oldestUnix, err := strconv.ParseInt(timestamps[len(timestamps)-1], 10, 64)
 	if err != nil {
-		return false, 0, ahead
+		return false, 0, ahead, false
 	}
 
 	age := time.Since(time.Unix(oldestUnix, 0))
-	return age >= ledgerSyncWedgeAge, age, ahead
+	return age >= ledgerSyncWedgeAge, age, ahead, false
 }
 
 // revListCount runs `git rev-list --count <range>`, falling back to

--- a/internal/daemon/sync_gc.go
+++ b/internal/daemon/sync_gc.go
@@ -261,8 +261,18 @@ func (s *SyncScheduler) ledgerSyncWedged(ctx context.Context, path string) (wedg
 	}
 
 	// bounded fetch to confirm we're actually online before concluding
-	// wedged — a fetch failure means offline, not stuck.
-	if _, err := gitutil.NewNetworkCmd(ctx, "-C", path, "fetch", "--quiet").CombinedOutput(); err != nil {
+	// wedged — a fetch failure means offline, not stuck. Locked (ADR-030
+	// D1): this probe runs on its own schedule, concurrently with the
+	// regular sync scheduler pull cycle in the SAME daemon process, so
+	// without the per-clone lock its fetch could interleave with the pull
+	// cycle's and corrupt FETCH_HEAD exactly like the 2026-09-02 incident.
+	// A lock-busy result is treated the same as offline: not confirmed, not
+	// wedged, retry next cycle.
+	fetchErr := gitutil.WithRepoLock(ctx, path, func() error {
+		_, err := gitutil.NewNetworkCmd(ctx, "-C", path, "fetch", "--quiet").CombinedOutput()
+		return err
+	})
+	if fetchErr != nil {
 		return false, 0, ahead
 	}
 

--- a/internal/daemon/sync_gc_wedge_test.go
+++ b/internal/daemon/sync_gc_wedge_test.go
@@ -38,7 +38,7 @@ func TestLedgerSyncWedged_FreshUnpushedCommit_NotWedged(t *testing.T) {
 	require.NoError(t, exec.Command("git", "-C", cloneDir, "add", "-A").Run())
 	require.NoError(t, exec.Command("git", "-C", cloneDir, "commit", "-m", "unpushed").Run())
 
-	wedged, _, count := s.ledgerSyncWedged(context.Background(), cloneDir)
+	wedged, _, count, _ := s.ledgerSyncWedged(context.Background(), cloneDir)
 	assert.False(t, wedged, "a fresh unpushed commit is not a wedge — normal push/pull will resolve it")
 	assert.Equal(t, 1, count)
 }
@@ -58,7 +58,7 @@ func TestLedgerSyncWedged_AheadOnly_NotWedged(t *testing.T) {
 	require.NoError(t, exec.Command("git", "-C", cloneDir, "commit", "-m", "unpushed").Run())
 	backdateCommitTimestamp(t, cloneDir, -4*time.Hour)
 
-	wedged, _, _ := s.ledgerSyncWedged(context.Background(), cloneDir)
+	wedged, _, _, _ := s.ledgerSyncWedged(context.Background(), cloneDir)
 	assert.False(t, wedged, "ahead-only, never behind, must not be wedged regardless of age")
 }
 
@@ -81,7 +81,7 @@ func TestLedgerSyncWedged_BehindOnly_NotWedged(t *testing.T) {
 	require.NoError(t, exec.Command("git", "-C", otherDir, "commit", "-m", "remote advance").Run())
 	require.NoError(t, exec.Command("git", "-C", otherDir, "push", "origin", "HEAD:main").Run())
 
-	wedged, _, _ := s.ledgerSyncWedged(context.Background(), cloneDir)
+	wedged, _, _, _ := s.ledgerSyncWedged(context.Background(), cloneDir)
 	assert.False(t, wedged, "behind-only (never ahead) must not be wedged — a plain pull resolves it")
 }
 
@@ -96,7 +96,7 @@ func TestLedgerSyncWedged_GenuinelyWedged_DetectsAfterAgeThreshold(t *testing.T)
 	diverge(t, bareDir, cloneDir, "local.txt", "remote.txt")
 
 	// too young: must not be wedged yet even though ahead+behind
-	wedged, age, count := s.ledgerSyncWedged(context.Background(), cloneDir)
+	wedged, age, count, _ := s.ledgerSyncWedged(context.Background(), cloneDir)
 	assert.False(t, wedged, "ahead+behind but younger than ledgerSyncWedgeAge must not be wedged yet")
 	assert.Equal(t, 1, count)
 	assert.Less(t, age, ledgerSyncWedgeAge)
@@ -104,7 +104,7 @@ func TestLedgerSyncWedged_GenuinelyWedged_DetectsAfterAgeThreshold(t *testing.T)
 	// backdate the local commit past the threshold
 	backdateCommitTimestamp(t, cloneDir, -4*time.Hour)
 
-	wedged, age, count = s.ledgerSyncWedged(context.Background(), cloneDir)
+	wedged, age, count, _ = s.ledgerSyncWedged(context.Background(), cloneDir)
 	assert.True(t, wedged, "ahead+behind older than ledgerSyncWedgeAge must be detected as wedged")
 	assert.GreaterOrEqual(t, age, ledgerSyncWedgeAge)
 	assert.Equal(t, 1, count)
@@ -126,8 +126,9 @@ func TestLedgerSyncWedged_Offline_NotWedged(t *testing.T) {
 	// point origin at a nonexistent path so fetch fails
 	require.NoError(t, exec.Command("git", "-C", cloneDir, "remote", "set-url", "origin", "/nonexistent/repo.git").Run())
 
-	wedged, _, _ := s.ledgerSyncWedged(context.Background(), cloneDir)
+	wedged, _, _, lockBusy := s.ledgerSyncWedged(context.Background(), cloneDir)
 	assert.False(t, wedged, "a fetch failure (offline) must not be classified as wedged")
+	assert.False(t, lockBusy, "a genuine offline fetch failure is not lock contention")
 }
 
 // diverge makes cloneDir simultaneously ahead (one unpushed local commit
@@ -757,7 +758,7 @@ func TestCheckAndRunGC_WedgeTrigger_ClearsSessionConflictIssueOnPlainSuccess(t *
 	// sanity check: confirm the fixture is genuinely wedged per the same
 	// heuristic checkAndRunGC itself calls, and that the net diff really is
 	// empty (the whole point of this fixture).
-	wedged, age, count := s.ledgerSyncWedged(context.Background(), ledgerDir)
+	wedged, age, count, _ := s.ledgerSyncWedged(context.Background(), ledgerDir)
 	require.True(t, wedged, "fixture must be genuinely wedged (ahead+behind, old enough)")
 	require.GreaterOrEqual(t, age, ledgerSyncWedgeAge)
 	require.Equal(t, 2, count)
@@ -797,4 +798,45 @@ func TestCheckAndRunGC_WedgeTrigger_ClearsSessionConflictIssueOnPlainSuccess(t *
 	_, stillPresent := tracker.GetIssue(IssueTypeSessionConflictWedge, "ledger")
 	assert.False(t, stillPresent,
 		"a successful GC that resolves a detected wedge must clear the session-conflict-wedge issue via checkAndRunGC's dispatch-level switch, even when recovered=false (nothing needed capturing)")
+}
+
+// TestLedgerSyncWedged_LockBusy_DoesNotClaimConfirmed proves the caller can
+// tell "no check ran because a peer held the repo lock" apart from "checked,
+// genuinely not wedged" — checkAndRunGC uses this to avoid spending the 6h
+// wedge-check cooldown on a cycle where nothing was actually verified. Before
+// this, a lock held by the daemon's own concurrent sync cycle (now common,
+// since ADR-030 serializes every fetch on the clone) would silently disable
+// wedge detection for up to ledgerGCWedgeCooldown with no signal that it had
+// happened.
+func TestLedgerSyncWedged_LockBusy_DoesNotClaimConfirmed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	bareDir, cloneDir := gcInitBareAndClone(t, t.TempDir())
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, "new.txt"), []byte("x"), 0o644))
+	require.NoError(t, exec.Command("git", "-C", cloneDir, "add", "-A").Run())
+	require.NoError(t, exec.Command("git", "-C", cloneDir, "commit", "-m", "unpushed").Run())
+	_ = bareDir
+
+	s := newTestScheduler(t.TempDir())
+
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = gitutil.WithRepoLock(context.Background(), cloneDir, func() error {
+			close(held)
+			<-release
+			return nil
+		})
+	}()
+	<-held
+	defer close(release)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	wedged, _, unpushedCount, lockBusy := s.ledgerSyncWedged(ctx, cloneDir)
+
+	assert.False(t, wedged, "a lock-busy result must never be reported as wedged")
+	assert.True(t, lockBusy, "a peer holding the repo lock must be distinguishable from a genuine offline fetch failure")
+	assert.Equal(t, 1, unpushedCount, "ahead-count is still known even when the confirming fetch couldn't run")
 }

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -108,7 +108,19 @@ const (
 	// skipReasonRemoteUnchanged / skipReasonRecentlyFetched: already current.
 	skipReasonRemoteUnchanged = "remote unchanged"
 	skipReasonRecentlyFetched = "recently fetched"
+	// skipReasonRepoLockBusy: another ox process (daemon goroutine or CLI)
+	// holds gitutil's per-clone lock past our wait budget. The clone is
+	// healthy — just in use — so this resolves itself next cycle. ADR-030.
+	skipReasonRepoLockBusy = "repo lock busy"
 )
+
+// fetchHeadRaceSignature is the (version-stable, prefix/suffix-agnostic)
+// substring of git's error when FETCH_HEAD carries more than one
+// merge-eligible head — the "two fetches interleaved" corruption ADR-030
+// closes with a per-clone lock. Matched against pull output so a transient
+// hit can be retried once instead of treated as a real conflict. See the
+// 2026-09-02 COE for the reproduction.
+const fetchHeadRaceSignature = "Cannot rebase onto multiple branches"
 
 // ManagedRepoPullResult describes what happened during pullManagedRepo.
 type ManagedRepoPullResult struct {
@@ -238,88 +250,155 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 		}
 	}
 
-	// --- Fetch ---
+	// --- Fetch + pull, serialized per clone ---
+	//
+	// ADR-030 D1: every mutating git operation on a managed clone runs
+	// inside gitutil.WithRepoLock so this pull cycle, the daemon's GC/wedge
+	// probe, a concurrent doctor pass, and any CLI invocation (ox status,
+	// ox doctor --fix) can never interleave a fetch or a rebase against the
+	// SAME clone. That interleaving is what corrupted FETCH_HEAD and
+	// produced "Cannot rebase onto multiple branches" in the 2026-09-02
+	// incident (COE: docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md).
+	var result ManagedRepoPullResult
+	lockErr := gitutil.WithRepoLock(ctx, path, func() error {
+		result = s.fetchAndPullLocked(ctx, opts, path, repoName, logger)
+		return nil
+	})
+	if lockErr != nil {
+		if gitutil.IsRepoLockBusy(lockErr) {
+			logger.Debug("repo locked by a concurrent ox process, skipping this cycle", "path", path, "error", lockErr)
+			return ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRepoLockBusy}
+		}
+		return ManagedRepoPullResult{Err: fmt.Errorf("acquire repo lock for %s: %w", repoName, lockErr)}
+	}
+	return result
+}
 
+// fetchAndPullLocked runs the fetch-then-pull sequence for pullManagedRepo.
+// The caller MUST already hold gitutil.WithRepoLock(path) — this method
+// performs no locking of its own and must not be called re-entrantly for
+// the same clone.
+func (s *SyncScheduler) fetchAndPullLocked(ctx context.Context, opts ManagedRepoPullOpts, path, repoName string, logger *slog.Logger) ManagedRepoPullResult {
 	// Refresh remote URL if credentials changed
 	projectEndpoint := endpoint.GetForProject(opts.ProjectRoot)
 	if err := gitserver.RefreshRemoteCredentials(path, projectEndpoint); err != nil {
 		logger.Warn("remote credential refresh failed", "path", path, "error", err)
 	}
 
-	// git fetch
-	fetchCtx, fetchSpan := perf.Start(ctx, "git_fetch")
-	fetchArgs := append([]string{"-C", path}, gitHTTPTimeoutFlags()...)
-	fetchArgs = append(fetchArgs, "fetch", "--quiet")
-	// NewNetworkCmd disables the credential prompt so a lapsed PAT fails fast
-	// instead of hanging the daemon's background sync cycle on a TTY-less prompt.
-	fetchCmd := gitutil.NewNetworkCmd(fetchCtx, fetchArgs...)
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
-		perf.RecordError(fetchSpan, err)
+	// ADR-030 D2: a pull that fails purely because two fetches interleaved
+	// (fetchHeadRaceSignature) is retried once — under the same lock, so
+	// the second fetch cannot race anything — before it is ever treated as
+	// a conflict. Any other failure, or a retry that hits the same wall,
+	// falls straight through to the ladder below on its final attempt.
+	const maxFetchPullAttempts = 2
+	var (
+		fetchHeadTime time.Time
+		diverged      bool
+		pullOutput    []byte
+		pullErr       error
+	)
+	for attempt := 1; attempt <= maxFetchPullAttempts; attempt++ {
+		// git fetch
+		fetchCtx, fetchSpan := perf.Start(ctx, "git_fetch")
+		fetchArgs := append([]string{"-C", path}, gitHTTPTimeoutFlags()...)
+		fetchArgs = append(fetchArgs, "fetch", "--quiet")
+		// NewNetworkCmd disables the credential prompt so a lapsed PAT fails fast
+		// instead of hanging the daemon's background sync cycle on a TTY-less prompt.
+		fetchCmd := gitutil.NewNetworkCmd(fetchCtx, fetchArgs...)
+		if output, err := fetchCmd.CombinedOutput(); err != nil {
+			perf.RecordError(fetchSpan, err)
+			fetchSpan.End()
+			detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
+			errMsg := "fetch failed"
+			if detail != "" {
+				errMsg = fmt.Sprintf("fetch failed: %s", detail)
+			}
+			return ManagedRepoPullResult{Err: fmt.Errorf("%s: %w", errMsg, err)}
+		}
 		fetchSpan.End()
-		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
-		errMsg := "fetch failed"
-		if detail != "" {
-			errMsg = fmt.Sprintf("fetch failed: %s", detail)
+
+		// Track FETCH_HEAD mtime
+		if info, err := os.Stat(filepath.Join(path, ".git", "FETCH_HEAD")); err == nil {
+			fetchHeadTime = info.ModTime().UTC()
+			s.recordRemoteChange(path, fetchHeadTime)
 		}
-		return ManagedRepoPullResult{Err: fmt.Errorf("%s: %w", errMsg, err)}
-	}
-	fetchSpan.End()
 
-	// Track FETCH_HEAD mtime
-	var fetchHeadTime time.Time
-	if info, err := os.Stat(filepath.Join(path, ".git", "FETCH_HEAD")); err == nil {
-		fetchHeadTime = info.ModTime().UTC()
-		s.recordRemoteChange(path, fetchHeadTime)
-	}
-
-	// --- Divergence detection ---
-	result := ManagedRepoPullResult{FetchHeadTime: fetchHeadTime}
-
-	if opts.DetectDivergence {
-		if detectDivergedBranchesAt(ctx, path) {
+		// --- Divergence detection ---
+		diverged = false
+		if opts.DetectDivergence && detectDivergedBranchesAt(ctx, path) {
 			logger.Info("branches diverged, rebasing to reconcile", "repo", repoName)
-			result.Diverged = true
+			diverged = true
 		}
-	}
 
-	// --- Pull pre-flight: ensure shared KB merge=union rules ---
-	//
-	// Applies to both ledger AND team-context repos: they're both
-	// multi-writer KB-style clones (server seed + CLI seed + multiple
-	// coworker writes) and have the same wedge failure mode on
-	// concurrent writes to root metadata files. Without this rule,
-	// add/add or content/content collisions on AGENTS.md / CLAUDE.md /
-	// README.md / SOUL.md etc. halt the rebase and surface as "diverged
-	// from remote" errors that require manual intervention.
-	//
-	// kb.EnsureMergeAttributes writes per-clone .git/info/attributes
-	// (no working-tree artifact); idempotent, atomic, safe to call on
-	// every pull cycle.
-	//
-	// Best-effort: failure here is degraded mode (rebases may wedge),
-	// not a pull failure. Logged at warn level so an operator can spot
-	// a permission/IO issue.
-	if opts.EnsureKBMergeAttrs {
-		if changed, ensureErr := kb.EnsureMergeAttributes(path); ensureErr != nil {
-			logger.Warn("ensure merge attributes failed", "repo", repoName, "error", ensureErr)
-		} else if changed {
-			logger.Info("healed kb merge attributes (auto-repair pre-flight)", "repo", repoName)
+		// --- Pull pre-flight: ensure shared KB merge=union rules ---
+		//
+		// Applies to both ledger AND team-context repos: they're both
+		// multi-writer KB-style clones (server seed + CLI seed + multiple
+		// coworker writes) and have the same wedge failure mode on
+		// concurrent writes to root metadata files. Without this rule,
+		// add/add or content/content collisions on AGENTS.md / CLAUDE.md /
+		// README.md / SOUL.md etc. halt the rebase and surface as "diverged
+		// from remote" errors that require manual intervention.
+		//
+		// kb.EnsureMergeAttributes writes per-clone .git/info/attributes
+		// (no working-tree artifact); idempotent, atomic, safe to call on
+		// every pull cycle.
+		//
+		// Best-effort: failure here is degraded mode (rebases may wedge),
+		// not a pull failure. Logged at warn level so an operator can spot
+		// a permission/IO issue.
+		if opts.EnsureKBMergeAttrs {
+			if changed, ensureErr := kb.EnsureMergeAttributes(path); ensureErr != nil {
+				logger.Warn("ensure merge attributes failed", "repo", repoName, "error", ensureErr)
+			} else if changed {
+				logger.Info("healed kb merge attributes (auto-repair pre-flight)", "repo", repoName)
+			}
 		}
+
+		// ADR-030 D3: never run `pull --rebase` on top of a rebase this
+		// call did not start. Under the repo lock nothing else can be
+		// mid-pull against this clone, so in the normal case this is
+		// false — recoverPreexistingRebase already handled anything that
+		// predates this cycle. It stays as defense in depth for a writer
+		// outside the lock (a human running raw git, or a not-yet-locked
+		// ox path): skip rather than touch state that isn't this call's
+		// to recover, exactly the failure mode that collided on
+		// index.lock in the 2026-09-02 incident.
+		if gitutil.IsRebaseInProgress(path) {
+			logger.Warn("rebase already in progress before pull, not started by this call — skipping", "path", path, "repo", repoName)
+			return ManagedRepoPullResult{FetchHeadTime: fetchHeadTime, Diverged: diverged, Skipped: true, SkipReason: skipReasonRebaseInProgress}
+		}
+
+		// --- Pull ---
+		_, pullSpan := perf.Start(ctx, "git_pull_rebase")
+		pullArgs := append([]string{"-C", path}, gitHTTPTimeoutFlags()...)
+		pullArgs = append(pullArgs, "pull", "--rebase", "--autostash", "--quiet")
+		pullCmd := gitutil.NewNetworkCmd(ctx, pullArgs...)
+		pullOutput, pullErr = pullCmd.CombinedOutput()
+		if pullErr != nil {
+			perf.RecordError(pullSpan, pullErr)
+		}
+		pullSpan.End()
+
+		if pullErr == nil {
+			break
+		}
+		if attempt < maxFetchPullAttempts && strings.Contains(string(pullOutput), fetchHeadRaceSignature) {
+			logger.Warn("FETCH_HEAD race detected (interleaved fetch), re-fetching and retrying once",
+				"repo", repoName, "attempt", attempt)
+			continue
+		}
+		break
 	}
 
-	// --- Pull ---
-
-	_, pullSpan := perf.Start(ctx, "git_pull_rebase")
-	pullArgs := append([]string{"-C", path}, gitHTTPTimeoutFlags()...)
-	pullArgs = append(pullArgs, "pull", "--rebase", "--autostash", "--quiet")
-	pullCmd := gitutil.NewNetworkCmd(ctx, pullArgs...)
-	output, err := pullCmd.CombinedOutput()
-	if err != nil {
-		perf.RecordError(pullSpan, err)
+	result := ManagedRepoPullResult{FetchHeadTime: fetchHeadTime, Diverged: diverged}
+	if pullErr == nil {
+		return result
 	}
-	pullSpan.End()
-	if err != nil {
-		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
+
+	{
+		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(pullOutput)))
+		err := pullErr
 		logger.Warn("pull failed", "error", err, "output", detail, "repo", repoName)
 
 		// Try auto-resolving conflicts in safe paths before giving up
@@ -438,8 +517,6 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 		result.Err = fmt.Errorf("%s: %w", errMsg, err)
 		return result
 	}
-
-	return result
 }
 
 // sessionConflictPaths returns the subset of unmerged (conflicted) paths

--- a/internal/daemon/sync_team.go
+++ b/internal/daemon/sync_team.go
@@ -263,22 +263,15 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 		s.workspaceRegistry.ClearWorkspaceError(r.ws.ID)
 		s.workspaceRegistry.ClearSyncFailures(r.ws.ID)
 		if s.issues != nil {
-			// IssueTypeSyncBackoff is set by shouldSyncOrBypass(ws.ID, ...)
-			// — keyed on ws.ID. IssueTypeRebaseStuck is set inside
-			// pullManagedRepo/pullTeamContext on repoName :=
-			// filepath.Base(ws.Path) (ManagedRepoPullOpts.RepoName) — a
-			// DIFFERENT key. They read alike but are not interchangeable:
-			// the two happen to coincide for a well-formed team ID
-			// (paths.TeamContextDir joins the team dir on the sanitized
-			// ID), but clearing on the wrong one would silently no-op —
-			// exactly the class of bug this fix exists to close. Each
-			// clear uses the key its issue was actually set with.
+			// Keyed on ws.ID because that's what shouldSyncOrBypass(ws.ID,
+			// ...) actually set it with — NOT the same key pullTeamContext
+			// uses for its own repo-scoped issues (repoName :=
+			// filepath.Base(path)). The two read alike but are set by
+			// different code with different keys; pullManagedRepo-raised
+			// issues (GitLock, MergeConflict, Diverged, RebaseStuck) are
+			// cleared inside pullTeamContext instead, next to where they're
+			// raised, so the key is never re-derived or guessed here.
 			s.issues.ClearIssue(IssueTypeSyncBackoff, r.ws.ID)
-			// bd ox-baz5.3: team-context clones go through the same
-			// pullManagedRepo recovery ladder as the ledger and can raise
-			// the same stuck-rebase issue; a successful pull clears it here
-			// too. See the matching comment in sync.go's doPull.
-			s.issues.ClearIssue(IssueTypeRebaseStuck, filepath.Base(r.ws.Path))
 		}
 
 		mCfg := s.applySparseCheckout(ctx, r.ws.Path)
@@ -508,10 +501,15 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 		s.issues.ClearIssue(IssueTypeGitLock, repoName)
 	}
 
-	// sync succeeded - clear merge conflict and diverged issues
+	// sync succeeded - clear merge conflict, diverged, and stuck-rebase issues
 	if s.issues != nil {
 		s.issues.ClearIssue(IssueTypeMergeConflict, repoName)
 		s.issues.ClearIssue(IssueTypeDiverged, repoName)
+		// bd ox-baz5.3: team-context clones go through the same
+		// pullManagedRepo recovery ladder as the ledger and can raise the
+		// same stuck-rebase issue, keyed on this same repoName
+		// (ManagedRepoPullOpts.RepoName above). See sync.go's doPull.
+		s.issues.ClearIssue(IssueTypeRebaseStuck, repoName)
 	}
 
 	return nil

--- a/internal/daemon/sync_team.go
+++ b/internal/daemon/sync_team.go
@@ -263,12 +263,22 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 		s.workspaceRegistry.ClearWorkspaceError(r.ws.ID)
 		s.workspaceRegistry.ClearSyncFailures(r.ws.ID)
 		if s.issues != nil {
+			// IssueTypeSyncBackoff is set by shouldSyncOrBypass(ws.ID, ...)
+			// — keyed on ws.ID. IssueTypeRebaseStuck is set inside
+			// pullManagedRepo/pullTeamContext on repoName :=
+			// filepath.Base(ws.Path) (ManagedRepoPullOpts.RepoName) — a
+			// DIFFERENT key. They read alike but are not interchangeable:
+			// the two happen to coincide for a well-formed team ID
+			// (paths.TeamContextDir joins the team dir on the sanitized
+			// ID), but clearing on the wrong one would silently no-op —
+			// exactly the class of bug this fix exists to close. Each
+			// clear uses the key its issue was actually set with.
 			s.issues.ClearIssue(IssueTypeSyncBackoff, r.ws.ID)
 			// bd ox-baz5.3: team-context clones go through the same
 			// pullManagedRepo recovery ladder as the ledger and can raise
 			// the same stuck-rebase issue; a successful pull clears it here
 			// too. See the matching comment in sync.go's doPull.
-			s.issues.ClearIssue(IssueTypeRebaseStuck, r.ws.ID)
+			s.issues.ClearIssue(IssueTypeRebaseStuck, filepath.Base(r.ws.Path))
 		}
 
 		mCfg := s.applySparseCheckout(ctx, r.ws.Path)

--- a/internal/daemon/sync_team.go
+++ b/internal/daemon/sync_team.go
@@ -264,6 +264,11 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 		s.workspaceRegistry.ClearSyncFailures(r.ws.ID)
 		if s.issues != nil {
 			s.issues.ClearIssue(IssueTypeSyncBackoff, r.ws.ID)
+			// bd ox-baz5.3: team-context clones go through the same
+			// pullManagedRepo recovery ladder as the ledger and can raise
+			// the same stuck-rebase issue; a successful pull clears it here
+			// too. See the matching comment in sync.go's doPull.
+			s.issues.ClearIssue(IssueTypeRebaseStuck, r.ws.ID)
 		}
 
 		mCfg := s.applySparseCheckout(ctx, r.ws.Path)

--- a/internal/fileutil/flock.go
+++ b/internal/fileutil/flock.go
@@ -45,10 +45,17 @@ const LockPollInterval = 25 * time.Millisecond
 
 // ErrLockTimeout is returned by WithFileLock when LockTimeout elapses
 // without acquiring the lock.
-type ErrLockTimeout struct{ Path string }
+type ErrLockTimeout struct {
+	Path    string
+	Timeout time.Duration
+}
 
 func (e *ErrLockTimeout) Error() string {
-	return fmt.Sprintf("acquire advisory lock %q: timed out after %s", e.Path, LockTimeout)
+	timeout := e.Timeout
+	if timeout == 0 {
+		timeout = LockTimeout
+	}
+	return fmt.Sprintf("acquire advisory lock %q: timed out after %s", e.Path, timeout)
 }
 
 // LockPath returns the canonical advisory-lock sidecar path for a target
@@ -117,18 +124,34 @@ func lockDir() string {
 // inProcessLocks, so two goroutines in the same binary are safe even
 // if cross-process locking is a no-op.
 func WithFileLock(ctx context.Context, targetPath string, fn func() error) error {
+	return WithFileLockTimeout(ctx, targetPath, LockTimeout, fn)
+}
+
+// WithFileLockTimeout is WithFileLock with a caller-chosen acquire deadline.
+// The default LockTimeout is sized for millisecond read-modify-writes; a
+// caller serializing something that legitimately runs for seconds or
+// minutes (a git fetch/pull on a managed clone — see gitutil.WithRepoLock)
+// needs a longer wait so a legitimately busy peer is not mistaken for a
+// stuck one.
+func WithFileLockTimeout(ctx context.Context, targetPath string, timeout time.Duration, fn func() error) error {
 	lockPath := LockPath(targetPath)
+	deadline := time.Now().Add(timeout)
 
 	// lockDir() creates the parent on first call; nothing else to
 	// pre-flight here — OpenFile below will surface any real error.
 
-	// In-process serialization first. Two goroutines in the same
-	// process trying to flock the same FD do NOT block each other on
-	// some POSIX implementations (flock-by-FD vs flock-by-inode
-	// semantics differ across kernels). We avoid the corner case by
-	// gating on a process-wide named mutex keyed by the lock path.
-	relock := acquireInProcess(lockPath)
-	defer relock()
+	// In-process serialization first, bounded by the SAME ctx/deadline as
+	// the cross-process flock below — see acquireInProcess's doc comment
+	// for why this must be interruptible rather than a plain mu.Lock().
+	// Two goroutines in the same process trying to flock the same FD do
+	// NOT block each other on some POSIX implementations (flock-by-FD vs
+	// flock-by-inode semantics differ across kernels); this gate closes
+	// that loophole.
+	release, err := acquireInProcess(ctx, lockPath, deadline)
+	if err != nil {
+		return err
+	}
+	defer release()
 
 	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
@@ -136,13 +159,12 @@ func WithFileLock(ctx context.Context, targetPath string, fn func() error) error
 	}
 	defer f.Close()
 
-	deadline := time.Now().Add(LockTimeout)
 	for {
 		if err := tryFlock(f); err == nil {
 			break
 		}
 		if time.Now().After(deadline) {
-			return &ErrLockTimeout{Path: lockPath}
+			return &ErrLockTimeout{Path: lockPath, Timeout: timeout}
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/fileutil/flock_inprocess.go
+++ b/internal/fileutil/flock_inprocess.go
@@ -1,38 +1,77 @@
 package fileutil
 
-import "sync"
+import (
+	"context"
+	"sync"
+	"time"
+)
 
-// inProcessLocks is a process-wide map of lock-path → mutex. It exists
-// because POSIX flock semantics differ across kernels for two goroutines
-// in the SAME process opening the SAME lock file: on some platforms the
-// second open inherits the lock and tryFlock succeeds spuriously. The
-// in-process mutex closes that loophole so two goroutines in the same
-// binary can't both believe they hold the lock.
+// inProcessLocks is a process-wide map of lock-path -> a 1-buffered
+// channel acting as a mutex. It exists because POSIX flock semantics
+// differ across kernels for two goroutines in the SAME process opening
+// the SAME lock file: on some platforms the second open inherits the
+// lock and tryFlock succeeds spuriously. The in-process gate closes
+// that loophole so two goroutines in the same binary can't both believe
+// they hold the lock.
+//
+// A channel, not a sync.Mutex: WithFileLockTimeout's callers pass a
+// context and a timeout that must bound the ENTIRE wait, including the
+// in-process leg. A plain mu.Lock() cannot be interrupted, so two
+// goroutines in the same process contending on a long-held lock (a git
+// fetch/pull via gitutil.WithRepoLock, which can legitimately run tens
+// of seconds — see ADR-030) would ignore both ctx cancellation and the
+// caller's timeout and block forever behind a same-process peer. That
+// gap is real: two of ADR-030's four lock sites (the daemon's sync
+// scheduler pull cycle and its GC/wedge probe) run as goroutines in the
+// SAME daemon process, not separate processes, so in-process contention
+// on a repo lock is an expected, not a corner, case.
 //
 // Keyed by the absolute lock path. Cleared lazily — entries don't get
-// removed when no one is contending, but the memory cost is one
-// sync.Mutex per locked path, which is fine for the bounded set of
-// shared files in ox (meta.json per session, config.local.toml,
-// AGENTS.md / CLAUDE.md / SOUL.md).
+// removed when no one is contending, but the memory cost is one channel
+// per locked path, which is fine for the bounded set of shared targets
+// in ox (one per session, a handful of per-project files, one per
+// managed git clone).
 var inProcessLocks struct {
 	sync.Mutex
-	m map[string]*sync.Mutex
+	m map[string]chan struct{}
 }
 
-// acquireInProcess returns a release function. Locks the process-wide
-// mutex for `lockPath` and returns a closure that unlocks it. Pair with
-// `defer release()`.
-func acquireInProcess(lockPath string) func() {
+func inProcessChan(lockPath string) chan struct{} {
 	inProcessLocks.Lock()
+	defer inProcessLocks.Unlock()
 	if inProcessLocks.m == nil {
-		inProcessLocks.m = map[string]*sync.Mutex{}
+		inProcessLocks.m = map[string]chan struct{}{}
 	}
-	mu, ok := inProcessLocks.m[lockPath]
+	ch, ok := inProcessLocks.m[lockPath]
 	if !ok {
-		mu = &sync.Mutex{}
-		inProcessLocks.m[lockPath] = mu
+		ch = make(chan struct{}, 1)
+		inProcessLocks.m[lockPath] = ch
 	}
-	inProcessLocks.Unlock()
-	mu.Lock()
-	return mu.Unlock
+	return ch
+}
+
+// acquireInProcess blocks until the in-process gate for lockPath is free,
+// honoring ctx.Done() and deadline. Returns a release function on success.
+func acquireInProcess(ctx context.Context, lockPath string, deadline time.Time) (func(), error) {
+	ch := inProcessChan(lockPath)
+
+	var timerC <-chan time.Time
+	if !deadline.IsZero() {
+		d := time.Until(deadline)
+		if d < 0 {
+			d = 0
+		}
+		timer := time.NewTimer(d)
+		defer timer.Stop()
+		timerC = timer.C
+	}
+
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timerC:
+		return nil, &ErrLockTimeout{Path: lockPath, Timeout: time.Until(deadline)}
+	}
 }

--- a/internal/fileutil/flock_inprocess.go
+++ b/internal/fileutil/flock_inprocess.go
@@ -56,12 +56,13 @@ func acquireInProcess(ctx context.Context, lockPath string, deadline time.Time) 
 	ch := inProcessChan(lockPath)
 
 	var timerC <-chan time.Time
+	var requested time.Duration
 	if !deadline.IsZero() {
-		d := time.Until(deadline)
-		if d < 0 {
-			d = 0
+		requested = time.Until(deadline)
+		if requested < 0 {
+			requested = 0
 		}
-		timer := time.NewTimer(d)
+		timer := time.NewTimer(requested)
 		defer timer.Stop()
 		timerC = timer.C
 	}
@@ -72,6 +73,10 @@ func acquireInProcess(ctx context.Context, lockPath string, deadline time.Time) 
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-timerC:
-		return nil, &ErrLockTimeout{Path: lockPath, Timeout: time.Until(deadline)}
+		// requested, not time.Until(deadline): the deadline has already
+		// passed by the time this branch runs, so re-deriving it here
+		// would report a near-zero duration instead of the wait the
+		// caller actually asked for.
+		return nil, &ErrLockTimeout{Path: lockPath, Timeout: requested}
 	}
 }

--- a/internal/fileutil/flock_test.go
+++ b/internal/fileutil/flock_test.go
@@ -337,3 +337,32 @@ func TestWithFileLockTimeout_InProcessContextCancel(t *testing.T) {
 		t.Fatal("did not return after context cancel — in-process gate ignored ctx.Done()")
 	}
 }
+
+// TestWithFileLockTimeout_CrossProcessGenuineTimeout exercises the
+// cross-process flock polling loop's OWN deadline check — distinct from
+// every other timeout test here, which all contend at the in-process gate
+// and never reach this loop at all. A child-process holder bypasses the
+// in-process map entirely, so this is the only way to prove the flock-level
+// ErrLockTimeout actually fires when the lock is genuinely still held.
+func TestWithFileLockTimeout_CrossProcessGenuineTimeout(t *testing.T) {
+	if !crossProcessFlockAvailable() {
+		t.Skip("cross-process flock not available on this platform")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "genuine-timeout.dat")
+
+	holder, release := startLockHolder(t, target)
+	defer release()
+	<-holder.acquired
+
+	start := time.Now()
+	err := WithFileLockTimeout(context.Background(), target, 100*time.Millisecond, func() error {
+		return errors.New("must not run — the child process still holds the lock")
+	})
+	elapsed := time.Since(start)
+
+	var timeoutErr *ErrLockTimeout
+	require.ErrorAs(t, err, &timeoutErr)
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond, "must actually wait out the requested timeout, not return early")
+	assert.Less(t, elapsed, 2*time.Second, "must not wait past the requested timeout")
+}

--- a/internal/fileutil/flock_test.go
+++ b/internal/fileutil/flock_test.go
@@ -10,6 +10,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestWithFileLock_SerializesGoroutines proves the in-process side of
@@ -222,4 +225,50 @@ func TestHelperFlockHolder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helper acquire failed: %v", err)
 	}
+}
+
+// TestErrLockTimeout_Error covers the Timeout field this PR added: the
+// zero-value fallback to the package default, and reporting the actual
+// caller-supplied timeout (gitutil.WithRepoLock passes its own 2-minute
+// budget here, not the 10s package default — a bare zero check would have
+// let that regress silently).
+func TestErrLockTimeout_Error(t *testing.T) {
+	zero := &ErrLockTimeout{Path: "/tmp/x.lock"}
+	assert.Contains(t, zero.Error(), LockTimeout.String(), "Timeout: 0 must fall back to the package default, not report a bogus 0s")
+
+	custom := &ErrLockTimeout{Path: "/tmp/x.lock", Timeout: 2 * time.Minute}
+	assert.Contains(t, custom.Error(), "2m0s", "a caller-supplied timeout must be reported as given, not the package default")
+	assert.NotContains(t, custom.Error(), LockTimeout.String())
+}
+
+// TestWithFileLockTimeout_ReportsRequestedTimeout is the regression for the
+// exact bug this PR fixed: acquireInProcess used to compute
+// time.Until(deadline) AFTER its timer fired, which is ~0 (sometimes
+// negative) by construction, not the timeout the caller actually asked for.
+func TestWithFileLockTimeout_ReportsRequestedTimeout(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "contended.dat")
+
+	release := make(chan struct{})
+	held := make(chan struct{})
+	go func() {
+		_ = WithFileLock(context.Background(), target, func() error { close(held); <-release; return nil })
+	}()
+	<-held
+	defer close(release)
+
+	const requested = 150 * time.Millisecond
+	err := WithFileLockTimeout(context.Background(), target, requested, func() error {
+		return errors.New("must not run")
+	})
+
+	var timeoutErr *ErrLockTimeout
+	require.ErrorAs(t, err, &timeoutErr)
+	// Within a few ms of what was asked for (clock-read jitter between the
+	// two time.Now() calls), not ~0s — which is what
+	// time.Until(deadline) computed AFTER the timer fires would report.
+	assert.InDelta(t, requested, timeoutErr.Timeout, float64(5*time.Millisecond),
+		"must report the timeout actually requested, not ~0s from time.Until(deadline) computed after the timer already fired")
+	assert.Greater(t, timeoutErr.Timeout, 100*time.Millisecond,
+		"the bug this regresses to reports a near-zero duration; anything under 100ms means it's back")
 }

--- a/internal/fileutil/flock_test.go
+++ b/internal/fileutil/flock_test.go
@@ -272,3 +272,68 @@ func TestWithFileLockTimeout_ReportsRequestedTimeout(t *testing.T) {
 	assert.Greater(t, timeoutErr.Timeout, 100*time.Millisecond,
 		"the bug this regresses to reports a near-zero duration; anything under 100ms means it's back")
 }
+
+// TestWithFileLockTimeout_AlreadyPastDeadline covers acquireInProcess's
+// negative-duration clamp: a caller whose deadline has already passed by
+// the time it calls in (a slow caller building the deadline earlier, then
+// getting delayed before the actual lock call) must fail fast, not panic
+// or block on a negative-duration timer.
+func TestWithFileLockTimeout_AlreadyPastDeadline(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "past-deadline.dat")
+
+	release := make(chan struct{})
+	held := make(chan struct{})
+	go func() {
+		_ = WithFileLock(context.Background(), target, func() error { close(held); <-release; return nil })
+	}()
+	<-held
+	defer close(release)
+
+	start := time.Now()
+	err := WithFileLockTimeout(context.Background(), target, -1*time.Second, func() error {
+		return errors.New("must not run")
+	})
+	elapsed := time.Since(start)
+
+	var timeoutErr *ErrLockTimeout
+	require.ErrorAs(t, err, &timeoutErr)
+	assert.Equal(t, time.Duration(0), timeoutErr.Timeout, "an already-past deadline clamps to zero, not a negative duration")
+	assert.Less(t, elapsed, time.Second, "must fail immediately, not block on a negative-duration timer")
+}
+
+// TestWithFileLockTimeout_InProcessContextCancel covers acquireInProcess's
+// OWN ctx.Done() branch specifically — contention from another goroutine in
+// the SAME process, not the cross-process flock's separate ctx check
+// (TestWithFileLock_RespectsContext exercises that one, via a child process
+// whose lock never contends the in-process gate at all). This is exactly
+// the path two of ADR-030's four WithRepoLock sites depend on: the daemon's
+// sync scheduler and its GC/wedge probe are goroutines in the same process,
+// not separate ones.
+func TestWithFileLockTimeout_InProcessContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "inprocess-cancel.dat")
+
+	release := make(chan struct{})
+	held := make(chan struct{})
+	go func() {
+		_ = WithFileLock(context.Background(), target, func() error { close(held); <-release; return nil })
+	}()
+	<-held
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	doneCh := make(chan error, 1)
+	go func() {
+		doneCh <- WithFileLockTimeout(ctx, target, LockTimeout, func() error { return nil })
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-doneCh:
+		assert.ErrorIs(t, err, context.Canceled, "in-process contention must respect ctx cancellation, not just the timeout")
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not return after context cancel — in-process gate ignored ctx.Done()")
+	}
+}

--- a/internal/fileutil/flock_test.go
+++ b/internal/fileutil/flock_test.go
@@ -366,3 +366,22 @@ func TestWithFileLockTimeout_CrossProcessGenuineTimeout(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond, "must actually wait out the requested timeout, not return early")
 	assert.Less(t, elapsed, 2*time.Second, "must not wait past the requested timeout")
 }
+
+// TestWithFileLockTimeout_OpenFileFails covers the os.OpenFile error path:
+// if the lock directory can't be created or opened, WithFileLockTimeout
+// must return a wrapped error, not panic or silently proceed as if
+// unlocked. Forced by pointing TMPDIR at a regular file instead of a
+// directory — portable and root-safe, unlike chmod-based permission
+// denial, which CI often runs privileged enough to ignore.
+func TestWithFileLockTimeout_OpenFileFails(t *testing.T) {
+	notADir := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o644))
+	t.Setenv("TMPDIR", notADir)
+
+	err := WithFileLockTimeout(context.Background(), "/some/target", LockTimeout, func() error {
+		return errors.New("must not run — the lock could not have been acquired")
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open lock file")
+}

--- a/internal/gitutil/repolock.go
+++ b/internal/gitutil/repolock.go
@@ -1,0 +1,65 @@
+package gitutil
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"time"
+
+	"github.com/sageox/ox/internal/fileutil"
+)
+
+// RepoLockTimeout bounds how long WithRepoLock waits for a peer to release a
+// managed clone. A fetch or pull on a large ledger can legitimately run for
+// tens of seconds; two minutes covers that with margin while still failing a
+// genuinely wedged peer fast enough that the daemon's next cycle retries.
+// Callers with a tighter budget (a CLI status check) bound the context
+// instead — the wait honors ctx.Done().
+const RepoLockTimeout = 2 * time.Minute
+
+// WithRepoLock serializes git operations that mutate a managed clone —
+// fetch, pull, rebase, checkout, commit, push — across every ox process on
+// the machine: the daemon's sync scheduler, its GC / wedge probe, its doctor
+// pass, and any concurrently running CLI (ox status, ox doctor --fix, ox
+// sync, session upload). ADR-030 D1.
+//
+// Why a lock and not the existing dedup heuristics: git writes
+// .git/FETCH_HEAD with no lock of its own. Two overlapping fetches interleave
+// their appends and leave two merge-eligible heads, after which
+// `git pull --rebase` refuses with "Cannot rebase onto multiple branches".
+// MinFetchHeadAge skips a fetch that happened *recently*; it cannot stop one
+// that starts *during* another. HasLockFiles detects git's own lock files;
+// FETCH_HEAD has none. Reproduced 5/5 on a real ledger (COE 2026-09-02).
+//
+// The lock is an advisory flock on a sidecar keyed by <clone>/.git/ox-sync
+// (fileutil.LockPath puts the physical file in the OS tmpdir, so nothing is
+// ever left inside the clone). flock is released by the kernel when the
+// holder dies, so a crashed process cannot wedge the clone and no stale-lock
+// reaper exists. It is advisory: a human running raw git in the clone does
+// not take it, which is the pre-existing state of the world.
+//
+// Not re-entrant. A caller already inside WithRepoLock must not call it
+// again for the same clone (the in-process mutex would deadlock, and the
+// deadline would then surface it as ErrRepoLockBusy). Keep read-only
+// plumbing (status, rev-parse, log, ls-files, show) outside the lock.
+func WithRepoLock(ctx context.Context, repoPath string, fn func() error) error {
+	return fileutil.WithFileLockTimeout(ctx, RepoLockTarget(repoPath), RepoLockTimeout, fn)
+}
+
+// RepoLockTarget is the path the clone's advisory lock is keyed on. Exposed
+// so tests can assert two callers contend on the same sidecar.
+func RepoLockTarget(repoPath string) string {
+	return filepath.Join(repoPath, ".git", "ox-sync")
+}
+
+// IsRepoLockBusy reports whether err means another ox process held the
+// clone for longer than RepoLockTimeout (or the caller's context expired
+// while waiting). Callers treat this as "skip this cycle", never as a repo
+// fault — the clone is healthy, just in use.
+func IsRepoLockBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	var timeout *fileutil.ErrLockTimeout
+	return errors.As(err, &timeout) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
+}

--- a/internal/gitutil/repolock_test.go
+++ b/internal/gitutil/repolock_test.go
@@ -1,0 +1,85 @@
+package gitutil
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/fileutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithRepoLock_SerializesCallers proves two callers on the same clone
+// never hold the lock at once — the property every fetch/pull site relies on.
+func TestWithRepoLock_SerializesCallers(t *testing.T) {
+	repo := t.TempDir()
+	var inside, overlaps atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := WithRepoLock(context.Background(), repo, func() error {
+				if inside.Add(1) > 1 {
+					overlaps.Add(1)
+				}
+				time.Sleep(5 * time.Millisecond)
+				inside.Add(-1)
+				return nil
+			})
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+	assert.Zero(t, overlaps.Load(), "two callers held the repo lock simultaneously")
+}
+
+// TestWithRepoLock_DifferentClonesDoNotContend guards the keying: locking
+// clone A must not block clone B, or one slow ledger would stall every team
+// context on the machine.
+func TestWithRepoLock_DifferentClonesDoNotContend(t *testing.T) {
+	a, b := t.TempDir(), t.TempDir()
+	require.NotEqual(t, RepoLockTarget(a), RepoLockTarget(b))
+	release := make(chan struct{})
+	go func() {
+		_ = WithRepoLock(context.Background(), a, func() error { <-release; return nil })
+	}()
+	time.Sleep(20 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := WithRepoLock(ctx, b, func() error { return nil })
+	close(release)
+	assert.NoError(t, err, "clone B must not wait on clone A's lock")
+}
+
+// TestWithRepoLock_ContextBoundsTheWait: a CLI with a 10s budget must not
+// sit for RepoLockTimeout behind a daemon fetch — it gives up on its own
+// deadline and the caller treats that as busy, not broken.
+func TestWithRepoLock_ContextBoundsTheWait(t *testing.T) {
+	repo := t.TempDir()
+	release := make(chan struct{})
+	held := make(chan struct{})
+	go func() {
+		_ = WithRepoLock(context.Background(), repo, func() error { close(held); <-release; return nil })
+	}()
+	<-held
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := WithRepoLock(ctx, repo, func() error { return errors.New("must not run") })
+	close(release)
+	require.Error(t, err)
+	assert.True(t, IsRepoLockBusy(err), "context expiry while waiting is 'busy': %v", err)
+	assert.Less(t, time.Since(start), 2*time.Second)
+}
+
+func TestIsRepoLockBusy(t *testing.T) {
+	assert.False(t, IsRepoLockBusy(nil))
+	assert.False(t, IsRepoLockBusy(errors.New("fatal: not a git repository")))
+	assert.True(t, IsRepoLockBusy(&fileutil.ErrLockTimeout{Path: "x", Timeout: time.Second}))
+	assert.True(t, IsRepoLockBusy(context.DeadlineExceeded))
+}

--- a/internal/gitutil/repolock_test.go
+++ b/internal/gitutil/repolock_test.go
@@ -45,10 +45,11 @@ func TestWithRepoLock_DifferentClonesDoNotContend(t *testing.T) {
 	a, b := t.TempDir(), t.TempDir()
 	require.NotEqual(t, RepoLockTarget(a), RepoLockTarget(b))
 	release := make(chan struct{})
+	held := make(chan struct{})
 	go func() {
-		_ = WithRepoLock(context.Background(), a, func() error { <-release; return nil })
+		_ = WithRepoLock(context.Background(), a, func() error { close(held); <-release; return nil })
 	}()
-	time.Sleep(20 * time.Millisecond)
+	<-held // wait for confirmation clone A actually holds the lock, not a fixed guess
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	err := WithRepoLock(ctx, b, func() error { return nil })

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -326,9 +326,18 @@ func checkSyncStatus(path string, status *Status) {
 	if age, ok := gitutil.FetchHeadAge(path); ok && age < gitutil.MinFetchHeadAge {
 		// use cached state — daemon keeps ledger current via its sync loop
 	} else {
-		// fetch with timeout to avoid hanging on network issues
+		// fetch with timeout to avoid hanging on network issues. Locked
+		// (ADR-030 D1): this is the CLI side of the FETCH_HEAD race — `ox
+		// status` fetching concurrently with the daemon's own pull cycle
+		// corrupted FETCH_HEAD in the 2026-09-02 incident. The existing
+		// 10s ctx already bounds the wait if the daemon holds the lock for
+		// a longer pull; on timeout we just fall through to cached state,
+		// same as a fetch failure always did.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		_, _ = gitutil.RunGit(ctx, path, "fetch", "--quiet")
+		_ = gitutil.WithRepoLock(ctx, path, func() error {
+			_, err := gitutil.RunGit(ctx, path, "fetch", "--quiet")
+			return err
+		})
 		cancel()
 	}
 


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a0635e-2c14-7c9a-bf25-68b26786b9f8">Session</a>
<!-- /sageox:pr-header -->

## Summary

- **What broke:** `git fetch` has no lock on `.git/FETCH_HEAD`. Four independent ox call sites (daemon sync cycle, daemon GC/wedge probe, `ox status`, `ox doctor --fix`) fetch the same managed clone with zero coordination. Two overlapping fetches interleave their writes and leave two merge-eligible heads, and the next `git pull --rebase` refuses with `fatal: Cannot rebase onto multiple branches.`
- **Why it got worse than a flaky error:** the pull-failure recovery ladder assumed any rebase directory it found belonged to itself, ran `rebase --skip`/`--abort` on a *concurrent process's* rebase, collided on `index.lock`, and raised `IssueTypeRebaseStuck` — which nothing ever cleared. Users saw a red, confirm-required "ledger is stuck in a broken rebase state" on `ox status` that persisted **after the ledger had already recovered on its own**, until a full daemon restart.
- **What this PR ships:** a per-clone advisory lock (`gitutil.WithRepoLock`) around every fetch/pull/rebase at all four sites, a retry-once on the specific transient error, a guard so the recovery ladder never touches a rebase it didn't start, and clearing of the stuck-issue on the next successful pull.
- **Root-caused from a live incident** on `sageox-monorepo` (reproduced 5/5 on the real ledger) — see the COE and plan of record linked below.

## What broke → what ships

```mermaid
flowchart LR
  subgraph before["Before"]
    A1["daemon sync cycle<br/>git fetch"] -.races.-> A2["ox status / doctor --fix<br/>git fetch"]
    A2 --> A3["FETCH_HEAD: 2 merge heads"]
    A3 --> A4["pull --rebase ✖<br/>'multiple branches'"]
    A4 --> A5["abort a FOREIGN rebase<br/>index.lock collision"]
    A5 --> A6["IssueTypeRebaseStuck<br/>latched, never cleared"]
  end
  subgraph after["After"]
    B1["daemon sync cycle<br/>WithRepoLock → fetch"] --> B2["ox status / doctor --fix<br/>WithRepoLock → fetch"]
    B2 -->|"serialized, no interleave"| B3["FETCH_HEAD: 1 merge head"]
    B3 --> B4["pull --rebase ✓"]
    B4 -.->|"if it still happens<br/>(non-ox writer)"| B5["retry once, self-heals"]
  end
```

## Root causes fixed (bd epic `ox-baz5`)

| # | Defect | Fix |
|---|---|---|
| `ox-baz5.1` | FETCH_HEAD race across daemon + CLI | `gitutil.WithRepoLock` (per-clone `flock`) wraps fetch/pull at `sync_managed.go`, `sync_gc.go`, `ledger.go`, `doctor_ledger_git.go`; retry-once on the exact race signature before treating it as a conflict |
| `ox-baz5.2` | Recovery ladder aborts a rebase it didn't start | `pullManagedRepo` now checks `IsRebaseInProgress` *before* pulling and skips — never touches — a foreign rebase |
| `ox-baz5.3` | `IssueTypeRebaseStuck` (and the sync-suspended warning) never cleared | `doPull` / `doTeamSync` clear it on the next successful pull, matching the other failure-issue types |

**Also fixed, found while building this:** `internal/fileutil`'s in-process lock gate (`acquireInProcess`) used a plain `sync.Mutex.Lock()` with no context/timeout awareness — fine for the existing millisecond-scale meta.json writers, but wrong for `WithRepoLock`, since two of the four lock sites are goroutines in the *same* daemon process (not separate processes), so a stuck peer would hang the other forever regardless of the caller's context. Caught live: my own context-bounds test deadlocked for the full 600s timeout on first run. Rewrote the gate as a context/deadline-aware channel (`internal/fileutil/flock_inprocess.go`); every existing `fileutil` caller keeps identical behavior — only the previously-unreachable-in-practice blocking case changed.

## Design

- **`gitutil.WithRepoLock(ctx, path, fn)`** — exclusive `flock` on `<clone>/.git/ox-sync`, released by the kernel on process death (no stale-lock reaper needed). Lock-busy (peer holding it past the caller's deadline) is treated as "skip this cycle," not an error — the clone is healthy, just in use.
- **Retry-once (D2):** on `Cannot rebase onto multiple branches`, re-fetch once under the same lock and retry the pull before entering conflict handling — this specific failure is provably transient.
- **Own-rebase guard (D3):** snapshot rebase-dir state before pulling; only enter the auto-resolve/abort ladder if *this* pull created it.
- Full design + alternatives considered: `docs/adr/ADR-030-per-clone-git-serialization.md` — on the companion docs branch (`faridun/daemon-git-sync-coe`), not yet pushed/PR'd.

## Test plan

- [x] Red-first: `TestPullManagedRepo_ConcurrentFetchDoesNotCorruptFETCH_HEAD` — stashed the fix, confirmed **9/15** iterations hit the real `Cannot rebase onto multiple branches` error against a real bare-remote fixture; restored the fix, 15/15 clean, `-race` clean.
- [x] Red-first: `TestDoPull_ClearsRebaseStuckOnSuccess` — confirmed failing on unpatched code, passing after.
- [x] New: `TestWithRepoLock_SerializesCallers`, `TestWithRepoLock_DifferentClonesDoNotContend`, `TestWithRepoLock_ContextBoundsTheWait`, `TestIsRepoLockBusy` (`internal/gitutil`), all `-race` clean.
- [x] Full `internal/daemon` suite (233s, 0 failures), `internal/ledger`, `internal/gitutil`, `internal/fileutil` — all green.
- [x] All 8 `doctor_ledger_git.go`-specific tests in `cmd/ox` — green.
- [x] `gofmt`, `goimports`, `go vet ./...`, `golangci-lint` (scoped to touched packages) — clean.
- [x] Ruled out one pre-existing, unrelated flake: two `TestDoctorFreshInstall_*` tests fail when run in a broad batch on this machine due to real (stale) KB-bubble state in `~/.local/share/sageox` — confirmed unrelated to this diff (passes in isolation with and without these changes; this PR touches nothing KB-related).

## Related

- Epic: bd `ox-baz5` (`.1`, `.2`, `.3` — this PR; `.4`/`.5` LFS insulation and `.6` ledger-clone atomicity are separate follow-up PRs)
- COE: `docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md`
- Plan of record (HTML, live review): `ox plan view 2026-09-02-daemon-git-sync-five-fixes`
- Reviewer: Ryan (owns every touched file — ox-computed expert route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGUJYrGMKR9XiJw85L9UyC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791004531&installation_model_id=433550&pr_number=868&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F868&signature=aa573a26bcfdc708b5f2548bdbac6638620d95c456b9fe5be3e4e4e7621c5cc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository synchronization reliability during concurrent operations.
  - Prevented fetch conflicts that could cause failed pulls or leave repositories out of sync.
  - Added automatic retry handling for certain corrupted fetch states.
  - Successful ledger and workspace synchronization now clears stale rebase and sync-backoff warnings.
  - Preserved pre-existing rebases during branch recovery.
  - Improved recovery for stalled or diverged branches, with clearer lock and fetch errors.
  - Repository operations now respect time limits and safely wait for active changes.
  - Improved stalled-sync detection when repository access is temporarily busy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->