### PR TITLE
docs: COE for daemon git sync race + ADR-030 and ADR-007 addendum

### DIFF
--- a/docs/adr/ADR-007-direct-lfs.md
+++ b/docs/adr/ADR-007-direct-lfs.md
@@ -125,8 +125,10 @@ and the team context silently stops syncing. `ox doctor` has a repair for this s
 
 - Every git command ox runs — daemon and CLI — passes
   `-c filter.lfs.smudge=cat -c filter.lfs.clean=cat -c filter.lfs.process= -c filter.lfs.required=false`.
-  This is the exact set `restoreRawLFSPointers` already uses; it now applies to
-  `gitutil.NewNetworkCmd` and the CLI git wrappers as a matter of course, not as a repair.
+  `restoreRawLFSPointers` (`cmd/ox/doctor_team.go`) already overrides three of these
+  (`smudge`, `process`, `required`) for its read-only `checkout` repair; the fourth,
+  `clean=cat`, is added for completeness — `git pull --autostash` can invoke the clean
+  filter when it stashes dirty LFS-filtered content, which a plain checkout never does.
 - The consequence "hydration goes through ox's own download path, never through smudge" is
   thereby made true regardless of the user's global git config, which ox does not control.
 - `StripLFSConfig` remains as the push-side half.

--- a/docs/adr/ADR-007-direct-lfs.md
+++ b/docs/adr/ADR-007-direct-lfs.md
@@ -102,7 +102,7 @@ Credentials are loaded from the local credential store (`gitserver.LoadCredentia
 **Tradeoffs**:
 - ox must implement and maintain its own LFS client against the Batch Transfer API spec. The API is stable and well-documented, but ox owns the HTTP plumbing.
 - `git lfs ls-files` is still used in one place: `RepairMissingLFSObjects` (push pre-flight) scans for orphaned pointers. This gracefully degrades — if git-lfs is not installed, the repair step is skipped.
-- Users cannot `git lfs pull` to hydrate ox's pointer files (no `.gitattributes` filter). Hydration goes through `ox` commands. This is intentional — ledger content is accessed through ox, not raw git operations.
+- Users cannot `git lfs pull` to hydrate ox's pointer files, in clones without a server-provided `filter=lfs` attribute (no `.gitattributes` filter, since ox never writes one). Hydration goes through `ox` commands. This is intentional — ledger content is accessed through ox, not raw git operations. (Team-context clones are the documented exception: they *do* carry a server-seeded `filter=lfs` — see the 2026-09-02 addendum below for the consequence that has for a machine with git-lfs installed.)
 - The `StripLFSConfig` pre-flight on every push is a workaround for a GitLab ALB behavior. If GitLab fixes this, the workaround becomes dead code (harmless but unnecessary).
 
 ## Addendum (2026-09-02): the user's git-lfs still runs on ox's clones
@@ -121,17 +121,26 @@ daemon's `pull --rebase --autostash` then fails on every cycle, leaks an autosta
 and the team context silently stops syncing. `ox doctor` has a repair for this shape
 (`restoreRawLFSPointers`) but the check gating it did not run against the affected clone.
 
-**Amended decision.** The insulation is complete only when it covers both directions:
+**Amended decision — planned, not yet implemented (`ox-baz5.4`).** The insulation will be
+complete only when it covers both directions:
 
-- Every git command ox runs — daemon and CLI — passes
+- Every git command ox runs — daemon and CLI — must pass
   `-c filter.lfs.smudge=cat -c filter.lfs.clean=cat -c filter.lfs.process= -c filter.lfs.required=false`.
-  `restoreRawLFSPointers` (`cmd/ox/doctor_team.go`) already overrides three of these
-  (`smudge`, `process`, `required`) for its read-only `checkout` repair; the fourth,
-  `clean=cat`, is added for completeness — `git pull --autostash` can invoke the clean
-  filter when it stashes dirty LFS-filtered content, which a plain checkout never does.
+  That's a wider surface than it first looks: `internal/gitutil.RunGit` — the most widely
+  used git-invocation helper in the codebase — currently sets only `commit.gpgsign`/
+  `tag.gpgsign` and none of the four `filter.lfs.*` overrides, so every one of its many
+  callers is exposed today. `restoreRawLFSPointers` (`cmd/ox/doctor_team.go`) already
+  overrides three of the four (`smudge`, `process`, `required`) for its read-only `checkout`
+  repair; the fourth, `clean=cat`, will also be needed there — `git pull --autostash` can
+  invoke the clean filter when it stashes dirty LFS-filtered content, which a plain checkout
+  never does. Several other call sites build `exec.Command("git", …)` directly, bypassing
+  `RunGit` entirely, and will need the same treatment.
 - The consequence "hydration goes through ox's own download path, never through smudge" is
-  thereby made true regardless of the user's global git config, which ox does not control.
-- `StripLFSConfig` remains as the push-side half.
+  only true once every path above carries the overrides — not yet the case.
+- `StripLFSConfig` remains as the push-side half (already implemented, unaffected by this).
+
+Until all of the above lands, `ox-baz5.4` stays open and the COE's Actions table correctly
+marks it "not started" — the analysis above is the decision, not a status report.
 
 Tracked as bd `ox-baz5.4` (insulation) and `ox-baz5.5` (doctor check scoping). Related:
 ADR-030 (per-clone serialization), `.claude/rules/lfs-no-git-lfs-binary.md`.

--- a/docs/adr/ADR-007-direct-lfs.md
+++ b/docs/adr/ADR-007-direct-lfs.md
@@ -2,6 +2,7 @@
 
 **Status**: Accepted
 **Date**: 2026-04-02
+**Amended**: 2026-09-02 — checkout-side insulation (see "Addendum" at the end)
 
 ## Context
 
@@ -103,3 +104,32 @@ Credentials are loaded from the local credential store (`gitserver.LoadCredentia
 - `git lfs ls-files` is still used in one place: `RepairMissingLFSObjects` (push pre-flight) scans for orphaned pointers. This gracefully degrades — if git-lfs is not installed, the repair step is skipped.
 - Users cannot `git lfs pull` to hydrate ox's pointer files (no `.gitattributes` filter). Hydration goes through `ox` commands. This is intentional — ledger content is accessed through ox, not raw git operations.
 - The `StripLFSConfig` pre-flight on every push is a workaround for a GitLab ALB behavior. If GitLab fixes this, the workaround becomes dead code (harmless but unnecessary).
+
+## Addendum (2026-09-02): the user's git-lfs still runs on ox's clones
+
+This ADR insulated ox from the user's global git-lfs on the **push** side (`StripLFSConfig`)
+and assumed the **checkout** side was safe because ox never writes `.gitattributes` with
+`filter=lfs`. That assumption does not hold for every clone ox manages: team-context repos are
+seeded server-side and *do* ship `.gitattributes` with `filter=lfs` on discussion attachments
+(their bytes are served through the API's LFS resolver — a deliberate decision in the owning
+service). On any machine where git-lfs is installed globally, its clean/smudge filters
+therefore run on every checkout of those clones.
+
+Observed consequence (COE 2026-09-02): a nested LFS pointer committed upstream is unwrapped one
+layer by git-lfs smudge on every checkout, so the worktree can never equal the index. The
+daemon's `pull --rebase --autostash` then fails on every cycle, leaks an autostash each time,
+and the team context silently stops syncing. `ox doctor` has a repair for this shape
+(`restoreRawLFSPointers`) but the check gating it did not run against the affected clone.
+
+**Amended decision.** The insulation is complete only when it covers both directions:
+
+- Every git command ox runs — daemon and CLI — passes
+  `-c filter.lfs.smudge=cat -c filter.lfs.clean=cat -c filter.lfs.process= -c filter.lfs.required=false`.
+  This is the exact set `restoreRawLFSPointers` already uses; it now applies to
+  `gitutil.NewNetworkCmd` and the CLI git wrappers as a matter of course, not as a repair.
+- The consequence "hydration goes through ox's own download path, never through smudge" is
+  thereby made true regardless of the user's global git config, which ox does not control.
+- `StripLFSConfig` remains as the push-side half.
+
+Tracked as bd `ox-baz5.4` (insulation) and `ox-baz5.5` (doctor check scoping). Related:
+ADR-030 (per-clone serialization), `.claude/rules/lfs-no-git-lfs-binary.md`.

--- a/docs/adr/ADR-030-per-clone-git-serialization.md
+++ b/docs/adr/ADR-030-per-clone-git-serialization.md
@@ -1,6 +1,6 @@
 # ADR-030: Per-clone serialization of git operations
 
-**Status:** Proposed
+**Status:** Accepted — implemented in [PR #868](https://github.com/sageox/ox/pull/868), merged 2026-09-03
 **Date:** 2026-09-02
 **Supersedes:** nothing
 **Related:** ADR-007 (direct LFS, amended alongside this), `adr-ledger-architecture.md`
@@ -122,9 +122,11 @@ pull, matching `IssueTypeDirtyWorkspace` / `IssueTypeGCFailed`.
 
 - COE: `docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md`
 - Issues: bd `ox-baz5.1` (D1, D2), `ox-baz5.2` (D3), `ox-baz5.3` (D4)
-- Implementation: [PR #868](https://github.com/sageox/ox/pull/868) — `internal/gitutil/repolock.go`
-  (`WithRepoLock`), `internal/fileutil/flock_inprocess.go` (made context/deadline-aware to
-  support D1: two of the four lock sites are goroutines in the same daemon process, not
-  separate processes, so the in-process gate needed the same ctx/timeout the cross-process
-  flock already honored)
+- Implementation: [PR #868](https://github.com/sageox/ox/pull/868) — merged (`a7466f08`) —
+  `internal/gitutil/repolock.go` (`WithRepoLock`), `internal/fileutil/flock_inprocess.go`
+  (made context/deadline-aware to support D1: two of the four lock sites are goroutines in
+  the same daemon process, not separate processes, so the in-process gate needed the same
+  ctx/timeout the cross-process flock already honored). D3 was also applied to
+  `cmd/ox/doctor_ledger_git.go`'s `fixLedgerBranchBehind` — found missing there in review,
+  see the COE's "Post-merge" section.
 - Precedent for flocked read-modify-write in this codebase: `internal/daemon/terminal_handler.go`

--- a/docs/adr/ADR-030-per-clone-git-serialization.md
+++ b/docs/adr/ADR-030-per-clone-git-serialization.md
@@ -1,0 +1,113 @@
+# ADR-030: Per-clone serialization of git operations
+
+**Status:** Proposed
+**Date:** 2026-09-02
+**Supersedes:** nothing
+**Related:** ADR-007 (direct LFS, amended alongside this), `adr-ledger-architecture.md` (D1:
+the daemon owns the ledger clone), `adr-ephemeral-mode.md`, `.claude/rules/daemon-git.md`,
+`docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md`
+
+---
+
+## Context
+
+ox drives git against managed clones — the ledger and every team context — from more than
+one actor at a time:
+
+- the daemon's sync scheduler (`internal/daemon/sync_managed.go`),
+- the daemon's GC / wedge probe on its own schedule (`internal/daemon/sync_gc.go`),
+- the daemon's doctor pass (`autofix RunNow`),
+- the CLI, in a separate process: `ox status` (`internal/ledger/ledger.go`), `ox doctor
+  --fix` (`cmd/ox/doctor_ledger_git.go`), `ox sync`, push-with-rebase paths.
+
+`.claude/rules/daemon-git.md` divides *intent* — the daemon reads (pull), the CLI writes
+(add/commit/push) — but a `git fetch` is a write to `.git/FETCH_HEAD`, and git itself does
+not lock that file. Two overlapping fetches interleave their appends and leave two
+merge-eligible heads, after which `git pull --rebase` refuses with *Cannot rebase onto
+multiple branches*. This is reproducible on demand (COE 2026-09-02, 5/5 trials) and has been
+possible since v0.1.0.
+
+The existing guards do not cover it:
+
+- `gitutil.MinFetchHeadAge` (30 s) skips a fetch if one happened *recently*. It cannot stop a
+  fetch that starts *during* another one.
+- `gitutil.HasLockFiles` / `RemoveStaleLockFiles` detect git's own lock files. `FETCH_HEAD`
+  has none.
+- The daemon's pull-failure recovery (`rebase --skip` / `AuditAndAbort`) assumes it is the
+  only actor and will act on a rebase directory created by a different process.
+
+The same shape caused the April 2026 COE (silent autostash-pop conflict committed to the
+ledger). Both incidents are a `--quiet` git pipeline whose error path assumes a single actor.
+
+## Decision
+
+### D1 — One advisory lock per clone, held across every mutating git operation
+
+Every fetch, pull, rebase, stash, checkout, commit, and push that ox runs against a managed
+clone runs inside `gitutil.WithRepoLock(clonePath, fn)`. The lock is an exclusive
+`flock(2)` on `<clone>/.git/ox-sync.lock`. It is process-shared by construction — the daemon
+and the CLI are different processes and both must take it.
+
+`flock` is chosen over a lockfile-with-age scheme because the kernel releases it when the
+holder dies. A crashed holder cannot wedge the clone, so no stale-lock reaper is needed and
+none is written.
+
+Read-only plumbing (`rev-parse`, `status`, `log`, `ls-files`, `show`) stays lock-free.
+
+### D2 — A pull that fails on a transient race retries before it recovers
+
+When `git pull --rebase` fails with `Cannot rebase onto multiple branches`, the daemon
+re-fetches once (under the lock) and retries the pull before entering the conflict-recovery
+ladder. The error is provably transient — it describes `FETCH_HEAD`, not the branch.
+
+### D3 — Recovery acts only on state this operation created
+
+The pull-failure ladder (`rebase --skip`, `rebase --abort`, `AuditAndAbort`) runs only when
+the rebase directory did not exist before the pull and exists after it. A rebase directory
+that was already present belongs to someone else and is left alone. `gitutil.RebaseAge()`
+already encodes "a fresh rebase is not ours to abort" for the pre-existing-rebase path; this
+extends the same rule to the failure path.
+
+### D4 — Every issue the daemon raises has a clear path
+
+A `DaemonIssue` type may not be added without the code path that clears it on recovery.
+`IssueTypeRebaseStuck` and the sync-suspended warning are cleared on the next successful
+pull, matching `IssueTypeDirtyWorkspace` / `IssueTypeGCFailed`.
+
+## Alternatives considered
+
+- **In-process mutex only.** Serializes the daemon's own goroutines but not the CLI. The
+  observed race had the CLI on one side. Rejected.
+- **Widen `MinFetchHeadAge`.** Reduces the window; does not close it. A fetch is not
+  idempotent while another is running. Rejected.
+- **Route every CLI git operation through daemon IPC.** Correct in principle; contradicts
+  `docs/specs/ipc-architecture.md` (IPC is never required, clone has a fallback) and
+  ephemeral mode (no daemon). The lock works in every mode. Rejected for now; the lock does
+  not preclude it later.
+- **Lockfile with mtime-based staleness.** Needs a reaper, a threshold, and a story for
+  clock skew; `flock` needs none. Rejected.
+
+## Consequences
+
+**Benefits**
+
+- The FETCH_HEAD race and every derivative of it (latched error, foreign-rebase abort) become
+  impossible rather than rare.
+- CLI and daemon can keep their current division of labour; only the primitive changes.
+- A single, named place to look when "two ox things touched one clone" comes up again.
+
+**Tradeoffs**
+
+- A long daemon operation (large fetch, GC) now blocks a concurrent `ox status` for its
+  duration instead of racing it. Acceptable: `ox status` already skips the fetch when
+  `FETCH_HEAD` is fresh, and a blocked-but-correct status beats a fast-but-wrong one.
+- `flock` is advisory. A non-ox process (a user running raw git in the ledger clone) does not
+  take it. That is the existing state of the world, not a regression, and
+  `.claude/rules/daemon-git.md` already says ledger content is accessed through ox.
+- One more file in `.git/`. It is never committed and needs no ignore rule.
+
+## References
+
+- COE: `docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md`
+- Issues: bd `ox-baz5.1` (D1, D2), `ox-baz5.2` (D3), `ox-baz5.3` (D4)
+- Precedent for flocked read-modify-write in this codebase: `internal/daemon/terminal_handler.go`

--- a/docs/adr/ADR-030-per-clone-git-serialization.md
+++ b/docs/adr/ADR-030-per-clone-git-serialization.md
@@ -3,8 +3,9 @@
 **Status:** Proposed
 **Date:** 2026-09-02
 **Supersedes:** nothing
-**Related:** ADR-007 (direct LFS, amended alongside this), `adr-ledger-architecture.md` (D1:
-the daemon owns the ledger clone), `adr-ephemeral-mode.md`, `.claude/rules/daemon-git.md`,
+**Related:** ADR-007 (direct LFS, amended alongside this), `adr-ledger-architecture.md`
+("Git operations are split between daemon and CLI" — the daemon owns read-side clone/fetch/pull),
+`adr-ephemeral-mode.md`, `.claude/rules/daemon-git.md`,
 `docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md`
 
 ---
@@ -44,9 +45,14 @@ ledger). Both incidents are a `--quiet` git pipeline whose error path assumes a 
 ### D1 — One advisory lock per clone, held across every mutating git operation
 
 Every fetch, pull, rebase, stash, checkout, commit, and push that ox runs against a managed
-clone runs inside `gitutil.WithRepoLock(clonePath, fn)`. The lock is an exclusive
-`flock(2)` on `<clone>/.git/ox-sync.lock`. It is process-shared by construction — the daemon
-and the CLI are different processes and both must take it.
+clone runs inside `gitutil.WithRepoLock(clonePath, fn)`. The lock is an exclusive `flock(2)`
+keyed on `<clone>/.git/ox-sync`, reusing `internal/fileutil`'s existing advisory-lock
+primitive (the same one session `meta.json` and `config.local.toml` writers use). The
+*physical* lock file is **not** written inside the clone: `fileutil.LockPath` puts it in the
+OS tmpdir, hashed from the key path — matching that package's existing rationale (a lock file
+inside a git-tracked tree risks getting committed, confuses `ls -a`, and is a state-divergence
+risk under blue-green GC reclone). It is process-shared by construction — the daemon and the
+CLI are different processes and both must take it.
 
 `flock` is chosen over a lockfile-with-age scheme because the kernel releases it when the
 holder dies. A crashed holder cannot wedge the clone, so no stale-lock reaper is needed and
@@ -95,6 +101,9 @@ pull, matching `IssueTypeDirtyWorkspace` / `IssueTypeGCFailed`.
   impossible rather than rare.
 - CLI and daemon can keep their current division of labour; only the primitive changes.
 - A single, named place to look when "two ox things touched one clone" comes up again.
+- Nothing new is written inside the clone — the physical lock file lives in the OS tmpdir
+  (`fileutil.LockPath`), so there is no new file to `.gitignore`, no risk of it being
+  committed, and no interaction with sparse-checkout or blue-green GC reclone.
 
 **Tradeoffs**
 
@@ -104,10 +113,18 @@ pull, matching `IssueTypeDirtyWorkspace` / `IssueTypeGCFailed`.
 - `flock` is advisory. A non-ox process (a user running raw git in the ledger clone) does not
   take it. That is the existing state of the world, not a regression, and
   `.claude/rules/daemon-git.md` already says ledger content is accessed through ox.
-- One more file in `.git/`. It is never committed and needs no ignore rule.
+- `internal/fileutil`'s cross-process `flock` is a no-op on Windows today (`flock_windows.go`
+  documents this: "we currently don't ship to Windows, but keep the build green"); only the
+  in-process gate serializes there. Not a regression given that existing scope, but worth
+  knowing before this primitive backs anything that does ship on Windows.
 
 ## References
 
 - COE: `docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md`
 - Issues: bd `ox-baz5.1` (D1, D2), `ox-baz5.2` (D3), `ox-baz5.3` (D4)
+- Implementation: [PR #868](https://github.com/sageox/ox/pull/868) — `internal/gitutil/repolock.go`
+  (`WithRepoLock`), `internal/fileutil/flock_inprocess.go` (made context/deadline-aware to
+  support D1: two of the four lock sites are goroutines in the same daemon process, not
+  separate processes, so the in-process gate needed the same ctx/timeout the cross-process
+  flock already honored)
 - Precedent for flocked read-modify-write in this codebase: `internal/daemon/terminal_handler.go`

--- a/docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md
+++ b/docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md
@@ -1,0 +1,184 @@
+# COE: Daemon Git Sync — FETCH_HEAD Race, Latched Recovery, and git-lfs Divergence
+
+**Incident window:** 2026-09-02 (latent since 2026-02-16; see "How long it lived")
+**Status:** Draft for team discussion
+**Timezone:** All timestamps Pacific Daylight Time (PDT, UTC-7)
+**Issues filed:** bd epic `ox-baz5` (`ox-baz5.1` … `ox-baz5.6`), `ox-zis2`
+**Plan of record:** `ox plan view 2026-09-02-daemon-git-sync-five-fixes` (HTML in the ledger)
+
+## Immediate symptoms
+
+A single `ox status` in `sageox-monorepo` produced three things that looked like data corruption and were not.
+
+**Symptom A — ledger sync fails with a git error nobody had seen before.**
+
+```
+pull failed: fatal: Cannot rebase onto multiple branches.: exit status 128
+```
+
+**Symptom B — a red, confirm-required error that outlives the problem.**
+`ox status` and `ox daemon status` showed *ledger is stuck in a broken rebase state. Run
+'git rebase --abort' manually or 'ox doctor --fix' to recover* — while the ledger was on
+`main`, clean, up to date, and had synced 19 seconds earlier. `git rebase --abort` had
+nothing to abort. Only a daemon restart clears it.
+
+**Symptom C — the SageOx Internal team context had stopped syncing.**
+`ahead 3, behind 534`, one modified attachment, four orphan `autostash` entries, and the
+session-start warning *team_xlcr6yzpec has diverged from remote and rebase failed*.
+`ox doctor --fix` reported nothing about it.
+
+A and B share one cause; C is independent. All three were found in the same session because
+the investigation of A led through the daemon's recovery path (B) and then into the only
+other diverged clone on the machine (C).
+
+---
+
+## What happened (issue timeline)
+
+Reconstructed from `ox daemon logs`, the ledger's `.git/FETCH_HEAD`, and live reproduction
+against the real ledger clone.
+
+### Cascade 1: two fetches, one `FETCH_HEAD`
+
+| When (PDT) | Actor | What happened |
+|---|---|---|
+| 11:27:11.2 | `ox status` | Auto-starts daemon 66708 for the monorepo. The daemon immediately starts **three** concurrent activities on the same ledger clone: the sync scheduler, a doctor pass (`autofix RunNow`), and codedb indexing. `ox status` itself is still running its own ledger status check. |
+| 11:27:15.5 | daemon sync | `git fetch --quiet` completes (1.86 s). |
+| 11:27:15.5–16.5 | second fetcher | A second `git fetch` on the same clone overlaps the window between the daemon's explicit fetch and the fetch that `git pull` performs internally. git opens `FETCH_HEAD` with `O_TRUNC` and appends — **there is no lock on `FETCH_HEAD`**. Both writers land. The file now has six lines instead of three: `main` appears **twice** as a merge-eligible head. |
+| 11:27:16.5 | daemon sync | `git pull --rebase --autostash --quiet` reads `FETCH_HEAD`, counts two merge heads, refuses: `fatal: Cannot rebase onto multiple branches.` **Symptom A.** |
+| 11:27:16.6 | daemon recovery | The pull-failure handler assumes a conflict. `gitutil.IsRebaseInProgress()` returns true — because the **other** process's `rebase-merge/` directory exists — so it runs `git rebase --skip`. That fails: `Unable to create '.git/index.lock': File exists` (held by the other process). |
+| 11:27:16.8 | daemon recovery | `AuditAndAbort` → `git rebase --abort` — same `index.lock` collision. The handler records `IssueTypeRebaseStuck` (severity error, `RequiresConfirm`). **Symptom B.** Sync enters backoff. |
+| 11:28:16 | daemon sync | Retry. The fetch rewrites `FETCH_HEAD` cleanly; the pull succeeds. The ledger is healthy. **The error is not cleared** — no code path clears `IssueTypeRebaseStuck`. It stays until the daemon is restarted. |
+
+**Reproduction (on the real ledger, read-only apart from `FETCH_HEAD`):**
+
+```
+2 concurrent `git fetch`                → FETCH_HEAD lines=6, merge_heads=2   (5 / 5 trials)
+`git fetch` spam racing `pull --rebase` → rc=128 "Cannot rebase onto multiple branches"  (2 / 6 trials)
+```
+
+The unserialized fetchers on one clone at the time of the incident:
+
+| Site | Caller | Since |
+|---|---|---|
+| `internal/daemon/sync_managed.go:252` | sync scheduler pull cycle | 2026-02-16 (v0.1.0) |
+| `internal/ledger/ledger.go:331` (`checkSyncStatus`) | CLI ledger status | 2026-02-16 (v0.1.0) |
+| `internal/daemon/sync_gc.go:265` (`ledgerSyncWedged`) | GC / wedge probe, own schedule | 2026-07-19 (`e95eb20e`) |
+| `cmd/ox/doctor_ledger_git.go:404,476` | `ox doctor --fix` | — |
+
+`gitutil.MinFetchHeadAge` (30 s) is a *dedup heuristic* — it skips a fetch if one happened
+recently. It cannot stop a fetch that starts inside another fetch's window. `HasLockFiles`
+cannot see this either: `FETCH_HEAD` has no lock file to detect.
+
+### Cascade 2: a file that can never match `HEAD`
+
+Independent of cascade 1. Observed on the SageOx Internal team-context clone.
+
+| Fact | Detail |
+|---|---|
+| The team-context repo ships `.gitattributes` | `discussions/**/attachments/**/*.jpg filter=lfs …` — server-side, deliberate (ADR-085 in the owning service; attachments are served through the API's LFS resolver). |
+| The user has git-lfs installed globally | `~/.gitconfig`: `filter.lfs.required=true`, `filter.lfs.smudge=git-lfs smudge`, `filter.lfs.process=git-lfs filter-process`. |
+| One committed attachment is a **nested pointer** | Index blob: a pointer to a **132-byte** object (`oid f18c9d…`, `size 132`). 132 bytes is the size of another pointer. The known #2885 shape. |
+| git-lfs smudge unwraps **one** layer on checkout | Worktree gets the inner pointer (`oid 10239e…`, `size 2497503`). Worktree ≠ index, always. |
+| Every daemon cycle | `pull --rebase --autostash`: stash the "modified" file → re-checkout `HEAD` → smudge → modified again → `cannot rebase: You have unstaged changes` → autostash left behind. **+1 orphan stash per cycle.** |
+| Last successful sync | 2026-09-01 19:00 UTC. First orphan autostash 2026-09-02 11:21. 534 commits behind by 12:00. |
+
+`ox doctor` has a check for exactly this (`checkDoubleEncodedLFSPointers` +
+`restoreRawLFSPointers`, `cmd/ox/doctor_team.go`, added 2026-08-14 in #768). Its inputs were
+verified to match this clone. It did not fire: the "Team Context" doctor section completes in
+~23 ms on both repos — it never scans the clone. The per-team loop iterates
+`localCfg.TeamContexts`, which does not include this clone.
+
+### Cascade 3 (found while documenting): a half-cloned ledger that commits nothing
+
+The ox repo's own ledger had `Clone failed: git clone failed: fatal: early EOF` at session
+start. It was left with `.git/HEAD → refs/heads/.invalid`, a `refs/heads/.invalid` file,
+and every tracked file staged as new. Every commit since fails with `cannot lock ref 'HEAD':
+reference already exists`. `ox plan save` warned *commit/push failed, deferring*; sessions
+recorded in this repo are not reaching the ledger. `ox doctor` flags it (`Ledger clean
+workdir (commit failed)` with auto-fix) but its fix fails with `No such ref: HEAD`.
+Tracked as `ox-baz5.6`; not analysed further here.
+
+---
+
+## Root causes
+
+Three independent code defects and two amplifiers.
+
+| # | Defect | Class |
+|---|---|---|
+| 1 | No cross-process mutual exclusion on git operations against a managed clone. Daemon goroutines and CLI processes fetch the same clone concurrently. | concurrency |
+| 2 | The pull-failure recovery ladder acts on *any* rebase directory, not one it created — running `rebase --skip` / `--abort` on a concurrent process's in-flight rebase. | ownership |
+| 3 | `IssueTypeRebaseStuck` is raised and never cleared. | state hygiene |
+| 4 | ox git invocations inherit the user's global git-lfs clean/smudge filters. ox's own policy (ADR-007) is to never depend on the git-lfs binary — but it only enforced that on the *push* side (`StripLFSConfig`), not on checkout. | insulation |
+| 5 | The doctor check written for #4's failure mode does not run against the clone that has it. | detection |
+
+## Why it survived — the actual lesson
+
+Bug 1 has been in the code since v0.1.0 (2026-02-16). Bugs 2 and 3 since 2026-04-01
+(#392). Bug 4 since `NewNetworkCmd` landed on 2026-06-08 (#649). None of them is subtle
+once you look. They survived seven months because each one hid the others:
+
+1. **The error message pointed away from the cause.** *Cannot rebase onto multiple branches*
+   reads as a branch-config problem. The clone's config was correct. Nobody would think
+   "two fetches overlapped" from that string.
+2. **The transient became permanent.** A retry one minute later succeeded — but the red
+   `IssueTypeRebaseStuck` error stayed on `ox status`, with instructions to run a git command
+   that did nothing. Every user who saw it concluded "my ledger is corrupt", ran the
+   suggested command, saw no change, and restarted the daemon. The restart cleared the
+   symptom and destroyed the evidence.
+3. **The recovery path made it worse and looked like a different bug.** The `index.lock`
+   collision in the abort path reads as "a git process crashed", which is a documented,
+   self-healing condition (`RemoveStaleLockFiles`). It was actually the daemon fighting a
+   live process.
+4. **The last line of defence was silent.** `ox doctor` is the project's stated backstop
+   ("detects and repairs every known failure mode"). For cascade 2 the check existed and
+   passed. A passing check is more misleading than a missing one.
+5. **The symptom looked user-side.** git-lfs is the user's install; `.gitattributes` is the
+   server's; the nested pointer is upstream content. Every ingredient of cascade 2 is
+   "not ox's fault" — which is exactly why ox has to insulate against all of them.
+
+The generalisable rule: **a daemon that repairs failures must be able to tell its own
+in-flight operations from someone else's, and must clear every issue it raises.** Both
+failures here are the same shape as the April COE (silent autostash-pop conflict committed
+to the ledger): a `--quiet` git pipeline whose error path assumes it is the only actor.
+
+---
+
+## Actions
+
+| Action | Issue | Owner | Priority |
+|---|---|---|---|
+| Per-clone `flock` around fetch / pull / rebase at all four sites; re-fetch-and-retry once on the exact `multiple branches` error | `ox-baz5.1` | Ryan | P1 |
+| Recovery ladder acts only on a rebase this pull started | `ox-baz5.2` | Ryan | P2 |
+| Clear `IssueTypeRebaseStuck` and the sync-suspended warning on the next successful pull | `ox-baz5.3` | Ryan | P2 |
+| Every ox git invocation passes `-c filter.lfs.smudge=cat -c filter.lfs.clean=cat -c filter.lfs.process= -c filter.lfs.required=false` | `ox-baz5.4` | Ryan | P1 |
+| `ox doctor` walks every team-context clone the daemon syncs; nested-pointer fixture | `ox-baz5.5` | Ryan | P2 |
+| Atomic ledger clone; doctor repairs `HEAD → .invalid` without discarding staged content | `ox-baz5.6` | — | P1 |
+| ADR-007 addendum (checkout-side insulation) and ADR-030 (per-clone serialization) | this PR | — | — |
+
+## Manual recovery (what was done on the affected machine)
+
+- Monorepo ledger: one clean `git fetch` + `git pull --rebase`. Nothing else needed — the
+  clone was never actually broken. The stale error cleared on daemon restart.
+- Team context: restore the raw index pointer with filters bypassed, then rebase with
+  filters bypassed, then drop the orphan autostashes:
+
+  ```bash
+  T=~/.local/share/sageox/sageox.ai/teams/team_xlcr6yzpec
+  NOLFS="-c filter.lfs.smudge=cat -c filter.lfs.process= -c filter.lfs.required=false"
+  git -C $T $NOLFS checkout -- <path/to/image.jpg>
+  git -C $T $NOLFS pull --rebase --autostash
+  git -C $T stash clear
+  ```
+
+  This is precisely what `restoreRawLFSPointers` does; it is here because the doctor check
+  that should have invoked it did not run (`ox-baz5.5`).
+
+## References
+
+- `docs/coes/2026-04-07-multi-node-write-conflicts.md` — same failure class (silent `--quiet` git pipeline, error path assumes a single actor)
+- ADR-007 — Direct LFS Without git-lfs CLI (push-side insulation; amended by this incident)
+- ADR-030 — Per-clone serialization of git operations (new)
+- `.claude/rules/daemon-git.md`, `.claude/rules/lfs-no-git-lfs-binary.md`
+- gastownhall/beads #4176 / #6080 / #6092 — unrelated bd migration failures hit in the same session; documented in the team rule `agents/rules/beads-dolt-v53-migrated.md`

--- a/docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md
+++ b/docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md
@@ -149,13 +149,39 @@ to the ledger): a `--quiet` git pipeline whose error path assumes it is the only
 
 | Action | Issue | Owner | Priority | Status |
 |---|---|---|---|---|
-| Per-clone `flock` around fetch / pull / rebase at all four sites; re-fetch-and-retry once on the exact `multiple branches` error | `ox-baz5.1` | Ryan | P1 | [PR #868](https://github.com/sageox/ox/pull/868) — open |
-| Recovery ladder acts only on a rebase this pull started | `ox-baz5.2` | Ryan | P2 | [PR #868](https://github.com/sageox/ox/pull/868) — open |
-| Clear `IssueTypeRebaseStuck` and the sync-suspended warning on the next successful pull | `ox-baz5.3` | Ryan | P2 | [PR #868](https://github.com/sageox/ox/pull/868) — open |
+| Per-clone `flock` around fetch / pull / rebase at all four sites; re-fetch-and-retry once on the exact `multiple branches` error | `ox-baz5.1` | Ryan | P1 | [PR #868](https://github.com/sageox/ox/pull/868) — merged (`a7466f08`) |
+| Recovery ladder acts only on a rebase this pull started | `ox-baz5.2` | Ryan | P2 | [PR #868](https://github.com/sageox/ox/pull/868) — merged (`a7466f08`) |
+| Clear `IssueTypeRebaseStuck` and the sync-suspended warning on the next successful pull | `ox-baz5.3` | Ryan | P2 | [PR #868](https://github.com/sageox/ox/pull/868) — merged (`a7466f08`) |
 | Every ox git invocation passes `-c filter.lfs.smudge=cat -c filter.lfs.clean=cat -c filter.lfs.process= -c filter.lfs.required=false` | `ox-baz5.4` | Ryan | P1 | not started |
 | `ox doctor` walks every team-context clone the daemon syncs; nested-pointer fixture | `ox-baz5.5` | Ryan | P2 | not started |
 | Atomic ledger clone; doctor repairs `HEAD → .invalid` without discarding staged content | `ox-baz5.6` | — | P1 | not started |
 | ADR-007 addendum (checkout-side insulation) and ADR-030 (per-clone serialization) | this PR | — | — | this docs PR |
+
+## Post-merge: what review caught in the fix itself
+
+Two rounds of CodeRabbit review on PR #868 found the *same bug class this COE describes*,
+twice more, inside the fix's own first draft:
+
+- **`fixLedgerBranchBehind`** (`cmd/ox/doctor_ledger_git.go`, part of `ox doctor --fix`) ran
+  `pull --rebase --autostash` plus the LLM-conflict-resolve/`AuditAndAbort` ladder completely
+  outside `WithRepoLock` — the exact unlocked-pull shape cascade 1 describes, just in a
+  fourth call site nobody had traced through yet. It also lacked the D3 own-rebase guard.
+  Both fixed in the round-2 commit.
+- **`sync_team.go`** cleared `IssueTypeRebaseStuck` on the wrong key (`ws.ID` instead of the
+  `repoName` `pullManagedRepo` actually raised it with) — a latent no-op that would have
+  reproduced the "error outlives the problem" symptom for team contexts specifically. Caught
+  before merge, not after.
+
+Consistent with "why it survived" above: this failure mode is easy to reintroduce by hand,
+one call site at a time, because each site *looks* like ordinary error handling until you
+know to ask "does this touch a rebase it might not own, under a lock it might not hold."
+Adversarial review closed the gap the first pass missed — not tooling, not a lint rule.
+
+Closing the diff-coverage floor on the merged PR needed two time-boxed exceptions
+(`.config/coverage-ratchets.json`, expire 2026-10-17, tracked as `ox-baz5.7`) for
+pre-existing LLM-resolver/`AuditAndAbort` code that entered the diff only by being
+re-indented, plus 10 new tests for everything genuinely new — real lock contention from a
+goroutine, not mocks, `-race` clean.
 
 ## Manual recovery (what was done on the affected machine)
 

--- a/docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md
+++ b/docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md
@@ -193,9 +193,15 @@ goroutine, not mocks, `-race` clean.
   ```bash
   T=~/.local/share/sageox/sageox.ai/teams/team_xlcr6yzpec
   NOLFS="-c filter.lfs.smudge=cat -c filter.lfs.process= -c filter.lfs.required=false"
-  git -C $T $NOLFS checkout -- <path/to/image.jpg>
-  git -C $T $NOLFS pull --rebase --autostash
-  git -C $T stash clear
+  git -C "$T" $NOLFS checkout -- PATH_TO_ATTACHMENT  # replace with the path `git status` reports as modified
+  git -C "$T" $NOLFS pull --rebase --autostash
+  # drop only the orphan autostash entries the loop above produced — never
+  # `stash clear`, which would also delete any unrelated stash a teammate has
+  # legitimately pending. Re-querying `stash list` each iteration (rather than
+  # dropping from a pre-captured list) sidesteps index shifting after each drop.
+  while ref=$(git -C "$T" stash list | grep -im1 autostash | cut -d: -f1); [ -n "$ref" ]; do
+    git -C "$T" stash drop "$ref"
+  done
   ```
 
   This is precisely what `restoreRawLFSPointers` does; it is here because the doctor check

--- a/docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md
+++ b/docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md
@@ -147,15 +147,15 @@ to the ledger): a `--quiet` git pipeline whose error path assumes it is the only
 
 ## Actions
 
-| Action | Issue | Owner | Priority |
-|---|---|---|---|
-| Per-clone `flock` around fetch / pull / rebase at all four sites; re-fetch-and-retry once on the exact `multiple branches` error | `ox-baz5.1` | Ryan | P1 |
-| Recovery ladder acts only on a rebase this pull started | `ox-baz5.2` | Ryan | P2 |
-| Clear `IssueTypeRebaseStuck` and the sync-suspended warning on the next successful pull | `ox-baz5.3` | Ryan | P2 |
-| Every ox git invocation passes `-c filter.lfs.smudge=cat -c filter.lfs.clean=cat -c filter.lfs.process= -c filter.lfs.required=false` | `ox-baz5.4` | Ryan | P1 |
-| `ox doctor` walks every team-context clone the daemon syncs; nested-pointer fixture | `ox-baz5.5` | Ryan | P2 |
-| Atomic ledger clone; doctor repairs `HEAD → .invalid` without discarding staged content | `ox-baz5.6` | — | P1 |
-| ADR-007 addendum (checkout-side insulation) and ADR-030 (per-clone serialization) | this PR | — | — |
+| Action | Issue | Owner | Priority | Status |
+|---|---|---|---|---|
+| Per-clone `flock` around fetch / pull / rebase at all four sites; re-fetch-and-retry once on the exact `multiple branches` error | `ox-baz5.1` | Ryan | P1 | [PR #868](https://github.com/sageox/ox/pull/868) — open |
+| Recovery ladder acts only on a rebase this pull started | `ox-baz5.2` | Ryan | P2 | [PR #868](https://github.com/sageox/ox/pull/868) — open |
+| Clear `IssueTypeRebaseStuck` and the sync-suspended warning on the next successful pull | `ox-baz5.3` | Ryan | P2 | [PR #868](https://github.com/sageox/ox/pull/868) — open |
+| Every ox git invocation passes `-c filter.lfs.smudge=cat -c filter.lfs.clean=cat -c filter.lfs.process= -c filter.lfs.required=false` | `ox-baz5.4` | Ryan | P1 | not started |
+| `ox doctor` walks every team-context clone the daemon syncs; nested-pointer fixture | `ox-baz5.5` | Ryan | P2 | not started |
+| Atomic ledger clone; doctor repairs `HEAD → .invalid` without discarding staged content | `ox-baz5.6` | — | P1 | not started |
+| ADR-007 addendum (checkout-side insulation) and ADR-030 (per-clone serialization) | this PR | — | — | this docs PR |
 
 ## Manual recovery (what was done on the affected machine)
 


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a0635e-2c14-7c9a-bf25-68b26786b9f8">Session</a>
<!-- /sageox:pr-header -->

## Summary

- **What this is:** the incident writeup and design record for the daemon git-sync race fixed in [#868](https://github.com/sageox/ox/pull/868). Docs only — no code.
- **Why a COE:** the same failure class (a `--quiet` git pipeline whose error path assumes it's the only actor) already caused the April 2026 incident (`docs/coes/2026-04-07-multi-node-write-conflicts.md`). This one's root causes had been in the code for up to 7 months before anyone connected the symptoms — the "why it survived" section is the actual lesson, more than any individual fix.
- **Why an ADR:** `WithRepoLock` is a new invariant (every mutating git op on a managed clone is serialized) that the next contributor could easily re-break without knowing why it exists.

## What's in this PR

| File | Content |
|---|---|
| `docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md` (new) | Symptoms → minute-by-minute timeline (reconstructed from `ox daemon logs` + live reproduction on the real ledger) → reproduction numbers → root-cause table → why it survived 7 months → actions mapped to `ox-baz5.1`–`.6`, now cross-linked to #868 |
| `docs/adr/ADR-030-per-clone-git-serialization.md` (new) | D1 per-clone `flock` (kernel-released, no stale-lock reaper), D2 retry-once on the transient error, D3 recovery only touches a rebase it started, D4 every raised issue needs a clear path. Alternatives considered and rejected: in-process-mutex-only, widening the dedup window, routing through daemon IPC, an mtime-staleness lockfile |
| `docs/adr/ADR-007-direct-lfs.md` (+addendum) | ADR-007 insulated ox from the user's global git-lfs on the **push** side only, assuming checkout was safe because ox never writes `filter=lfs`. Team-context repos do ship it server-side (ADR-085, attachment storage) — addendum extends the insulation to checkout. Planned work (`ox-baz5.4`/`.5`), not yet built |

## Self-review before pushing

Cross-checked every claim in the first draft against the actual code that shipped in #868 (not just internal consistency) and found two factual errors, now fixed in a second commit:

- **ADR-030 D1** originally claimed the lock file lives at `<clone>/.git/ox-sync.lock`. It doesn't — `internal/gitutil/repolock.go`'s own doc comment says the physical file lives in the OS tmpdir (`fileutil.LockPath`); nothing is ever written inside the clone. Fixed, and flipped the wrongly-stated "one more file in `.git/`" tradeoff into the benefit it actually is.
- **ADR-007 addendum** claimed its 4-flag `filter.lfs.*` override was "the exact set `restoreRawLFSPointers` already uses." That function uses only 3 (no `clean=cat` — a read-only checkout never exercises the clean/write filter). Corrected, with the actual reason the 4th flag is needed (`pull --autostash` can invoke clean when stashing).
- Also fixed a dead `D1` anchor citation into a file that doesn't use D-numbered sections, and a markdown table row left at 4 cells against a 5-column header.

## Test plan

- [x] Docs only — no code changes, no build/test impact.
- [x] `ox decision enrich --file` run on both new ADRs before and after the fix; only pre-existing corpus warning is unrelated duplicate ADR numbering elsewhere (002/003/006/007/008/009/018/019/023) — ADR-030 itself is not a collision.
- [x] Every code reference in both ADRs (function names, file paths, flag sets, line-of-reasoning) verified against the code that actually shipped in #868, not just written from memory.

## Related

- Code: [#868](https://github.com/sageox/ox/pull/868) — implements `ox-baz5.1`/`.2`/`.3`, the fixes this COE/ADR document
- Epic: bd `ox-baz5`
- Plan of record (HTML, live review): `ox plan view 2026-09-02-daemon-git-sync-five-fixes`
- Reviewer: Ryan (owns every file the fixes touch — ox-computed expert route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGUJYrGMKR9XiJw85L9UyC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791005383&installation_model_id=433550&pr_number=869&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F869&signature=e146636d3565ef99ea17d442a691fb6613eafcfdd89d3960755ff79420fe75ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified Git LFS guidance, including exceptions for team-context clones and planned follow-up work.
  - Accepted and finalized guidance for serializing Git operations within individual clones.
  - Added incident documentation covering synchronization races, LFS divergence, damaged clone recovery, remediation status, testing, and manual recovery procedures.
  - Updated recovery instructions to use safer attachment handling and target only identified stale stashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->