### PR TITLE
test(cmd/ox): stop the doctor --fix test from rewriting the repo's AGENTS.md

### DIFF
--- a/cmd/ox/doctor_display_test.go
+++ b/cmd/ox/doctor_display_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -465,28 +467,58 @@ func TestRunDoctorChecks_CategoryStructure(t *testing.T) {
 	}
 }
 
-// TestRunDoctorChecks_WithFixFlag verifies fix flag is passed through
+// adapterBlockFixture is an AGENTS.md carrying one adapter prime block
+// between the two universal markers: what `--fix` must remove, wrapped in
+// what it must leave alone.
+const adapterBlockFixture = "<!-- ox:prime-check -->\n\n" +
+	"<!-- ox:prime:pi:start -->\n## Pi block\nox agent prime\n<!-- ox:prime:pi:end -->\n" +
+	"<!-- ox:prime --> footer\n"
+
+// TestRunDoctorChecks_WithFixFlag verifies the fix flag reaches the checks.
 func TestRunDoctorChecks_WithFixFlag(t *testing.T) {
 	// Not part of the fast tier. This drives a REAL doctor pass with fix=true —
 	// network probes (the ledger connectivity check alone allows 10s), API calls,
 	// and git operations — and it cannot be cached because it has side effects.
-	// In isolation it takes ~5s; under `-parallel 32` contention it measured
-	// 192s, roughly half the entire `make test` wall clock for this one test.
-	// It still runs in `make test-all` and CI, which is where it belongs.
+	// In isolation it takes ~5s. It still runs in `make test-all` and CI, which
+	// is where it belongs.
 	if testing.Short() {
 		t.Skip("short: drives a real doctor --fix pass with network probes")
 	}
-	t.Parallel()
+
+	// Read the shared fix=false result first, while the working directory is
+	// still the one every other consumer of the cache sees. The cache is a
+	// sync.Once, so whichever test populates it decides what they all read.
+	categoriesWithoutFix := getCachedDoctorChecks(t)
+	require.NotEmpty(t, categoriesWithoutFix, "runDoctorChecks(false) returned no categories")
+
+	// Deliberately not t.Parallel. A fix pass resolves its target through
+	// findGitRoot(), i.e. through the process-wide working directory, so the
+	// only way to keep it off the developer's checkout is to move that
+	// directory — which is not safe while parallel tests share the process.
+	//
+	// Failure prevented: run from the checkout, this test's own --fix pass
+	// stripped the adapter prime block out of the repository's tracked
+	// AGENTS.md on every full-tier run, and reported ok while doing it.
+	dir := setupGitRepoWithFiles(t, map[string]string{"AGENTS.md": adapterBlockFixture})
+
 	// run with fix=true (can't cache this since it may have side effects)
 	categoriesWithFix := runDoctorChecks(context.Background(), doctorOptions{fix: true})
 	require.NotEmpty(t, categoriesWithFix, "runDoctorChecks(true) returned no categories")
 
-	// use cached fix=false result
-	categoriesWithoutFix := getCachedDoctorChecks(t)
-	require.NotEmpty(t, categoriesWithoutFix, "runDoctorChecks(false) returned no categories")
+	// The flag reached the checks, and it reached them here rather than in the
+	// checkout: the adapter block is gone from the throwaway repo while the
+	// universal markers around it survive.
+	fixed, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(fixed), "ox:prime:pi:start",
+		"fix=true left the adapter prime block in place")
+	assert.Contains(t, string(fixed), "<!-- ox:prime -->",
+		"fix=true removed a universal marker it must preserve")
 
-	// both should return similar category structure; minor differences acceptable
-	// due to conditional checks that may only appear in one mode
+	// The two passes ran in different working directories, so this compares the
+	// shape of the check registry rather than anything about the fix flag: the
+	// count is structurally the same in both modes, and the tolerance only
+	// absorbs conditional checks that may appear in one of them.
 	assert.InDelta(t, len(categoriesWithFix), len(categoriesWithoutFix), 3, "category count difference too large")
 }
 

--- a/cmd/ox/doctor_display_test.go
+++ b/cmd/ox/doctor_display_test.go
@@ -467,12 +467,25 @@ func TestRunDoctorChecks_CategoryStructure(t *testing.T) {
 	}
 }
 
+// adapterBlockLines are the lines of the Pi adapter block in
+// adapterBlockFixture: every one of them must be gone after a fix pass, since
+// stripBlock removes the whole span between the markers, not just the markers.
+// Spelled out literally rather than read from adapterBlockMarkers so that
+// dropping an entry from that table cannot quietly turn this into a test of a
+// different block.
+var adapterBlockLines = []string{
+	"<!-- ox:prime:pi:start -->",
+	"## Pi block",
+	"ox agent prime",
+	"<!-- ox:prime:pi:end -->",
+}
+
 // adapterBlockFixture is an AGENTS.md carrying one adapter prime block
 // between the two universal markers: what `--fix` must remove, wrapped in
 // what it must leave alone.
-const adapterBlockFixture = "<!-- ox:prime-check -->\n\n" +
+const adapterBlockFixture = OxPrimeCheckMarker + "\n\n" +
 	"<!-- ox:prime:pi:start -->\n## Pi block\nox agent prime\n<!-- ox:prime:pi:end -->\n" +
-	"<!-- ox:prime --> footer\n"
+	OxPrimeMarker + " footer\n"
 
 // TestRunDoctorChecks_WithFixFlag verifies the fix flag reaches the checks.
 func TestRunDoctorChecks_WithFixFlag(t *testing.T) {
@@ -510,10 +523,14 @@ func TestRunDoctorChecks_WithFixFlag(t *testing.T) {
 	// universal markers around it survive.
 	fixed, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
 	require.NoError(t, err)
-	assert.NotContains(t, string(fixed), "ox:prime:pi:start",
-		"fix=true left the adapter prime block in place")
-	assert.Contains(t, string(fixed), "<!-- ox:prime -->",
-		"fix=true removed a universal marker it must preserve")
+	for _, line := range adapterBlockLines {
+		assert.NotContains(t, string(fixed), line,
+			"fix=true left part of the adapter prime block behind: %q", line)
+	}
+	assert.Contains(t, string(fixed), OxPrimeCheckMarker,
+		"fix=true removed the universal ox:prime-check header it must preserve")
+	assert.Contains(t, string(fixed), OxPrimeMarker,
+		"fix=true removed the universal ox:prime footer it must preserve")
 
 	// The two passes ran in different working directories, so this compares the
 	// shape of the check registry rather than anything about the fix flag: the


### PR DESCRIPTION
Fixes #865.

## What broke

`TestRunDoctorChecks_WithFixFlag` drove a real `ox doctor --fix` pass with no working-directory
isolation. `--fix` resolves its target through `findGitRoot()`, which reads the process working
directory — so the target was **the contributor's own checkout**, and the pass stripped the adapter
prime block out of the repository's tracked `AGENTS.md` on every full-tier run, reporting `ok` while
doing it.

- **Blast radius:** exactly 12 deletions in one tracked file, every `make test-all` / `make test-preflight`.
- **Silent:** the test passed. Nothing in the suite asserts the repo is unchanged.
- **Easy to commit by accident:** `AGENTS.md` is the instruction file agents read, and the deletion
  lands in an unrelated PR's diff.

```mermaid
flowchart TD
    T["TestRunDoctorChecks_WithFixFlag<br/>(no chdir)"] --> R["runDoctorChecks(fix: true)"]
    R --> C["checkAdapterPrimeBlocks(shouldFix)"]
    C --> G["findGitRoot()<br/>reads process cwd"]
    G --> W{"cwd is..."}
    W -->|"the checkout"| BAD["AtomicWriteBytes strips<br/>ox:prime:pi block from<br/>tracked AGENTS.md"]
    W -->|"a temp repo"| OK["writes to the throwaway<br/>fixture — correct"]
    style BAD fill:#f8d7da,stroke:#b02a37
    style OK fill:#d1e7dd,stroke:#0f5132
```

- **Why the fast tier never caught it:** the test skips under `-short`, so `make test` gives a clean
  all-clear. Only the full tier runs it — i.e. it fires exactly when a contributor validates before
  opening a PR.
- **`TEST_GIT_ISOLATION` does not help:** it neutralizes gitconfig and signing, not the working directory.
- **Not fixed by #859:** A/B'd against #859's head — identical 12 deletions, identical blob hashes
  (`b7859ce3` → `5e438a68`). #859 guards `ensurePrimeBeforeSession`; this path never calls it.

## What this PR ships

Test-only. **No production file is modified.**

| Change | Why |
|---|---|
| Run inside a throwaway repo via the existing `setupGitRepoWithFiles` fixture | The actual fix. Reuses the helper already built for this check rather than adding a new one. |
| Drop `t.Parallel()` | **Required, not incidental.** The working directory is process-global, so it cannot be moved safely while parallel tests share the process. This is why the fix is not the one-liner the issue suggested. |
| Read `getCachedDoctorChecks` **before** the chdir | `sync.Once` shared across the package — whichever test populates it decides what every other consumer reads. Chdir'ing first would have silently fed temp-repo doctor results to unrelated tests: a worse bug than the one being fixed. |
| Assert the block was actually removed | The old test only compared category counts within a delta of 3, which passes for almost any behavior. It now asserts the adapter block is gone from the fixture and the universal `ox:prime` markers survive. |

Two sentences of the test's comment were dropped as no longer true: they described `-parallel 32`
contention timings that stop applying once the test is not parallel.

The category-count assertion is **kept**, with its comment corrected. It now compares two passes that
ran in different working directories, and the count turns out to be a structural property of the check
registry — measured at 19 for `fix=false` in the checkout and 19 for `fix=true` in the temp repo. It
is harmless and stable, but the block-removal assertions above are what give the test its meaning.

## Scope: is this the only one?

Per `.claude/rules/testing.md` ("test the CLASS of failure, not the specific patch"), I audited every
test that drives a real doctor pass rather than only the reported one:

| Test | Drives a real pass | Isolated? |
|---|---|---|
| `doctor_fresh_install_test.go` ×3 | yes | ✅ already `os.Chdir` into a temp repo |
| `doctor_test.go:33` (cached, `fix: false`) | yes | n/a — read-only |
| `TestRunDoctorChecks_WithFixFlag` | yes, **`fix: true`** | ❌ **this PR** |

The other ten `doctorOptions{fix: true}` occurrences in `cmd/ox` are pure `shouldFix` /
`shouldFixAdapterSlug` predicate tests — no doctor pass, no filesystem access.

**This was the only unisolated one.**

## Test Plan

- **Reproduced first, on a clean branch off `main`:** `AGENTS.md` `b7859ce3…` → `5e438a68…`, 12 deletions.
- **After the fix:** hash unchanged through a full `go test ./... -race` **and** through
  `make test-preflight` — the exact gate that used to corrupt it.
- **The new assertion is not vacuous.** Ran the identical fixture through a `fix: false` pass: the
  adapter block **survives**. Under `fix: true` it is **removed**. So the assertion discriminates on
  the flag and fails if `--fix` stops reaching the check.
- `make lint` — **0 issues**.
- `make test-preflight` — slow tier 9,249 tests / 0 failures; lint clean; `AGENTS.md` untouched.

**Pre-existing failures, not from this change** (test-only diff in `cmd/ox`; Go links each package's
tests into a separate binary, so this file is never compiled into those packages):

- `internal/ledger` — reproduced on **clean `main`** under the same full-suite load. All 8 reported
  failures stem from one assertion: `github_sync_test.go:546` uses `t.Errorf` (which does not halt)
  and then indexes `[0]` on the empty slice at `:548`, panicking the package and taking 7 unrelated
  `TestCloneWithSparseCheckout_*` tests with it. Filing separately — the amplification is a defect
  regardless of what makes the assertion fail.
- `internal/codedb/store`, `internal/daemon` — load-dependent; pass in isolation on both this branch
  and `main`, and the failing sets differ between runs.

## Not fixed here

Nothing structurally prevents the next unisolated `--fix` test. A `git diff --exit-code` step after
the suite would turn "a test silently rewrote a tracked file" into a hard failure, with precedent in
`TestDoctorFreshCheckout_NoSideEffectDirectories` (added for bug #35, the same family). Happy to add
it here or as a follow-up — it touches the Makefile/CI, so I did not assume.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791050328&installation_model_id=433550&pr_number=872&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F872&signature=9396368c1cb3907836a489b127bddb94e05a5735601bb1c0f3e6ea6010c8aa58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for the doctor fix workflow, including removal of adapter-specific PRIME blocks while preserving universal PRIME markers.
  - Improved test isolation for doctor checks with and without the fix option.
  - Added validation that cached results remain consistent across repeated doctor runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->