### PR TITLE
fix(codedb): serve a read-only index instead of deleting it as corrupt

### DIFF
--- a/cmd/ox/code.go
+++ b/cmd/ox/code.go
@@ -314,7 +314,7 @@ const (
 // branch on `status` rather than parsing stderr — this turns a hard error into
 // a recoverable signal that includes the recommended fallback.
 type indexNotReadyResponse struct {
-	Status       string `json:"status"`        // "indexing" | "not_indexed"
+	Status       string `json:"status"` // "indexing" | "not_indexed"
 	Message      string `json:"message"`
 	FallbackHint string `json:"fallback_hint"`
 }
@@ -659,10 +659,21 @@ var codeStatusCmd = &cobra.Command{
 		}
 		var repos []repoRow
 
+		// openErr records why the counts below are missing. Without it the
+		// output of an index that could not be opened is byte-identical to a
+		// warm index holding nothing — zeros under index_exists: true — and a
+		// caller searching that store gets no results and reports none.
+		var openErr string
+		var readOnly bool
+
 		daemonIndexing := codeStats != nil && ((useLedger && codeStats.LedgerIndexingNow) || (!useLedger && codeStats.IndexingNow))
 		if indexExists && !daemonIndexing {
 			db, err := codedb.Open(dataDir)
+			if err != nil {
+				openErr = err.Error()
+			}
 			if err == nil {
+				readOnly = db.ReadOnly()
 				_ = db.Store().QueryRow("SELECT COUNT(*) FROM commits").Scan(&totalCommits)
 				_ = db.Store().QueryRow("SELECT COUNT(*) FROM blobs").Scan(&totalBlobs)
 				_ = db.Store().QueryRow("SELECT COUNT(*) FROM symbols").Scan(&totalSymbols)
@@ -722,6 +733,12 @@ var codeStatusCmd = &cobra.Command{
 				IndexingNow bool            `json:"indexing_now"`
 				LastIndexed *time.Time      `json:"last_indexed,omitempty"`
 				LastError   string          `json:"last_error,omitempty"`
+				// OpenError is set when the index directory exists but could not
+				// be opened. When present the counts above are unknown, not zero.
+				OpenError string `json:"open_error,omitempty"`
+				// ReadOnly reports an index served from media ox cannot write:
+				// searchable, but never re-indexed or self-healed in place.
+				ReadOnly bool `json:"read_only,omitempty"`
 			}
 			out := jsonStats{
 				Commits:     totalCommits,
@@ -732,6 +749,8 @@ var codeStatusCmd = &cobra.Command{
 				DiskBytes:   dirSize(dataDir),
 				DataDir:     dataDir,
 				IndexExists: indexExists,
+				OpenError:   openErr,
+				ReadOnly:    readOnly,
 			}
 			if codeStats != nil {
 				out.IndexingNow = codeStats.IndexingNow
@@ -803,6 +822,14 @@ var codeStatusCmd = &cobra.Command{
 			b.WriteString("\n")
 			fmt.Print(b.String())
 			return nil
+		case openErr != "":
+			// Ranked above every daemon-derived state: the daemon's cached
+			// counts describe an index this machine just failed to open, and
+			// reporting them would hide that failure behind a healthy number.
+			b.WriteString(statusErrorStyle.Render("✗ unreadable"))
+			b.WriteString("\n")
+			b.WriteString(statusLabelStyle.Render(""))
+			b.WriteString(statusMutedStyle.Render(openErr))
 		case codeStats != nil && codeStats.IndexingNow:
 			b.WriteString(statusWarningStyle.Render("◐ indexing…"))
 		case codeStats != nil && codeStats.LastError != "" && totalCommits == 0:
@@ -826,6 +853,17 @@ var codeStatusCmd = &cobra.Command{
 			b.WriteString(statusSuccessStyle.Render("✓ indexed"))
 		}
 		b.WriteString("\n")
+
+		if readOnly {
+			b.WriteString(statusLabelStyle.Render("Mode"))
+			b.WriteString(statusWarningStyle.Render("read-only"))
+			b.WriteString("\n")
+			b.WriteString(statusLabelStyle.Render(""))
+			b.WriteString(statusMutedStyle.Render("Served from media ox cannot write — searchable, but "))
+			b.WriteString(statusHighlightStyle.Render("ox code index"))
+			b.WriteString(statusMutedStyle.Render(" will refuse"))
+			b.WriteString("\n")
+		}
 
 		// repo identity — show GitHub remote name if detected
 		if ghOwner != "" && ghRepo != "" {

--- a/cmd/ox/code.go
+++ b/cmd/ox/code.go
@@ -753,7 +753,12 @@ var codeStatusCmd = &cobra.Command{
 				ReadOnly:    readOnly,
 			}
 			if codeStats != nil {
-				out.IndexingNow = codeStats.IndexingNow
+				// daemonIndexing, not codeStats.IndexingNow: when this repo
+				// reads the ledger index, LedgerIndexingNow is the flag that
+				// gated the direct open above. Reporting the shared index's
+				// flag here says "not indexing" while the counts came from the
+				// daemon's cache precisely because it is.
+				out.IndexingNow = daemonIndexing
 				if !codeStats.LastIndexed.IsZero() {
 					t := codeStats.LastIndexed
 					out.LastIndexed = &t
@@ -812,7 +817,7 @@ var codeStatusCmd = &cobra.Command{
 		// status line — health signal first
 		b.WriteString(statusLabelStyle.Render("Status"))
 		switch {
-		case !indexExists && (codeStats == nil || !codeStats.IndexingNow):
+		case !indexExists && !daemonIndexing:
 			b.WriteString(statusWarningStyle.Render("⚠ not indexed"))
 			b.WriteString("\n")
 			b.WriteString(statusLabelStyle.Render(""))
@@ -830,7 +835,7 @@ var codeStatusCmd = &cobra.Command{
 			b.WriteString("\n")
 			b.WriteString(statusLabelStyle.Render(""))
 			b.WriteString(statusMutedStyle.Render(openErr))
-		case codeStats != nil && codeStats.IndexingNow:
+		case daemonIndexing:
 			b.WriteString(statusWarningStyle.Render("◐ indexing…"))
 		case codeStats != nil && codeStats.LastError != "" && totalCommits == 0:
 			b.WriteString(statusWarningStyle.Render("⚠ pending"))
@@ -1032,7 +1037,7 @@ var codeStatusCmd = &cobra.Command{
 		b.WriteString("\n")
 
 		// next check — only when daemon is running and index exists
-		if codeStats != nil && !codeStats.IndexingNow && indexExists && syncInterval > 0 && !codeStats.LastIndexed.IsZero() {
+		if codeStats != nil && !daemonIndexing && indexExists && syncInterval > 0 && !codeStats.LastIndexed.IsZero() {
 			nextCheck := codeStats.LastIndexed.Add(syncInterval)
 			remaining := time.Until(nextCheck)
 			b.WriteString(statusLabelStyle.Render("Next check"))

--- a/cmd/ox/code_status_readonly_test.go
+++ b/cmd/ox/code_status_readonly_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,11 +17,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// codeStatusJSON stands up a git project wired to a shared CodeDB dir, lets the
-// caller seed and then break that dir, and returns the parsed `ox code status
-// --json` envelope. Running the real command is the point: the defect being
-// guarded is what a caller reads off this JSON, not what a helper returns.
-func codeStatusJSON(t *testing.T, seed func(dataDir string)) map[string]any {
+// runCodeStatus stands up a git project wired to a shared CodeDB dir, lets the
+// caller seed and then break that dir, and runs the real `ox code status`.
+// Running the real command is the point: the defect being guarded is what a
+// caller reads off this output, not what a helper returns.
+//
+// Returns the human-readable text; when jsonMode is set the parsed `--json`
+// envelope is returned instead and the text is empty. The human path prints
+// through fmt.Print, so os.Stdout is what has to be captured.
+func runCodeStatus(t *testing.T, jsonMode bool, seed func(dataDir string)) (map[string]any, string) {
 	t.Helper()
 
 	projectRoot := t.TempDir()
@@ -57,13 +62,31 @@ func codeStatusJSON(t *testing.T, seed func(dataDir string)) map[string]any {
 
 	var buf bytes.Buffer
 	cmd := &cobra.Command{Use: codeStatusCmd.Use, RunE: codeStatusCmd.RunE}
-	cmd.Flags().Bool("json", true, "")
+	cmd.Flags().Bool("json", jsonMode, "")
 	cmd.SetOut(&buf)
-	require.NoError(t, cmd.RunE(cmd, nil))
 
+	stdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	require.NoError(t, pipeErr)
+	os.Stdout = w
+	// Drain concurrently: a full pipe buffer would deadlock the command mid-print.
+	drained := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		drained <- string(b)
+	}()
+	runErr := cmd.RunE(cmd, nil)
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+	human := <-drained
+	require.NoError(t, runErr)
+
+	if !jsonMode {
+		return nil, human
+	}
 	var out map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "output: %s", buf.String())
-	return out
+	return out, ""
 }
 
 func requireChmodDeniesWrites(t *testing.T, dir string) {
@@ -83,7 +106,7 @@ func requireChmodDeniesWrites(t *testing.T, dir string) {
 // it and say where it came from — a caller that sees read_only knows `ox code
 // index` will refuse before it tries.
 func TestCodeStatusJSON_ReadOnlyIndexIsCountedAndLabeled(t *testing.T) {
-	out := codeStatusJSON(t, func(dataDir string) {
+	out, _ := runCodeStatus(t, true, func(dataDir string) {
 		requireChmodDeniesWrites(t, dataDir)
 	})
 
@@ -97,7 +120,7 @@ func TestCodeStatusJSON_ReadOnlyIndexIsCountedAndLabeled(t *testing.T) {
 // under index_exists: true — byte-identical to a warm index holding nothing.
 // An agent reads that as "nothing here", searches, finds nothing, and says so.
 func TestCodeStatusJSON_UnreadableIndexIsNotReportedAsEmpty(t *testing.T) {
-	out := codeStatusJSON(t, func(dataDir string) {
+	out, _ := runCodeStatus(t, true, func(dataDir string) {
 		// Truncate to a schema-less file: readable, openable, and carrying none
 		// of the tables status counts — the shape of an index ox cannot use.
 		require.NoError(t, os.WriteFile(filepath.Join(dataDir, store.MetadataDBFile), nil, 0o600))
@@ -107,4 +130,36 @@ func TestCodeStatusJSON_UnreadableIndexIsNotReportedAsEmpty(t *testing.T) {
 	require.Equal(t, true, out["index_exists"])
 	require.NotEmpty(t, out["open_error"],
 		"an index that could not be opened must not read as an empty one: %v", out)
+}
+
+// The JSON envelope is not the only surface a coworker reads. Human output must
+// carry the same two facts, and carry them where the eye lands first — on the
+// Status line, not buried under counts that look healthy.
+func TestCodeStatusHuman_LabelsReadOnlyAndUnreadable(t *testing.T) {
+	t.Run("read-only index says so and points at the consequence", func(t *testing.T) {
+		_, human := runCodeStatus(t, false, func(dataDir string) {
+			requireChmodDeniesWrites(t, dataDir)
+		})
+		require.Contains(t, human, "read-only")
+		require.Contains(t, human, "ox code index")
+		require.NotContains(t, human, "unreadable")
+	})
+
+	t.Run("unreadable index reports the reason, not an empty one", func(t *testing.T) {
+		_, human := runCodeStatus(t, false, func(dataDir string) {
+			require.NoError(t, os.WriteFile(filepath.Join(dataDir, store.MetadataDBFile), nil, 0o600))
+			requireChmodDeniesWrites(t, dataDir)
+		})
+		require.Contains(t, human, "unreadable")
+		require.Contains(t, human, "read-only")
+		// "empty index" is the state this must never be confused with.
+		require.NotContains(t, human, "empty index")
+	})
+
+	t.Run("absent index still reads as not indexed", func(t *testing.T) {
+		_, human := runCodeStatus(t, false, func(dataDir string) {
+			require.NoError(t, os.RemoveAll(dataDir))
+		})
+		require.Contains(t, human, "not indexed")
+	})
 }

--- a/cmd/ox/code_status_readonly_test.go
+++ b/cmd/ox/code_status_readonly_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/sageox/ox/internal/codedb"
+	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// codeStatusJSON stands up a git project wired to a shared CodeDB dir, lets the
+// caller seed and then break that dir, and returns the parsed `ox code status
+// --json` envelope. Running the real command is the point: the defect being
+// guarded is what a caller reads off this JSON, not what a helper returns.
+func codeStatusJSON(t *testing.T, seed func(dataDir string)) map[string]any {
+	t.Helper()
+
+	projectRoot := t.TempDir()
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	for _, args := range [][]string{{"init"}, {"config", "user.email", "t@example.com"}, {"config", "user.name", "T"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = projectRoot
+		require.NoError(t, cmd.Run(), "git %v", args)
+	}
+
+	sageoxDir := filepath.Join(projectRoot, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0o755))
+	cfg, err := json.Marshal(map[string]string{"repo_id": "repo_01abc123", "endpoint": "https://sageox.ai"})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), cfg, 0o644))
+
+	dataDir := paths.CodeDBSharedDir("repo_01abc123", "https://sageox.ai")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	db, err := codedb.Open(dataDir)
+	require.NoError(t, err)
+	_, err = db.Store().Exec(`INSERT INTO repos (id, name, path) VALUES (1, 'demo', '/tmp/demo')`)
+	require.NoError(t, err)
+	_, err = db.Store().Exec(`INSERT INTO commits (id, repo_id, hash, author, message, timestamp) VALUES (1, 1, 'abc', 'a', 'm', 0)`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	seed(dataDir)
+
+	// chdir last: FindRepoRoot and the daemon socket both resolve from cwd, so
+	// this is what keeps the test off any daemon running for the real repo.
+	t.Chdir(projectRoot)
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{Use: codeStatusCmd.Use, RunE: codeStatusCmd.RunE}
+	cmd.Flags().Bool("json", true, "")
+	cmd.SetOut(&buf)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out), "output: %s", buf.String())
+	return out
+}
+
+func requireChmodDeniesWrites(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod does not make a directory unwritable on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod does not deny writes")
+	}
+	out, err := exec.Command("chmod", "-R", "a-w", dir).CombinedOutput()
+	require.NoError(t, err, "chmod: %s", out)
+	t.Cleanup(func() { _ = exec.Command("chmod", "-R", "u+w", dir).Run() })
+}
+
+// An index served from read-only media is real data, and status must both count
+// it and say where it came from — a caller that sees read_only knows `ox code
+// index` will refuse before it tries.
+func TestCodeStatusJSON_ReadOnlyIndexIsCountedAndLabeled(t *testing.T) {
+	out := codeStatusJSON(t, func(dataDir string) {
+		requireChmodDeniesWrites(t, dataDir)
+	})
+
+	require.Equal(t, true, out["index_exists"])
+	require.Equal(t, true, out["read_only"], "read-only index must be labeled: %v", out)
+	require.Equal(t, float64(1), out["commits"], "read-only index must still be counted: %v", out)
+	require.Nil(t, out["open_error"])
+}
+
+// The reported defect (#871): an index status could not open reported zeros
+// under index_exists: true — byte-identical to a warm index holding nothing.
+// An agent reads that as "nothing here", searches, finds nothing, and says so.
+func TestCodeStatusJSON_UnreadableIndexIsNotReportedAsEmpty(t *testing.T) {
+	out := codeStatusJSON(t, func(dataDir string) {
+		// Truncate to a schema-less file: readable, openable, and carrying none
+		// of the tables status counts — the shape of an index ox cannot use.
+		require.NoError(t, os.WriteFile(filepath.Join(dataDir, store.MetadataDBFile), nil, 0o600))
+		requireChmodDeniesWrites(t, dataDir)
+	})
+
+	require.Equal(t, true, out["index_exists"])
+	require.NotEmpty(t, out["open_error"],
+		"an index that could not be opened must not read as an empty one: %v", out)
+}

--- a/cmd/ox/code_test.go
+++ b/cmd/ox/code_test.go
@@ -181,11 +181,14 @@ func TestCodeStatusDisplay_EmptyIndex(t *testing.T) {
 	var codeStats *daemon.CodeDBStats // nil = no daemon running
 
 	// Evaluate the switch conditions in order, matching codeStatusCmd logic.
+	// daemonIndexing folds in the ledger index's flag; codeStats is nil here,
+	// so it is false and the branch order is what is under test.
+	daemonIndexing := codeStats != nil && codeStats.IndexingNow
 	var statusCase string
 	switch {
-	case !indexExists && (codeStats == nil || !codeStats.IndexingNow):
+	case !indexExists && !daemonIndexing:
 		statusCase = "not-indexed"
-	case codeStats != nil && codeStats.IndexingNow:
+	case daemonIndexing:
 		statusCase = "indexing"
 	case codeStats != nil && codeStats.LastError != "" && totalCommits == 0:
 		statusCase = "pending"

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **See where a slow pipeline actually spends its time** — `ox viz render waterfall` draws the browser-devtools waterfall for any timed sequence: one row per stage on one clock, so overlap and serialization are obvious at a glance. Give the rows dependency edges and it computes the critical path, dims everything that didn't set the total, marks the long pole, and draws the idle wait between stages — the dead time a bar-only chart hides and the cheapest latency to delete.
 - **Preview any visualization in a browser without hand-building a page** — `ox viz render <id> --page` wraps the fragment in a standalone themed document carrying the same stylesheet the visual ships against, so what you see is what lands in the artifact.
+- **Search a code index you can't write** — `ox code search` now serves a codedb on read-only media: a read-only mount, a container image layer, or a copy on a locked-down volume. A scheduled job can mount an index another process maintains and query it without keeping a second copy or paying for a cold rebuild.
+
+### Fixed
+
+- **A read-only code index is no longer mistaken for a corrupt one and deleted** — ox read "cannot write this database" as "this database is damaged" and tried to delete it; only the read-only filesystem stopped it. The same misreading on writable media would have destroyed a healthy index that costs minutes to rebuild.
+- **`ox code status` no longer reports an index it could not open as an empty one** — it answered zeros under `index_exists: true`, which reads exactly like a warm index holding nothing. It now shows `✗ unreadable` with the reason (`open_error` in `--json`), and labels a read-only index as such.
+- **`ox code index` refuses a read-only index up front** — with a message naming the directory, instead of failing partway through a pass.
 
 ## [0.14.3] - 2026-08-31
 

--- a/internal/codedb/codedb.go
+++ b/internal/codedb/codedb.go
@@ -59,6 +59,12 @@ func (db *DB) Store() *store.Store {
 	return db.store
 }
 
+// ReadOnly reports whether the codedb was opened from media this process cannot
+// write. Reads work; indexing is refused.
+func (db *DB) ReadOnly() bool {
+	return db.store.ReadOnly
+}
+
 // IndexRepo clones/fetches and indexes a git repository.
 func (db *DB) IndexRepo(ctx context.Context, url string, opts index.IndexOptions) error {
 	return index.IndexRepo(ctx, db.store, url, opts)
@@ -87,6 +93,15 @@ func OpenIndexWithHeal(ctx context.Context, dataDir string, indexFn func(context
 	db, err := Open(dataDir)
 	if err != nil {
 		return nil, err
+	}
+
+	// Every recovery below this point writes: the marker escalation and the
+	// corruption retry both wipe dataDir, and indexFn itself only writes. On a
+	// read-only store none of that is possible, so say so once here instead of
+	// failing partway through a pass.
+	if db.ReadOnly() {
+		_ = db.Close()
+		return nil, fmt.Errorf("cannot index into %s: %w", dataDir, store.ErrReadOnly)
 	}
 
 	// Open self-heals a structurally-corrupt bleve sub-index transparently: it

--- a/internal/codedb/codedb_heal_test.go
+++ b/internal/codedb/codedb_heal_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
 	"github.com/sageox/ox/internal/codedb"
 	"github.com/sageox/ox/internal/codedb/index"
+	"github.com/sageox/ox/internal/codedb/store"
 )
 
 // The crash-loop this fix targets: an indexing pass fails against a half-written
@@ -174,5 +177,48 @@ func TestBuildCodeDBAtomic_ConcurrentBuildsLeaveValidCache(t *testing.T) {
 	_ = db.Close()
 	if leftovers, _ := filepath.Glob(finalDir + ".*"); len(leftovers) != 0 {
 		t.Fatalf("expected no staging/backup leftovers after concurrent builds, found %v", leftovers)
+	}
+}
+
+// A read-only store has no writable path through OpenIndexWithHeal: indexFn
+// only writes, and both recovery arms (marker escalation, corruption retry)
+// wipe dataDir. Refusing up front keeps a mounted read-only index from being
+// half-processed and, more importantly, from reaching os.RemoveAll.
+func TestOpenIndexWithHeal_RefusesReadOnlyStore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod does not make a directory unwritable on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod does not deny writes")
+	}
+
+	dataDir := filepath.Join(t.TempDir(), "codedb")
+	seed, err := codedb.Open(dataDir)
+	if err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("seed close: %v", err)
+	}
+	if out, err := exec.Command("chmod", "-R", "a-w", dataDir).CombinedOutput(); err != nil {
+		t.Fatalf("chmod: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("chmod", "-R", "u+w", dataDir).Run() })
+
+	called := false
+	db, err := codedb.OpenIndexWithHeal(context.Background(), dataDir,
+		func(context.Context, *codedb.DB) error { called = true; return nil })
+	if err == nil {
+		_ = db.Close()
+		t.Fatal("OpenIndexWithHeal succeeded on a read-only store; want refusal")
+	}
+	if !errors.Is(err, store.ErrReadOnly) {
+		t.Errorf("error = %v, want store.ErrReadOnly", err)
+	}
+	if called {
+		t.Error("indexFn ran against a read-only store")
+	}
+	if _, statErr := os.Stat(filepath.Join(dataDir, store.MetadataDBFile)); statErr != nil {
+		t.Errorf("metadata.db missing after refusal: %v", statErr)
 	}
 }

--- a/internal/codedb/store/migration_test.go
+++ b/internal/codedb/store/migration_test.go
@@ -575,7 +575,7 @@ func TestCreateSchema_ConcurrentFreshOpen(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start // maximize overlap on the check-then-ALTER race window
-			db, err := openSQLite(root)
+			db, _, err := openSQLite(root)
 			errs[i] = err
 			dbs[i] = db
 		}(i)
@@ -599,7 +599,7 @@ func TestCreateSchema_ConcurrentFreshOpen(t *testing.T) {
 
 	// Regardless of which opener "won" each migration's race, the schema
 	// must have landed fully and be queryable from an independent connection.
-	verifyDB, err := openSQLite(root)
+	verifyDB, _, err := openSQLite(root)
 	if err != nil {
 		t.Fatalf("reopen after concurrent creation: %v", err)
 	}

--- a/internal/codedb/store/readonly.go
+++ b/internal/codedb/store/readonly.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/blevesearch/bleve/v2"
+)
+
+// ErrReadOnly reports that the codedb store lives on media this process cannot
+// write. It is deliberately not ErrCorrupt: nothing about the store is damaged,
+// so nothing about it is deleted, rebuilt, or self-healed. A read-only store
+// that opens successfully serves reads and sets Store.ReadOnly; one that cannot
+// be served read-only fails with this error explaining why.
+var ErrReadOnly = errors.New("codedb index is read-only")
+
+// storeIsWritable reports whether this process can create a file inside root.
+//
+// It exists to keep "cannot write" from being diagnosed as "corrupt". On
+// read-only media, PRAGMA integrity_check fails with SQLITE_READONLY_DIRECTORY
+// — WAL mode has to create the `-shm` wal-index before it can read anything —
+// and at that call site the failure is indistinguishable from real corruption,
+// whose remedy is deleting the database. So writability is settled before any
+// corruption verdict is reached.
+//
+// Probing with a real file rather than reading mode bits is what makes the
+// answer true for the cases that actually occur: a read-only bind mount, a
+// container image layer, an ACL, or a chmod. It runs on every open of an
+// existing store; a create-close-unlink is cheap next to the SQLite and bleve
+// opens that follow it in the same call.
+func storeIsWritable(root string) bool {
+	f, err := os.CreateTemp(root, ".ox-write-probe-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return true
+}
+
+// openSQLiteReadOnly opens metadata.db for reading on media this process cannot
+// write. The store is in WAL mode, so which of SQLite's two read-only openings
+// applies depends on whether an un-checkpointed WAL is sitting next to it.
+//
+//   - No WAL sidecar (the state a cleanly closed store is left in: SQLite
+//     checkpoints and deletes it when the last connection closes) — the main
+//     file is the whole database, and `immutable=1` reads it without creating
+//     the `-shm` wal-index it would otherwise need. Plain `mode=ro` fails here
+//     with SQLITE_READONLY_DIRECTORY.
+//
+//   - A WAL sidecar with content (a store copied or killed mid-write) — SQLite
+//     reads a WAL database with no write access as long as both `-wal` and
+//     `-shm` are present and readable, so `mode=ro` sees the whole database and
+//     immutable=1 must NOT be used: it ignores the WAL, and the rows parked
+//     there can be anything up to the entire schema. If that open fails,
+//     refuse. A partial database answering queries fluently is the failure this
+//     whole path exists to prevent.
+func openSQLiteReadOnly(dbPath string) (*sql.DB, error) {
+	immutable := true
+	if fi, err := os.Stat(dbPath + "-wal"); err == nil && fi.Size() > 0 {
+		immutable = false
+	}
+
+	db, err := sql.Open("sqlite", readOnlyDSN(dbPath, immutable))
+	if err != nil {
+		return nil, fmt.Errorf("%w: open sqlite: %w", ErrReadOnly, err)
+	}
+
+	// Prove the store answers a query before handing it back, so an unreadable
+	// file, an absent schema, or a WAL whose `-shm` is missing surfaces here
+	// instead of as "no such table" on every later query. PRAGMA
+	// integrity_check is skipped: it costs O(database size) — 0.8s to 18s on
+	// stores we already ship — and its only remedy is the deletion this path
+	// exists to refuse.
+	var name string
+	if err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name='commits'`).Scan(&name); err != nil {
+		_ = db.Close()
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s has no codedb schema and cannot be initialized without write access", ErrReadOnly, dbPath)
+		}
+		if !immutable {
+			return nil, fmt.Errorf("%w: %s holds un-checkpointed writes and its write-ahead log cannot be read here: %w", ErrReadOnly, dbPath, err)
+		}
+		return nil, fmt.Errorf("%w: %w", ErrReadOnly, err)
+	}
+	return db, nil
+}
+
+// readOnlyDSN builds the SQLite URI for a read-only open. The `file:` scheme is
+// what makes SQLite parse `immutable` at all, and the URI form means the path
+// must be escaped — a database under a home directory containing a space would
+// otherwise be truncated at the space. journal_mode, synchronous and
+// foreign_keys are all write-side and are omitted.
+func readOnlyDSN(dbPath string, immutable bool) string {
+	u := url.URL{Scheme: "file", Path: dbPath}
+	dsn := u.String() + "?mode=ro&_pragma=cache_size(-65536)&_pragma=mmap_size(268435456)&_pragma=temp_store(MEMORY)"
+	if immutable {
+		dsn += "&immutable=1"
+	}
+	return dsn
+}
+
+// openBleveReadOnly opens one bleve sub-index with scorch's read_only config,
+// which opens root.bolt O_RDONLY and creates no directory — the two things
+// bleve.Open does that a read-only store cannot afford.
+//
+// Errors are returned as-is. The self-heal and mapping-upgrade paths that handle
+// them on a writable store both nuke and recreate the sub-index directory, which
+// is neither possible nor wanted here.
+func openBleveReadOnly(path, name string) (idx bleve.Index, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			idx = nil
+			err = fmt.Errorf("%w: bleve %s sub-index at %s panicked on open: %v", ErrReadOnly, name, path, r)
+		}
+	}()
+	idx, err = bleve.OpenUsing(path, map[string]interface{}{"read_only": true})
+	if err != nil {
+		return nil, fmt.Errorf("%w: open bleve %s sub-index at %s: %w", ErrReadOnly, name, path, err)
+	}
+	return idx, nil
+}

--- a/internal/codedb/store/readonly.go
+++ b/internal/codedb/store/readonly.go
@@ -152,16 +152,27 @@ func readOnlyDSN(dbPath string, immutable bool) string {
 // Errors are returned as-is. The self-heal and mapping-upgrade paths that handle
 // them on a writable store both nuke and recreate the sub-index directory, which
 // is neither possible nor wanted here.
-func openBleveReadOnly(path, name string) (idx bleve.Index, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			idx = nil
-			err = fmt.Errorf("%w: bleve %s sub-index at %s panicked on open: %v", ErrReadOnly, name, path, r)
-		}
-	}()
-	idx, err = bleve.OpenUsing(path, map[string]interface{}{"read_only": true})
+func openBleveReadOnly(path, name string) (bleve.Index, error) {
+	idx, err := recoverBleveOpen(func() (bleve.Index, error) {
+		return bleve.OpenUsing(path, map[string]interface{}{"read_only": true})
+	})
 	if err != nil {
 		return nil, fmt.Errorf("%w: open bleve %s sub-index at %s: %w", ErrReadOnly, name, path, err)
 	}
 	return idx, nil
+}
+
+// recoverBleveOpen runs open, turning a panic into an error. bleve can panic on
+// a structurally broken index rather than returning one — safeOpenBleve carries
+// the same guard for the writable path. Factored out so the recovery contract is
+// testable without a corrupt index on disk, the same reason runBleveProbe is
+// separate from CheckIntegrity.
+func recoverBleveOpen(open func() (bleve.Index, error)) (idx bleve.Index, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			idx = nil
+			err = fmt.Errorf("panic during open: %v", r)
+		}
+	}()
+	return open()
 }

--- a/internal/codedb/store/readonly.go
+++ b/internal/codedb/store/readonly.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/blevesearch/bleve/v2"
 )
@@ -87,6 +89,23 @@ func openSQLiteReadOnly(dbPath string) (*sql.DB, error) {
 		}
 		return nil, fmt.Errorf("%w: %w", ErrReadOnly, err)
 	}
+
+	// A store built by an older ox is missing tables and columns the current
+	// search path queries, and the writable open repairs that by running
+	// CreateSchema on every open. Here it cannot, so a stale store would answer
+	// some queries and fail others with "no such column".
+	//
+	// CreateSchema is reused as the check rather than a hand-listed set of
+	// required objects: every statement in it is guarded (CREATE ... IF NOT
+	// EXISTS, addColumnsIfMissing, the issue-474 sentinel), so against a
+	// fully-migrated store it writes nothing and succeeds on a read-only
+	// connection, and against a stale one it attempts the missing DDL and fails
+	// naming the object. A parallel list would drift from the migrations the
+	// first time someone adds one.
+	if err := CreateSchema(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("%w: %s needs a schema migration that cannot be applied without write access: %w", ErrReadOnly, dbPath, err)
+	}
 	return db, nil
 }
 
@@ -95,8 +114,18 @@ func openSQLiteReadOnly(dbPath string) (*sql.DB, error) {
 // must be escaped — a database under a home directory containing a space would
 // otherwise be truncated at the space. journal_mode, synchronous and
 // foreign_keys are all write-side and are omitted.
+//
+// Windows needs both conversions below. ToSlash turns `C:\...` separators into
+// the `/` SQLite's URI parser requires (a no-op on POSIX, where a backslash is
+// an ordinary filename character and must stay one). The leading slash makes a
+// drive-letter path absolute: without it `url.URL` renders `C:` as the URI's
+// authority — `file://C:/...` — and the open fails.
 func readOnlyDSN(dbPath string, immutable bool) string {
-	u := url.URL{Scheme: "file", Path: dbPath}
+	uriPath := filepath.ToSlash(dbPath)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	u := url.URL{Scheme: "file", Path: uriPath}
 	dsn := u.String() + "?mode=ro&_pragma=cache_size(-65536)&_pragma=mmap_size(268435456)&_pragma=temp_store(MEMORY)"
 	if immutable {
 		dsn += "&immutable=1"

--- a/internal/codedb/store/readonly.go
+++ b/internal/codedb/store/readonly.go
@@ -44,6 +44,18 @@ func storeIsWritable(root string) bool {
 	return true
 }
 
+// fileIsWritable reports whether this process can open path for writing.
+// Distinct from storeIsWritable, which asks about the directory: SQLite needs
+// both, and a store can fail on either one alone.
+func fileIsWritable(path string) bool {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
 // openSQLiteReadOnly opens metadata.db for reading on media this process cannot
 // write. The store is in WAL mode, so which of SQLite's two read-only openings
 // applies depends on whether an un-checkpointed WAL is sitting next to it.

--- a/internal/codedb/store/readonly_test.go
+++ b/internal/codedb/store/readonly_test.go
@@ -440,6 +440,12 @@ func TestOpenReadOnlyDatabaseFileInWritableDirIsNotDeleted(t *testing.T) {
 		_ = got.Close()
 		t.Fatal("Open succeeded with an unwritable database needing migration; want refusal")
 	}
+	// Same physical condition as an unwritable directory, so it must carry the
+	// same error class — a caller asking "is this index writable?" should not
+	// have to know which half of the store said no.
+	if !errors.Is(err, ErrReadOnly) {
+		t.Errorf("error = %v, want ErrReadOnly", err)
+	}
 	if errors.Is(err, ErrCorrupt) {
 		t.Errorf("error = %v, must not be reported as corruption", err)
 	}

--- a/internal/codedb/store/readonly_test.go
+++ b/internal/codedb/store/readonly_test.go
@@ -297,6 +297,31 @@ func TestReadOnlyDSNEscapesPath(t *testing.T) {
 	}
 }
 
+// fileIsWritable decides whether a failed migration is a read-only store or a
+// real error, so a wrong answer either way matters: false-negative loses the
+// classification, false-positive lets the corruption remedy run.
+func TestFileIsWritable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metadata.db")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !fileIsWritable(path) {
+		t.Error("fileIsWritable = false on a 0600 file, want true")
+	}
+
+	requirePOSIXPermissions(t)
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	if fileIsWritable(path) {
+		t.Error("fileIsWritable = true on a 0444 file, want false")
+	}
+	if fileIsWritable(filepath.Join(t.TempDir(), "absent.db")) {
+		t.Error("fileIsWritable = true for a file that does not exist, want false")
+	}
+}
+
 // storeIsWritable is the gate that keeps "cannot write" from reaching the
 // corruption verdict, so both of its answers need to be true.
 func TestStoreIsWritable(t *testing.T) {
@@ -452,4 +477,29 @@ func TestOpenReadOnlyDatabaseFileInWritableDirIsNotDeleted(t *testing.T) {
 	if _, statErr := os.Stat(dbPath); statErr != nil {
 		t.Errorf("metadata.db was deleted from a writable directory: %v", statErr)
 	}
+}
+
+// A read-only store is never repaired, so a bleve sub-index that panics on open
+// must come back as an error the caller can report — an escaping panic would
+// take down `ox code search` instead.
+func TestRecoverBleveOpen(t *testing.T) {
+	t.Run("panic becomes an error", func(t *testing.T) {
+		idx, err := recoverBleveOpen(func() (bleve.Index, error) { panic("torn scorch segment") })
+		if err == nil {
+			t.Fatal("panic did not surface as an error")
+		}
+		if idx != nil {
+			t.Error("index must be nil after a panic")
+		}
+		if !strings.Contains(err.Error(), "torn scorch segment") {
+			t.Errorf("error = %v, want it to carry the panic value", err)
+		}
+	})
+
+	t.Run("ordinary results pass through", func(t *testing.T) {
+		want := errors.New("index path does not exist")
+		if _, err := recoverBleveOpen(func() (bleve.Index, error) { return nil, want }); !errors.Is(err, want) {
+			t.Errorf("error = %v, want it unchanged", err)
+		}
+	})
 }

--- a/internal/codedb/store/readonly_test.go
+++ b/internal/codedb/store/readonly_test.go
@@ -1,0 +1,260 @@
+package store
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2"
+)
+
+// requireUnwritableMedia makes dir and everything under it unwritable, or skips.
+// chmod is a no-op for root and does not model a read-only filesystem on
+// Windows, so a test relying on it would silently assert nothing there.
+func requireUnwritableMedia(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod does not make a directory unwritable on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod does not deny writes")
+	}
+	if out, err := exec.Command("chmod", "-R", "a-w", dir).CombinedOutput(); err != nil {
+		t.Fatalf("chmod -R a-w %s: %v: %s", dir, err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("chmod", "-R", "u+w", dir).Run() })
+
+	if f, err := os.CreateTemp(dir, ".probe-*"); err == nil {
+		name := f.Name()
+		_ = f.Close()
+		_ = os.Remove(name)
+		t.Skipf("%s is still writable after chmod -R a-w", dir)
+	}
+}
+
+// seedStore builds a store holding one repo row and one indexed code document,
+// then closes it so SQLite checkpoints and removes the WAL.
+func seedStore(t *testing.T, root string) {
+	t.Helper()
+	s, err := Open(root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := s.Exec(`INSERT INTO repos (name, path) VALUES ('demo', '/tmp/demo')`); err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	if err := s.CodeIndex.Index("doc1", map[string]any{"content": "func createRepoWorkspace() {}"}); err != nil {
+		t.Fatalf("index doc: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+// A store on read-only media is a legitimate state, not a damaged one: it must
+// open, answer SQL and bleve queries, and above all still be on disk afterwards.
+// The reported failure (#871) was PRAGMA integrity_check reading
+// SQLITE_READONLY_DIRECTORY as corruption and deleting the index over it.
+func TestOpenReadOnlyStoreServesReadsWithoutDeleting(t *testing.T) {
+	root := t.TempDir()
+	seedStore(t, root)
+	requireUnwritableMedia(t, root)
+
+	s, err := Open(root)
+	if err != nil {
+		t.Fatalf("Open on read-only media: %v", err)
+	}
+	defer s.Close()
+
+	if !s.ReadOnly {
+		t.Error("Store.ReadOnly = false, want true")
+	}
+
+	var repos int
+	if err := s.QueryRow(`SELECT COUNT(*) FROM repos`).Scan(&repos); err != nil {
+		t.Fatalf("count repos: %v", err)
+	}
+	if repos != 1 {
+		t.Errorf("repos = %d, want 1", repos)
+	}
+
+	res, err := s.CodeIndex.Search(bleve.NewSearchRequest(bleve.NewMatchQuery("createRepoWorkspace")))
+	if err != nil {
+		t.Fatalf("bleve search: %v", err)
+	}
+	if res.Total != 1 {
+		t.Errorf("bleve hits = %d, want 1", res.Total)
+	}
+}
+
+// A store captured mid-write holds committed rows — up to and including the
+// whole schema — only in its WAL sidecar, and immutable=1 would skip past them.
+// Reading it must either see the WAL (SQLite's sidecar-present read-only mode)
+// or refuse; what it must never do is answer confidently from the main file
+// alone, which is the same fluent-empty-answer failure as #871 itself.
+func TestOpenReadOnlyStoreHonorsUncheckpointedWAL(t *testing.T) {
+	live := t.TempDir()
+	s, err := Open(live)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := s.Exec(`INSERT INTO repos (name, path) VALUES ('demo', '/tmp/demo')`); err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+
+	// Copy while the connection is open, so the snapshot keeps the WAL sidecar.
+	snap := t.TempDir()
+	if out, err := exec.Command("cp", "-R", live+"/.", snap).CombinedOutput(); err != nil {
+		t.Fatalf("cp: %v: %s", err, out)
+	}
+	_ = s.Close()
+
+	if fi, err := os.Stat(filepath.Join(snap, MetadataDBFile+"-wal")); err != nil || fi.Size() == 0 {
+		t.Skipf("snapshot has no un-checkpointed WAL to test against (err=%v)", err)
+	}
+	requireUnwritableMedia(t, snap)
+
+	got, err := Open(snap)
+	if err != nil {
+		if !errors.Is(err, ErrReadOnly) {
+			t.Errorf("error = %v, want ErrReadOnly", err)
+		}
+		if errors.Is(err, ErrCorrupt) {
+			t.Errorf("error = %v, must not be reported as corruption", err)
+		}
+	} else {
+		defer got.Close()
+		if !got.ReadOnly {
+			t.Error("Store.ReadOnly = false, want true")
+		}
+		// The row lives only in the WAL. Seeing zero here means immutable=1
+		// read past it and the store is answering from half a database.
+		var repos int
+		if err := got.QueryRow(`SELECT COUNT(*) FROM repos`).Scan(&repos); err != nil {
+			t.Fatalf("count repos: %v", err)
+		}
+		if repos != 1 {
+			t.Errorf("repos = %d, want 1 — the WAL was skipped", repos)
+		}
+	}
+	// Backstop for the corruption remedy itself. On read-only media the
+	// removal fails anyway, so the load-bearing assertion is the ErrCorrupt
+	// check above; this catches a future path that deletes from a writable
+	// parent instead.
+	if _, statErr := os.Stat(filepath.Join(snap, MetadataDBFile)); statErr != nil {
+		t.Errorf("metadata.db missing after read-only open: %v", statErr)
+	}
+}
+
+// Guards the choice made in openSQLiteReadOnly: immutable=1 is what lets a
+// cleanly closed store be read at all, and it is exactly what must be dropped
+// when a WAL sidecar is present, because immutable ignores the WAL.
+func TestReadOnlyDSNImmutableOnlyWhenAsked(t *testing.T) {
+	if !strings.Contains(readOnlyDSN("/tmp/metadata.db", true), "immutable=1") {
+		t.Error("immutable DSN is missing immutable=1")
+	}
+	if strings.Contains(readOnlyDSN("/tmp/metadata.db", false), "immutable") {
+		t.Error("WAL-present DSN sets immutable, which would skip the WAL")
+	}
+}
+
+// OpenSQLOnly shares openSQLite with Open, so it must report the same state —
+// `ox code insights` and the status counters go through it.
+func TestOpenSQLOnlyReportsReadOnly(t *testing.T) {
+	root := t.TempDir()
+	seedStore(t, root)
+	requireUnwritableMedia(t, root)
+
+	s, err := OpenSQLOnly(root)
+	if err != nil {
+		t.Fatalf("OpenSQLOnly on read-only media: %v", err)
+	}
+	defer s.Close()
+
+	if !s.ReadOnly {
+		t.Error("Store.ReadOnly = false, want true")
+	}
+	var repos int
+	if err := s.QueryRow(`SELECT COUNT(*) FROM repos`).Scan(&repos); err != nil {
+		t.Fatalf("count repos: %v", err)
+	}
+	if repos != 1 {
+		t.Errorf("repos = %d, want 1", repos)
+	}
+}
+
+// A read-only store missing its schema must say so, not hand back a handle that
+// fails "no such table" on every later query.
+func TestOpenReadOnlyStoreRejectsMissingSchema(t *testing.T) {
+	root := t.TempDir()
+	seedStore(t, root)
+	// Replace metadata.db with an empty (valid, schema-less) SQLite file.
+	dbPath := filepath.Join(root, MetadataDBFile)
+	if err := os.WriteFile(dbPath, nil, 0o600); err != nil {
+		t.Fatalf("truncate db: %v", err)
+	}
+	requireUnwritableMedia(t, root)
+
+	got, err := Open(root)
+	if err == nil {
+		_ = got.Close()
+		t.Fatal("Open succeeded on a schema-less read-only store; want refusal")
+	}
+	if !errors.Is(err, ErrReadOnly) {
+		t.Errorf("error = %v, want ErrReadOnly", err)
+	}
+}
+
+// The read-only DSN is a file: URI, so an unescaped path would be truncated at
+// the first space — silently opening a different (nonexistent) database.
+func TestReadOnlyDSNEscapesPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "dir with space")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seedStore(t, root)
+
+	dsn := readOnlyDSN(filepath.Join(root, MetadataDBFile), true)
+	if strings.Contains(dsn, "dir with space") {
+		t.Errorf("DSN %q leaves the space unescaped", dsn)
+	}
+
+	requireUnwritableMedia(t, root)
+	s, err := Open(root)
+	if err != nil {
+		t.Fatalf("Open on read-only media with a spaced path: %v", err)
+	}
+	defer s.Close()
+	var repos int
+	if err := s.QueryRow(`SELECT COUNT(*) FROM repos`).Scan(&repos); err != nil {
+		t.Fatalf("count repos: %v", err)
+	}
+	if repos != 1 {
+		t.Errorf("repos = %d, want 1", repos)
+	}
+}
+
+// storeIsWritable is the gate that keeps "cannot write" from reaching the
+// corruption verdict, so both of its answers need to be true.
+func TestStoreIsWritable(t *testing.T) {
+	root := t.TempDir()
+	if !storeIsWritable(root) {
+		t.Fatal("storeIsWritable = false on a fresh temp dir, want true")
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("probe left %d entries behind: %v", len(entries), entries)
+	}
+
+	requireUnwritableMedia(t, root)
+	if storeIsWritable(root) {
+		t.Error("storeIsWritable = true on unwritable media, want false")
+	}
+}

--- a/internal/codedb/store/readonly_test.go
+++ b/internal/codedb/store/readonly_test.go
@@ -12,17 +12,24 @@ import (
 	"github.com/blevesearch/bleve/v2"
 )
 
-// requireUnwritableMedia makes dir and everything under it unwritable, or skips.
-// chmod is a no-op for root and does not model a read-only filesystem on
-// Windows, so a test relying on it would silently assert nothing there.
-func requireUnwritableMedia(t *testing.T, dir string) {
+// requirePOSIXPermissions skips a test that models read-only media with POSIX
+// tooling. chmod is a no-op for root, and neither chmod nor cp behaves this way
+// on Windows — a test relying on either would silently assert nothing there.
+// Call it before the first such command, not merely before the chmod.
+func requirePOSIXPermissions(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
-		t.Skip("chmod does not make a directory unwritable on Windows")
+		t.Skip("chmod/cp do not model read-only media on Windows")
 	}
 	if os.Geteuid() == 0 {
 		t.Skip("running as root: chmod does not deny writes")
 	}
+}
+
+// requireUnwritableMedia makes dir and everything under it unwritable, or skips.
+func requireUnwritableMedia(t *testing.T, dir string) {
+	t.Helper()
+	requirePOSIXPermissions(t)
 	if out, err := exec.Command("chmod", "-R", "a-w", dir).CombinedOutput(); err != nil {
 		t.Fatalf("chmod -R a-w %s: %v: %s", dir, err, out)
 	}
@@ -97,6 +104,10 @@ func TestOpenReadOnlyStoreServesReadsWithoutDeleting(t *testing.T) {
 // or refuse; what it must never do is answer confidently from the main file
 // alone, which is the same fluent-empty-answer failure as #871 itself.
 func TestOpenReadOnlyStoreHonorsUncheckpointedWAL(t *testing.T) {
+	// Before the cp below, not just before the chmod inside
+	// requireUnwritableMedia — cp is not a Windows executable.
+	requirePOSIXPermissions(t)
+
 	live := t.TempDir()
 	s, err := Open(live)
 	if err != nil {
@@ -187,6 +198,41 @@ func TestOpenSQLOnlyReportsReadOnly(t *testing.T) {
 	}
 }
 
+// A store built by an older ox lacks tables and columns the current search path
+// queries. The writable open repairs that with CreateSchema; a read-only one
+// cannot, so it must refuse rather than answer some queries and fail others
+// with "no such column".
+func TestOpenReadOnlyStoreRejectsStaleSchema(t *testing.T) {
+	root := t.TempDir()
+	s, err := Open(root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Roll the store back to a pre-migration shape.
+	if _, err := s.Exec(`ALTER TABLE symbols DROP COLUMN signature`); err != nil {
+		t.Fatalf("drop symbols.signature: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	requireUnwritableMedia(t, root)
+
+	got, err := Open(root)
+	if err == nil {
+		_ = got.Close()
+		t.Fatal("Open succeeded on a read-only store needing migration; want refusal")
+	}
+	if !errors.Is(err, ErrReadOnly) {
+		t.Errorf("error = %v, want ErrReadOnly", err)
+	}
+	if errors.Is(err, ErrCorrupt) {
+		t.Errorf("error = %v, must not be reported as corruption", err)
+	}
+	if !strings.Contains(err.Error(), "signature") {
+		t.Errorf("error = %v, want it to name the missing object", err)
+	}
+}
+
 // A read-only store missing its schema must say so, not hand back a handle that
 // fails "no such table" on every later query.
 func TestOpenReadOnlyStoreRejectsMissingSchema(t *testing.T) {
@@ -206,6 +252,19 @@ func TestOpenReadOnlyStoreRejectsMissingSchema(t *testing.T) {
 	}
 	if !errors.Is(err, ErrReadOnly) {
 		t.Errorf("error = %v, want ErrReadOnly", err)
+	}
+}
+
+// The read-only DSN is a file: URI. Both of these are silent-wrong-database
+// bugs: an unescaped space truncates the path, and a path rendered without the
+// third slash puts its first segment in the URI's authority — which is what a
+// Windows `C:\...` path does.
+func TestReadOnlyDSNIsAnAbsoluteFileURI(t *testing.T) {
+	for _, p := range []string{"/tmp/x/metadata.db", `C:\Users\a\metadata.db`, "C:/Users/a/metadata.db"} {
+		dsn := readOnlyDSN(p, true)
+		if !strings.HasPrefix(dsn, "file:///") {
+			t.Errorf("readOnlyDSN(%q) = %q, want a file:/// URI (authority must stay empty)", p, dsn)
+		}
 	}
 }
 
@@ -256,5 +315,135 @@ func TestStoreIsWritable(t *testing.T) {
 	requireUnwritableMedia(t, root)
 	if storeIsWritable(root) {
 		t.Error("storeIsWritable = true on unwritable media, want false")
+	}
+}
+
+// SQLite can only read a WAL database without write access when BOTH sidecars
+// are present and readable. With the `-shm` gone the store is unreadable here,
+// and the error must say that rather than blame corruption — the immutable=1
+// fallback that would "work" reads past the WAL and answers from a partial
+// database.
+func TestOpenReadOnlyStoreRefusesWALWithoutSharedMemory(t *testing.T) {
+	requirePOSIXPermissions(t)
+
+	live := t.TempDir()
+	s, err := Open(live)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := s.Exec(`INSERT INTO repos (name, path) VALUES ('demo', '/tmp/demo')`); err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	snap := t.TempDir()
+	if out, err := exec.Command("cp", "-R", live+"/.", snap).CombinedOutput(); err != nil {
+		t.Fatalf("cp: %v: %s", err, out)
+	}
+	_ = s.Close()
+
+	if fi, err := os.Stat(filepath.Join(snap, MetadataDBFile+"-wal")); err != nil || fi.Size() == 0 {
+		t.Skipf("snapshot has no un-checkpointed WAL to test against (err=%v)", err)
+	}
+	if err := os.Remove(filepath.Join(snap, MetadataDBFile+"-shm")); err != nil {
+		t.Fatalf("remove -shm: %v", err)
+	}
+	requireUnwritableMedia(t, snap)
+
+	got, err := Open(snap)
+	if err == nil {
+		_ = got.Close()
+		t.Fatal("Open succeeded on a WAL store with no -shm; want refusal")
+	}
+	if !errors.Is(err, ErrReadOnly) {
+		t.Errorf("error = %v, want ErrReadOnly", err)
+	}
+	if errors.Is(err, ErrCorrupt) {
+		t.Errorf("error = %v, must not be reported as corruption", err)
+	}
+}
+
+// A read-only store whose bleve sub-index is gone cannot be repaired: the
+// writable path would nuke and recreate it, which needs a writable directory.
+// It must report that, not return a store whose searches dereference nil.
+func TestOpenReadOnlyStoreReportsMissingBleveSubIndex(t *testing.T) {
+	root := t.TempDir()
+	seedStore(t, root)
+	if err := os.RemoveAll(filepath.Join(root, "bleve", "code")); err != nil {
+		t.Fatalf("remove bleve/code: %v", err)
+	}
+	requireUnwritableMedia(t, root)
+
+	got, err := Open(root)
+	if err == nil {
+		_ = got.Close()
+		t.Fatal("Open succeeded with no bleve code sub-index; want refusal")
+	}
+	if !errors.Is(err, ErrReadOnly) {
+		t.Errorf("error = %v, want ErrReadOnly", err)
+	}
+	if !strings.Contains(err.Error(), "code") {
+		t.Errorf("error = %v, want it to name the sub-index", err)
+	}
+}
+
+// A read-only file that is not a SQLite database at all is still not ox's to
+// delete. The verdict must be "I cannot read this", never "this is corrupt" —
+// only the latter reaches removeSQLiteFiles.
+func TestOpenReadOnlyStoreRejectsNonDatabaseFile(t *testing.T) {
+	root := t.TempDir()
+	seedStore(t, root)
+	if err := os.WriteFile(filepath.Join(root, MetadataDBFile), []byte("this is not a database"), 0o600); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	requireUnwritableMedia(t, root)
+
+	got, err := Open(root)
+	if err == nil {
+		_ = got.Close()
+		t.Fatal("Open succeeded on a read-only non-database file; want refusal")
+	}
+	if !errors.Is(err, ErrReadOnly) {
+		t.Errorf("error = %v, want ErrReadOnly", err)
+	}
+	if errors.Is(err, ErrCorrupt) {
+		t.Errorf("error = %v, must not be reported as corruption", err)
+	}
+}
+
+// The database file is read-only but its directory is not, so SQLite can create
+// the WAL sidecars and integrity_check passes — the store looks fine until a
+// migration tries to write. This is the one shape where the corruption remedy
+// COULD delete the file, which is what makes the survival assertion here mean
+// something: the failure is a refusal, not a deletion.
+func TestOpenReadOnlyDatabaseFileInWritableDirIsNotDeleted(t *testing.T) {
+	requirePOSIXPermissions(t)
+
+	root := t.TempDir()
+	s, err := Open(root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := s.Exec(`ALTER TABLE symbols DROP COLUMN signature`); err != nil {
+		t.Fatalf("drop symbols.signature: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	dbPath := filepath.Join(root, MetadataDBFile)
+	if err := os.Chmod(dbPath, 0o444); err != nil {
+		t.Fatalf("chmod db: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dbPath, 0o644) })
+
+	got, err := Open(root)
+	if err == nil {
+		_ = got.Close()
+		t.Fatal("Open succeeded with an unwritable database needing migration; want refusal")
+	}
+	if errors.Is(err, ErrCorrupt) {
+		t.Errorf("error = %v, must not be reported as corruption", err)
+	}
+	if _, statErr := os.Stat(dbPath); statErr != nil {
+		t.Errorf("metadata.db was deleted from a writable directory: %v", statErr)
 	}
 }

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -147,6 +147,11 @@ type Store struct {
 	Root         string
 	closeOnce    sync.Once
 
+	// ReadOnly is set when the store was opened from media this process cannot
+	// write (read-only mount, container layer, chmod). Reads are served; every
+	// write, self-heal and mapping upgrade is refused rather than attempted.
+	ReadOnly bool
+
 	// dirty overlays for uncommitted worktree files (keyed by worktree ID)
 	dirtyCodeIndexes  map[string]bleve.Index
 	CombinedCodeIndex bleve.Index // alias of CodeIndex + all dirty indexes, or just CodeIndex
@@ -177,13 +182,16 @@ type Store struct {
 // that need bleve (e.g. `ox code search`) just see empty results until the
 // daemon repopulates; callers that don't need bleve (e.g. `ox code insights`)
 // should use OpenSQLOnly to skip bleve entirely.
+//
+// Read-only media: a store the process cannot write is opened read-only (see
+// ErrReadOnly) with Store.ReadOnly set, not diagnosed as corrupt and deleted.
 func Open(root string) (*Store, error) {
-	db, err := openSQLite(root)
+	db, readOnly, err := openSQLite(root)
 	if err != nil {
 		return nil, err
 	}
 
-	codeIndex, diffIndex, commentIndex, err := openBleveIndexes(root)
+	codeIndex, diffIndex, commentIndex, err := openBleveIndexes(root, readOnly)
 	if err != nil {
 		_ = db.Close()
 		return nil, err
@@ -196,6 +204,7 @@ func Open(root string) (*Store, error) {
 		DiffIndex:        diffIndex,
 		CommentIndex:     commentIndex,
 		Root:             root,
+		ReadOnly:         readOnly,
 		dirtyCodeIndexes: make(map[string]bleve.Index),
 	}
 	s.CombinedCodeIndex = s.CodeIndex // default: no overlay
@@ -211,7 +220,7 @@ func Open(root string) (*Store, error) {
 // or otherwise unavailable. SQLite's WAL mode makes concurrent reads safe
 // even while the daemon is actively writing.
 func OpenSQLOnly(root string) (*Store, error) {
-	db, err := openSQLite(root)
+	db, readOnly, err := openSQLite(root)
 	if err != nil {
 		return nil, err
 	}
@@ -219,23 +228,36 @@ func OpenSQLOnly(root string) (*Store, error) {
 		db:               db,
 		queries:          codedbsqlc.New(db),
 		Root:             root,
+		ReadOnly:         readOnly,
 		dirtyCodeIndexes: make(map[string]bleve.Index),
 	}, nil
 }
 
 // openSQLite handles the SQLite half of store construction. Shared by Open
 // and OpenSQLOnly so the SQLite pragma string and integrity check live in one
-// place.
-func openSQLite(root string) (*sql.DB, error) {
+// place. The bool reports whether the store had to be opened read-only.
+func openSQLite(root string) (*sql.DB, bool, error) {
+	dbPath := filepath.Join(root, MetadataDBFile)
+
+	// Settle writability before anything diagnoses the store. On read-only
+	// media SQLite fails with SQLITE_READONLY_DIRECTORY — WAL mode has to
+	// create the `-shm` wal-index before it can read anything — and at the
+	// integrity_check call site below that is indistinguishable from
+	// corruption, whose remedy is deleting the database. A store we cannot
+	// write is not a store that is damaged (#871).
+	if _, err := os.Stat(dbPath); err == nil && !storeIsWritable(root) {
+		db, roErr := openSQLiteReadOnly(dbPath)
+		return db, true, roErr
+	}
+
 	reposDir := filepath.Join(root, "repos")
 	bleveDir := filepath.Join(root, "bleve")
 	for _, dir := range []string{root, reposDir, bleveDir} {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
-			return nil, fmt.Errorf("create dir %s: %w", dir, err)
+			return nil, false, fmt.Errorf("create dir %s: %w", dir, err)
 		}
 	}
 
-	dbPath := filepath.Join(root, MetadataDBFile)
 	// WAL: concurrent readers + one writer. busy_timeout: wait up to 5s for
 	// write locks instead of failing immediately. This matters when multiple
 	// daemons (one per worktree) share the same index. Long-term fix is
@@ -245,21 +267,28 @@ func openSQLite(root string) (*sql.DB, error) {
 	// to normal I/O for pages beyond the mmap region or on unsupported systems.
 	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)&_pragma=cache_size(-65536)&_pragma=mmap_size(268435456)&_pragma=temp_store(MEMORY)")
 	if err != nil {
-		return nil, fmt.Errorf("open sqlite: %w", err)
+		return nil, false, fmt.Errorf("open sqlite: %w", err)
 	}
 
 	if err := checkSQLiteIntegrity(db); err != nil {
 		_ = db.Close()
+		// Re-probe. The check at the top of this function is skipped when no
+		// metadata.db existed yet, and media can turn read-only in between (a
+		// remount, a revoked ACL). Deleting the index over either is
+		// unrecoverable — a cold rebuild costs minutes.
+		if !storeIsWritable(root) {
+			return nil, true, fmt.Errorf("%w: %w", ErrReadOnly, err)
+		}
 		slog.Error("sqlite corruption detected, removing database", "path", dbPath, "err", err)
 		removeSQLiteFiles(dbPath)
-		return nil, fmt.Errorf("sqlite integrity check failed: %w", ErrCorrupt)
+		return nil, false, fmt.Errorf("sqlite integrity check failed: %w", ErrCorrupt)
 	}
 
 	if err := CreateSchema(db); err != nil {
 		_ = db.Close()
-		return nil, fmt.Errorf("create schema: %w", err)
+		return nil, false, fmt.Errorf("create schema: %w", err)
 	}
-	return db, nil
+	return db, false, nil
 }
 
 // bleveMappingFor returns the bleve index mapping for a sub-index.
@@ -376,19 +405,30 @@ func upgradeBleveSubIndex(root, path, name string, fromVersion int) (bleve.Index
 // openBleveIndexes opens (or self-heals + recreates) the three bleve
 // sub-indexes. Returns all three on success; closes any successfully opened
 // indexes if a later one fails.
-func openBleveIndexes(root string) (codeIdx, diffIdx, commentIdx bleve.Index, err error) {
+//
+// A read-only store gets neither self-heal nor mapping-version upgrade: both
+// are nuke-and-recreate, and both need a writable directory. It opens what is
+// on disk or reports why it could not.
+func openBleveIndexes(root string, readOnly bool) (codeIdx, diffIdx, commentIdx bleve.Index, err error) {
 	bleveDir := filepath.Join(root, "bleve")
+	open := func(name string) (bleve.Index, error) {
+		path := filepath.Join(bleveDir, name)
+		if readOnly {
+			return openBleveReadOnly(path, name)
+		}
+		return openOrCreateBleveIndex(root, path, name)
+	}
 
-	codeIdx, err = openOrCreateBleveIndex(root, filepath.Join(bleveDir, "code"), "code")
+	codeIdx, err = open("code")
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("open code index: %w", err)
 	}
-	diffIdx, err = openOrCreateBleveIndex(root, filepath.Join(bleveDir, "diff"), "diff")
+	diffIdx, err = open("diff")
 	if err != nil {
 		_ = codeIdx.Close()
 		return nil, nil, nil, fmt.Errorf("open diff index: %w", err)
 	}
-	commentIdx, err = openOrCreateBleveIndex(root, filepath.Join(bleveDir, "comment"), "comment")
+	commentIdx, err = open("comment")
 	if err != nil {
 		_ = codeIdx.Close()
 		_ = diffIdx.Close()

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -286,6 +286,15 @@ func openSQLite(root string) (*sql.DB, bool, error) {
 
 	if err := CreateSchema(db); err != nil {
 		_ = db.Close()
+		// An unwritable database file inside a writable directory reaches here
+		// rather than the read-only branch above: the directory probe passed,
+		// and SQLite could create the WAL sidecars, so nothing objected until a
+		// migration tried to write. Same physical condition, so same error
+		// class — which side of the store is unwritable should not decide how
+		// callers classify it.
+		if !fileIsWritable(dbPath) {
+			return nil, true, fmt.Errorf("%w: %s needs a schema migration that cannot be applied: %w", ErrReadOnly, dbPath, err)
+		}
 		return nil, false, fmt.Errorf("create schema: %w", err)
 	}
 	return db, false, nil


### PR DESCRIPTION
Fixes #871.

## What broke

`ox` opened the codedb read-write and ran `PRAGMA integrity_check` at open. On read-only media that check fails with `SQLITE_READONLY_DIRECTORY` — WAL mode has to create the `-shm` wal-index before it can read anything — and `ox` read that failure as **corruption**, whose remedy is **deletion**.

In the reporter's repro the delete only failed because the filesystem was read-only. On writable media the same misreading destroys a healthy index; a large monorepo index is reported at ~1.8 GB and ~10 minutes of cold rebuild ([agent-toolkit#30](https://github.com/sageox/agent-toolkit/issues/30)).

```mermaid
flowchart TD
    A["store.Open(dataDir)"] --> B["PRAGMA integrity_check"]
    B -->|"error"| C{"before: any failure<br/>= corruption"}
    C --> D["slog.Error 'removing database'<br/>removeSQLiteFiles()"]
    D --> E["ErrCorrupt<br/>index gone on writable media"]

    B -->|"error"| F{"after: can we write<br/>this directory?"}
    F -->|"yes"| C
    F -->|"no"| G["open read-only<br/>Store.ReadOnly = true"]
    G --> H["reads served<br/>nothing deleted"]

    style D fill:#7f1d1d,color:#fff
    style E fill:#7f1d1d,color:#fff
    style G fill:#14532d,color:#fff
    style H fill:#14532d,color:#fff
```

## What this PR ships

### 1. Writability is settled before corruption is diagnosed

- `openSQLite` probes whether it can create a file in the store directory **before** `integrity_check` renders a verdict, and re-probes on the delete path itself as a backstop.
- A store `ox` cannot write returns the new `store.ErrReadOnly`, never `ErrCorrupt`. `removeSQLiteFiles` is unreachable for this class.
- The probe is a create-close-unlink, and only on stores that already exist — cheap next to the SQLite and bleve opens that follow it in the same call.

### 2. Read-only search actually works — not just a better error message

The issue's motivating case is mounting a warm index read-only from a scheduled job. A clearer error would still have left that unbuildable, so the read path is now real:

- **SQLite:** `file:<escaped-path>?mode=ro&immutable=1`. `immutable=1` is **required**, not an optimization — plain `mode=ro` still fails with `SQLITE_READONLY_DIRECTORY` because WAL mode needs the `-shm`.
- **The WAL trap:** `immutable=1` also makes SQLite *ignore* `metadata.db-wal`. Verified empirically — opening a live-WAL snapshot with `immutable=1` returns **`no such table: repos`**, because the entire schema was still parked in the WAL. Answering from that would be the same fluent-empty-answer failure as the bug itself. So when a `-wal` sidecar has content, `immutable` is dropped and SQLite's sidecar-present read-only mode is used, which sees the whole database; if that open fails, the store is refused rather than half-read.
- **Bleve:** `bleve.OpenUsing(path, {"read_only": true})` opens `root.bolt` `O_RDONLY` and creates nothing. Self-heal and mapping-version upgrade are skipped — both are nuke-and-recreate and both need a writable directory.
- **`integrity_check` is skipped on the read-only path** — it costs O(database size) (0.8s–18s on stores we already ship) and its only remedy is the deletion this path exists to refuse. A cheap `sqlite_master` probe proves readability instead.
- **Stale schemas are refused, using the schema itself as the check.** A store built by an older `ox` lacks tables and columns the current search path queries; the writable open repairs that by running `CreateSchema` on every open, and a read-only one cannot. Rather than hand-list required objects — a second copy of the schema that drifts from the migrations — the read-only path *runs `CreateSchema`*. Every statement in it is guarded (`CREATE ... IF NOT EXISTS`, `addColumnsIfMissing`, the issue-474 sentinel), so against a complete store it writes nothing and succeeds on a read-only connection, and against a stale one it fails naming the object (`add column symbols.signature: attempt to write a readonly database`).
- **The DSN is a valid `file:` URI on Windows too.** `url.URL{Path: "C:/..."}` renders `file://C:/...`, putting the drive letter in the URI *authority*; the backslash form escapes to `%5C`. `filepath.ToSlash` plus a leading slash fixes both, and is deliberately a no-op on POSIX where a backslash is an ordinary filename character.

### 3. `ox code status` has a distinct state for an index it could not open

Previously it answered zeros under `index_exists: true` — byte-identical to a warm index holding nothing. For an LLM-driven caller that is the worst available answer: it searches, gets nothing, and says so fluently.

- `open_error` (JSON) / `✗ unreadable` + the reason (human), ranked **above** every daemon-derived state — the daemon's cached counts describe an index this machine just failed to open.
- `read_only` (JSON) / a `Mode: read-only` row telling the caller `ox code index` will refuse.
- **`indexing_now` stops lying about the ledger index.** `daemonIndexing` already folds in `LedgerIndexingNow`, but the JSON and the human switch read `codeStats.IndexingNow` — so a repo reading the ledger index reported `indexing_now: false` while its counts came from the daemon's cache *precisely because* it was indexing. `codeStats.IndexingNow` is now referenced only inside the `daemonIndexing` definition, so the remaining branches cannot drift back.

### 4. `ox code index` refuses a read-only store up front

Guarded in `OpenIndexWithHeal`: `indexFn` only writes, and both recovery arms (marker escalation, corruption retry) call `os.RemoveAll(dataDir)`.

## Test Plan

### Verified against a real 617 MB store

Copied this repo's live codedb, `chmod -R a-w`, ran the issue's exact repro:

| Command | Before | After |
|---|---|---|
| `code status --json` | `commits: 0`, `index_exists: true`, `ERROR ... removing database` | `commits: 841`, `symbols: 41252`, `read_only: true` |
| `code search "openSQLite"` | `Error: sqlite integrity check failed: codedb index is corrupt` | 5 results in 15 ms |
| `code index` | — | `Error: cannot index into <dir>: codedb index is read-only` (exit 1) |

`code defs` returns 0 results on both the read-only copy and the writable original, so that is not a regression.

### Automated

- **17 new tests**, all red-first verified. With the fix neutered they fail on the claim itself — `sqlite integrity check failed: codedb index is corrupt` — and the status test prints `commits:0 ... index_exists:true`, the issue's defect 3 verbatim.
- Coverage: read-only open serves SQL **and** bleve; the WAL sidecar is honored rather than skipped; a WAL with no `-shm` is refused; `OpenSQLOnly` reports the same state; schema-less, stale-schema, non-database, and missing-sub-index stores are each refused with a reason and never as corruption; the `file:` URI escapes spaces and keeps its authority empty for Windows paths; `storeIsWritable` is correct in both directions and leaves nothing behind; `OpenIndexWithHeal` refuses without running `indexFn`.
- **One assertion about deletion is non-vacuous.** On read-only media the delete would fail anyway, so `TestOpenReadOnlyDatabaseFileInWritableDirIsNotDeleted` uses the one shape where the corruption remedy *could* succeed — an unwritable database file inside a writable directory — and proves the file survives.
- `ox code status` is asserted by driving the **real command** end to end (temp git repo, real codedb, real `chmod`), in both `--json` and human form, not by re-deriving its switch in the test body.
- Changed-line coverage: **91.2%** against the 90% floor.
- Tests skip on Windows and as root, where `chmod` does not model read-only media.
- `make lint` — 0 issues. `make test` — 0 failed.

Not covered by a test: the daemon-cached status path needs a live socket, and `daemon.NewClientForCurrentRepoWithTimeout` is not injectable from `cmd/ox` tests. Called out rather than papered over.

## Follow-up, deliberately not in this PR

A **broader instance of the same class** is still open: any failure of `integrity_check` to *run* — OOM, EIO, EMFILE — is currently treated as proof of damage, when only a completed check returning non-`ok` is evidence of it. During one full-tree run I saw all 16 openers of `TestCreateSchema_ConcurrentFreshOpen` get `integrity check failed → corrupt` on a *writable* fresh store, which on `main` means delete. It did not reproduce, so I left it rather than widen scope on one unreproduced observation. Worth its own issue.

Separately, `TestConcurrentSelfHeal_MultiProcess` failed once under heavy parallel load (6 re-exec'd processes on a fixed 6s retry budget). It does not touch this code path and passes isolated and on a clean re-run under the same load — pre-existing load-sensitive flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SageOx-Session: https://sageox.ai/c/ses_01a06857-3901-76d2-88c4-c5d15e4bd74f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Search code indexes stored on read-only media.
  - View read-only status in `code status`, including JSON output.
  - See clear status information for unreadable or unavailable indexes.

- **Bug Fixes**
  - Improved status reporting for indexes that cannot be opened.
  - Prevented indexing and recovery actions from modifying read-only indexes or deleting their data.
  - Preserved readable data from indexes with uncheckpointed changes when opened read-only.
  - Corrected daemon indexing status reporting across code indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->