### PR TITLE
fix(auth): stop expiry warning on auto-refreshing logins

### DIFF
--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ox code status` no longer reports an index it could not open as an empty one** — it answered zeros under `index_exists: true`, which reads exactly like a warm index holding nothing. It now shows `✗ unreadable` with the reason (`open_error` in `--json`), and labels a read-only index as such.
 - **`ox code index` refuses a read-only index up front** — with a message naming the directory, instead of failing partway through a pass.
 
+### Fixed
+
+- **`ox` no longer tells you to rotate a perfectly healthy login** — every interactive `ox status`, `ox doctor`, and `ox agent prime` signed off with `warn=ox_token_expiring`, claiming your credential expired in a few hours and pointing you at the token-creation page — while the same `ox status` reported your session as auto-refreshing. It was reading the OAuth access-token stamp, which the refresh grant rotates on its own, as if it were your credential's lifetime. The warning now applies only to a `SAGEOX_TOKEN` credential, where expiry is real and rotating the token is the actual remedy.
+
 ## [0.14.3] - 2026-08-31
 
 Code indexing stays safe on every worktree layout, a wedged checkout repairs itself, and team-scoped credentials just work with `ox query`.

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -18,9 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A read-only code index is no longer mistaken for a corrupt one and deleted** — ox read "cannot write this database" as "this database is damaged" and tried to delete it; only the read-only filesystem stopped it. The same misreading on writable media would have destroyed a healthy index that costs minutes to rebuild.
 - **`ox code status` no longer reports an index it could not open as an empty one** — it answered zeros under `index_exists: true`, which reads exactly like a warm index holding nothing. It now shows `✗ unreadable` with the reason (`open_error` in `--json`), and labels a read-only index as such.
 - **`ox code index` refuses a read-only index up front** — with a message naming the directory, instead of failing partway through a pass.
-
-### Fixed
-
 - **`ox` no longer tells you to rotate a perfectly healthy login** — every interactive `ox status`, `ox doctor`, and `ox agent prime` signed off with `warn=ox_token_expiring`, claiming your credential expired in a few hours and pointing you at the token-creation page — while the same `ox status` reported your session as auto-refreshing. It was reading the OAuth access-token stamp, which the refresh grant rotates on its own, as if it were your credential's lifetime. The warning now applies only to a `SAGEOX_TOKEN` credential, where expiry is real and rotating the token is the actual remedy.
 
 ## [0.14.3] - 2026-08-31

--- a/internal/auth/expiry_warn.go
+++ b/internal/auth/expiry_warn.go
@@ -39,10 +39,10 @@ func resetExpiryWarnedKeysForTest() {
 	expiryWarnedKeys = map[string]bool{}
 }
 
-// CheckAndWarnExpiry emits a single-line stderr warning when the PAT for
-// the given endpoint is within max(1d, lifetime*pct) of expiry. Returns
-// true if a warning was emitted; false otherwise (including all skip
-// cases — ephemeral, never-expires, dedup, non-TTY, no auth).
+// CheckAndWarnExpiry emits a single-line stderr warning when the SAGEOX_TOKEN
+// credential for the given endpoint is within max(1d, lifetime*pct) of expiry.
+// Returns true if a warning was emitted; false otherwise (including all skip
+// cases — ephemeral, disk-stored, never-expires, dedup, non-TTY, no auth).
 //
 // Skipped silently when:
 //   - runtime.Caps().Browser is false (no human at keyboard — sandbox,
@@ -51,6 +51,9 @@ func resetExpiryWarnedKeysForTest() {
 //   - the writer is not a TTY (unless the *os.File path resolves to stderr
 //     and the caller has already decided to force; today the policy is
 //     "TTY only" with no override flag — keep it simple)
+//   - the credential came from auth.json rather than SAGEOX_TOKEN — its
+//     expiry is an auto-rotating access-token stamp, not a lifetime a user
+//     can act on (see resolveTokenExpiry)
 //   - the token has never-expires semantics (ExpiresAt == nil)
 //   - the same token hash already warned this process
 //   - no token is configured for the endpoint (nothing to warn about)
@@ -83,7 +86,7 @@ func CheckAndWarnExpiry(ctx context.Context, ep string, w io.Writer) bool {
 		return false
 	}
 
-	expiresAt, createdAt, label, ok := resolveTokenExpiry(ctx, ep, token)
+	expiresAt, createdAt, ok := resolveTokenExpiry(ctx, ep, token)
 	if !ok {
 		return false
 	}
@@ -111,44 +114,43 @@ func CheckAndWarnExpiry(ctx context.Context, ep string, w io.Writer) bool {
 	expiryWarnedKeys[key] = true
 	expiryWarnedKeysMu.Unlock()
 
-	emitExpiryWarning(w, ep, label, remaining)
+	emitExpiryWarning(w, ep, "env", remaining)
 	return true
 }
 
-// resolveTokenExpiry returns the authoritative expiry + creation time for
-// the token. For env-supplied tokens it consults the token-meta cache
-// (calling /api/v1/auth/me when stale); for disk-stored tokens it trusts
-// StoredToken.ExpiresAt directly. The third return value is a short
-// human label ("env" or "disk") for the warning's diagnostic key.
+// resolveTokenExpiry returns the authoritative expiry + creation time for an
+// env-supplied token, read from the token-meta cache.
 //
-// Returns ok=false when the token is never-expires (ExpiresAt nil or
-// zero-valued) or when no expiry information is available.
-func resolveTokenExpiry(ctx context.Context, ep string, token *StoredToken) (expiresAt time.Time, createdAt time.Time, label string, ok bool) {
-	if isEnvToken(ep, token) {
-		meta, err := FetchTokenMetaCached(ctx, ep, token.AccessToken)
-		if err != nil || meta == nil {
-			return time.Time{}, time.Time{}, "", false
-		}
-		if meta.ExpiresAt == nil || meta.ExpiresAt.IsZero() {
-			// never-expires token: no warning, ever.
-			return time.Time{}, time.Time{}, "", false
-		}
-		created := meta.CreatedAt
-		if created.IsZero() {
-			created = meta.ExpiresAt.Add(-envTokenAssumedLifetime)
-		}
-		return *meta.ExpiresAt, created, "env", true
+// Only env-supplied tokens can produce a warning. device_flow.go and refresh.go
+// are the only writers of auth.json, so a disk-stored StoredToken.ExpiresAt is
+// always the OAuth ACCESS token's expiry — a value in the hours that the refresh
+// grant rotates on its own — never a credential lifetime. Warning on it told
+// every logged-in user their token expired within the hour and pointed them at
+// the PAT minting page; status.go renders "auto-refresh enabled" for the same
+// reason. When the server issues no refresh credential at all, re-login is
+// genuinely required, but that is already surfaced at login (device_flow.go)
+// and by status.go's "Re-login by" row, and `ox login` — not a new PAT — is the
+// remedy this warning would name.
+//
+// Returns ok=false for any disk-stored token, for a never-expires token
+// (ExpiresAt nil or zero-valued), and when no expiry information is available.
+func resolveTokenExpiry(ctx context.Context, ep string, token *StoredToken) (expiresAt time.Time, createdAt time.Time, ok bool) {
+	if !isEnvToken(ep, token) {
+		return time.Time{}, time.Time{}, false
 	}
-
-	// disk-stored token — ExpiresAt is set by the OAuth flow.
-	if token.ExpiresAt.IsZero() {
-		return time.Time{}, time.Time{}, "", false
+	meta, err := FetchTokenMetaCached(ctx, ep, token.AccessToken)
+	if err != nil || meta == nil {
+		return time.Time{}, time.Time{}, false
 	}
-	// CreatedAt isn't tracked on StoredToken — approximate via fixed
-	// assumed lifetime. The threshold math still floors at 1 day so this
-	// can't pathologically over-warn.
-	created := token.ExpiresAt.Add(-envTokenAssumedLifetime)
-	return token.ExpiresAt, created, "disk", true
+	if meta.ExpiresAt == nil || meta.ExpiresAt.IsZero() {
+		// never-expires token: no warning, ever.
+		return time.Time{}, time.Time{}, false
+	}
+	created := meta.CreatedAt
+	if created.IsZero() {
+		created = meta.ExpiresAt.Add(-envTokenAssumedLifetime)
+	}
+	return *meta.ExpiresAt, created, true
 }
 
 // computeExpiryThreshold returns the duration before expiry at which the

--- a/internal/auth/expiry_warn.go
+++ b/internal/auth/expiry_warn.go
@@ -223,7 +223,12 @@ func humanizeDuration(d time.Duration) string {
 // writerIsTTY returns true when w is an *os.File pointing at a TTY. Any
 // other writer (bytes.Buffer in tests, pipes, files) returns false — we
 // never spam non-interactive consumers.
-func writerIsTTY(w io.Writer) bool {
+//
+// A var, not a plain func, so tests can reach the code below the gate. Every
+// caller passes os.Stderr and no test can hand it a real terminal without a
+// pty, so with a fixed gate the entire decision — threshold, dedupe, and the
+// emitted line itself — is unreachable from the test suite.
+var writerIsTTY = func(w io.Writer) bool {
 	f, ok := w.(*os.File)
 	if !ok {
 		return false

--- a/internal/auth/expiry_warn_test.go
+++ b/internal/auth/expiry_warn_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -188,8 +189,8 @@ func TestResolveTokenExpiry_EnvTokenStillWarns(t *testing.T) {
 }
 
 // TestResolveTokenExpiry_DiskTokenNeverWarns — Failure prevented: `ox status`
-// prints "✓ auto-refresh enabled" and then, on the next line, tells the same
-// user their token expires in minutes and to mint a new one at /settings/tokens.
+// reports "✓ auto-refresh enabled" and then signs off telling the same user
+// their token expires in minutes and to mint a new one at /settings/tokens.
 // device_flow.go and refresh.go are the only writers of auth.json, so a disk
 // StoredToken.ExpiresAt is always the OAuth access-token stamp — hours away by
 // construction, and always inside the warning threshold.
@@ -223,6 +224,90 @@ func TestResolveTokenExpiry_DiskTokenNeverWarns(t *testing.T) {
 			assert.False(t, ok, "a disk-stored token must never produce an expiry warning")
 		})
 	}
+}
+
+// fakeTTY forces writerIsTTY true for the duration of the test so the decision
+// below the gate — threshold, dedupe, emitted line — is reachable at all.
+func fakeTTY(t *testing.T) {
+	t.Helper()
+	real := writerIsTTY
+	writerIsTTY = func(io.Writer) bool { return true }
+	t.Cleanup(func() { writerIsTTY = real })
+}
+
+// TestCheckAndWarnExpiry_EndToEnd drives the real entry point the CLI calls,
+// not the resolver underneath it, for both credential sources.
+//
+// Failure prevented: the disk-token regression is "fixed" in resolveTokenExpiry
+// while CheckAndWarnExpiry still emits — nothing else covers the path from the
+// public function through to the bytes on stderr.
+func TestCheckAndWarnExpiry_EndToEnd(t *testing.T) {
+	t.Run("env token at a terminal warns", func(t *testing.T) {
+		clearEphemeralForTest(t)
+		fakeTTY(t)
+		resetExpiryWarnedKeysForTest()
+		expires := time.Now().Add(48 * time.Hour).UTC()
+		srv, _ := serveEnvTokenMeta(t, map[string]any{
+			"expires_at": expires.Format(time.RFC3339),
+			"name":       "ci-token",
+		})
+
+		var buf bytes.Buffer
+		emitted := CheckAndWarnExpiry(context.Background(), srv.URL, &buf)
+		require.True(t, emitted, "an expiring SAGEOX_TOKEN at a terminal must warn")
+		assert.Contains(t, buf.String(), "warn=ox_token_expiring")
+		assert.Contains(t, buf.String(), "source=env")
+
+		// Dedupe: the same process must not nag twice for the same credential.
+		var second bytes.Buffer
+		assert.False(t, CheckAndWarnExpiry(context.Background(), srv.URL, &second))
+		assert.Empty(t, second.String())
+	})
+
+	t.Run("auto-refreshing disk login stays silent", func(t *testing.T) {
+		clearEphemeralForTest(t)
+		fakeTTY(t)
+		resetExpiryWarnedKeysForTest()
+		t.Setenv(EnvVarToken, "") // credential comes from auth.json, not the env
+		dir := t.TempDir()
+		t.Setenv("HOME", dir)
+		t.Setenv("XDG_CONFIG_HOME", dir)
+
+		const ep = "https://sageox.ai"
+		require.NoError(t, SaveTokenForEndpoint(ep, &StoredToken{
+			AccessToken:  "jwt.access",
+			RefreshToken: "refresh-present",
+			// The stamp that used to drive the warning: hours out, auto-rotated.
+			ExpiresAt: time.Now().Add(11 * time.Minute),
+			TokenType: "Bearer",
+		}))
+
+		var buf bytes.Buffer
+		emitted := CheckAndWarnExpiry(context.Background(), ep, &buf)
+		assert.False(t, emitted, "a refreshing disk login must never warn")
+		assert.Empty(t, buf.String(), "nothing may reach stderr for a healthy login")
+	})
+}
+
+// TestResolveTokenExpiry_ServerUnreachable — Failure prevented: a metadata
+// endpoint that errors turns a best-effort warning into a hard failure or a
+// bogus expiry. FetchTokenMetaCached soft-fails to nil; we must stay silent.
+func TestResolveTokenExpiry_ServerUnreachable(t *testing.T) {
+	clearEphemeralForTest(t)
+	withTempCacheDir(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv(endpoint.EnvVar, srv.URL)
+	t.Setenv(EnvVarToken, "oxp_test_4bDZfN")
+
+	stored, state := EnvTokenFor(srv.URL)
+	require.Equal(t, EnvTokenValid, state)
+
+	_, _, ok := resolveTokenExpiry(context.Background(), srv.URL, stored)
+	assert.False(t, ok, "an unreadable metadata response must not produce an expiry")
 }
 
 // TestEmitExpiryWarning_Format — Failure prevented: warning format drifts

--- a/internal/auth/expiry_warn_test.go
+++ b/internal/auth/expiry_warn_test.go
@@ -3,6 +3,9 @@ package auth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/ephemeral"
 	"github.com/sageox/ox/internal/runtime"
 )
@@ -133,17 +137,92 @@ func TestCheckAndWarnExpiry_SkippedForNonTTY(t *testing.T) {
 	assert.Empty(t, buf.String())
 }
 
+// serveEnvTokenMeta binds a CRC-valid SAGEOX_TOKEN to a stub metadata server
+// and returns the StoredToken the env layer produces for it. The endpoint env
+// var must point at the same server or envTokenBoundValue refuses the token.
+func serveEnvTokenMeta(t *testing.T, body map[string]any) (*httptest.Server, *StoredToken) {
+	t.Helper()
+	withTempCacheDir(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv(endpoint.EnvVar, srv.URL)
+	t.Setenv(EnvVarToken, "oxp_test_4bDZfN")
+
+	stored, state := EnvTokenFor(srv.URL)
+	require.Equal(t, EnvTokenValid, state, "fixture token must pass the local CRC check")
+	return srv, stored
+}
+
 // TestResolveTokenExpiry_NeverExpires — Failure prevented: a never-expires
-// token (server returns ExpiresAt == nil) somehow triggers a warning,
+// token (server returns expires_at: null) somehow triggers a warning,
 // which would be permanently noisy and nonsensical.
 func TestResolveTokenExpiry_NeverExpires(t *testing.T) {
 	clearEphemeralForTest(t)
-	tok := &StoredToken{
-		AccessToken: "oxp_never",
-		ExpiresAt:   time.Time{}, // zero-value: never expires
+	srv, stored := serveEnvTokenMeta(t, map[string]any{"expires_at": nil, "name": "forever"})
+
+	_, _, ok := resolveTokenExpiry(context.Background(), srv.URL, stored)
+	assert.False(t, ok, "a null expires_at must be treated as never-expires")
+}
+
+// TestResolveTokenExpiry_EnvTokenStillWarns — Failure prevented: suppressing the
+// disk-token false alarm goes too far and silences the one credential class the
+// warning exists for. An env token has no refresh credential, so its expiry is
+// terminal and a human must go rotate it.
+func TestResolveTokenExpiry_EnvTokenStillWarns(t *testing.T) {
+	clearEphemeralForTest(t)
+	expires := time.Now().Add(48 * time.Hour).UTC()
+	srv, stored := serveEnvTokenMeta(t, map[string]any{
+		"expires_at": expires.Format(time.RFC3339),
+		"name":       "ci-token",
+	})
+
+	got, created, ok := resolveTokenExpiry(context.Background(), srv.URL, stored)
+	require.True(t, ok, "an expiring env token must still resolve an expiry")
+	assert.WithinDuration(t, expires, got, time.Second)
+	assert.False(t, created.IsZero(), "createdAt must fall back to the assumed lifetime")
+}
+
+// TestResolveTokenExpiry_DiskTokenNeverWarns — Failure prevented: `ox status`
+// prints "✓ auto-refresh enabled" and then, on the next line, tells the same
+// user their token expires in minutes and to mint a new one at /settings/tokens.
+// device_flow.go and refresh.go are the only writers of auth.json, so a disk
+// StoredToken.ExpiresAt is always the OAuth access-token stamp — hours away by
+// construction, and always inside the warning threshold.
+func TestResolveTokenExpiry_DiskTokenNeverWarns(t *testing.T) {
+	t.Setenv(EnvVarToken, "") // no env credential — force the disk path
+
+	tests := []struct {
+		name  string
+		token *StoredToken
+	}{
+		{"auto-refreshing session", &StoredToken{
+			AccessToken:  "jwt.access",
+			RefreshToken: "refresh-present",
+			ExpiresAt:    time.Now().Add(11 * time.Minute),
+		}},
+		{"better-auth session token as refresh credential", &StoredToken{
+			AccessToken:  "jwt.access",
+			SessionToken: "session-present",
+			ExpiresAt:    time.Now().Add(2 * time.Hour),
+		}},
+		// Re-login IS required here, but `ox login` is the remedy — not the new
+		// PAT this warning would advertise. Login and `ox status` already say so.
+		{"no refresh credential at all", &StoredToken{
+			AccessToken: "jwt.access",
+			ExpiresAt:   time.Now().Add(23 * time.Hour),
+		}},
 	}
-	_, _, _, ok := resolveTokenExpiry(context.Background(), "https://sageox.ai", tok)
-	assert.False(t, ok, "zero-time ExpiresAt must be treated as never-expires")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, ok := resolveTokenExpiry(context.Background(), "https://sageox.ai", tc.token)
+			assert.False(t, ok, "a disk-stored token must never produce an expiry warning")
+		})
+	}
 }
 
 // TestEmitExpiryWarning_Format — Failure prevented: warning format drifts
@@ -151,10 +230,10 @@ func TestResolveTokenExpiry_NeverExpires(t *testing.T) {
 // depend on this shape.
 func TestEmitExpiryWarning_Format(t *testing.T) {
 	var buf bytes.Buffer
-	emitExpiryWarning(&buf, "https://sageox.ai", "disk", 4*24*time.Hour+3*time.Hour)
+	emitExpiryWarning(&buf, "https://sageox.ai", "env", 4*24*time.Hour+3*time.Hour)
 	out := buf.String()
 	assert.True(t, strings.HasPrefix(out, "warn=ox_token_expiring"), "missing warn= prefix")
-	assert.Contains(t, out, "source=disk")
+	assert.Contains(t, out, "source=env")
 	assert.Contains(t, out, "expires_in=4d3h")
 	assert.Contains(t, out, "create_new=https://sageox.ai/settings/tokens")
 	assert.True(t, strings.HasSuffix(out, "\n"), "must be single line terminated by \\n")


### PR DESCRIPTION
## What broke

Every interactive `ox status`, `ox doctor`, and `ox agent prime` signed off with a warning telling the user their credential was about to expire and pointing them at the token-creation page — on a completely healthy, auto-refreshing login.

Real output on a normal `ox login` session, captured under a pty (line numbers from the unfiltered run):

```
     6  Session             ✓ auto-refresh enabled (…/.config/sageox/auth.json)
     …
    18  ✦ Use ox logout to clear credentials when switching accounts
    19  warn=ox_token_expiring source=disk expires_in=3h55m create_new=https://sageox.ai/settings/tokens
```

Line 6 says nothing to do. Line 19 — the last thing left on screen — says go mint a new token.

- **`expires_in` tracked the OAuth access-token stamp**, not a credential lifetime. Observed as `2h54m`, `11m`, and `3h55m` across three runs of the same healthy login.
- **The remedy was wrong too.** `create_new=…/settings/tokens` is the PAT minting page; a disk session that genuinely needs attention needs `ox login`, not a new PAT.
- **It could never *not* fire.** See below.

## Why it always fired

`resolveTokenExpiry`'s disk branch treated `StoredToken.ExpiresAt` as a credential lifetime. It isn't — `device_flow.go` and `refresh.go` are the **only** writers of `auth.json`, so that field is always the OAuth access token's expiry, hours away by construction and rotated by the refresh grant.

Having no creation time, the branch invented one: `created = expires − 90 days`. That fabricated lifetime fed the threshold math and produced a 108-hour window, which a token with <24h remaining is always inside.

```mermaid
flowchart LR
  A["StoredToken.ExpiresAt<br/>(access token, ~hours)"] --> B["created = expires − 90d<br/>(fabricated)"]
  B --> C["threshold = 5% × 90d<br/>= 108h"]
  A --> D["remaining < 24h"]
  D --> E{"remaining ≤ threshold?"}
  C --> E
  E -->|"always true"| F["warn on every invocation"]
```

Dedupe is per-process and every `ox` command is a new process, so it fired every time.

It went unreported because of who can see it: `writerIsTTY` means agent harnesses never render it — under Claude Code stderr isn't a TTY. The heaviest users of ox are structurally blind to it. Humans in a plain terminal got it on every command.

`status.go` already knew this was wrong and documents it — it renders "auto-refresh enabled" precisely because showing the short access-token expiry "historically confused users into thinking they had to ox login on a near-daily basis." The warning path never got that fix, and it does worse than display a confusing timestamp: it prescribes a wrong remedy.

## What this PR ships

- **`resolveTokenExpiry` returns `ok=false` for any disk-stored token.** Only a `SAGEOX_TOKEN` credential can produce a warning — it has no refresh path, so its expiry is terminal and rotation is genuinely the remedy.
- **Drops the `label` return.** With the disk branch gone the only surviving source is `env`, so the fourth return value was a constant.
- **No behavior change for `SAGEOX_TOKEN`.** Same cache, same threshold math, same never-expires handling.

The no-refresh disk case is deliberately included: re-login *is* required there, but that is already surfaced at login (`device_flow.go`) and by `status.go`'s "Re-login by" row — and `ox login`, not a new PAT, is the remedy this warning would have named.

## Test plan

- **Red-first, verified.** Neutered the fix by restoring the old disk branch; all three cases in `TestResolveTokenExpiry_DiskTokenNeverWarns` went red on the claim assertion. Restored → green.
- **Guard against over-reach.** Added `TestResolveTokenExpiry_EnvTokenStillWarns`. Without it, deleting the warning outright would pass the suite — this pins that `SAGEOX_TOKEN` expiry still resolves.
- **Rewrote `TestResolveTokenExpiry_NeverExpires`.** After the change it would have passed via the new disk gate rather than the nil-expiry gate it claims to test. It now drives the real env path against a stub metadata server.
- **Live before/after under a pty.** Identical output through line 18; line 19 gone.
- `make lint` clean. `make test` green — 18,175 passed, 0 failed.

## Related

Server-side and out of scope here:

| Issue | Scope |
|---|---|
| `sageox-monorepo#3706` | The other half of this feature — the team-token expiry lookup calls a user-only endpoint. Blocked: api-go's introspect returns no expiry for user principals, so swapping the endpoint today would trade the `oxt_` blind spot for an `oxp_` one. |
| `sageox-monorepo#3977` | The underlying gap — a shared team token expires and its *owner* is never told. Not solvable in the CLI: the owner is by construction not at the terminal where the token is used. |

SageOx-Session: https://sageox.ai/c/ses_01a05e1b-a659-7da8-bd58-0ae2a7feb9cc

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791056699&installation_model_id=433550&pr_number=876&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F876&signature=aca843efbfa041e99564c0b3b5e37bc474ba0e4441ccc85b59437424817b2522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token-expiration warnings in `ox status`, `ox doctor`, and `ox agent prime`.
  * Warnings now appear only for expiring `SAGEOX_TOKEN` credentials.
  * OAuth access-token expirations stored in `auth.json` no longer trigger warnings.
  * Improved handling of unreachable token metadata and non-expiring environment tokens.
  * Updated warning details and documentation to clarify which token lifetimes require action and reduce unnecessary authentication warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->