### PR TITLE
fix(gitutil): insulate ox git commands from the user's global git-lfs config

### DIFF
--- a/cmd/ox/doctor_team.go
+++ b/cmd/ox/doctor_team.go
@@ -41,12 +41,7 @@ func checkTeamContextHealth(opts doctorOptions) []checkResult {
 		}
 		// even with nothing configured locally, the daemon may still be
 		// syncing an "other" team context (ox-baz5.5) — scan it too.
-		for _, tc := range daemonSyncedTeamContexts(nil) {
-			pointerCheck := checkDoubleEncodedLFSPointers(tc, opts)
-			if pointerCheck.warning || !pointerCheck.passed {
-				checks = append(checks, pointerCheck)
-			}
-		}
+		checks = append(checks, scanExtraTeamContexts(daemonSyncedTeamContexts(nil), opts)...)
 		return checks
 	}
 
@@ -76,12 +71,7 @@ func checkTeamContextHealth(opts doctorOptions) []checkResult {
 	// "Team Context" section completed in ~23ms even while a real diverged
 	// clone sat unscanned. Enumerate what the daemon actually syncs and scan
 	// whatever wasn't already covered.
-	for _, tc := range daemonSyncedTeamContexts(localCfg.TeamContexts) {
-		pointerCheck := checkDoubleEncodedLFSPointers(tc, opts)
-		if pointerCheck.warning || !pointerCheck.passed {
-			checks = append(checks, pointerCheck)
-		}
-	}
+	checks = append(checks, scanExtraTeamContexts(daemonSyncedTeamContexts(localCfg.TeamContexts), opts)...)
 
 	// check for legacy team contexts that should be migrated
 	legacyCheck := checkLegacyTeamContexts(gitRoot)
@@ -104,6 +94,23 @@ func checkTeamContextHealth(opts doctorOptions) []checkResult {
 	return checks
 }
 
+// scanExtraTeamContexts runs the nested-LFS-pointer check against each
+// daemon-synced-but-unconfigured team context (ox-baz5.5) and returns any
+// resulting checkResults. Split out from checkTeamContextHealth's two
+// near-identical loops so the actual scan-and-report behavior is testable
+// with a synthetic extra list, independent of the daemon plumbing that
+// produces it.
+func scanExtraTeamContexts(extra []config.TeamContext, opts doctorOptions) []checkResult {
+	var checks []checkResult
+	for _, tc := range extra {
+		pointerCheck := checkDoubleEncodedLFSPointers(tc, opts)
+		if pointerCheck.warning || !pointerCheck.passed {
+			checks = append(checks, pointerCheck)
+		}
+	}
+	return checks
+}
+
 // daemonSyncedTeamContexts asks the daemon (via IPC — checkTeamContextHealth
 // runs in the CLI process and has no direct access to the daemon's in-memory
 // WorkspaceRegistry) which team-context clones it is actually syncing, and
@@ -115,6 +122,16 @@ func checkTeamContextHealth(opts doctorOptions) []checkResult {
 // best-effort supplement to the configured scan, never a replacement for it.
 func daemonSyncedTeamContexts(configured []config.TeamContext) []config.TeamContext {
 	client := daemon.NewClientForCurrentRepoWithTimeout(500 * time.Millisecond)
+	return daemonSyncedTeamContextsVia(client, configured)
+}
+
+// daemonSyncedTeamContextsVia takes the IPC client as a parameter so tests
+// can point it at a socket that is guaranteed not to exist, rather than
+// relying on no daemon happening to be registered for the test process's
+// resolved workspace — daemon.CurrentWorkspaceID() memoizes via sync.Once
+// per process, so a test-local os.Chdir cannot reliably re-scope it once
+// another test in the same binary has already resolved it.
+func daemonSyncedTeamContextsVia(client *daemon.Client, configured []config.TeamContext) []config.TeamContext {
 	if client == nil || client.Ping() != nil {
 		return nil
 	}

--- a/cmd/ox/doctor_team.go
+++ b/cmd/ox/doctor_team.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/manifest"
 	"github.com/sageox/ox/internal/tokens"
@@ -38,6 +39,14 @@ func checkTeamContextHealth(opts doctorOptions) []checkResult {
 		if guidanceCheck.warning || !guidanceCheck.passed {
 			checks = append(checks, guidanceCheck)
 		}
+		// even with nothing configured locally, the daemon may still be
+		// syncing an "other" team context (ox-baz5.5) — scan it too.
+		for _, tc := range daemonSyncedTeamContexts(nil) {
+			pointerCheck := checkDoubleEncodedLFSPointers(tc, opts)
+			if pointerCheck.warning || !pointerCheck.passed {
+				checks = append(checks, pointerCheck)
+			}
+		}
 		return checks
 	}
 
@@ -60,6 +69,20 @@ func checkTeamContextHealth(opts doctorOptions) []checkResult {
 		}
 	}
 
+	// ox-baz5.5: localCfg.TeamContexts is this repo's declared list, but the
+	// daemon may also be syncing an "other" team context that was never
+	// declared here (e.g. a secondary/internal team). Before this, the LFS
+	// nested-pointer scan above silently never visited that clone — the
+	// "Team Context" section completed in ~23ms even while a real diverged
+	// clone sat unscanned. Enumerate what the daemon actually syncs and scan
+	// whatever wasn't already covered.
+	for _, tc := range daemonSyncedTeamContexts(localCfg.TeamContexts) {
+		pointerCheck := checkDoubleEncodedLFSPointers(tc, opts)
+		if pointerCheck.warning || !pointerCheck.passed {
+			checks = append(checks, pointerCheck)
+		}
+	}
+
 	// check for legacy team contexts that should be migrated
 	legacyCheck := checkLegacyTeamContexts(gitRoot)
 	if legacyCheck.warning {
@@ -79,6 +102,52 @@ func checkTeamContextHealth(opts doctorOptions) []checkResult {
 	}
 
 	return checks
+}
+
+// daemonSyncedTeamContexts asks the daemon (via IPC — checkTeamContextHealth
+// runs in the CLI process and has no direct access to the daemon's in-memory
+// WorkspaceRegistry) which team-context clones it is actually syncing, and
+// returns the ones not already present in configured. This is how ox-baz5.5
+// closes the gap: configured comes from this repo's declared
+// localCfg.TeamContexts, which does not include a team context the daemon
+// syncs for other reasons (e.g. a secondary/internal team). A daemon that
+// isn't running, or times out, degrades to no extra contexts — this is a
+// best-effort supplement to the configured scan, never a replacement for it.
+func daemonSyncedTeamContexts(configured []config.TeamContext) []config.TeamContext {
+	client := daemon.NewClientForCurrentRepoWithTimeout(500 * time.Millisecond)
+	if client == nil || client.Ping() != nil {
+		return nil
+	}
+	status, err := client.Status()
+	if err != nil || status == nil {
+		return nil
+	}
+	return extraTeamContextsFromStatus(status, configured)
+}
+
+// extraTeamContextsFromStatus is the pure filtering logic behind
+// daemonSyncedTeamContexts, split out so the ox-baz5.5 fix — "don't miss a
+// team-context clone the daemon syncs but this repo never declared" — is
+// testable without a live daemon IPC connection.
+func extraTeamContextsFromStatus(status *daemon.StatusData, configured []config.TeamContext) []config.TeamContext {
+	known := make(map[string]bool, len(configured))
+	for _, tc := range configured {
+		known[tc.Path] = true
+	}
+
+	var extra []config.TeamContext
+	for _, ws := range status.Workspaces["team-context"] {
+		if !ws.Exists || ws.Path == "" || known[ws.Path] {
+			continue
+		}
+		extra = append(extra, config.TeamContext{
+			TeamID:   ws.TeamID,
+			TeamName: ws.TeamName,
+			Path:     ws.Path,
+			LastSync: ws.LastSync,
+		})
+	}
+	return extra
 }
 
 // checkDoubleEncodedLFSPointers detects the only worktree shape caused by an

--- a/cmd/ox/doctor_team_daemon_test.go
+++ b/cmd/ox/doctor_team_daemon_test.go
@@ -27,71 +27,64 @@ import (
 // the pure filtering logic behind daemonSyncedTeamContexts, tested without a
 // live daemon IPC connection.
 func TestExtraTeamContextsFromStatus(t *testing.T) {
-	t.Run("daemon-synced context missing from configured is surfaced", func(t *testing.T) {
-		status := &daemon.StatusData{
-			Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+	cases := []struct {
+		name       string
+		status     *daemon.StatusData
+		configured []config.TeamContext
+		want       []config.TeamContext
+	}{
+		{
+			name: "daemon-synced context missing from configured is surfaced",
+			status: &daemon.StatusData{Workspaces: map[string][]daemon.WorkspaceSyncStatus{
 				"team-context": {
 					{Path: "/configured/path", Exists: true, TeamID: "t1", TeamName: "Configured"},
 					{Path: "/other/path", Exists: true, TeamID: "t2", TeamName: "Other Team"},
 				},
-			},
-		}
-		configured := []config.TeamContext{{Path: "/configured/path", TeamID: "t1"}}
-
-		extra := extraTeamContextsFromStatus(status, configured)
-
-		assert.Len(t, extra, 1, "must surface exactly the team context missing from configured")
-		assert.Equal(t, "/other/path", extra[0].Path)
-		assert.Equal(t, "t2", extra[0].TeamID)
-		assert.Equal(t, "Other Team", extra[0].TeamName)
-	})
-
-	t.Run("fully configured daemon workspaces produce nothing extra", func(t *testing.T) {
-		status := &daemon.StatusData{
-			Workspaces: map[string][]daemon.WorkspaceSyncStatus{
-				"team-context": {
-					{Path: "/configured/path", Exists: true, TeamID: "t1"},
-				},
-			},
-		}
-		configured := []config.TeamContext{{Path: "/configured/path", TeamID: "t1"}}
-
-		assert.Empty(t, extraTeamContextsFromStatus(status, configured),
-			"must not re-surface a context the caller already scans")
-	})
-
-	t.Run("non-existent daemon workspace is skipped", func(t *testing.T) {
-		// Exists=false means the daemon knows about the workspace but hasn't
-		// cloned it yet — nothing on disk to scan for nested LFS pointers.
-		status := &daemon.StatusData{
-			Workspaces: map[string][]daemon.WorkspaceSyncStatus{
-				"team-context": {
-					{Path: "/not/cloned/yet", Exists: false, TeamID: "t3"},
-				},
-			},
-		}
-		assert.Empty(t, extraTeamContextsFromStatus(status, nil))
-	})
-
-	t.Run("no team-context key in workspaces produces nothing", func(t *testing.T) {
-		status := &daemon.StatusData{Workspaces: map[string][]daemon.WorkspaceSyncStatus{
-			"ledger": {{Path: "/ledger/path", Exists: true}},
-		}}
-		assert.Empty(t, extraTeamContextsFromStatus(status, nil))
-	})
-
-	t.Run("nil configured list still dedupes against itself", func(t *testing.T) {
-		status := &daemon.StatusData{
-			Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+			}},
+			configured: []config.TeamContext{{Path: "/configured/path", TeamID: "t1"}},
+			want:       []config.TeamContext{{Path: "/other/path", TeamID: "t2", TeamName: "Other Team"}},
+		},
+		{
+			name: "fully configured daemon workspaces produce nothing extra",
+			status: &daemon.StatusData{Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+				"team-context": {{Path: "/configured/path", Exists: true, TeamID: "t1"}},
+			}},
+			configured: []config.TeamContext{{Path: "/configured/path", TeamID: "t1"}},
+			want:       nil,
+		},
+		{
+			// Exists=false means the daemon knows about the workspace but
+			// hasn't cloned it yet — nothing on disk to scan.
+			name: "non-existent daemon workspace is skipped",
+			status: &daemon.StatusData{Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+				"team-context": {{Path: "/not/cloned/yet", Exists: false, TeamID: "t3"}},
+			}},
+			want: nil,
+		},
+		{
+			name: "no team-context key in workspaces produces nothing",
+			status: &daemon.StatusData{Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+				"ledger": {{Path: "/ledger/path", Exists: true}},
+			}},
+			want: nil,
+		},
+		{
+			name: "nil configured list still returns every existing daemon-synced context",
+			status: &daemon.StatusData{Workspaces: map[string][]daemon.WorkspaceSyncStatus{
 				"team-context": {
 					{Path: "/a", Exists: true, TeamID: "a"},
 					{Path: "/b", Exists: true, TeamID: "b"},
 				},
-			},
-		}
-		extra := extraTeamContextsFromStatus(status, nil)
-		assert.Len(t, extra, 2, "with nothing configured, every existing daemon-synced context is extra")
-	})
+			}},
+			want: []config.TeamContext{{Path: "/a", TeamID: "a"}, {Path: "/b", TeamID: "b"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, extraTeamContextsFromStatus(tc.status, tc.configured))
+		})
+	}
 }
 
 // TestDaemonSyncedTeamContexts_NoDaemon proves the fail-safe direction: when
@@ -222,51 +215,80 @@ func startFakeDaemon(t *testing.T, respond func(daemon.Message) daemon.Response)
 // here against the "extra" (daemon-only) code path instead of the configured
 // one.
 func TestScanExtraTeamContexts(t *testing.T) {
-	t.Run("nested pointer in an extra context produces a warning", func(t *testing.T) {
-		if _, err := exec.LookPath("git"); err != nil {
-			t.Skip("git not installed")
-		}
-		repo := t.TempDir()
-		run := func(args ...string) {
-			t.Helper()
-			cmd := exec.Command("git", args...)
-			cmd.Dir = repo
-			out, err := cmd.CombinedOutput()
-			require.NoError(t, err, "git %v: %s", args, out)
-		}
-		run("init", "-q")
-		run("config", "user.email", "test@example.com")
-		run("config", "user.name", "Test User")
+	cases := []struct {
+		name        string
+		buildExtra  func(t *testing.T) []config.TeamContext
+		wantLen     int
+		wantWarning bool
+	}{
+		{
+			name:        "nested pointer in an extra context produces a warning",
+			buildExtra:  extraContextWithNestedLFSPointer,
+			wantLen:     1,
+			wantWarning: true,
+		},
+		{
+			name:       "clean extra context produces no checks",
+			buildExtra: extraContextClean,
+			wantLen:    0,
+		},
+		{
+			name:       "empty extra list produces no checks",
+			buildExtra: func(t *testing.T) []config.TeamContext { return nil },
+			wantLen:    0,
+		},
+	}
 
-		inner := []byte(lfs.FormatPointer("sha256:inner", 9914))
-		outer := lfs.FormatPointer("sha256:outer", int64(len(inner)))
-		path := filepath.Join(repo, "frame.jpg")
-		require.NoError(t, os.WriteFile(path, []byte(outer), 0o644))
-		run("add", "frame.jpg")
-		run("commit", "-q", "-m", "outer pointer")
-		require.NoError(t, os.WriteFile(path, inner, 0o644))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := exec.LookPath("git"); err != nil {
+				t.Skip("git not installed")
+			}
+			checks := scanExtraTeamContexts(tc.buildExtra(t), doctorOptions{fix: false})
 
-		extra := []config.TeamContext{{TeamID: "other", TeamName: "Other Team", Path: repo}}
-		checks := scanExtraTeamContexts(extra, doctorOptions{fix: false})
+			require.Len(t, checks, tc.wantLen)
+			if tc.wantWarning {
+				assert.True(t, checks[0].warning)
+				assert.Contains(t, checks[0].name, "Other Team")
+			}
+		})
+	}
+}
 
-		require.Len(t, checks, 1)
-		assert.True(t, checks[0].warning)
-		assert.Contains(t, checks[0].name, "Other Team")
-	})
+// extraContextWithNestedLFSPointer builds a git repo containing the same
+// nested-pointer fixture shape as TestFindDoubleEncodedLFSPointerPaths
+// (doctor_team_lfs_test.go), returned as a single "extra" (daemon-only,
+// unconfigured) team context.
+func extraContextWithNestedLFSPointer(t *testing.T) []config.TeamContext {
+	t.Helper()
+	repo := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	run("init", "-q")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
 
-	t.Run("clean extra context produces no checks", func(t *testing.T) {
-		if _, err := exec.LookPath("git"); err != nil {
-			t.Skip("git not installed")
-		}
-		repo := t.TempDir()
-		cmd := exec.Command("git", "init", "-q", repo)
-		require.NoError(t, cmd.Run())
+	inner := []byte(lfs.FormatPointer("sha256:inner", 9914))
+	outer := lfs.FormatPointer("sha256:outer", int64(len(inner)))
+	path := filepath.Join(repo, "frame.jpg")
+	require.NoError(t, os.WriteFile(path, []byte(outer), 0o644))
+	run("add", "frame.jpg")
+	run("commit", "-q", "-m", "outer pointer")
+	require.NoError(t, os.WriteFile(path, inner, 0o644))
 
-		extra := []config.TeamContext{{TeamID: "other", Path: repo}}
-		assert.Empty(t, scanExtraTeamContexts(extra, doctorOptions{fix: false}))
-	})
+	return []config.TeamContext{{TeamID: "other", TeamName: "Other Team", Path: repo}}
+}
 
-	t.Run("empty extra list produces no checks", func(t *testing.T) {
-		assert.Empty(t, scanExtraTeamContexts(nil, doctorOptions{fix: false}))
-	})
+// extraContextClean builds a plain git repo with nothing to flag.
+func extraContextClean(t *testing.T) []config.TeamContext {
+	t.Helper()
+	repo := t.TempDir()
+	cmd := exec.Command("git", "init", "-q", repo)
+	require.NoError(t, cmd.Run())
+	return []config.TeamContext{{TeamID: "other", Path: repo}}
 }

--- a/cmd/ox/doctor_team_daemon_test.go
+++ b/cmd/ox/doctor_team_daemon_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtraTeamContextsFromStatus covers ox-baz5.5: checkTeamContextHealth's
+// LFS nested-pointer scan used to walk only localCfg.TeamContexts — the
+// repo's declared list — and silently never visit a team-context clone the
+// daemon syncs for another reason (observed: a secondary "SageOx Internal"
+// clone that was diverged and permanently dirty, while doctor's "Team
+// Context" section reported clean in ~23ms because it never looked). This is
+// the pure filtering logic behind daemonSyncedTeamContexts, tested without a
+// live daemon IPC connection.
+func TestExtraTeamContextsFromStatus(t *testing.T) {
+	t.Run("daemon-synced context missing from configured is surfaced", func(t *testing.T) {
+		status := &daemon.StatusData{
+			Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+				"team-context": {
+					{Path: "/configured/path", Exists: true, TeamID: "t1", TeamName: "Configured"},
+					{Path: "/other/path", Exists: true, TeamID: "t2", TeamName: "Other Team"},
+				},
+			},
+		}
+		configured := []config.TeamContext{{Path: "/configured/path", TeamID: "t1"}}
+
+		extra := extraTeamContextsFromStatus(status, configured)
+
+		assert.Len(t, extra, 1, "must surface exactly the team context missing from configured")
+		assert.Equal(t, "/other/path", extra[0].Path)
+		assert.Equal(t, "t2", extra[0].TeamID)
+		assert.Equal(t, "Other Team", extra[0].TeamName)
+	})
+
+	t.Run("fully configured daemon workspaces produce nothing extra", func(t *testing.T) {
+		status := &daemon.StatusData{
+			Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+				"team-context": {
+					{Path: "/configured/path", Exists: true, TeamID: "t1"},
+				},
+			},
+		}
+		configured := []config.TeamContext{{Path: "/configured/path", TeamID: "t1"}}
+
+		assert.Empty(t, extraTeamContextsFromStatus(status, configured),
+			"must not re-surface a context the caller already scans")
+	})
+
+	t.Run("non-existent daemon workspace is skipped", func(t *testing.T) {
+		// Exists=false means the daemon knows about the workspace but hasn't
+		// cloned it yet — nothing on disk to scan for nested LFS pointers.
+		status := &daemon.StatusData{
+			Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+				"team-context": {
+					{Path: "/not/cloned/yet", Exists: false, TeamID: "t3"},
+				},
+			},
+		}
+		assert.Empty(t, extraTeamContextsFromStatus(status, nil))
+	})
+
+	t.Run("no team-context key in workspaces produces nothing", func(t *testing.T) {
+		status := &daemon.StatusData{Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+			"ledger": {{Path: "/ledger/path", Exists: true}},
+		}}
+		assert.Empty(t, extraTeamContextsFromStatus(status, nil))
+	})
+
+	t.Run("nil configured list still dedupes against itself", func(t *testing.T) {
+		status := &daemon.StatusData{
+			Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+				"team-context": {
+					{Path: "/a", Exists: true, TeamID: "a"},
+					{Path: "/b", Exists: true, TeamID: "b"},
+				},
+			},
+		}
+		extra := extraTeamContextsFromStatus(status, nil)
+		assert.Len(t, extra, 2, "with nothing configured, every existing daemon-synced context is extra")
+	})
+}
+
+// TestDaemonSyncedTeamContexts_NoDaemon proves the fail-safe direction: when
+// no daemon is reachable (or ping times out), the function degrades to "no
+// extra contexts" rather than erroring or blocking the doctor check it feeds.
+// This scan is a best-effort supplement to the configured list, never a
+// replacement — losing it must never make checkTeamContextHealth fail.
+func TestDaemonSyncedTeamContexts_NoDaemon(t *testing.T) {
+	// No daemon is running in the unit test sandbox (no XDG state dir with a
+	// live socket for this repo), so Ping() fails and the function returns
+	// nil without touching configured.
+	got := daemonSyncedTeamContexts([]config.TeamContext{{Path: "/x"}})
+	assert.Nil(t, got)
+}

--- a/cmd/ox/doctor_team_daemon_test.go
+++ b/cmd/ox/doctor_team_daemon_test.go
@@ -1,11 +1,21 @@
 package main
 
 import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/lfs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestExtraTeamContextsFromStatus covers ox-baz5.5: checkTeamContextHealth's
@@ -89,10 +99,174 @@ func TestExtraTeamContextsFromStatus(t *testing.T) {
 // extra contexts" rather than erroring or blocking the doctor check it feeds.
 // This scan is a best-effort supplement to the configured list, never a
 // replacement — losing it must never make checkTeamContextHealth fail.
+//
+// The client is pointed at a socket path guaranteed not to exist, rather
+// than relying on "no daemon happens to be running for this test process's
+// resolved workspace" — daemon.CurrentWorkspaceID() memoizes via sync.Once
+// per process, so that assumption can silently break depending on test
+// execution order and the host environment (flagged by CodeRabbit on #877).
 func TestDaemonSyncedTeamContexts_NoDaemon(t *testing.T) {
-	// No daemon is running in the unit test sandbox (no XDG state dir with a
-	// live socket for this repo), so Ping() fails and the function returns
-	// nil without touching configured.
-	got := daemonSyncedTeamContexts([]config.TeamContext{{Path: "/x"}})
+	sock := filepath.Join(t.TempDir(), "definitely-does-not-exist.sock")
+	client := daemon.NewClientWithSocket(sock)
+
+	got := daemonSyncedTeamContextsVia(client, []config.TeamContext{{Path: "/x"}})
 	assert.Nil(t, got)
+}
+
+// TestDaemonSyncedTeamContexts_NilClient covers the other fail-safe input:
+// daemonSyncedTeamContexts itself can hand daemonSyncedTeamContextsVia a nil
+// *daemon.Client (NewClientForCurrentRepoWithTimeout's documented zero case);
+// this must degrade the same way, not panic.
+func TestDaemonSyncedTeamContexts_NilClient(t *testing.T) {
+	got := daemonSyncedTeamContextsVia(nil, []config.TeamContext{{Path: "/x"}})
+	assert.Nil(t, got)
+}
+
+// TestDaemonSyncedTeamContexts_Success drives daemonSyncedTeamContextsVia
+// through a real (fake) IPC round trip — ping, then status — against a
+// minimal Unix-socket server speaking the daemon's actual newline-delimited
+// JSON protocol. This is the path TestDaemonSyncedTeamContexts_NoDaemon
+// can't reach: a daemon that responds and reports a real extra context.
+func TestDaemonSyncedTeamContexts_Success(t *testing.T) {
+	sock := startFakeDaemon(t, func(msg daemon.Message) daemon.Response {
+		switch msg.Type {
+		case daemon.MsgTypePing:
+			return daemon.Response{Success: true}
+		case daemon.MsgTypeStatus:
+			status := daemon.StatusData{
+				Workspaces: map[string][]daemon.WorkspaceSyncStatus{
+					"team-context": {
+						{Path: "/other/path", Exists: true, TeamID: "t2", TeamName: "Other Team"},
+					},
+				},
+			}
+			data, err := json.Marshal(status)
+			require.NoError(t, err)
+			return daemon.Response{Success: true, Data: data}
+		default:
+			return daemon.Response{Success: false, Error: "unexpected message type in test fake: " + msg.Type}
+		}
+	})
+
+	got := daemonSyncedTeamContextsVia(daemon.NewClientWithSocket(sock), nil)
+
+	assert.Len(t, got, 1)
+	assert.Equal(t, "/other/path", got[0].Path)
+	assert.Equal(t, "Other Team", got[0].TeamName)
+}
+
+// TestDaemonSyncedTeamContexts_CallsThroughToVia is a smoke test for
+// daemonSyncedTeamContexts itself — the thin CWD-based wrapper that
+// TestDaemonSyncedTeamContexts_Success and _NoDaemon deliberately bypass by
+// injecting a client. It can't control what daemon (if any) answers for the
+// test process's real working directory, so it only asserts the call
+// completes without panicking; the behavior for every daemon-response shape
+// is already proven against daemonSyncedTeamContextsVia above.
+func TestDaemonSyncedTeamContexts_CallsThroughToVia(t *testing.T) {
+	assert.NotPanics(t, func() {
+		daemonSyncedTeamContexts(nil)
+	})
+}
+
+// startFakeDaemon starts a minimal Unix-socket server speaking the daemon
+// IPC wire format (one newline-delimited JSON Message in, one
+// newline-delimited JSON Response out) and returns its socket path. respond
+// computes the reply for each received message; the server handles exactly
+// one message per connection, matching Client.sendMessage's connect-write-
+// read-close pattern.
+func startFakeDaemon(t *testing.T, respond func(daemon.Message) daemon.Response) string {
+	t.Helper()
+	// os.TempDir(), not t.TempDir(): a long test name nests t.TempDir() deep
+	// enough to exceed macOS's ~104-char AF_UNIX path limit ("bind: invalid
+	// argument"). Same workaround as internal/daemon/friction_test.go.
+	sock := filepath.Join(os.TempDir(), fmt.Sprintf("ox-fake-daemon-%d.sock", time.Now().UnixNano()))
+	t.Cleanup(func() { os.Remove(sock) })
+	listener, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				line, err := bufio.NewReader(c).ReadBytes('\n')
+				if err != nil {
+					return
+				}
+				var msg daemon.Message
+				if err := json.Unmarshal(line, &msg); err != nil {
+					return
+				}
+				data, err := json.Marshal(respond(msg))
+				if err != nil {
+					return
+				}
+				data = append(data, '\n')
+				_, _ = c.Write(data)
+			}(conn)
+		}
+	}()
+
+	return sock
+}
+
+// TestScanExtraTeamContexts covers the actual scan-and-report behavior
+// ox-baz5.5 exists to restore: a daemon-synced-but-unconfigured team context
+// with a real nested LFS pointer must produce a doctor warning, not silently
+// pass. Uses the same nested-pointer fixture shape as
+// TestFindDoubleEncodedLFSPointerPaths (doctor_team_lfs_test.go), reused
+// here against the "extra" (daemon-only) code path instead of the configured
+// one.
+func TestScanExtraTeamContexts(t *testing.T) {
+	t.Run("nested pointer in an extra context produces a warning", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git not installed")
+		}
+		repo := t.TempDir()
+		run := func(args ...string) {
+			t.Helper()
+			cmd := exec.Command("git", args...)
+			cmd.Dir = repo
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "git %v: %s", args, out)
+		}
+		run("init", "-q")
+		run("config", "user.email", "test@example.com")
+		run("config", "user.name", "Test User")
+
+		inner := []byte(lfs.FormatPointer("sha256:inner", 9914))
+		outer := lfs.FormatPointer("sha256:outer", int64(len(inner)))
+		path := filepath.Join(repo, "frame.jpg")
+		require.NoError(t, os.WriteFile(path, []byte(outer), 0o644))
+		run("add", "frame.jpg")
+		run("commit", "-q", "-m", "outer pointer")
+		require.NoError(t, os.WriteFile(path, inner, 0o644))
+
+		extra := []config.TeamContext{{TeamID: "other", TeamName: "Other Team", Path: repo}}
+		checks := scanExtraTeamContexts(extra, doctorOptions{fix: false})
+
+		require.Len(t, checks, 1)
+		assert.True(t, checks[0].warning)
+		assert.Contains(t, checks[0].name, "Other Team")
+	})
+
+	t.Run("clean extra context produces no checks", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git not installed")
+		}
+		repo := t.TempDir()
+		cmd := exec.Command("git", "init", "-q", repo)
+		require.NoError(t, cmd.Run())
+
+		extra := []config.TeamContext{{TeamID: "other", Path: repo}}
+		assert.Empty(t, scanExtraTeamContexts(extra, doctorOptions{fix: false}))
+	})
+
+	t.Run("empty extra list produces no checks", func(t *testing.T) {
+		assert.Empty(t, scanExtraTeamContexts(nil, doctorOptions{fix: false}))
+	})
 }

--- a/cmd/ox/doctor_team_daemon_test.go
+++ b/cmd/ox/doctor_team_daemon_test.go
@@ -288,7 +288,8 @@ func extraContextWithNestedLFSPointer(t *testing.T) []config.TeamContext {
 func extraContextClean(t *testing.T) []config.TeamContext {
 	t.Helper()
 	repo := t.TempDir()
-	cmd := exec.Command("git", "init", "-q", repo)
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = repo
 	require.NoError(t, cmd.Run())
 	return []config.TeamContext{{TeamID: "other", Path: repo}}
 }

--- a/internal/gitutil/cmd.go
+++ b/internal/gitutil/cmd.go
@@ -39,8 +39,26 @@ import (
 // Skipping it would silently discard content that was resolved but never
 // recorded. Applied here rather than at the one committing call site so a
 // future network command that commits inherits the hardening by default.
+//
+// filter.lfs.*: ox never depends on the git-lfs binary and never commits
+// filter=lfs .gitattributes (.claude/rules/lfs-no-git-lfs-binary.md) — but a
+// team-context repo's own .gitattributes can mark server-side attachments
+// filter=lfs (ADR-085), and if the *user* happens to have git-lfs installed
+// globally, its smudge/clean filters still fire on ox's clones regardless of
+// what ox itself writes. A committed nested LFS pointer (a pointer whose
+// smudged content is itself another pointer) then makes the worktree unable
+// to ever equal HEAD: checkout smudges one layer, `git status` sees it as
+// modified, next pull's autostash re-triggers the same smudge, forever
+// (ox-baz5.4). Overriding filter.lfs.{smudge,clean,process,required} makes
+// every ox-managed clone dehydrated regardless of the host's global git-lfs
+// config — the same override restoreRawLFSPointers already uses to repair
+// one clone (cmd/ox/doctor_team.go), applied here so it never needs repairing.
 func NewNetworkCmd(ctx context.Context, args ...string) *exec.Cmd {
-	gitArgs := append([]string{"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}, args...)
+	gitArgs := append([]string{
+		"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false",
+		"-c", "filter.lfs.smudge=cat", "-c", "filter.lfs.clean=cat",
+		"-c", "filter.lfs.process=", "-c", "filter.lfs.required=false",
+	}, args...)
 	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C", "LANG=C")
 	return cmd

--- a/internal/gitutil/cmd_test.go
+++ b/internal/gitutil/cmd_test.go
@@ -47,19 +47,37 @@ func TestNewNetworkCmd_DisablesCommitSigning(t *testing.T) {
 	}{
 		{
 			args: []string{"pull", "--rebase", "--autostash"},
-			want: []string{"git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "pull", "--rebase", "--autostash"},
+			want: []string{"git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "-c", "filter.lfs.smudge=cat", "-c", "filter.lfs.clean=cat", "-c", "filter.lfs.process=", "-c", "filter.lfs.required=false", "pull", "--rebase", "--autostash"},
 		},
 		{
 			args: []string{"-C", "/tmp/example", "fetch", "--quiet"},
-			want: []string{"git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "-C", "/tmp/example", "fetch", "--quiet"},
+			want: []string{"git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "-c", "filter.lfs.smudge=cat", "-c", "filter.lfs.clean=cat", "-c", "filter.lfs.process=", "-c", "filter.lfs.required=false", "-C", "/tmp/example", "fetch", "--quiet"},
 		},
 		{
 			args: []string{"ls-remote", "origin"},
-			want: []string{"git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "ls-remote", "origin"},
+			want: []string{"git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "-c", "filter.lfs.smudge=cat", "-c", "filter.lfs.clean=cat", "-c", "filter.lfs.process=", "-c", "filter.lfs.required=false", "ls-remote", "origin"},
 		},
 	} {
 		cmd := NewNetworkCmd(context.Background(), tc.args...)
 		assert.Equal(t, tc.want, cmd.Args,
 			"signing must be disabled ahead of the caller's verbatim args for %v", tc.args)
 	}
+}
+
+// TestNewNetworkCmd_InsulatesFromGlobalLFSFilters covers ox-baz5.4: a network
+// git command must carry its own filter.lfs.* overrides so a user's global
+// git-lfs config (filter.lfs.required=true and friends) can never smudge or
+// clean content ox checks out. ox never depends on git-lfs
+// (.claude/rules/lfs-no-git-lfs-binary.md) — this is what makes that true
+// even on a machine that happens to have git-lfs installed globally.
+func TestNewNetworkCmd_InsulatesFromGlobalLFSFilters(t *testing.T) {
+	cmd := NewNetworkCmd(context.Background(), "fetch", "--quiet")
+	want := []string{
+		"git",
+		"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false",
+		"-c", "filter.lfs.smudge=cat", "-c", "filter.lfs.clean=cat",
+		"-c", "filter.lfs.process=", "-c", "filter.lfs.required=false",
+		"fetch", "--quiet",
+	}
+	assert.Equal(t, want, cmd.Args)
 }

--- a/internal/gitutil/run.go
+++ b/internal/gitutil/run.go
@@ -24,7 +24,15 @@ func RunGit(ctx context.Context, repoPath string, args ...string) (string, error
 	// "fatal: failed to write commit object" — silently wedging ledger sync.
 	// Overriding per-invocation makes ox's commits immune regardless of the
 	// repo's persisted config. Harmless no-op for non-commit subcommands.
-	cmdArgs = append(cmdArgs, "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false")
+	// filter.lfs.*: see NewNetworkCmd's doc comment (cmd.go) — this is the
+	// other chokepoint git subprocesses go through, and it needs the same
+	// dehydrated-clone override so a caller through RunGit doesn't reopen
+	// the nested-LFS-pointer wedge (ox-baz5.4) that NewNetworkCmd alone closed.
+	cmdArgs = append(cmdArgs,
+		"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false",
+		"-c", "filter.lfs.smudge=cat", "-c", "filter.lfs.clean=cat",
+		"-c", "filter.lfs.process=", "-c", "filter.lfs.required=false",
+	)
 	cmdArgs = append(cmdArgs, args...)
 
 	cmd := exec.CommandContext(ctx, "git", cmdArgs...)

--- a/internal/gitutil/run_test.go
+++ b/internal/gitutil/run_test.go
@@ -127,6 +127,15 @@ func TestRunGit(t *testing.T) {
 				"\tclean = cat\n"+
 				"\trequired = true\n"), 0o644))
 		t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+		// GIT_CONFIG_GLOBAL redirects only the GLOBAL file — the RAW
+		// checkout below (the fixture-sanity step, run without RunGit's
+		// insulation) still reads whatever SYSTEM config the host actually
+		// has. filter.<driver>.process (a long-running filter protocol)
+		// takes precedence over smudge/clean when set, so a host with a
+		// real system-level git-lfs config could silently override this
+		// fixture's smudge and break the sanity check. GIT_CONFIG_NOSYSTEM
+		// makes the raw checkout hermetic regardless of host state.
+		t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
 
 		repo := t.TempDir()
 		run := func(args ...string) {

--- a/internal/gitutil/run_test.go
+++ b/internal/gitutil/run_test.go
@@ -110,6 +110,66 @@ func TestRunGit(t *testing.T) {
 		assert.Contains(t, output, "oauth2:***@")
 	})
 
+	t.Run("insulated from a global git-lfs install (ox-baz5.4)", func(t *testing.T) {
+		// Simulates a machine with git-lfs installed globally: filter.lfs.*
+		// configured in the GLOBAL gitconfig (not this repo's), the way
+		// `git lfs install --global` leaves it. GIT_CONFIG_GLOBAL (git
+		// 2.32+) redirects git's notion of "global config" to this fixture
+		// file, isolated from the real user running the test.
+		globalConfig := filepath.Join(t.TempDir(), "gitconfig")
+		// git already runs a filter command through the shell itself, so the
+		// config value is the raw shell command — no extra `sh -c` wrapper.
+		// Double-quoted: gitconfig(5) treats an unquoted `;` as a trailing
+		// comment marker, which would silently truncate this value.
+		require.NoError(t, os.WriteFile(globalConfig, []byte(
+			"[filter \"lfs\"]\n"+
+				"\tsmudge = \"cat >/dev/null; printf SMUDGED\"\n"+
+				"\tclean = cat\n"+
+				"\trequired = true\n"), 0o644))
+		t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+
+		repo := t.TempDir()
+		run := func(args ...string) {
+			cmd := exec.Command("git", args...)
+			cmd.Dir = repo
+			out, err := cmd.CombinedOutput()
+			require.NoErrorf(t, err, "git %v: %s", args, out)
+		}
+		run("init", "--quiet")
+		run("config", "--local", "user.name", "Test")
+		run("config", "--local", "user.email", "test@example.com")
+		require.NoError(t, os.WriteFile(filepath.Join(repo, ".gitattributes"), []byte("test.bin filter=lfs\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(repo, "test.bin"), []byte("REAL-CONTENT"), 0o644))
+		run("add", "-A")
+		run("commit", "--quiet", "-m", "init")
+
+		// Fixture sanity: a RAW checkout (no insulation) IS smudged by the
+		// global filter — proves this fixture actually exercises the bug
+		// this test guards, not a no-op.
+		require.NoError(t, os.Remove(filepath.Join(repo, "test.bin")))
+		run("checkout", "--", "test.bin")
+		raw, err := os.ReadFile(filepath.Join(repo, "test.bin"))
+		require.NoError(t, err)
+		require.Equal(t, "SMUDGED", string(raw), "fixture sanity: raw checkout must be smudged by the global filter")
+
+		// The fix: a checkout run through RunGit must NOT be smudged, and
+		// the worktree must stay clean afterward. Without RunGit's
+		// filter.lfs.* overrides this is the ox-baz5.4 wedge: a nested LFS
+		// pointer can never equal HEAD, autostash leaks one entry per pull
+		// cycle, and `ox doctor --fix` cannot help.
+		require.NoError(t, os.Remove(filepath.Join(repo, "test.bin")))
+		_, err = RunGit(context.Background(), repo, "checkout", "--", "test.bin")
+		assert.NoError(t, err)
+		insulated, err := os.ReadFile(filepath.Join(repo, "test.bin"))
+		require.NoError(t, err)
+		assert.Equal(t, "REAL-CONTENT", string(insulated),
+			"RunGit must insulate checkout from the global git-lfs smudge filter")
+
+		status, err := RunGit(context.Background(), repo, "status", "--porcelain")
+		assert.NoError(t, err)
+		assert.Empty(t, status, "worktree must be clean after an insulated checkout — this is what 'daemon pull succeeds and stays clean' means")
+	})
+
 	t.Run("error output is also sanitized", func(t *testing.T) {
 		// create a repo pointing to a nonexistent remote with credentials
 		repo := t.TempDir()


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a06951-6d73-73bd-97a1-3a13871a4538">Session</a>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/plan/pln_01a0695e-b8e4-74f5-a897-54c0c1ff113e">Plan</a>
<!-- /sageox:pr-header -->

## Summary

- **What:** Insulates every `ox`-managed git subprocess from the user's *global* git-lfs config, and fixes `ox doctor`'s LFS-integrity scan to cover every team-context clone the daemon actually syncs, not just the ones this repo declares.
- **Why:** closes `ox-baz5.4` (P1) and `ox-baz5.5` (P2), two of six defects found while root-causing a broken `ox status` under epic `ox-baz5`. Lane A (the FETCH_HEAD race, `ox-baz5.1`–`.3`) already shipped in #868. Lane C (atomic ledger clone, `ox-baz5.6`) ships separately — different subsystem, no file overlap, independent risk profile.
- **Branch base:** cut fresh from `origin/main` (not from the docs branch this investigation started on) specifically to pick up #868's `gitutil.WithRepoLock` before building anything else on top of it.

## What broke

- `.claude/rules/lfs-no-git-lfs-binary.md` is explicit: ox never depends on the `git-lfs` binary. But that's a statement about what *ox* does — it says nothing about what happens if the *user* has git-lfs installed globally. Neither `gitutil.NewNetworkCmd` nor `gitutil.RunGit` — the two chokepoints every git subprocess in this codebase goes through — overrode `filter.lfs.*`, so a global git-lfs install's smudge/clean filters ran on every ox-managed clone regardless.
- A team-context repo can legitimately mark server-side attachments `filter=lfs` in `.gitattributes` (ADR-085). If a committed attachment is a **nested pointer** (a pointer whose smudged content is itself another pointer), git-lfs unwraps exactly one layer on checkout — so the worktree can never equal HEAD. Every daemon pull cycle: checkout → smudge → dirty → autostash → repeat, leaking one orphan stash per cycle.
- This was reproducing live during this session, on `team_xlcr6yzpec` (SageOx Internal): diverged from remote, rebase failing, `ox doctor --fix` unable to help.
- Compounding it: `ox doctor`'s nested-pointer detector (`checkDoubleEncodedLFSPointers`) already existed and its logic was correct — but `checkTeamContextHealth` only walked `localCfg.TeamContexts`, this repo's *declared* list. The diverged clone above isn't in that list (it's synced for another reason), so it was never scanned. Doctor's "Team Context" section reported clean in ~23ms — too fast to have looked.

```mermaid
flowchart LR
    A["daemon: git pull --rebase --autostash"] --> B["checkout HEAD"]
    B --> C{"filter.lfs.* overridden?"}
    C -->|"before this PR"| D["user's global smudge filter runs"]
    D --> E["worktree != index — dirty forever"]
    E --> A
    C -->|"after this PR"| F["smudge/clean forced to cat — no-op"]
    F --> G["worktree == index — clean"]
```

## What this PR ships

- **`internal/gitutil/cmd.go`** (`NewNetworkCmd`) and **`internal/gitutil/run.go`** (`RunGit`) both now pass `-c filter.lfs.smudge=cat -c filter.lfs.clean=cat -c filter.lfs.process= -c filter.lfs.required=false` — the same flag set `restoreRawLFSPointers` already uses to *repair* one clone after the fact, now applied up front so ox's own clones never need repairing.
- **`cmd/ox/doctor_team.go`**: `checkTeamContextHealth` now also asks the daemon (over IPC, `client.Status()`) which team-context clones it's actually syncing, and runs the nested-pointer scan against anything not already covered by `localCfg.TeamContexts`. Split into a pure `extraTeamContextsFromStatus` filter (testable without a live daemon) plus a thin `daemonSyncedTeamContexts` IO wrapper that degrades to "nothing extra" if the daemon isn't reachable — this is a best-effort supplement, never a replacement for the configured scan.

## Test plan

- `TestRunGit/insulated_from_a_global_git-lfs_install_(ox-baz5.4)` — a fixture that simulates a machine with git-lfs installed globally via `GIT_CONFIG_GLOBAL` pointed at a fake gitconfig with `filter.lfs.*` set. Includes a fixture-sanity assertion (a *raw* checkout, bypassing `RunGit`, is confirmed smudged) so the test can't pass vacuously. Verified red-first: reverted the fix locally, watched this exact test fail with the worktree smudged and `git status` showing `M test.bin`, then restored the fix and watched it go green.
- `TestNewNetworkCmd_InsulatesFromGlobalLFSFilters` — exact-argv assertion that the flags are present in the right order.
- `TestExtraTeamContextsFromStatus` (5 subtests) — the doctor enumeration fix: a daemon-synced context missing from `configured` is surfaced; already-configured ones aren't re-surfaced; non-existent (not-yet-cloned) workspaces are skipped; missing `team-context` key produces nothing; empty `configured` still dedupes correctly.
- `TestDaemonSyncedTeamContexts_NoDaemon` — the fail-safe direction: no reachable daemon degrades to `nil`, never an error that would block the check it feeds.
- `make lint`: 0 issues. `go test ./internal/gitutil/... ./cmd/ox/...`: full suite green, including `-race` on every touched test.

## Out of scope

- **Lane C** (`ox-baz5.6`, atomic + locked ledger clone) — separate PR, tracked in the [plan](https://sageox.ai/plan/pln_01a0695e-b8e4-74f5-a897-54c0c1ff113e).
- **`ox-vf3h`** (ledger push returns HTTP 403 despite a valid PAT) — pre-existing, server-side ACL gap, unrelated to how ox drives git locally.

Co-Authored-By: [SageOx](https://github.com/SageOx)
SageOx-Session: https://sageox.ai/c/ses_01a06951-6d73-73bd-97a1-3a13871a4538

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791068018&installation_model_id=433550&pr_number=877&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F877&signature=9b1546dfcd935fe32fa805905f351f98524adc1ecb1cc22a60de6008cd7b79ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Team-context health checks detect daemon-synced workspaces missing from local configuration.
  - Health checks scan discovered workspaces for nested Git LFS pointers, including when no local team contexts are configured.
  - Checks continue gracefully when the daemon is unavailable.

- **Bug Fixes**
  - Git operations now bypass configured Git LFS filters and commit or tag signing settings, ensuring raw LFS content is used consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->