### PR TITLE
fix(daemon): atomic + locked ledger clone, repair invalid HEAD

### DIFF
--- a/.config/coverage-ratchets.json
+++ b/.config/coverage-ratchets.json
@@ -21,6 +21,16 @@
         "path": "internal/daemon/sync_managed.go",
         "reason": "PR #868 (ADR-030 per-clone git locking): the new lock/retry/D3-guard logic in pullManagedRepo and fetchAndPullLocked is directly tested (TestPullManagedRepo_ConcurrentFetchDoesNotCorruptFETCH_HEAD, -race clean). The remaining uncovered lines are the pre-existing auto-resolve/LLM-resolver/AuditAndAbort conflict ladder, extracted verbatim (unchanged in behavior) out of the old pullManagedRepo body. Same automerge mocking gap as doctor_ledger_git.go, tracked together under bd ox-baz5.7.",
         "expires": "2026-10-17"
+      },
+      {
+        "path": "internal/daemon/sync.go",
+        "reason": "ox-baz5.6 (atomic + pre-clone-locked ledger clone): the new WithPreCloneLock wrapper, temp-dir-then-rename atomicity, and HEAD-resolves verification are directly tested (TestSyncScheduler_Checkout_LedgerCloneIsAtomic, _FailedLedgerCloneLeavesNoHalfClone, _ConcurrentLedgerCloneRace, _EmptyRemoteFailsVerification, all -race clean). The remaining uncovered lines are the pre-existing team-context two-phase-clone dispatch branch, re-indented into the diff by the new lock wrapper but unchanged in behavior. Covering it needs a real smart-HTTP git server test fixture — the dumb-HTTP static file serving used for the ledger-clone tests above can't negotiate git's partial-clone protocol (--filter=blob:none) that gitserver.TwoPhaseClone requires. Tracked as bd ox-baz5.6.1.",
+        "expires": "2026-10-17"
+      },
+      {
+        "path": "cmd/ox/doctor_ledger_invalid_head.go",
+        "reason": "ox-baz5.6 (doctor ledger-HEAD-integrity repair): the reachable repair, conflict-detection, and rollback branches are directly tested (12 tests including TestRepairInvalidHead_RefusesConflictingContent, _RestoreErrorTriggersRollback, _RenameAsideFails, TestRestoreLedgerDir_WalkErrorOnUnreadableSubdir/_ConflictCheckReadFailure, TestFilesIdentical_ReadErrors, TestFixLedgerInvalidHead_SerializesWithPreCloneLock). The remaining 7 lines are genuinely unreachable without a race or root: rollback()'s own restore-rename failing after its paired rename into the same parent dir already succeeded (no hook to fail only the second); filepath.Rel erroring on a path WalkDir itself produced from the same root (dead defensive code); and a file-copy's parent-dir MkdirAll failing after WalkDir already visited and created that same directory moments earlier in the traversal. Tracked as bd ox-baz5.6.1.",
+        "expires": "2026-10-17"
       }
     ]
   },

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -1216,6 +1216,14 @@ func enrichCheckResult(check *checkResult) {
 var ledgerGitHealthOrder = []string{
 	// network check (git ls-remote); runs only under --fix to avoid slow I/O.
 	CheckSlugLedgerRemoteReachable,
+	// ox-baz5.6: MUST run before every other check below. An unresolvable
+	// HEAD (a syntactically invalid ref left by an interrupted clone) makes
+	// stranded-commits, unmerged-paths, stuck-operation, clean-workdir, and
+	// branch-status all assume something false about HEAD — before this
+	// check existed they silently skipped or failed on a cryptic git error
+	// instead of naming the real problem. Repair here first; everything
+	// downstream then runs against a resolvable HEAD.
+	CheckSlugLedgerInvalidHead,
 	// ox-akab: MUST be the first mutating check. Commits reachable only from
 	// HEAD have to be given a branch BEFORE anything downstream can move HEAD —
 	// the unmerged-paths and stuck-operation fixes both abort in-progress

--- a/cmd/ox/doctor_ledger_invalid_head.go
+++ b/cmd/ox/doctor_ledger_invalid_head.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/fs"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/gitutil"
 )
 
 // CheckSlugLedgerInvalidHead detects a ledger whose .git/HEAD points at a
@@ -33,6 +35,11 @@ const CheckSlugLedgerInvalidHead = "ledger-invalid-head"
 // invalidHeadCheckTimeout bounds the local git plumbing this check runs
 // (rev-parse, check-ref-format, status) — all local, no network.
 const invalidHeadCheckTimeout = 30 * time.Second
+
+// invalidHeadRepairTimeout bounds the --fix path, which re-clones the whole
+// ledger from origin — real ledgers observed in the field run to hundreds of
+// MB, so this needs far more headroom than the read-only detection above.
+const invalidHeadRepairTimeout = 10 * time.Minute
 
 func init() {
 	RegisterDoctorCheck(&DoctorCheck{
@@ -130,15 +137,46 @@ func invalidHeadCheck(ledgerPath string, fix bool) checkResult {
 		return r
 	}
 
-	return fixLedgerInvalidHead(ctx, ledgerPath, invalidRef)
+	// The repair re-clones the whole ledger from origin — needs far more
+	// headroom than the read-only detection above, which is why this gets
+	// its own context rather than reusing the 30s one this function started
+	// with.
+	repairCtx, repairCancel := context.WithTimeout(context.Background(), invalidHeadRepairTimeout)
+	defer repairCancel()
+	return fixLedgerInvalidHead(repairCtx, ledgerPath, invalidRef)
 }
 
-// fixLedgerInvalidHead repairs an unresolvable HEAD: move the corrupted
-// clone aside (never delete it), clone fresh from origin, restore any
-// uncommitted sessions/ and data/ content from the backup, and commit it.
-// The backup is left on disk — not cleaned up — so a failure at any step
-// leaves the original recoverable exactly where it was.
+// fixLedgerInvalidHead repairs an unresolvable HEAD. The whole operation
+// runs under gitutil.WithPreCloneLock — the same lock Checkout() takes
+// before cloning into this same path — because an unlocked rename +
+// reclone here would reopen the exact concurrent-clone race ox-baz5.6
+// exists to close: the daemon could be mid-clone (or mid-recovery of its
+// own) on this exact path at the same moment this runs.
 func fixLedgerInvalidHead(ctx context.Context, ledgerPath, invalidRef string) checkResult {
+	const name = "Ledger HEAD integrity"
+
+	var result checkResult
+	if lockErr := gitutil.WithPreCloneLock(ctx, ledgerPath, func() error {
+		result = repairInvalidHead(ctx, ledgerPath, invalidRef)
+		return nil
+	}); lockErr != nil {
+		return FailedCheck(name, "could not acquire the ledger clone lock to repair HEAD",
+			fmt.Sprintf("%v — another ox process may be cloning or repairing this same path; try again shortly", lockErr))
+	}
+	return result
+}
+
+// repairInvalidHead does the actual repair: move the corrupted clone aside,
+// clone fresh from origin, restore any uncommitted sessions/ and data/
+// content from the backup, and commit it. Always called with
+// gitutil.WithPreCloneLock held (see fixLedgerInvalidHead).
+//
+// On ANY failure below the rename, this rolls back to the EXACT original
+// corrupted state at ledgerPath — never a partially-repaired clone. A
+// partial repair left in place would make checkLedgerGitHealth's later
+// checks (branch-status, clean-workdir, ...) run against incomplete
+// recovered data and report it as if it were fine.
+func repairInvalidHead(ctx context.Context, ledgerPath, invalidRef string) checkResult {
 	const name = "Ledger HEAD integrity"
 
 	remoteURLOut, err := exec.CommandContext(ctx, "git", "-C", ledgerPath, "remote", "get-url", "origin").Output()
@@ -156,14 +194,20 @@ func fixLedgerInvalidHead(ctx context.Context, ledgerPath, invalidRef string) ch
 		return FailedCheck(name, "could not move the corrupted clone aside", err.Error())
 	}
 
-	if err := gitserver.CloneFromURLWithEndpoint(ctx, remoteURL, ledgerPath, projectEndpoint, nil); err != nil {
-		// non-destructive on failure: put the original back exactly where it was.
+	// rollback restores ledgerPath to its EXACT original state and removes
+	// backupPath in the process (it's been moved back) — "nothing was lost,
+	// but nothing was published either." Used on every failure path below.
+	rollback := func(reason string) checkResult {
 		_ = os.RemoveAll(ledgerPath)
 		if restoreErr := os.Rename(backupPath, ledgerPath); restoreErr != nil {
-			return FailedCheck(name, "reclone failed AND could not restore the original — nothing was lost, but manual recovery is needed",
-				fmt.Sprintf("reclone error: %v; restore error: %v; the corrupted clone is intact at %s", err, restoreErr, backupPath))
+			return FailedCheck(name, reason+" — AND could not restore the original; manual recovery needed",
+				fmt.Sprintf("restore error: %v; the corrupted original is intact at %s", restoreErr, backupPath))
 		}
-		return FailedCheck(name, "reclone failed; original left untouched", err.Error())
+		return FailedCheck(name, reason, "The original is left exactly as it was; nothing was published, nothing was lost.")
+	}
+
+	if err := gitserver.CloneFromURLWithEndpoint(ctx, remoteURL, ledgerPath, projectEndpoint, nil); err != nil {
+		return rollback(fmt.Sprintf("reclone failed: %v", err))
 	}
 
 	restoredDirs := 0
@@ -174,10 +218,26 @@ func fixLedgerInvalidHead(ctx context.Context, ledgerPath, invalidRef string) ch
 			continue
 		}
 		dst := filepath.Join(ledgerPath, dir)
-		if err := copyLedgerDir(src, dst); err != nil {
-			return FailedCheck(name,
-				fmt.Sprintf("re-cloned, but failed to restore %s/ from the backup", dir),
-				fmt.Sprintf("%v — the original content is untouched at %s", err, backupPath))
+		conflicts, err := restoreLedgerDir(src, dst)
+		if err != nil {
+			return rollback(fmt.Sprintf("re-clone succeeded, but restoring %s/ failed: %v", dir, err))
+		}
+		if len(conflicts) > 0 {
+			// ox-baz5.6's corruption is a never-completed FIRST clone, which
+			// has no prior synced state to be stale relative to — but this
+			// check's detection (an unresolvable HEAD) isn't scoped only to
+			// that shape. A backup that IS behind origin must never silently
+			// overwrite what origin already has, so any same-path/
+			// different-content collision refuses the whole repair rather
+			// than guessing which side is newer. The original is fully
+			// intact after rollback; a human can reconcile the two by hand.
+			sample := conflicts[0]
+			if len(conflicts) > 1 {
+				sample = fmt.Sprintf("%s (+%d more)", sample, len(conflicts)-1)
+			}
+			return rollback(fmt.Sprintf(
+				"%d file(s) under %s/ differ between the backup and the fresh clone from origin (e.g. %s) — refusing to guess which is newer",
+				len(conflicts), dir, sample))
 		}
 		restoredDirs++
 	}
@@ -198,8 +258,9 @@ func fixLedgerInvalidHead(ctx context.Context, ledgerPath, invalidRef string) ch
 	result := fixLedgerDirtyWorkdir(ledgerPath, fileCount)
 	result.name = name
 	if !result.passed {
-		// surface the exact commit failure; the reclone itself already
-		// succeeded and the backup is still there.
+		// surface the exact commit failure; the reclone + restore already
+		// succeeded (no conflicts) and the backup is still there — this is a
+		// normal "dirty workdir, didn't commit yet" state, not corruption.
 		result.detail = fmt.Sprintf("%s (backup at %s)", result.detail, backupPath)
 		return result
 	}
@@ -210,25 +271,57 @@ func fixLedgerInvalidHead(ctx context.Context, ledgerPath, invalidRef string) ch
 			"nothing else needs recovering.", invalidRef, backupPath))
 }
 
-// copyLedgerDir recursively copies a directory tree from src to dst,
-// preserving file modes. Used only by fixLedgerInvalidHead to restore
-// sessions/ and data/ from a backed-up corrupted clone.
-func copyLedgerDir(src, dst string) error {
-	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+// restoreLedgerDir copies files from src into dst, refusing to silently
+// overwrite a destination file that already exists with DIFFERENT content.
+// Returns the relative paths of any such conflicts; callers must treat any
+// non-empty result as "do not commit" — dst is otherwise left with whatever
+// non-conflicting files were already copied before the conflict was hit.
+func restoreLedgerDir(src, dst string) (conflicts []string, err error) {
+	walkErr := filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		relPath, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
+		relPath, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
 		}
 		dstPath := filepath.Join(dst, relPath)
 		if d.IsDir() {
 			return os.MkdirAll(dstPath, 0o755)
 		}
+
+		if existing, statErr := os.Stat(dstPath); statErr == nil && !existing.IsDir() {
+			same, cmpErr := filesIdentical(path, dstPath)
+			if cmpErr != nil {
+				return cmpErr
+			}
+			if same {
+				return nil // already present with identical content — nothing to do
+			}
+			conflicts = append(conflicts, relPath)
+			return nil // do not overwrite; recorded above for the caller to act on
+		}
+
 		if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
 			return err
 		}
 		return copyFile(path, dstPath)
 	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return conflicts, nil
+}
+
+// filesIdentical reports whether a and b have byte-identical content.
+func filesIdentical(a, b string) (bool, error) {
+	aBytes, err := os.ReadFile(a)
+	if err != nil {
+		return false, err
+	}
+	bBytes, err := os.ReadFile(b)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(aBytes, bBytes), nil
 }

--- a/cmd/ox/doctor_ledger_invalid_head.go
+++ b/cmd/ox/doctor_ledger_invalid_head.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/gitserver"
+)
+
+// CheckSlugLedgerInvalidHead detects a ledger whose .git/HEAD points at a
+// syntactically invalid ref (the ox-baz5.6 shape: refs/heads/.invalid) that
+// git itself refuses to resolve.
+//
+// bd ox-baz5.6: an early-EOF during clone (a large ledger dropping
+// mid-transfer) can leave a half-initialized .git with exactly this shape —
+// HEAD unresolvable, an invalid ref file present, every tracked file staged
+// as new. Every subsequent commit then fails ("cannot lock ref HEAD:
+// reference already exists"), and ox doctor's OTHER ledger checks — branch
+// status, stranded commits, clean workdir — all assume HEAD resolves, so
+// they silently skip or fail on a cryptic git error instead of naming the
+// real problem. This check names it, and --fix repairs it by re-cloning
+// from origin while preserving any uncommitted sessions/ and data/ content
+// per .claude/rules/daemon-git.md ("never discard uncommitted changes").
+const CheckSlugLedgerInvalidHead = "ledger-invalid-head"
+
+// invalidHeadCheckTimeout bounds the local git plumbing this check runs
+// (rev-parse, check-ref-format, status) — all local, no network.
+const invalidHeadCheckTimeout = 30 * time.Second
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:     CheckSlugLedgerInvalidHead,
+		Name:     "Ledger HEAD integrity",
+		Category: "Ledger Git Health",
+		// Confirm, never Auto: the repair moves the corrupted clone aside,
+		// re-clones from origin, and restores staged content into the fresh
+		// clone before committing it. That is real surgery on the user's only
+		// local copy of whatever never made it to the ledger — a human should
+		// see it happen, matching the stranded-commits check's own reasoning
+		// for FixLevelConfirm.
+		FixLevel:    FixLevelConfirm,
+		Description: "Detects HEAD pointing at an unresolvable ref (e.g. refs/heads/.invalid) and repairs by re-cloning while preserving uncommitted content",
+		Run:         func(fix bool) checkResult { return checkLedgerInvalidHead(fix) },
+	})
+}
+
+// detectInvalidHead reports the ref .git/HEAD names and whether git itself
+// refuses to resolve it because the ref NAME is syntactically invalid — the
+// ox-baz5.6 shape specifically. Two other shapes must NOT be claimed here,
+// because each already has its own doctor check with its own repair:
+//   - a raw SHA (detached HEAD, not a symbolic ref) — not this shape at all.
+//   - a valid branch name with zero commits (a genuine unborn branch) —
+//     unbornLedgerFailure (doctor_ledger_git.go) already owns this; its repair
+//     (fetch/checkout from remote, or fail closed on a genuinely empty remote)
+//     would be actively wrong to skip in favor of a reclone here.
+func detectInvalidHead(ctx context.Context, ledgerPath string) (invalidRef string, corrupted bool) {
+	headBytes, err := os.ReadFile(filepath.Join(ledgerPath, ".git", "HEAD"))
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(string(headBytes))
+	const prefix = "ref: "
+	if !strings.HasPrefix(line, prefix) {
+		return "", false // detached HEAD (raw SHA) — a different, unrelated shape
+	}
+	ref := strings.TrimPrefix(line, prefix)
+
+	// resolves fine via git's own resolution — nothing wrong here, regardless
+	// of what the raw HEAD file's target looks like syntactically.
+	if exec.CommandContext(ctx, "git", "-C", ledgerPath, "rev-parse", "--verify", "-q", ref).Run() == nil {
+		return "", false
+	}
+
+	// Doesn't resolve — but that alone is also true of a plain unborn branch
+	// (valid name, zero commits), which unbornLedgerFailure already owns.
+	// Only claim it here if the ref NAME ITSELF fails git's own validation.
+	branchName := strings.TrimPrefix(ref, "refs/heads/")
+	if exec.CommandContext(ctx, "git", "-C", ledgerPath, "check-ref-format", "--branch", branchName).Run() == nil {
+		return "", false // valid name, just unborn — not this check's shape
+	}
+	return ref, true
+}
+
+func checkLedgerInvalidHead(fix bool) checkResult {
+	return invalidHeadCheck(getLedgerPath(), fix)
+}
+
+// invalidHeadCheck is the testable core: it takes the ledger path as a
+// parameter instead of reading it from ambient config, the same split
+// checkLedgerStrandedCommits/strandedCommitsCheck uses and for the same
+// reason — a test should be able to point this at a fixture directly.
+func invalidHeadCheck(ledgerPath string, fix bool) checkResult {
+	const name = "Ledger HEAD integrity"
+	if ledgerPath == "" {
+		return SkippedCheck(name, "no ledger found", "")
+	}
+	if !isGitRepo(ledgerPath) {
+		return SkippedCheck(name, "ledger not a git repo", "")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), invalidHeadCheckTimeout)
+	defer cancel()
+
+	invalidRef, corrupted := detectInvalidHead(ctx, ledgerPath)
+	if !corrupted {
+		return PassedCheck(name, "HEAD resolves")
+	}
+
+	staged := 0
+	if out, err := exec.CommandContext(ctx, "git", "-C", ledgerPath, "status", "--porcelain").Output(); err == nil {
+		if s := strings.TrimSpace(string(out)); s != "" {
+			staged = len(strings.Split(s, "\n"))
+		}
+	}
+
+	if !fix {
+		r := CriticalCheck(name,
+			fmt.Sprintf("HEAD points at an unresolvable ref %q — every commit fails", invalidRef),
+			fmt.Sprintf("%d file(s) likely staged but nothing can commit while HEAD is unresolvable.\n       "+
+				"Run `ox doctor --fix-slug=%s` to repair by re-cloning from origin while preserving any "+
+				"uncommitted sessions/ and data/ content.", staged, CheckSlugLedgerInvalidHead))
+		r.fixLevel = FixLevelConfirm
+		return r
+	}
+
+	return fixLedgerInvalidHead(ctx, ledgerPath, invalidRef)
+}
+
+// fixLedgerInvalidHead repairs an unresolvable HEAD: move the corrupted
+// clone aside (never delete it), clone fresh from origin, restore any
+// uncommitted sessions/ and data/ content from the backup, and commit it.
+// The backup is left on disk — not cleaned up — so a failure at any step
+// leaves the original recoverable exactly where it was.
+func fixLedgerInvalidHead(ctx context.Context, ledgerPath, invalidRef string) checkResult {
+	const name = "Ledger HEAD integrity"
+
+	remoteURLOut, err := exec.CommandContext(ctx, "git", "-C", ledgerPath, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return FailedCheck(name, "cannot determine remote URL to re-clone from",
+			fmt.Sprintf("git remote get-url origin: %v", err))
+	}
+	remoteURL := strings.TrimSpace(string(remoteURLOut))
+
+	gitRoot := findGitRoot()
+	projectEndpoint := endpoint.GetForProject(gitRoot)
+
+	backupPath := fmt.Sprintf("%s.corrupt-backup-%d", ledgerPath, time.Now().UnixNano())
+	if err := os.Rename(ledgerPath, backupPath); err != nil {
+		return FailedCheck(name, "could not move the corrupted clone aside", err.Error())
+	}
+
+	if err := gitserver.CloneFromURLWithEndpoint(ctx, remoteURL, ledgerPath, projectEndpoint, nil); err != nil {
+		// non-destructive on failure: put the original back exactly where it was.
+		_ = os.RemoveAll(ledgerPath)
+		if restoreErr := os.Rename(backupPath, ledgerPath); restoreErr != nil {
+			return FailedCheck(name, "reclone failed AND could not restore the original — nothing was lost, but manual recovery is needed",
+				fmt.Sprintf("reclone error: %v; restore error: %v; the corrupted clone is intact at %s", err, restoreErr, backupPath))
+		}
+		return FailedCheck(name, "reclone failed; original left untouched", err.Error())
+	}
+
+	restoredDirs := 0
+	for _, dir := range []string{"sessions", "data"} {
+		src := filepath.Join(backupPath, dir)
+		info, statErr := os.Stat(src)
+		if statErr != nil || !info.IsDir() {
+			continue
+		}
+		dst := filepath.Join(ledgerPath, dir)
+		if err := copyLedgerDir(src, dst); err != nil {
+			return FailedCheck(name,
+				fmt.Sprintf("re-cloned, but failed to restore %s/ from the backup", dir),
+				fmt.Sprintf("%v — the original content is untouched at %s", err, backupPath))
+		}
+		restoredDirs++
+	}
+
+	statusOut, _ := exec.CommandContext(ctx, "git", "-C", ledgerPath, "status", "--porcelain").Output()
+	fileCount := 0
+	if s := strings.TrimSpace(string(statusOut)); s != "" {
+		fileCount = len(strings.Split(s, "\n"))
+	}
+
+	if restoredDirs == 0 || fileCount == 0 {
+		return WarningCheck(name,
+			fmt.Sprintf("re-cloned a healthy ledger (HEAD was %q); nothing to restore", invalidRef),
+			fmt.Sprintf("The corrupted clone had no sessions/ or data/ content beyond what the fresh clone already "+
+				"has. Backup kept at %s — delete it once you've confirmed nothing else needs recovering.", backupPath))
+	}
+
+	result := fixLedgerDirtyWorkdir(ledgerPath, fileCount)
+	result.name = name
+	if !result.passed {
+		// surface the exact commit failure; the reclone itself already
+		// succeeded and the backup is still there.
+		result.detail = fmt.Sprintf("%s (backup at %s)", result.detail, backupPath)
+		return result
+	}
+
+	return WarningCheck(name,
+		fmt.Sprintf("repaired: re-cloned from origin, restored and committed %d file(s)", fileCount),
+		fmt.Sprintf("The corrupted clone (HEAD -> %s) is preserved at %s — delete it once you've confirmed "+
+			"nothing else needs recovering.", invalidRef, backupPath))
+}
+
+// copyLedgerDir recursively copies a directory tree from src to dst,
+// preserving file modes. Used only by fixLedgerInvalidHead to restore
+// sessions/ and data/ from a backed-up corrupted clone.
+func copyLedgerDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, relPath)
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0o755)
+		}
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+			return err
+		}
+		return copyFile(path, dstPath)
+	})
+}

--- a/cmd/ox/doctor_ledger_invalid_head_test.go
+++ b/cmd/ox/doctor_ledger_invalid_head_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,7 +81,8 @@ func corruptHEADToInvalidRef(t *testing.T, cloneDir string) {
 
 	// staging works even with HEAD broken — this is what makes the corruption
 	// so confusing in the field: `git add` succeeds, `git commit` doesn't.
-	cmd := exec.Command("git", "-C", cloneDir, "add", "-A")
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Dir = cloneDir
 	require.NoError(t, cmd.Run())
 }
 
@@ -155,6 +157,34 @@ func TestInvalidHeadCheck_ReportsWithoutFix(t *testing.T) {
 func TestInvalidHeadCheck_NoLedgerSkips(t *testing.T) {
 	result := invalidHeadCheck("", false)
 	assert.True(t, result.skipped)
+}
+
+func TestInvalidHeadCheck_NotAGitRepoSkips(t *testing.T) {
+	result := invalidHeadCheck(t.TempDir(), false)
+	assert.True(t, result.skipped)
+}
+
+func TestDetectInvalidHead_UnreadableHEADIsNotThisShape(t *testing.T) {
+	// no .git/HEAD at all (as opposed to one containing a bad ref) — a
+	// different failure mode this check must not misclassify.
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	ref, corrupted := detectInvalidHead(context.Background(), root)
+	assert.False(t, corrupted)
+	assert.Empty(t, ref)
+}
+
+// checkLedgerInvalidHead is the getLedgerPath()-based wrapper around
+// invalidHeadCheck; every other test in this file calls invalidHeadCheck
+// directly against a fixture path, so this is the only thing that exercises
+// the wrapper itself. It can't control what ledger (if any) getLedgerPath()
+// resolves to outside a configured project, so this only asserts the call
+// completes without panicking — invalidHeadCheck's behavior for every input
+// shape is already proven directly above.
+func TestCheckLedgerInvalidHead_CallsThroughToInvalidHeadCheck(t *testing.T) {
+	assert.NotPanics(t, func() {
+		checkLedgerInvalidHead(false)
+	})
 }
 
 // --- fix path: the real repair, against a real local git server ---
@@ -241,6 +271,88 @@ func TestInvalidHeadCheck_FixReClonesAndRestoresStagedContent(t *testing.T) {
 	assert.Equal(t, "session content\n", string(backupSession), "backup must retain the original staged content untouched")
 }
 
+// TestInvalidHeadCheck_FixIdenticalContentIsNoOp covers restoreLedgerDir's
+// "already present, identical content" path: if the backup's file and the
+// fresh clone's file at the same relative path happen to match byte-for-
+// byte, that's not a conflict — it's copied over as a no-op and the repair
+// proceeds normally.
+func TestInvalidHeadCheck_FixIdenticalContentIsNoOp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	isolateLedgerRepairCredentials(t)
+
+	fakeEndpoint := "https://fake-ledger-repair-identical-test.invalid"
+	t.Setenv(endpoint.EnvVar, fakeEndpoint)
+	require.NoError(t, gitserver.SaveCredentialsForEndpoint(fakeEndpoint, gitserver.GitCredentials{
+		Token:     "test-token",
+		ServerURL: fakeEndpoint,
+		Username:  "oauth2",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}))
+
+	bareDir, cloneDir := setupHealthyLedgerClone(t)
+	httpURL := serveDumbHTTP(t, bareDir)
+	runGitLedgerT(t, cloneDir, "remote", "set-url", "origin", httpURL)
+
+	// origin already has sessions/s1.txt with content X...
+	writerDir := filepath.Join(t.TempDir(), "writer")
+	runGitLedgerT(t, filepath.Dir(bareDir), "clone", "--quiet", bareDir, writerDir)
+	runGitLedgerT(t, writerDir, "config", "user.email", "test@example.com")
+	runGitLedgerT(t, writerDir, "config", "user.name", "Test User")
+	require.NoError(t, os.MkdirAll(filepath.Join(writerDir, "sessions"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(writerDir, "sessions", "s1.txt"), []byte("identical content\n"), 0o644))
+	runGitLedgerT(t, writerDir, "add", "-A")
+	runGitLedgerT(t, writerDir, "commit", "-q", "-m", "session already on origin")
+	runGitLedgerT(t, writerDir, "push", "-q", "origin", "main")
+	runGitLedgerT(t, bareDir, "update-server-info")
+
+	// ...and the corrupted local backup independently staged the SAME
+	// content X at the same path — not a conflict, just redundant.
+	corruptHEADToInvalidRef(t, cloneDir)
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, "sessions", "s1.txt"), []byte("identical content\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, "data", "d1.txt"), []byte("still new\n"), 0o644))
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Dir = cloneDir
+	require.NoError(t, cmd.Run())
+
+	result := invalidHeadCheck(cloneDir, true)
+
+	require.True(t, result.passed, "identical content must not be treated as a conflict: %s / %s", result.message, result.detail)
+	sessionContent, err := os.ReadFile(filepath.Join(cloneDir, "sessions", "s1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "identical content\n", string(sessionContent))
+	dataContent, err := os.ReadFile(filepath.Join(cloneDir, "data", "d1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "still new\n", string(dataContent), "the genuinely-new file must still be restored alongside the identical one")
+}
+
+// TestRepairInvalidHead_NoOriginRemoteFailsCleanly covers repairInvalidHead's
+// earliest failure branch: a clone with no "origin" remote configured (or
+// one that's been removed) can't be re-cloned from anywhere. Must fail
+// before touching the corrupted clone at all.
+func TestRepairInvalidHead_NoOriginRemoteFailsCleanly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	_, cloneDir := setupHealthyLedgerClone(t)
+	corruptHEADToInvalidRef(t, cloneDir)
+	runGitLedgerT(t, cloneDir, "remote", "remove", "origin")
+
+	result := invalidHeadCheck(cloneDir, true)
+
+	assert.False(t, result.passed)
+	assert.Contains(t, result.message, "remote URL")
+
+	// nothing was touched — the failure happened before any rename.
+	head, err := os.ReadFile(filepath.Join(cloneDir, ".git", "HEAD"))
+	require.NoError(t, err)
+	assert.Equal(t, "ref: refs/heads/.invalid\n", string(head))
+	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
+	require.NoError(t, err)
+	assert.Empty(t, backups)
+}
+
 func TestInvalidHeadCheck_FixIsNonDestructiveWhenRecloneFails(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short: git operations")
@@ -285,4 +397,379 @@ func TestInvalidHeadCheck_FixIsNonDestructiveWhenRecloneFails(t *testing.T) {
 	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
 	require.NoError(t, err)
 	assert.Empty(t, backups, "a successfully-restored failure should not leave an orphaned backup dir")
+}
+
+// TestRepairInvalidHead_RefusesConflictingContent covers the case flagged on
+// review: the backed-up (corrupted) clone could in principle be BEHIND
+// origin, not just a never-completed first clone. If origin already has a
+// DIFFERENT version of a path the backup also wants to restore, blindly
+// overwriting it would publish stale content over what origin already has.
+// The repair must refuse instead of guessing, and leave the original
+// exactly as it was.
+func TestRepairInvalidHead_RefusesConflictingContent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	isolateLedgerRepairCredentials(t)
+
+	fakeEndpoint := "https://fake-ledger-repair-conflict-test.invalid"
+	t.Setenv(endpoint.EnvVar, fakeEndpoint)
+	require.NoError(t, gitserver.SaveCredentialsForEndpoint(fakeEndpoint, gitserver.GitCredentials{
+		Token:     "test-token",
+		ServerURL: fakeEndpoint,
+		Username:  "oauth2",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}))
+
+	bareDir, cloneDir := setupHealthyLedgerClone(t)
+	httpURL := serveDumbHTTP(t, bareDir)
+	runGitLedgerT(t, cloneDir, "remote", "set-url", "origin", httpURL)
+
+	// corrupt the local clone with STALE versions of TWO paths staged, BOTH
+	// under sessions/ — proves the "(+N more)" summary for multiple conflicts
+	// in the same directory, not just the single-conflict case...
+	corruptHEADToInvalidRef(t, cloneDir)
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, "sessions", "s1.txt"), []byte("STALE local content 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, "sessions", "s2.txt"), []byte("STALE local content 2\n"), 0o644))
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Dir = cloneDir
+	require.NoError(t, cmd.Run())
+
+	// ...while origin independently gains DIFFERENT versions of both exact
+	// paths via a separate writer clone, pushed AFTER the corruption above —
+	// simulating a backup that is behind origin, not just a fresh clone that
+	// never finished.
+	writerDir := filepath.Join(t.TempDir(), "writer")
+	runGitLedgerT(t, filepath.Dir(bareDir), "clone", "--quiet", bareDir, writerDir)
+	runGitLedgerT(t, writerDir, "config", "user.email", "test@example.com")
+	runGitLedgerT(t, writerDir, "config", "user.name", "Test User")
+	require.NoError(t, os.MkdirAll(filepath.Join(writerDir, "sessions"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(writerDir, "sessions", "s1.txt"), []byte("NEWER origin content 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(writerDir, "sessions", "s2.txt"), []byte("NEWER origin content 2\n"), 0o644))
+	runGitLedgerT(t, writerDir, "add", "-A")
+	runGitLedgerT(t, writerDir, "commit", "-q", "-m", "newer content from origin")
+	runGitLedgerT(t, writerDir, "push", "-q", "origin", "main")
+	// re-serve so the dumb-HTTP mirror picks up the new commit before reclone.
+	runGitLedgerT(t, bareDir, "update-server-info")
+
+	result := invalidHeadCheck(cloneDir, true)
+
+	assert.False(t, result.passed, "repair must refuse when backup content conflicts with origin's current content")
+	assert.Contains(t, result.message, "differ")
+	assert.Contains(t, result.message, "more", "a second conflict in the same dir must be summarized, not silently dropped")
+
+	// the original corrupted clone must be restored EXACTLY — including the
+	// stale content that was staged, untouched — so nothing is silently
+	// discarded or published.
+	head, err := os.ReadFile(filepath.Join(cloneDir, ".git", "HEAD"))
+	require.NoError(t, err)
+	assert.Equal(t, "ref: refs/heads/.invalid\n", string(head))
+	staleContent, err := os.ReadFile(filepath.Join(cloneDir, "sessions", "s1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "STALE local content 1\n", string(staleContent), "the stale local content must survive the refused repair untouched")
+
+	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
+	require.NoError(t, err)
+	assert.Empty(t, backups, "a rolled-back conflict must not leave an orphaned backup dir")
+}
+
+// TestRepairInvalidHead_NothingToRestoreIsAWarningNotAFailure covers the
+// case where the corrupted backup never got as far as staging any
+// sessions/ or data/ content at all (e.g. the clone dropped before the
+// daemon wrote anything beyond the initial checkout) — a repair with
+// nothing to restore is still a genuine repair (HEAD now resolves), just
+// with nothing to commit on top of it.
+func TestRepairInvalidHead_NothingToRestoreIsAWarningNotAFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	isolateLedgerRepairCredentials(t)
+
+	fakeEndpoint := "https://fake-ledger-repair-empty-test.invalid"
+	t.Setenv(endpoint.EnvVar, fakeEndpoint)
+	require.NoError(t, gitserver.SaveCredentialsForEndpoint(fakeEndpoint, gitserver.GitCredentials{
+		Token:     "test-token",
+		ServerURL: fakeEndpoint,
+		Username:  "oauth2",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}))
+
+	bareDir, cloneDir := setupHealthyLedgerClone(t)
+	httpURL := serveDumbHTTP(t, bareDir)
+	runGitLedgerT(t, cloneDir, "remote", "set-url", "origin", httpURL)
+
+	// corrupt HEAD only — no sessions/ or data/ ever got created, so there's
+	// nothing beyond the corruption itself to restore.
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, ".git", "HEAD"), []byte("ref: refs/heads/.invalid\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(cloneDir, ".git", "refs", "heads"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, ".git", "refs", "heads", ".invalid"), nil, 0o644))
+
+	result := invalidHeadCheck(cloneDir, true)
+
+	require.True(t, result.passed, "a repair with nothing to restore is still a successful repair: %s / %s", result.message, result.detail)
+	assert.True(t, result.warning)
+	assert.Contains(t, result.message, "nothing to restore")
+
+	out, err := exec.Command("git", "-C", cloneDir, "rev-parse", "--verify", "-q", "HEAD").CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
+	require.NoError(t, err)
+	assert.Len(t, backups, 1, "the corrupted original is still preserved even when there was nothing to restore from it")
+}
+
+// TestRepairInvalidHead_CommitFailureSurfacesButKeepsRepair covers the
+// branch where reclone + restore both succeed (no conflicts) but the
+// subsequent commit fails — fixLedgerDirtyWorkdir already refuses to
+// auto-commit content carrying literal git conflict markers. This is NOT
+// corruption (HEAD resolves fine, the content is sitting right there on
+// disk, staged) so — unlike a reclone or restore failure — this must NOT
+// roll back; it's a normal "dirty workdir, needs a human" state the
+// existing clean-workdir check already knows how to report on the next run.
+func TestRepairInvalidHead_CommitFailureSurfacesButKeepsRepair(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	isolateLedgerRepairCredentials(t)
+
+	fakeEndpoint := "https://fake-ledger-repair-commitfail-test.invalid"
+	t.Setenv(endpoint.EnvVar, fakeEndpoint)
+	require.NoError(t, gitserver.SaveCredentialsForEndpoint(fakeEndpoint, gitserver.GitCredentials{
+		Token:     "test-token",
+		ServerURL: fakeEndpoint,
+		Username:  "oauth2",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}))
+
+	bareDir, cloneDir := setupHealthyLedgerClone(t)
+	httpURL := serveDumbHTTP(t, bareDir)
+	runGitLedgerT(t, cloneDir, "remote", "set-url", "origin", httpURL)
+
+	corruptHEADToInvalidRef(t, cloneDir)
+	// overwrite the staged session content with literal conflict markers —
+	// firstUnstageableFileInIndex (session_upload.go) refuses to auto-commit
+	// this, the same guard the routine session-upload commit path uses.
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, "sessions", "s1.txt"),
+		[]byte("<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"), 0o644))
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Dir = cloneDir
+	require.NoError(t, cmd.Run())
+
+	result := invalidHeadCheck(cloneDir, true)
+
+	assert.False(t, result.passed, "a commit-time refusal must surface as a failure")
+	assert.Contains(t, result.detail, "backup at")
+
+	// unlike a reclone/restore failure, this must NOT roll back: HEAD now
+	// resolves and the restored content is genuinely on disk, just uncommitted.
+	out, err := exec.Command("git", "-C", cloneDir, "rev-parse", "--verify", "-q", "HEAD").CombinedOutput()
+	require.NoError(t, err, "the repaired clone's HEAD must resolve even though the commit itself failed: %s", out)
+	content, err := os.ReadFile(filepath.Join(cloneDir, "sessions", "s1.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "<<<<<<<", "the conflicted content must still be present, uncommitted, for a human to resolve")
+
+	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
+	require.NoError(t, err)
+	assert.Len(t, backups, 1, "the backup must still be kept as a safety net")
+}
+
+// TestRepairInvalidHead_RenameAsideFails covers the earliest failure point
+// inside repairInvalidHead itself: moving the corrupted clone aside can fail
+// (e.g. a read-only parent directory) before any network call is made. Must
+// fail cleanly with no clone attempted and nothing renamed.
+func TestRepairInvalidHead_RenameAsideFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission-denied fixtures don't apply")
+	}
+	_, cloneDir := setupHealthyLedgerClone(t)
+	corruptHEADToInvalidRef(t, cloneDir)
+
+	// remove write permission on the parent directory — renaming cloneDir
+	// aside requires modifying ITS parent's directory entries, not cloneDir
+	// itself, so read/traverse (needed for the git commands that run first)
+	// still works.
+	parent := filepath.Dir(cloneDir)
+	require.NoError(t, os.Chmod(parent, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	result := invalidHeadCheck(cloneDir, true)
+
+	assert.False(t, result.passed)
+	assert.Contains(t, result.message, "could not move the corrupted clone aside")
+}
+
+// TestRepairInvalidHead_RestoreErrorTriggersRollback covers restoreLedgerDir
+// returning a genuine error (as opposed to a content conflict): origin now
+// has a plain FILE at "sessions" where the backup has a whole directory of
+// staged content. Creating the destination directory fails outright, and
+// that failure must roll back exactly like a conflict or a reclone failure —
+// nothing published, original preserved.
+func TestRepairInvalidHead_RestoreErrorTriggersRollback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	isolateLedgerRepairCredentials(t)
+
+	fakeEndpoint := "https://fake-ledger-repair-restoreerr-test.invalid"
+	t.Setenv(endpoint.EnvVar, fakeEndpoint)
+	require.NoError(t, gitserver.SaveCredentialsForEndpoint(fakeEndpoint, gitserver.GitCredentials{
+		Token:     "test-token",
+		ServerURL: fakeEndpoint,
+		Username:  "oauth2",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}))
+
+	bareDir, cloneDir := setupHealthyLedgerClone(t)
+	httpURL := serveDumbHTTP(t, bareDir)
+	runGitLedgerT(t, cloneDir, "remote", "set-url", "origin", httpURL)
+
+	writerDir := filepath.Join(t.TempDir(), "writer")
+	runGitLedgerT(t, filepath.Dir(bareDir), "clone", "--quiet", bareDir, writerDir)
+	runGitLedgerT(t, writerDir, "config", "user.email", "test@example.com")
+	runGitLedgerT(t, writerDir, "config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(writerDir, "sessions"), []byte("not a directory\n"), 0o644))
+	runGitLedgerT(t, writerDir, "add", "-A")
+	runGitLedgerT(t, writerDir, "commit", "-q", "-m", "sessions becomes a file upstream")
+	runGitLedgerT(t, writerDir, "push", "-q", "origin", "main")
+	runGitLedgerT(t, bareDir, "update-server-info")
+
+	corruptHEADToInvalidRef(t, cloneDir)
+
+	result := invalidHeadCheck(cloneDir, true)
+
+	assert.False(t, result.passed, "restoring into a path origin now uses for something else must fail, not silently drop content")
+	assert.Contains(t, result.message, "restoring")
+
+	head, err := os.ReadFile(filepath.Join(cloneDir, ".git", "HEAD"))
+	require.NoError(t, err)
+	assert.Equal(t, "ref: refs/heads/.invalid\n", string(head))
+	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
+	require.NoError(t, err)
+	assert.Empty(t, backups, "a rolled-back restore failure must not leave an orphaned backup dir")
+}
+
+// --- restoreLedgerDir / filesIdentical: direct unit tests for the
+// walk-error and read-error branches. These are pure filesystem functions,
+// so the permission fixtures can be set up before the walk even starts —
+// unlike the git-backed repairInvalidHead tests above, no clone timing
+// window to work around.
+
+func TestRestoreLedgerDir_WalkErrorOnUnreadableSubdir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission-denied fixtures don't apply")
+	}
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	blocked := filepath.Join(src, "blocked")
+	require.NoError(t, os.MkdirAll(blocked, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(blocked, "f.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.Chmod(blocked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+
+	_, err := restoreLedgerDir(src, dst)
+	assert.Error(t, err, "an unreadable subdirectory must surface as an error, not be silently skipped")
+}
+
+func TestRestoreLedgerDir_ConflictCheckReadFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission-denied fixtures don't apply")
+	}
+
+	t.Run("unreadable source file", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		srcFile := filepath.Join(src, "s1.txt")
+		dstFile := filepath.Join(dst, "s1.txt")
+		require.NoError(t, os.WriteFile(srcFile, []byte("src content\n"), 0o644))
+		require.NoError(t, os.WriteFile(dstFile, []byte("dst content\n"), 0o644))
+		require.NoError(t, os.Chmod(srcFile, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(srcFile, 0o644) })
+
+		_, err := restoreLedgerDir(src, dst)
+		assert.Error(t, err, "a source file the process can't read must surface as an error, not be treated as a conflict or skipped")
+	})
+
+	t.Run("unreadable destination file", func(t *testing.T) {
+		src := t.TempDir()
+		dst := t.TempDir()
+		srcFile := filepath.Join(src, "s1.txt")
+		dstFile := filepath.Join(dst, "s1.txt")
+		require.NoError(t, os.WriteFile(srcFile, []byte("src content\n"), 0o644))
+		require.NoError(t, os.WriteFile(dstFile, []byte("dst content\n"), 0o644))
+		require.NoError(t, os.Chmod(dstFile, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(dstFile, 0o644) })
+
+		_, err := restoreLedgerDir(src, dst)
+		assert.Error(t, err, "a destination file the process can't read must surface as an error, not be silently overwritten")
+	})
+}
+
+func TestFilesIdentical_ReadErrors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission-denied fixtures don't apply")
+	}
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	require.NoError(t, os.WriteFile(a, []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(b, []byte("b"), 0o644))
+
+	_, err := filesIdentical(filepath.Join(dir, "missing.txt"), b)
+	assert.Error(t, err, "an unreadable first file must surface as an error")
+
+	_, err = filesIdentical(a, filepath.Join(dir, "missing2.txt"))
+	assert.Error(t, err, "an unreadable second file must surface as an error")
+}
+
+// TestFixLedgerInvalidHead_SerializesWithPreCloneLock covers the review
+// finding that fixLedgerInvalidHead ran completely unlocked: a concurrent
+// daemon Checkout() (or another doctor repair) racing the same path could
+// observe a missing or partial ledger. The repair must take the same
+// gitutil.WithPreCloneLock Checkout() takes before cloning, so a peer
+// holding the lock blocks the repair from ever starting — proven here by
+// asserting the corrupted clone is completely untouched when the lock
+// cannot be acquired in time.
+func TestFixLedgerInvalidHead_SerializesWithPreCloneLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	_, cloneDir := setupHealthyLedgerClone(t)
+	corruptHEADToInvalidRef(t, cloneDir)
+
+	headBefore, err := os.ReadFile(filepath.Join(cloneDir, ".git", "HEAD"))
+	require.NoError(t, err)
+
+	// hold the pre-clone lock on this exact path from outside, as if a
+	// concurrent daemon Checkout() (or another repair) were already running.
+	holding := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = gitutil.WithPreCloneLock(context.Background(), cloneDir, func() error {
+			close(holding)
+			<-release
+			return nil
+		})
+	}()
+	<-holding
+	defer close(release)
+
+	shortCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	result := fixLedgerInvalidHead(shortCtx, cloneDir, "refs/heads/.invalid")
+
+	assert.False(t, result.passed)
+	assert.Contains(t, result.message, "could not acquire the ledger clone lock")
+
+	// the corrupted clone must be completely untouched — the lock gated
+	// entry into the repair before it ever renamed anything aside.
+	headAfter, err := os.ReadFile(filepath.Join(cloneDir, ".git", "HEAD"))
+	require.NoError(t, err)
+	assert.Equal(t, string(headBefore), string(headAfter))
+	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
+	require.NoError(t, err)
+	assert.Empty(t, backups, "a repair blocked by the lock must never have started renaming anything")
 }

--- a/cmd/ox/doctor_ledger_invalid_head_test.go
+++ b/cmd/ox/doctor_ledger_invalid_head_test.go
@@ -246,8 +246,7 @@ func TestInvalidHeadCheck_FixReClonesAndRestoresStagedContent(t *testing.T) {
 	assert.Contains(t, result.message, "repaired")
 
 	// the repaired clone must be healthy: HEAD resolves.
-	out, err := exec.Command("git", "-C", cloneDir, "rev-parse", "--verify", "-q", "HEAD").CombinedOutput()
-	require.NoError(t, err, string(out))
+	runGitLedgerT(t, cloneDir, "rev-parse", "--verify", "-q", "HEAD")
 
 	// the staged content must have survived the reclone, committed.
 	sessionContent, err := os.ReadFile(filepath.Join(cloneDir, "sessions", "s1.txt"))
@@ -257,9 +256,8 @@ func TestInvalidHeadCheck_FixReClonesAndRestoresStagedContent(t *testing.T) {
 	require.NoError(t, err, "data/d1.txt must survive the repair")
 	assert.Equal(t, "data content\n", string(dataContent))
 
-	statusOut, err := exec.Command("git", "-C", cloneDir, "status", "--porcelain").CombinedOutput()
-	require.NoError(t, err)
-	assert.Empty(t, string(statusOut), "restored content must be committed, not left staged")
+	statusOut := runGitLedgerT(t, cloneDir, "status", "--porcelain")
+	assert.Empty(t, statusOut, "restored content must be committed, not left staged")
 
 	// the corrupted original must be preserved, never deleted, per
 	// .claude/rules/daemon-git.md "never discard uncommitted changes".
@@ -510,8 +508,7 @@ func TestRepairInvalidHead_NothingToRestoreIsAWarningNotAFailure(t *testing.T) {
 	assert.True(t, result.warning)
 	assert.Contains(t, result.message, "nothing to restore")
 
-	out, err := exec.Command("git", "-C", cloneDir, "rev-parse", "--verify", "-q", "HEAD").CombinedOutput()
-	require.NoError(t, err, string(out))
+	runGitLedgerT(t, cloneDir, "rev-parse", "--verify", "-q", "HEAD")
 
 	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
 	require.NoError(t, err)
@@ -562,8 +559,7 @@ func TestRepairInvalidHead_CommitFailureSurfacesButKeepsRepair(t *testing.T) {
 
 	// unlike a reclone/restore failure, this must NOT roll back: HEAD now
 	// resolves and the restored content is genuinely on disk, just uncommitted.
-	out, err := exec.Command("git", "-C", cloneDir, "rev-parse", "--verify", "-q", "HEAD").CombinedOutput()
-	require.NoError(t, err, "the repaired clone's HEAD must resolve even though the commit itself failed: %s", out)
+	runGitLedgerT(t, cloneDir, "rev-parse", "--verify", "-q", "HEAD")
 	content, err := os.ReadFile(filepath.Join(cloneDir, "sessions", "s1.txt"))
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "<<<<<<<", "the conflicted content must still be present, uncommitted, for a human to resolve")
@@ -747,7 +743,9 @@ func TestFixLedgerInvalidHead_SerializesWithPreCloneLock(t *testing.T) {
 	// concurrent daemon Checkout() (or another repair) were already running.
 	holding := make(chan struct{})
 	release := make(chan struct{})
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		_ = gitutil.WithPreCloneLock(context.Background(), cloneDir, func() error {
 			close(holding)
 			<-release
@@ -755,7 +753,10 @@ func TestFixLedgerInvalidHead_SerializesWithPreCloneLock(t *testing.T) {
 		})
 	}()
 	<-holding
-	defer close(release)
+	defer func() {
+		close(release)
+		<-done // wait for the holder's unlock to finish before t.TempDir() cleanup runs
+	}()
 
 	shortCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()

--- a/cmd/ox/doctor_ledger_invalid_head_test.go
+++ b/cmd/ox/doctor_ledger_invalid_head_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/gitserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ox-baz5.6 — a ledger clone that dropped mid-transfer left .git/HEAD
+// pointing at refs/heads/.invalid: a syntactically illegal branch name git
+// refuses to resolve. Every subsequent commit failed ("cannot lock ref
+// HEAD"), and every other ledger doctor check silently skipped or errored
+// cryptically because each assumes HEAD resolves. These tests reproduce the
+// exact corruption (verified manually against real git before writing this
+// file: `git status --porcelain` reports every tracked file as staged-new,
+// `git commit` fails with "cannot lock ref 'HEAD': unable to resolve
+// reference 'refs/heads/.invalid': reference broken") and drive the
+// detect + repair path against it.
+
+// runGitLedgerT runs a git command in dir, failing the test on error.
+func runGitLedgerT(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+	return string(out)
+}
+
+// setupHealthyLedgerClone creates a bare remote with one commit and a local
+// clone of it — a normal, uncorrupted ledger.
+func setupHealthyLedgerClone(t *testing.T) (bareDir, cloneDir string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	bareDir = filepath.Join(root, "bare.git")
+	work := filepath.Join(root, "work")
+	runGitLedgerT(t, root, "init", "--bare", "--initial-branch=main", bareDir)
+	runGitLedgerT(t, root, "clone", "--quiet", bareDir, work)
+	runGitLedgerT(t, work, "config", "user.email", "test@example.com")
+	runGitLedgerT(t, work, "config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(work, "seed.txt"), []byte("seed\n"), 0o644))
+	runGitLedgerT(t, work, "add", "-A")
+	runGitLedgerT(t, work, "commit", "-q", "-m", "seed")
+	runGitLedgerT(t, work, "push", "-q", "origin", "main")
+
+	cloneDir = filepath.Join(root, "ledger")
+	runGitLedgerT(t, root, "clone", "--quiet", bareDir, cloneDir)
+	runGitLedgerT(t, cloneDir, "config", "user.email", "test@example.com")
+	runGitLedgerT(t, cloneDir, "config", "user.name", "Test User")
+	return bareDir, cloneDir
+}
+
+// corruptHEADToInvalidRef reproduces the ox-baz5.6 shape in-place on an
+// existing clone: HEAD -> refs/heads/.invalid (a name git's own
+// check-ref-format rejects), the matching ref file present, and
+// sessions/data content staged but never committed.
+func corruptHEADToInvalidRef(t *testing.T, cloneDir string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, ".git", "HEAD"), []byte("ref: refs/heads/.invalid\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(cloneDir, ".git", "refs", "heads"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, ".git", "refs", "heads", ".invalid"), nil, 0o644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(cloneDir, "sessions"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(cloneDir, "data"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, "sessions", "s1.txt"), []byte("session content\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, "data", "d1.txt"), []byte("data content\n"), 0o644))
+
+	// staging works even with HEAD broken — this is what makes the corruption
+	// so confusing in the field: `git add` succeeds, `git commit` doesn't.
+	cmd := exec.Command("git", "-C", cloneDir, "add", "-A")
+	require.NoError(t, cmd.Run())
+}
+
+// --- detectInvalidHead ---
+
+func TestDetectInvalidHead_HealthyClone(t *testing.T) {
+	_, cloneDir := setupHealthyLedgerClone(t)
+	ref, corrupted := detectInvalidHead(context.Background(), cloneDir)
+	assert.False(t, corrupted)
+	assert.Empty(t, ref)
+}
+
+func TestDetectInvalidHead_UnbornBranchIsNotThisShape(t *testing.T) {
+	// a valid branch name with zero commits — unbornLedgerFailure's territory,
+	// not this check's. Must not be claimed here.
+	root := t.TempDir()
+	runGitLedgerT(t, root, "init", "-q", "--initial-branch=main", root)
+	ref, corrupted := detectInvalidHead(context.Background(), root)
+	assert.False(t, corrupted, "an unborn branch with a VALID name is not the ox-baz5.6 shape")
+	assert.Empty(t, ref)
+}
+
+func TestDetectInvalidHead_DetachedHeadIsNotThisShape(t *testing.T) {
+	_, cloneDir := setupHealthyLedgerClone(t)
+	sha := runGitLedgerT(t, cloneDir, "rev-parse", "HEAD")
+	runGitLedgerT(t, cloneDir, "checkout", "-q", trimNL(sha))
+	ref, corrupted := detectInvalidHead(context.Background(), cloneDir)
+	assert.False(t, corrupted)
+	assert.Empty(t, ref)
+}
+
+func TestDetectInvalidHead_InvalidRefIsDetected(t *testing.T) {
+	_, cloneDir := setupHealthyLedgerClone(t)
+	corruptHEADToInvalidRef(t, cloneDir)
+
+	ref, corrupted := detectInvalidHead(context.Background(), cloneDir)
+	assert.True(t, corrupted)
+	assert.Equal(t, "refs/heads/.invalid", ref)
+}
+
+func trimNL(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// --- invalidHeadCheck (report path) ---
+
+func TestInvalidHeadCheck_CleanLedgerPasses(t *testing.T) {
+	_, cloneDir := setupHealthyLedgerClone(t)
+	result := invalidHeadCheck(cloneDir, false)
+	assert.True(t, result.passed)
+	assert.False(t, result.warning)
+}
+
+func TestInvalidHeadCheck_ReportsWithoutFix(t *testing.T) {
+	_, cloneDir := setupHealthyLedgerClone(t)
+	corruptHEADToInvalidRef(t, cloneDir)
+
+	result := invalidHeadCheck(cloneDir, false)
+	assert.False(t, result.passed)
+	assert.Equal(t, "critical", result.priority)
+	assert.Contains(t, result.message, ".invalid")
+
+	// report-only must not touch the corrupted clone at all.
+	head, err := os.ReadFile(filepath.Join(cloneDir, ".git", "HEAD"))
+	require.NoError(t, err)
+	assert.Equal(t, "ref: refs/heads/.invalid\n", string(head), "reporting must not repair")
+}
+
+func TestInvalidHeadCheck_NoLedgerSkips(t *testing.T) {
+	result := invalidHeadCheck("", false)
+	assert.True(t, result.skipped)
+}
+
+// --- fix path: the real repair, against a real local git server ---
+
+// isolateLedgerRepairCredentials points gitserver's credential store at a
+// throwaway temp dir (never the real machine's ~/.sageox) and forces file
+// storage instead of the OS keychain, matching internal/daemon's
+// isolateCredentialsWithDir pattern.
+func isolateLedgerRepairCredentials(t *testing.T) {
+	t.Helper()
+	prevConfigDir := gitserver.TestSetConfigDirOverride(t.TempDir())
+	prevForceFile := gitserver.TestSetForceFileStorage(true)
+	t.Cleanup(func() {
+		gitserver.TestSetConfigDirOverride(prevConfigDir)
+		gitserver.TestSetForceFileStorage(prevForceFile)
+	})
+}
+
+// serveDumbHTTP serves a bare repo over dumb HTTP (a plain static file
+// server) and returns the URL. gitserver's URL validation (like sync.go's
+// isValidCloneURL) allows http:// only for localhost/127.0.0.1, which
+// httptest.NewServer binds to; file:// is not an option for either path.
+func serveDumbHTTP(t *testing.T, bareDir string) string {
+	t.Helper()
+	runGitLedgerT(t, bareDir, "update-server-info")
+	srv := httptest.NewServer(http.FileServer(http.Dir(bareDir)))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestInvalidHeadCheck_FixReClonesAndRestoresStagedContent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	isolateLedgerRepairCredentials(t)
+
+	fakeEndpoint := "https://fake-ledger-repair-test.invalid"
+	t.Setenv(endpoint.EnvVar, fakeEndpoint)
+	require.NoError(t, gitserver.SaveCredentialsForEndpoint(fakeEndpoint, gitserver.GitCredentials{
+		Token:     "test-token",
+		ServerURL: fakeEndpoint,
+		Username:  "oauth2",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}))
+
+	bareDir, cloneDir := setupHealthyLedgerClone(t)
+	httpURL := serveDumbHTTP(t, bareDir)
+	// point the corrupted clone's origin at the HTTP mirror the fix will
+	// re-clone from — production ledgers always have a real http(s) origin;
+	// the on-disk bare path is only reachable in this test harness.
+	runGitLedgerT(t, cloneDir, "remote", "set-url", "origin", httpURL)
+
+	corruptHEADToInvalidRef(t, cloneDir)
+
+	result := invalidHeadCheck(cloneDir, true)
+
+	require.True(t, result.passed, "fix should succeed: %s / %s", result.message, result.detail)
+	assert.True(t, result.warning, "a repair is reported as a warning, not a silent pass")
+	assert.Contains(t, result.message, "repaired")
+
+	// the repaired clone must be healthy: HEAD resolves.
+	out, err := exec.Command("git", "-C", cloneDir, "rev-parse", "--verify", "-q", "HEAD").CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// the staged content must have survived the reclone, committed.
+	sessionContent, err := os.ReadFile(filepath.Join(cloneDir, "sessions", "s1.txt"))
+	require.NoError(t, err, "sessions/s1.txt must survive the repair")
+	assert.Equal(t, "session content\n", string(sessionContent))
+	dataContent, err := os.ReadFile(filepath.Join(cloneDir, "data", "d1.txt"))
+	require.NoError(t, err, "data/d1.txt must survive the repair")
+	assert.Equal(t, "data content\n", string(dataContent))
+
+	statusOut, err := exec.Command("git", "-C", cloneDir, "status", "--porcelain").CombinedOutput()
+	require.NoError(t, err)
+	assert.Empty(t, string(statusOut), "restored content must be committed, not left staged")
+
+	// the corrupted original must be preserved, never deleted, per
+	// .claude/rules/daemon-git.md "never discard uncommitted changes".
+	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
+	require.NoError(t, err)
+	require.Len(t, backups, 1, "the corrupted clone must be preserved as a backup, not deleted")
+	backupSession, err := os.ReadFile(filepath.Join(backups[0], "sessions", "s1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "session content\n", string(backupSession), "backup must retain the original staged content untouched")
+}
+
+func TestInvalidHeadCheck_FixIsNonDestructiveWhenRecloneFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	isolateLedgerRepairCredentials(t)
+
+	fakeEndpoint := "https://fake-ledger-repair-fail-test.invalid"
+	t.Setenv(endpoint.EnvVar, fakeEndpoint)
+	require.NoError(t, gitserver.SaveCredentialsForEndpoint(fakeEndpoint, gitserver.GitCredentials{
+		Token:     "test-token",
+		ServerURL: fakeEndpoint,
+		Username:  "oauth2",
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}))
+
+	_, cloneDir := setupHealthyLedgerClone(t)
+
+	// a real HTTP server that 404s everything — the reclone must fail cleanly.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	runGitLedgerT(t, cloneDir, "remote", "set-url", "origin", srv.URL)
+
+	corruptHEADToInvalidRef(t, cloneDir)
+
+	result := invalidHeadCheck(cloneDir, true)
+
+	assert.False(t, result.passed, "fix must fail when the reclone itself fails")
+
+	// the original corrupted content must be restored to its EXACT original
+	// path — non-destructive failure, not "moved somewhere and abandoned".
+	sessionContent, err := os.ReadFile(filepath.Join(cloneDir, "sessions", "s1.txt"))
+	require.NoError(t, err, "original clone must be restored to cloneDir on reclone failure")
+	assert.Equal(t, "session content\n", string(sessionContent))
+
+	head, err := os.ReadFile(filepath.Join(cloneDir, ".git", "HEAD"))
+	require.NoError(t, err)
+	assert.Equal(t, "ref: refs/heads/.invalid\n", string(head))
+
+	// no orphaned backup directory when the restore succeeded.
+	backups, err := filepath.Glob(cloneDir + ".corrupt-backup-*")
+	require.NoError(t, err)
+	assert.Empty(t, backups, "a successfully-restored failure should not leave an orphaned backup dir")
+}

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -2271,66 +2271,116 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// send progress: connecting
-	if progress != nil {
-		_ = progress.WriteStage("connecting", "Connecting to remote...")
-	}
-	s.logger.Info("checkout: starting clone", "url", payload.CloneURL, "path", payload.RepoPath, "type", payload.RepoType)
+	// ox-baz5.6: everything from here through a completed clone runs under a
+	// lock keyed on payload.RepoPath. Two Checkout() calls racing for the
+	// same target (a background clone retry, GC self-heal, and a codedb
+	// indexing kickoff have all been observed firing within ~1-2s of each
+	// other) would otherwise both pass the exists-check above and both start
+	// cloning into the same destination — the cloneSem acquired earlier
+	// bounds TOTAL concurrent clones, not clones-per-target. gitutil.
+	// WithRepoLock can't cover this phase: it keys on <clone>/.git/ox-sync,
+	// which doesn't exist until a clone has already created a .git
+	// directory. See gitutil.WithPreCloneLock's doc comment for the full
+	// reproduction.
+	lockCtx, lockCancel := context.WithTimeout(context.Background(), gitutil.PreCloneLockTimeout+10*time.Second)
+	defer lockCancel()
+	err := gitutil.WithPreCloneLock(lockCtx, payload.RepoPath, func() error {
+		// Re-verify directory state now that we hold the lock — a peer that
+		// raced us here may have finished cloning while we waited for it
+		// (or for the semaphore slot, above). Mirrors the semaphore's own
+		// TOCTOU recheck.
+		if info, statErr := os.Stat(payload.RepoPath); statErr == nil && info.IsDir() {
+			gitDir := filepath.Join(payload.RepoPath, ".git")
+			if _, err := os.Stat(gitDir); err == nil {
+				if payload.RepoType != "team-context" {
+					s.logger.Debug("checkout: repo appeared while waiting for pre-clone lock", "path", payload.RepoPath)
+					result.AlreadyExists = true
+					return nil
+				}
+				sageoxDir := filepath.Join(payload.RepoPath, ".sageox")
+				if _, sErr := os.Stat(sageoxDir); sErr == nil {
+					s.logger.Debug("checkout: team-context completed while waiting for pre-clone lock", "path", payload.RepoPath)
+					result.AlreadyExists = true
+					return nil
+				}
+			}
+		}
 
-	// send progress: cloning
-	if progress != nil {
-		_ = progress.WriteStage("cloning", "Cloning repository...")
-	}
-
-	// Clone with bare URL + an in-argv credential helper instead of embedding
-	// the PAT into the origin URL. Per ox-eeqi, embedded credentials persist
-	// into .git/config and leak via backups, `git remote -v`, and GIT_TRACE.
-	// After clone succeeds, we install the helper into the cloned repo's
-	// .git/config (see post-clone block) so future fetch/push operations
-	// resolve credentials the same way.
-	//
-	// The `-c credential.helper=` (empty) before the real helper resets any
-	// inherited helpers so ours is authoritative for this single invocation.
-	cloneURL := payload.CloneURL
-	endpointURL := s.workspaceRegistry.GetEndpoint()
-	s.logger.Info("checkout: clone via credential helper",
-		"endpoint", endpointURL, "clone_url", payload.CloneURL)
-	// Sanity check: we have credentials for this endpoint (caller already
-	// authenticated). Without them, the helper will return nothing and git
-	// falls back to its own prompt — fine for interactive use, broken for
-	// daemon. So we log clearly when creds are missing.
-	if creds, err := s.creds.LoadCredentialsForEndpoint(endpointURL); err != nil {
-		s.logger.Error("checkout: failed to load git credentials", "error", err, "endpoint", endpointURL)
-	} else if creds == nil || creds.Token == "" {
-		s.logger.Warn("checkout: no git credentials found; clone may fail",
-			"endpoint", endpointURL)
-	}
-
-	// branch on repo type: team contexts use two-phase partial clone,
-	// ledgers use full clone (they need complete history for CLI writes)
-	if payload.RepoType == "team-context" {
+		// send progress: connecting
 		if progress != nil {
-			_ = progress.WriteStage("cloning", "Fetching repository structure...")
+			_ = progress.WriteStage("connecting", "Connecting to remote...")
 		}
-		mCfg, err := s.twoPhaseClone(ctx, cloneURL, payload.RepoPath, progress)
-		if err != nil {
-			s.logger.Error("checkout: two-phase clone failed", "error", err)
-			s.recordError(fmt.Sprintf("clone %s failed: %v", payload.RepoType, err))
-			return nil, err
-		}
-		if mCfg != nil {
-			if mCfg.SyncIntervalMin > 0 {
-				s.workspaceRegistry.SetSyncIntervalMin(payload.RepoPath, mCfg.SyncIntervalMin)
-			}
-			if mCfg.GCIntervalDays > 0 {
-				s.workspaceRegistry.SetGCInterval(payload.RepoPath, mCfg.GCIntervalDays)
-			}
-		}
-	} else {
-		// ledger: full clone
+		s.logger.Info("checkout: starting clone", "url", payload.CloneURL, "path", payload.RepoPath, "type", payload.RepoType)
+
+		// send progress: cloning
 		if progress != nil {
 			_ = progress.WriteStage("cloning", "Cloning repository...")
 		}
+
+		// Clone with bare URL + an in-argv credential helper instead of embedding
+		// the PAT into the origin URL. Per ox-eeqi, embedded credentials persist
+		// into .git/config and leak via backups, `git remote -v`, and GIT_TRACE.
+		// After clone succeeds, we install the helper into the cloned repo's
+		// .git/config (see post-clone block) so future fetch/push operations
+		// resolve credentials the same way.
+		//
+		// The `-c credential.helper=` (empty) before the real helper resets any
+		// inherited helpers so ours is authoritative for this single invocation.
+		cloneURL := payload.CloneURL
+		endpointURL := s.workspaceRegistry.GetEndpoint()
+		s.logger.Info("checkout: clone via credential helper",
+			"endpoint", endpointURL, "clone_url", payload.CloneURL)
+		// Sanity check: we have credentials for this endpoint (caller already
+		// authenticated). Without them, the helper will return nothing and git
+		// falls back to its own prompt — fine for interactive use, broken for
+		// daemon. So we log clearly when creds are missing.
+		if creds, err := s.creds.LoadCredentialsForEndpoint(endpointURL); err != nil {
+			s.logger.Error("checkout: failed to load git credentials", "error", err, "endpoint", endpointURL)
+		} else if creds == nil || creds.Token == "" {
+			s.logger.Warn("checkout: no git credentials found; clone may fail",
+				"endpoint", endpointURL)
+		}
+
+		// branch on repo type: team contexts use two-phase partial clone,
+		// ledgers use full clone (they need complete history for CLI writes)
+		if payload.RepoType == "team-context" {
+			if progress != nil {
+				_ = progress.WriteStage("cloning", "Fetching repository structure...")
+			}
+			mCfg, err := s.twoPhaseClone(ctx, cloneURL, payload.RepoPath, progress)
+			if err != nil {
+				s.logger.Error("checkout: two-phase clone failed", "error", err)
+				s.recordError(fmt.Sprintf("clone %s failed: %v", payload.RepoType, err))
+				return err
+			}
+			if mCfg != nil {
+				if mCfg.SyncIntervalMin > 0 {
+					s.workspaceRegistry.SetSyncIntervalMin(payload.RepoPath, mCfg.SyncIntervalMin)
+				}
+				if mCfg.GCIntervalDays > 0 {
+					s.workspaceRegistry.SetGCInterval(payload.RepoPath, mCfg.GCIntervalDays)
+				}
+			}
+			return nil
+		}
+
+		// ledger: full clone, into a temp sibling directory first — never
+		// straight into payload.RepoPath. ox-baz5.6: a clone that drops
+		// mid-transfer (observed on a 711MB ledger over HTTPS: "fetch-pack:
+		// unexpected disconnect while reading sideband packet") used to leave
+		// a half-initialized .git in the FINAL location, which the daemon
+		// and every CLI command thereafter treated as a real ledger —
+		// HEAD pointing at refs/heads/.invalid, every commit failing with
+		// "cannot lock ref HEAD: reference already exists". Renaming into
+		// place only after a verified-complete clone means a failure at any
+		// point leaves nothing at payload.RepoPath for anything else to
+		// mistake for a real clone.
+		if progress != nil {
+			_ = progress.WriteStage("cloning", "Cloning repository...")
+		}
+		tempPath := fmt.Sprintf("%s.tmp-%d", payload.RepoPath, time.Now().UnixNano())
+		defer func() { _ = os.RemoveAll(tempPath) }() // no-op once renamed away
+
 		// Per ox-eeqi: clone with ox-managed credential helper, not embedded
 		// URL credentials. CredentialHelperArgs clears inherited helpers and
 		// installs ours for this single invocation. Shared with the
@@ -2352,7 +2402,7 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 		}
 		cloneArgs = append(cloneArgs,
 			"-c", "protocol.ext.allow=never",
-			"clone", "--quiet", "--", cloneURL, payload.RepoPath,
+			"clone", "--quiet", "--", cloneURL, tempPath,
 		)
 		// NewNetworkCmd sets GIT_TERMINAL_PROMPT=0 so a credential gap fails
 		// fast instead of EOFing on a username prompt in the daemon's TTY-less
@@ -2368,21 +2418,55 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 			s.logger.Error("checkout: clone failed", "error", err, "output", sanitizedOutput)
 			s.recordError(fmt.Sprintf("clone %s failed: %v", payload.RepoType, err))
 			if sanitizedOutput != "" {
-				return nil, fmt.Errorf("git clone failed: %s", sanitizedOutput)
+				return fmt.Errorf("git clone failed: %s", sanitizedOutput)
 			}
-			return nil, fmt.Errorf("git clone failed: %w", err)
+			return fmt.Errorf("git clone failed: %w", err)
 		}
 
-		// create AGENTS.md for newly cloned ledger repos
+		// verify the temp clone is actually complete before it ever becomes
+		// visible at payload.RepoPath — an early-EOF clone can exit non-zero
+		// (caught above) or, less commonly, leave a .git without a
+		// resolvable HEAD despite git reporting success.
+		if _, err := os.Stat(filepath.Join(tempPath, ".git")); err != nil {
+			return fmt.Errorf("clone verification failed: temp clone has no .git directory: %w", err)
+		}
+		if err := exec.CommandContext(ctx, "git", "-C", tempPath, "rev-parse", "--verify", "-q", "HEAD").Run(); err != nil {
+			return fmt.Errorf("clone verification failed: temp clone's HEAD does not resolve: %w", err)
+		}
+
+		// create AGENTS.md for newly cloned ledger repos — inside the temp
+		// dir, before it becomes visible, so a failure here can't leave a
+		// half-initialized ledger at the final path either.
 		if progress != nil {
 			_ = progress.WriteStage("initializing", "Creating AGENTS.md...")
 		}
 		agentsOpts := &gitserver.AgentsMDOptions{
 			RepoType: payload.RepoType,
 		}
-		if err := gitserver.CreateAgentsMD(ctx, payload.RepoPath, agentsOpts); err != nil {
+		if err := gitserver.CreateAgentsMD(ctx, tempPath, agentsOpts); err != nil {
 			s.logger.Warn("checkout: failed to create AGENTS.MD", "error", err)
 		}
+
+		// atomic swap: the only moment payload.RepoPath goes from
+		// non-existent to a complete, verified clone. If another actor
+		// somehow created it between our lock-holder recheck above and now
+		// (shouldn't happen — this whole closure runs under the pre-clone
+		// lock for this exact path — but os.Rename onto an existing
+		// directory fails safely rather than merging into it either way),
+		// this fails loudly instead of silently corrupting either side.
+		if err := os.Rename(tempPath, payload.RepoPath); err != nil {
+			return fmt.Errorf("failed to move completed clone into place: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		if gitutil.IsPreCloneLockBusy(err) {
+			return nil, fmt.Errorf("another clone is already in progress for %s: %w", payload.RepoPath, err)
+		}
+		return nil, err
+	}
+	if result.AlreadyExists {
+		return result, nil
 	}
 
 	// send progress: verifying

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -187,10 +187,11 @@ type SyncScheduler struct {
 	configSyncSkipped sync.Map
 
 	// test hooks (nil in production)
-	onBeforeCloneSem        func()        // called just before acquiring cloneSem; tests use this to observe blocking
-	cloneSemTimeoutOverride time.Duration // override cloneSemTimeout for tests (0 = use default)
-	gcAsyncTestHook         func()        // called at the start of TriggerGCAsync's goroutine, before runTriggerGC; tests use this to hold the goroutine open deterministically
-	gcSwapWindowTestHook    func()        // called right after runBlueGreenGCOpts writes .gc-swap-lock, before the rename; tests use this to observe the lock file mid-swap
+	onBeforeCloneSem         func()        // called just before acquiring cloneSem; tests use this to observe blocking
+	cloneSemTimeoutOverride  time.Duration // override cloneSemTimeout for tests (0 = use default)
+	preCloneLockWaitOverride time.Duration // override the pre-clone lock's wait budget for tests (0 = use gitutil.PreCloneLockTimeout+10s)
+	gcAsyncTestHook          func()        // called at the start of TriggerGCAsync's goroutine, before runTriggerGC; tests use this to hold the goroutine open deterministically
+	gcSwapWindowTestHook     func()        // called right after runBlueGreenGCOpts writes .gc-swap-lock, before the rename; tests use this to observe the lock file mid-swap
 
 	// callbacks
 	onActivity   func()                                                           // called on any sync activity
@@ -2268,9 +2269,6 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 		return nil, fmt.Errorf("invalid clone URL: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
 	// ox-baz5.6: everything from here through a completed clone runs under a
 	// lock keyed on payload.RepoPath. Two Checkout() calls racing for the
 	// same target (a background clone retry, GC self-heal, and a codedb
@@ -2282,7 +2280,11 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 	// which doesn't exist until a clone has already created a .git
 	// directory. See gitutil.WithPreCloneLock's doc comment for the full
 	// reproduction.
-	lockCtx, lockCancel := context.WithTimeout(context.Background(), gitutil.PreCloneLockTimeout+10*time.Second)
+	lockWait := s.preCloneLockWaitOverride
+	if lockWait == 0 {
+		lockWait = gitutil.PreCloneLockTimeout + 10*time.Second
+	}
+	lockCtx, lockCancel := context.WithTimeout(context.Background(), lockWait)
 	defer lockCancel()
 	err := gitutil.WithPreCloneLock(lockCtx, payload.RepoPath, func() error {
 		// Re-verify directory state now that we hold the lock — a peer that
@@ -2305,6 +2307,18 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 				}
 			}
 		}
+
+		// The clone's own network deadline starts HERE, only once we actually
+		// hold the lock — not before waiting for it. Starting it earlier (the
+		// original bug, flagged on review) let a long lock wait consume the
+		// budget: a waiter that acquired the lock after, say, 55s of a 60s
+		// deadline would have its `git clone` killed almost immediately by
+		// "context deadline exceeded", which IsPreCloneLockBusy then
+		// misclassifies as benign lock contention (matches
+		// context.DeadlineExceeded) — masking a real clone failure as a
+		// harmless retry-next-cycle.
+		cloneCtx, cloneCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cloneCancel()
 
 		// send progress: connecting
 		if progress != nil {
@@ -2347,7 +2361,7 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 			if progress != nil {
 				_ = progress.WriteStage("cloning", "Fetching repository structure...")
 			}
-			mCfg, err := s.twoPhaseClone(ctx, cloneURL, payload.RepoPath, progress)
+			mCfg, err := s.twoPhaseClone(cloneCtx, cloneURL, payload.RepoPath, progress)
 			if err != nil {
 				s.logger.Error("checkout: two-phase clone failed", "error", err)
 				s.recordError(fmt.Sprintf("clone %s failed: %v", payload.RepoType, err))
@@ -2407,7 +2421,7 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 		// NewNetworkCmd sets GIT_TERMINAL_PROMPT=0 so a credential gap fails
 		// fast instead of EOFing on a username prompt in the daemon's TTY-less
 		// environment.
-		cloneCmd := gitutil.NewNetworkCmd(ctx, cloneArgs...)
+		cloneCmd := gitutil.NewNetworkCmd(cloneCtx, cloneArgs...)
 		// set cmd.Dir so git doesn't fail when daemon CWD has been deleted
 		if parentDir := filepath.Dir(payload.RepoPath); parentDir != "" {
 			_ = os.MkdirAll(parentDir, 0755)
@@ -2430,7 +2444,7 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 		if _, err := os.Stat(filepath.Join(tempPath, ".git")); err != nil {
 			return fmt.Errorf("clone verification failed: temp clone has no .git directory: %w", err)
 		}
-		if err := exec.CommandContext(ctx, "git", "-C", tempPath, "rev-parse", "--verify", "-q", "HEAD").Run(); err != nil {
+		if err := exec.CommandContext(cloneCtx, "git", "-C", tempPath, "rev-parse", "--verify", "-q", "HEAD").Run(); err != nil {
 			return fmt.Errorf("clone verification failed: temp clone's HEAD does not resolve: %w", err)
 		}
 
@@ -2443,7 +2457,7 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 		agentsOpts := &gitserver.AgentsMDOptions{
 			RepoType: payload.RepoType,
 		}
-		if err := gitserver.CreateAgentsMD(ctx, tempPath, agentsOpts); err != nil {
+		if err := gitserver.CreateAgentsMD(cloneCtx, tempPath, agentsOpts); err != nil {
 			s.logger.Warn("checkout: failed to create AGENTS.MD", "error", err)
 		}
 
@@ -2481,7 +2495,11 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 	}
 
 	// configure pull strategy to use rebase (avoids merge commits, cleaner history)
-	configCmd := exec.CommandContext(ctx, "git", "-C", payload.RepoPath, "config", "pull.rebase", "true")
+	// own short-lived context: this is local config, not network I/O, and must
+	// not inherit whatever budget the clone above happened to have left.
+	configCtx, configCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer configCancel()
+	configCmd := exec.CommandContext(configCtx, "git", "-C", payload.RepoPath, "config", "pull.rebase", "true")
 	if output, err := configCmd.CombinedOutput(); err != nil {
 		s.logger.Warn("checkout: failed to set pull.rebase config", "error", err, "output", string(output))
 	}

--- a/internal/daemon/sync_clone.go
+++ b/internal/daemon/sync_clone.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/sageox/ox/internal/gitutil"
 )
 
 // cloneBackoffMax is the maximum backoff duration for transient clone errors (1 hour).
@@ -84,6 +86,15 @@ func (s *SyncScheduler) cloneInBackground(cloneURL, repoPath, repoType, workspac
 		// semaphore timeout is transient — retry next cycle without escalating backoff
 		if errors.Is(err, ErrCloneSemaphoreTimeout) {
 			s.logger.Info("clone semaphore busy, will retry next cycle", "type", repoType, "path", repoPath)
+			return
+		}
+
+		// ox-baz5.6: another actor is already cloning this exact path (a
+		// concurrent trigger lost the pre-clone lock race) — same "not our
+		// fault, just wait" shape as the semaphore case above, not a real
+		// clone failure worth escalating backoff over.
+		if gitutil.IsPreCloneLockBusy(err) {
+			s.logger.Info("another clone already in progress for this path, will retry next cycle", "type", repoType, "path", repoPath)
 			return
 		}
 

--- a/internal/daemon/sync_ledger_atomic_test.go
+++ b/internal/daemon/sync_ledger_atomic_test.go
@@ -1,0 +1,267 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ox-baz5.6 — Checkout()'s ledger branch used to clone straight into the
+// final payload.RepoPath with no atomicity and no per-path lock. A clone
+// that dropped mid-transfer (observed: "fetch-pack: unexpected disconnect
+// while reading sideband packet" on a 711MB ledger) left a half-initialized
+// .git AT the final location, which every subsequent daemon cycle and CLI
+// command then treated as a real ledger — HEAD pointing at
+// refs/heads/.invalid, every commit failing with "cannot lock ref HEAD:
+// reference already exists". Worse, the bounded clone semaphore limits
+// TOTAL concurrent clones but does not serialize by target path, so
+// multiple independent triggers (background retry, GC self-heal, codedb
+// indexing kickoff) could each pass the exists-check and race into cloning
+// the same destination concurrently — the same failure class as the
+// FETCH_HEAD race PR #868 closed, one layer earlier (before a .git even
+// exists to lock on).
+//
+// These tests drive Checkout() against a real local git server (dumb HTTP
+// over a plain static file server — isValidCloneURL only allows https or
+// http on localhost/127.0.0.1, so file:// is not an option here) rather
+// than mocking the clone step, per the "simulate the real environment"
+// principle: a mock can't reproduce a genuine concurrent-clone race.
+
+// setupBareLedgerHTTP creates a bare git repo with one commit, serves it
+// over dumb HTTP via httptest, and returns the clone URL. isValidCloneURL
+// accepts http:// only for localhost/127.0.0.1, which httptest.NewServer
+// binds to.
+func setupBareLedgerHTTP(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	root := t.TempDir()
+	bare := filepath.Join(root, "bare.git")
+	work := filepath.Join(root, "work")
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	run(root, "init", "--bare", "--initial-branch=main", bare)
+	run(root, "clone", "--quiet", bare, work)
+	run(work, "config", "user.email", "test@example.com")
+	run(work, "config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(work, "seed.txt"), []byte("seed\n"), 0o644))
+	run(work, "add", "-A")
+	run(work, "commit", "-q", "-m", "seed")
+	run(work, "push", "-q", "origin", "main")
+
+	// dumb-HTTP needs the derived info/refs the smart-http path would
+	// otherwise generate on the fly.
+	run(bare, "update-server-info")
+
+	srv := httptest.NewServer(http.FileServer(http.Dir(bare)))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// checkoutTestScheduler returns a scheduler configured with isolated
+// credentials (never touches the real machine's ~/.sageox store) and a
+// generous clone timeout for local HTTP fixtures.
+func checkoutTestScheduler(t *testing.T) *SyncScheduler {
+	t.Helper()
+	isolateCredentialsWithDir(t)
+	cfg := DefaultConfig()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return NewSyncScheduler(cfg, logger)
+}
+
+// tmpCloneSiblings lists any ".tmp-*" directories left next to repoPath —
+// the atomic clone's temp staging area. None should survive a Checkout()
+// call, success or failure.
+func tmpCloneSiblings(t *testing.T, repoPath string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(repoPath + ".tmp-*")
+	require.NoError(t, err)
+	return matches
+}
+
+// TestSyncScheduler_Checkout_LedgerCloneIsAtomic proves the happy path
+// still works end to end through the new temp-dir-then-rename path: a
+// successful clone lands a complete, verifiable git repo at exactly
+// payload.RepoPath, with no leftover temp staging directory.
+func TestSyncScheduler_Checkout_LedgerCloneIsAtomic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	cloneURL := setupBareLedgerHTTP(t)
+	s := checkoutTestScheduler(t)
+
+	repoPath := filepath.Join(t.TempDir(), "ledger")
+	result, err := s.Checkout(CheckoutPayload{
+		CloneURL: cloneURL,
+		RepoPath: repoPath,
+		RepoType: "ledger",
+	}, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Cloned)
+	assert.False(t, result.AlreadyExists)
+
+	// the clone must be complete and healthy — HEAD resolves.
+	out, err := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "-q", "HEAD").CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	assert.Empty(t, tmpCloneSiblings(t, repoPath), "no temp staging directory should survive a successful clone")
+}
+
+// TestSyncScheduler_Checkout_FailedLedgerCloneLeavesNoHalfClone is the
+// direct regression test for the original symptom: a clone that fails must
+// leave NOTHING at payload.RepoPath — not a half-initialized .git with an
+// unresolvable HEAD, not an orphaned temp directory either.
+func TestSyncScheduler_Checkout_FailedLedgerCloneLeavesNoHalfClone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	s := checkoutTestScheduler(t)
+
+	// a real HTTP server that serves 404 for everything — git's clone
+	// fails cleanly (unlike a raw connection-refused, this exercises the
+	// path where git has already started talking to a server and still
+	// fails partway through negotiation, closer to the real early-EOF
+	// shape than an instant connection error).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	repoPath := filepath.Join(t.TempDir(), "ledger")
+	result, err := s.Checkout(CheckoutPayload{
+		CloneURL: srv.URL,
+		RepoPath: repoPath,
+		RepoType: "ledger",
+	}, nil)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+
+	_, statErr := os.Stat(repoPath)
+	assert.True(t, os.IsNotExist(statErr), "failed clone must leave nothing at the target path, got: %v", statErr)
+	assert.Empty(t, tmpCloneSiblings(t, repoPath), "failed clone must not leave an orphaned temp staging directory")
+}
+
+// TestSyncScheduler_Checkout_ConcurrentLedgerCloneRace is the core
+// regression test for ox-baz5.6: N goroutines call Checkout() concurrently
+// for the SAME new ledger path (the exact shape of a background clone
+// retry racing GC self-heal racing a codedb indexing kickoff). Before the
+// pre-clone lock, nothing prevented more than one of these from actually
+// invoking `git clone` into the same destination at once. Red on main
+// (pre-ox-baz5.6): flip WithPreCloneLock to a no-op and this test should
+// show more than one goroutine's clone command actually running, and/or a
+// corrupted final repo.
+func TestSyncScheduler_Checkout_ConcurrentLedgerCloneRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	cloneURL := setupBareLedgerHTTP(t)
+	s := checkoutTestScheduler(t)
+	// enough headroom that the semaphore itself never gates this test —
+	// the pre-clone lock is what's under test, not maxConcurrentClones.
+	s.cloneSemTimeoutOverride = 30 * time.Second
+
+	repoPath := filepath.Join(t.TempDir(), "ledger")
+
+	const n = 8
+	var wg sync.WaitGroup
+	results := make([]*CheckoutResult, n)
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = s.Checkout(CheckoutPayload{
+				CloneURL: cloneURL,
+				RepoPath: repoPath,
+				RepoType: "ledger",
+			}, nil)
+		}(i)
+	}
+	wg.Wait()
+
+	var cloned, alreadyExists, failed int
+	var failureMsgs []string
+	for i := range n {
+		switch {
+		case errs[i] != nil:
+			failed++
+			failureMsgs = append(failureMsgs, errs[i].Error())
+		case results[i].Cloned:
+			cloned++
+		case results[i].AlreadyExists:
+			alreadyExists++
+		}
+	}
+
+	assert.Empty(t, failureMsgs, "no Checkout() call should fail under a race for the same new path: %s", strings.Join(failureMsgs, " | "))
+	assert.Equal(t, 1, cloned, "exactly one of %d concurrent callers should have actually cloned", n)
+	assert.Equal(t, n-1, alreadyExists, "every other caller should observe AlreadyExists once the winner finishes")
+	assert.Zero(t, failed)
+
+	// the final repo must be a single, healthy clone — not corrupted by a
+	// second clone racing into the same destination.
+	out, err := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "-q", "HEAD").CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Empty(t, tmpCloneSiblings(t, repoPath), "no temp staging directories should survive the race")
+}
+
+// TestWithPreCloneLock_SerializesConcurrentCallers is a focused unit test
+// on the lock primitive itself, independent of Checkout()'s plumbing:
+// concurrent holders for the SAME path never run their critical sections
+// at overlapping times.
+func TestWithPreCloneLock_SerializesConcurrentCallers(t *testing.T) {
+	repoPath := filepath.Join(t.TempDir(), "target")
+
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+	const n = 6
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			_ = gitutil.WithPreCloneLock(context.Background(), repoPath, func() error {
+				mu.Lock()
+				active++
+				if active > maxActive {
+					maxActive = active
+				}
+				mu.Unlock()
+
+				time.Sleep(10 * time.Millisecond)
+
+				mu.Lock()
+				active--
+				mu.Unlock()
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 1, maxActive, "at most one caller should be inside the locked section at a time")
+}

--- a/internal/daemon/sync_ledger_atomic_test.go
+++ b/internal/daemon/sync_ledger_atomic_test.go
@@ -265,3 +265,85 @@ func TestWithPreCloneLock_SerializesConcurrentCallers(t *testing.T) {
 
 	assert.Equal(t, 1, maxActive, "at most one caller should be inside the locked section at a time")
 }
+
+// TestCloneInBackground_PreCloneLockBusyDoesNotEscalateBackoff covers the
+// caller-side half of ox-baz5.6's pre-clone lock: when Checkout() reports
+// the lock is busy (another actor is already cloning this exact path),
+// cloneInBackground must treat it the same way it already treats a busy
+// clone semaphore — retry next cycle without escalating backoff — not as a
+// real clone failure worth penalizing.
+func TestCloneInBackground_PreCloneLockBusyDoesNotEscalateBackoff(t *testing.T) {
+	s := checkoutTestScheduler(t)
+	// short wait budget so the test doesn't sit for the production 5m10s
+	// default while a peer holds the lock.
+	s.preCloneLockWaitOverride = 200 * time.Millisecond
+
+	repoPath := filepath.Join(t.TempDir(), "ledger")
+	workspaceID := "ws-lock-busy-test"
+
+	holding := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_ = gitutil.WithPreCloneLock(context.Background(), repoPath, func() error {
+			close(holding)
+			<-release
+			return nil
+		})
+	}()
+	<-holding
+	defer close(release)
+
+	s.cloneWg.Add(1)
+	// a URL that passes isValidCloneURL (localhost is always allowed) but is
+	// never actually dialed — the lock must block entry before any network
+	// attempt happens.
+	s.cloneInBackground("http://127.0.0.1:1/repo.git", repoPath, "ledger", workspaceID)
+
+	attempts, _ := s.workspaceRegistry.GetCloneRetryInfo(workspaceID)
+	assert.Zero(t, attempts, "a busy pre-clone lock must not increment the retry/backoff counter")
+
+	_, statErr := os.Stat(repoPath)
+	assert.True(t, os.IsNotExist(statErr), "nothing should have been cloned while the lock was held by a peer")
+}
+
+// TestSyncScheduler_Checkout_EmptyRemoteFailsVerification covers the second
+// half of the atomic clone's own verification (the first half — clone exit
+// code — is covered by FailedLedgerCloneLeavesNoHalfClone above): `git
+// clone` can exit 0 against a genuinely empty bare remote (zero commits)
+// and still produce a temp clone whose HEAD does not resolve to anything.
+// The atomic-clone verification must catch this before ever renaming the
+// temp clone into place, the same way it catches an early-EOF exit failure.
+func TestSyncScheduler_Checkout_EmptyRemoteFailsVerification(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// a bare remote with ZERO commits — `git clone` against it succeeds
+	// (exit 0) but leaves an unborn HEAD in the resulting clone.
+	root := t.TempDir()
+	bare := filepath.Join(root, "empty.git")
+	cmd := exec.Command("git", "init", "--bare", "--initial-branch=main", bare)
+	require.NoError(t, cmd.Run())
+	require.NoError(t, exec.Command("git", "-C", bare, "update-server-info").Run())
+	srv := httptest.NewServer(http.FileServer(http.Dir(bare)))
+	t.Cleanup(srv.Close)
+
+	s := checkoutTestScheduler(t)
+	repoPath := filepath.Join(t.TempDir(), "ledger")
+	result, err := s.Checkout(CheckoutPayload{
+		CloneURL: srv.URL,
+		RepoPath: repoPath,
+		RepoType: "ledger",
+	}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HEAD does not resolve")
+	assert.Nil(t, result)
+
+	_, statErr := os.Stat(repoPath)
+	assert.True(t, os.IsNotExist(statErr), "a clone whose HEAD doesn't resolve must not be published to the final path")
+	assert.Empty(t, tmpCloneSiblings(t, repoPath), "no temp staging directory should survive a failed verification")
+}

--- a/internal/daemon/sync_ledger_atomic_test.go
+++ b/internal/daemon/sync_ledger_atomic_test.go
@@ -283,7 +283,9 @@ func TestCloneInBackground_PreCloneLockBusyDoesNotEscalateBackoff(t *testing.T) 
 
 	holding := make(chan struct{})
 	release := make(chan struct{})
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		_ = gitutil.WithPreCloneLock(context.Background(), repoPath, func() error {
 			close(holding)
 			<-release
@@ -291,7 +293,10 @@ func TestCloneInBackground_PreCloneLockBusyDoesNotEscalateBackoff(t *testing.T) 
 		})
 	}()
 	<-holding
-	defer close(release)
+	defer func() {
+		close(release)
+		<-done // wait for the holder's unlock to finish before t.TempDir() cleanup runs
+	}()
 
 	s.cloneWg.Add(1)
 	// a URL that passes isValidCloneURL (localhost is always allowed) but is

--- a/internal/gitutil/repolock.go
+++ b/internal/gitutil/repolock.go
@@ -63,3 +63,51 @@ func IsRepoLockBusy(err error) bool {
 	var timeout *fileutil.ErrLockTimeout
 	return errors.As(err, &timeout) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }
+
+// PreCloneLockTimeout bounds how long WithPreCloneLock waits for a peer
+// clone of the same target to finish. A ledger clone can legitimately run
+// for minutes on a large repo (711MB observed in ox-baz5.6); the timeout is
+// generous with the same reasoning as RepoLockTimeout — a legitimately slow
+// peer must not be mistaken for a stuck one.
+const PreCloneLockTimeout = 5 * time.Minute
+
+// WithPreCloneLock serializes every attempt to create a git clone at
+// repoPath — the phase WithRepoLock cannot cover, since it keys on
+// <clone>/.git/ox-sync and that file does not exist until a clone has
+// already created a .git directory. ox-baz5.6: multiple independent
+// triggers (a daemon background clone retry, GC self-heal, a codedb
+// indexing kickoff) can each observe the target missing and race to clone
+// into the same destination concurrently — the cloneSem in sync.go bounds
+// TOTAL concurrent clones but does not serialize by target path, so two
+// racing triggers can both pass the exists-check and both start cloning
+// into repoPath. This reproduced deterministically on a large ledger whose
+// clone intermittently dropped mid-transfer, corrupting the destination on
+// every retry.
+//
+// The lock is keyed directly on repoPath via PreCloneLockTarget (hashed by
+// fileutil.LockPath into an OS-tmpdir sidecar — the same mechanism
+// WithRepoLock uses), not on any file inside repoPath, since nothing there
+// is guaranteed to exist yet.
+func WithPreCloneLock(ctx context.Context, repoPath string, fn func() error) error {
+	return fileutil.WithFileLockTimeout(ctx, PreCloneLockTarget(repoPath), PreCloneLockTimeout, fn)
+}
+
+// PreCloneLockTarget is the path the pre-clone lock is keyed on. Suffixed
+// (not the bare repoPath) so its hash never collides with a WithRepoLock
+// key for the same path, even though the two are never expected to be held
+// simultaneously — WithRepoLock's key only exists once repoPath/.git does.
+func PreCloneLockTarget(repoPath string) string {
+	return repoPath + ".preclone-lock"
+}
+
+// IsPreCloneLockBusy reports whether err means another ox process is
+// already cloning this same target — the pre-clone analog of
+// IsRepoLockBusy. Callers treat this as "someone else is handling it,
+// retry next cycle without escalating backoff", never as a clone fault.
+func IsPreCloneLockBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	var timeout *fileutil.ErrLockTimeout
+	return errors.As(err, &timeout) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
+}

--- a/internal/gitutil/repolock_test.go
+++ b/internal/gitutil/repolock_test.go
@@ -84,3 +84,58 @@ func TestIsRepoLockBusy(t *testing.T) {
 	assert.True(t, IsRepoLockBusy(&fileutil.ErrLockTimeout{Path: "x", Timeout: time.Second}))
 	assert.True(t, IsRepoLockBusy(context.DeadlineExceeded))
 }
+
+// TestWithPreCloneLock_SerializesCallers is WithRepoLock's proof, applied to
+// the pre-clone lock: two callers targeting the same not-yet-cloned path
+// never hold the lock at once.
+func TestWithPreCloneLock_SerializesCallers(t *testing.T) {
+	target := t.TempDir() + "/not-yet-cloned"
+	var inside, overlaps atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := WithPreCloneLock(context.Background(), target, func() error {
+				if inside.Add(1) > 1 {
+					overlaps.Add(1)
+				}
+				time.Sleep(5 * time.Millisecond)
+				inside.Add(-1)
+				return nil
+			})
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+	assert.Zero(t, overlaps.Load(), "two callers held the pre-clone lock simultaneously")
+}
+
+// TestWithPreCloneLock_DifferentTargetsDoNotContend guards the keying, and
+// that it's distinct from WithRepoLock's key for the same path — the two
+// are never expected to be held simultaneously, but a hash collision would
+// be a silent, hard-to-diagnose deadlock risk.
+func TestWithPreCloneLock_DifferentTargetsDoNotContend(t *testing.T) {
+	a, b := t.TempDir()+"/a", t.TempDir()+"/b"
+	require.NotEqual(t, PreCloneLockTarget(a), PreCloneLockTarget(b))
+	require.NotEqual(t, PreCloneLockTarget(a), RepoLockTarget(a), "pre-clone and post-clone locks for the same path must not collide")
+
+	release := make(chan struct{})
+	held := make(chan struct{})
+	go func() {
+		_ = WithPreCloneLock(context.Background(), a, func() error { close(held); <-release; return nil })
+	}()
+	<-held
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := WithPreCloneLock(ctx, b, func() error { return nil })
+	close(release)
+	assert.NoError(t, err, "target B must not wait on target A's lock")
+}
+
+func TestIsPreCloneLockBusy(t *testing.T) {
+	assert.False(t, IsPreCloneLockBusy(nil))
+	assert.False(t, IsPreCloneLockBusy(errors.New("fatal: not a git repository")))
+	assert.True(t, IsPreCloneLockBusy(&fileutil.ErrLockTimeout{Path: "x", Timeout: time.Second}))
+	assert.True(t, IsPreCloneLockBusy(context.DeadlineExceeded))
+}


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a06ad3-3b54-76a3-93fd-57d2e6b01fda">Session</a>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/plan/pln_01a0695e-b8e4-74f5-a897-54c0c1ff113e">Plan</a>
<!-- /sageox:pr-header -->

## Summary

- **What:** Makes the daemon's ledger clone atomic (temp-dir + rename) and adds a pre-clone lock that serializes concurrent clone attempts for the same target path. Adds an `ox doctor` check that detects and repairs the corruption this closes: `HEAD` pointing at an unresolvable ref.
- **Why:** closes `ox-baz5.6` (P1), the last P1 in epic `ox-baz5`. Lane A (`#1`–`.3`) shipped in #868, lane B (`.4`/`.5`) in #877. This is lane C — different subsystem (daemon clone path + doctor, vs. git-lfs config in #877), zero file overlap, independent risk profile.

## What broke

`Checkout()`'s ledger branch (`internal/daemon/sync.go`) cloned straight into the final `payload.RepoPath`, with no atomicity and no per-path lock:

- **No atomicity.** A clone that drops mid-transfer — confirmed on a 711MB ledger over HTTPS (`fetch-pack: unexpected disconnect while reading sideband packet`) — left a half-initialized `.git` **at the final location**. Every daemon cycle and CLI command thereafter treated it as a real ledger: `HEAD` pointing at `refs/heads/.invalid` (a branch name git's own `check-ref-format` rejects), every commit failing with `cannot lock ref 'HEAD': unable to resolve reference 'refs/heads/.invalid'`. `ox plan save` / session finalize silently deferred; nothing recorded there was durable.
- **No per-path lock.** The existing `cloneSem` bounds *total* concurrent clones, not clones *per target path*. Multiple independent triggers — a background clone retry, GC self-heal, a codedb indexing kickoff — could each observe the target missing and race to clone into the same destination concurrently. This is the same failure class as the FETCH_HEAD race #868 closed, one layer earlier: `gitutil.WithRepoLock` can't cover this phase because it keys on `<clone>/.git/ox-sync`, which doesn't exist until a clone has already created a `.git` directory.
- **Invisible to every other doctor check.** `ox doctor` flagged `Ledger clean workdir (commit failed)` and its auto-fix died on `git symbolic-ref: fatal: No such ref: HEAD` — because branch-status, stranded-commits, and clean-workdir all assume `HEAD` resolves. None of them named the real problem.

```mermaid
flowchart LR
    A["background clone retry"] -->|"target missing"| L{"pre-clone lock<br/>on target path"}
    B["GC self-heal"] -->|"target missing"| L
    C["codedb indexing kickoff"] -->|"target missing"| L
    L -->|"winner"| D["clone into .tmp-N"]
    L -->|"losers: wait, recheck"| E["target now exists<br/>AlreadyExists"]
    D --> F{"clone complete +<br/>HEAD resolves?"}
    F -->|"yes"| G["rename .tmp-N -> final path"]
    F -->|"no (early EOF, etc.)"| H["remove .tmp-N<br/>nothing left at final path"]
```

## What this PR ships

- **`internal/gitutil/repolock.go`**: `WithPreCloneLock` — a companion to `WithRepoLock`, keyed directly on the target path (via `fileutil.LockPath`, the same OS-tmpdir sidecar mechanism) rather than a file inside the clone, since nothing there is guaranteed to exist yet. Plus `IsPreCloneLockBusy` for callers that want to treat contention as "retry next cycle," not a fault.
- **`internal/daemon/sync.go`**: `Checkout()`'s ledger branch now runs its clone under `WithPreCloneLock`, clones into `<path>.tmp-<nanos>`, verifies the temp clone (`.git` present, `HEAD` resolves) before creating `AGENTS.md` there too, then atomically renames into place. Failure at any point leaves nothing at the final path.
- **`internal/daemon/sync_clone.go`**: the background clone retry loop treats a busy pre-clone lock the same way it already treats a busy semaphore — retry next cycle without escalating backoff.
- **`cmd/ox/doctor_ledger_invalid_head.go`**: new check `ledger-invalid-head`, registered to run **first** in the Ledger Git Health category (before stranded-commits, unmerged-paths, branch-status — all of which assume `HEAD` resolves). Detects a `HEAD` pointing at a ref that fails git's own `check-ref-format` validation (carefully **not** matching a plain unborn branch, which `unbornLedgerFailure` already owns). `--fix` moves the corrupted clone aside (never deletes it), re-clones from `origin`, restores any `sessions/`/`data/` content from the backup, and commits it via the existing `fixLedgerDirtyWorkdir` path.

## Test plan

- `TestSyncScheduler_Checkout_ConcurrentLedgerCloneRace` — 8 goroutines racing `Checkout()` for the same new path against a real local git server: exactly 1 clones, the rest see `AlreadyExists`, zero errors, final repo is a single healthy clone.
- `TestSyncScheduler_Checkout_LedgerCloneIsAtomic` / `TestSyncScheduler_Checkout_FailedLedgerCloneLeavesNoHalfClone` — happy path lands a complete clone with no leftover temp dir; a failed clone (real HTTP 404 server) leaves nothing at the target and no orphaned temp dir.
- `TestWithPreCloneLock_SerializesConcurrentCallers` — focused unit test on the lock primitive: 6 concurrent holders for the same path never overlap.
- `TestDetectInvalidHead_*` — the exact corruption reproduced against real git (verified manually before writing the test: `git status --porcelain` shows every tracked file as staged-new, `git commit` fails with `cannot lock ref 'HEAD'`), plus negative cases proving an unborn branch and a detached HEAD are correctly **not** claimed by this check.
- `TestInvalidHeadCheck_FixReClonesAndRestoresStagedContent` — full repair cycle against a real local git server: staged `sessions/`/`data/` content survives, gets committed, and the corrupted original is preserved as a backup, never deleted.
- `TestInvalidHeadCheck_FixIsNonDestructiveWhenRecloneFails` — a failed reclone restores the original to its exact original path; no orphaned backup left behind.
- All of the above verified **red-first**: neutered each fix (the lock, the content restore), watched the exact assertion fail, restored, watched it pass.
- `make lint`: 0 issues. Full `cmd/ox` + `internal/daemon` + `internal/gitutil` suites green with `-race` (one unrelated codedb-indexing test flaked once under load from the concurrency tests in this same run; reran in isolation and reran the full suite clean — not a regression from this change).

## Out of scope

- **`ox-baz5.7`** (P3) — mock the automerge resolver contract to close two time-boxed coverage-ratchet exceptions from #868; not blocking, expires 2026-10-17.
- **`ox-vf3h`** — ledger push returns HTTP 403 despite a valid PAT (server-side ACL gap). Unrelated to how ox drives git locally.
- Team-context clones share the same underlying race (no per-path lock before this PR) but not the atomicity gap addressed here — `twoPhaseClone` was left as-is; no incident has been observed there and widening scope to it wasn't part of `ox-baz5.6`'s acceptance criteria.

Co-Authored-By: [SageOx](https://github.com/SageOx)
SageOx-Session: https://sageox.ai/c/ses_01a06ad3-3b54-76a3-93fd-57d2e6b01fda

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791093222&installation_model_id=433550&pr_number=878&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F878&signature=2e432757c7e985ec76cc9d7914124fdda2b4ff39188d9bb52a17e91f1c2296cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a ledger health check for invalid Git branch references.
  - Added guided recovery that recreates affected ledgers, restores local content, and preserves backups.
- **Bug Fixes**
  - Ledger cloning now completes atomically, preventing incomplete repositories from appearing ready.
  - Concurrent clone attempts are serialized and retried without escalating failures.
  - Failed cloning no longer leaves partial repository data behind.
  - Recovery rolls back safely after failures and reports file conflicts instead of overwriting differing content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->