### PR TITLE
fix(prime): emit well-formed XML, force re-prime on PreCompact

### DIFF
--- a/.claude/rules/session-draft.md
+++ b/.claude/rules/session-draft.md
@@ -18,6 +18,10 @@ wholesale at session stop.
 
 Full rationale: [docs/adr/ADR-029-session-draft-placeholder.md](../../docs/adr/ADR-029-session-draft-placeholder.md).
 
+Consumers **outside** this repo — anything that reads `sessions/<name>/meta.json` over the
+API rather than off disk — are bound by the same rule plus two counter rules. See ADR-029,
+"The contract for consumers outside the CLI."
+
 ---
 
 ## The one rule

--- a/.claude/rules/session-draft.md
+++ b/.claude/rules/session-draft.md
@@ -18,9 +18,11 @@ wholesale at session stop.
 
 Full rationale: [docs/adr/ADR-029-session-draft-placeholder.md](../../docs/adr/ADR-029-session-draft-placeholder.md).
 
-Consumers **outside** this repo — anything that reads `sessions/<name>/meta.json` over the
-API rather than off disk — are bound by the same rule plus two counter rules. See ADR-029,
-"The contract for consumers outside the CLI."
+Consumers **outside** this repo cannot call `IsDraft()` — it is an internal Go method. Their
+rule is the wire equivalent: **inspect the JSON `draft` field in `sessions/<name>/meta.json`,
+and treat absent or `false` as not-a-draft.** Same fail-safe direction, same three obligations
+(plus the two counter rules). See ADR-029, "The contract for consumers outside the CLI."
+`IsDraft()` stays the in-repo Go form of that one rule.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,15 +285,3 @@ bd close <id>         # Complete work
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
-
-<!-- ox:prime:pi:start -->
-## SageOx Team Context
-
-This project uses [SageOx](https://sageox.ai) for team context. Run the following command at the start of every session to load team knowledge:
-
-```bash
-ox agent prime
-```
-
-This provides architectural decisions, coding conventions, and session history from your team.
-<!-- ox:prime:pi:end -->

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -222,9 +222,14 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	hookInput := ReadAgentHookInput()
 	var agentSessionID string
 	var hookSource string // "" when invoked directly (no piped hook stdin), else startup/resume/clear/compact
+	// The EVENT name as well as the source field: agentx documents Source as
+	// populated "only for session start/end", so a PreCompact payload carries an
+	// empty Source and the compact-vs-full decision cannot be made from it alone.
+	var hookEventName string
 	if hookInput != nil {
 		agentSessionID = hookInput.SessionID
 		hookSource = hookInput.Source
+		hookEventName = hookInput.HookEventName
 	}
 
 	// fallback: if no session ID from hook stdin, try agent's native env var
@@ -632,7 +637,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	// (primeCallCount==1, set above), always yields compactReprime=false
 	// (full preamble). See prime.ShouldCompactReprime for the full
 	// belt-and-suspenders rationale.
-	compactReprime := prime.ShouldCompactReprime(primeCallCount, hookSource)
+	compactReprime := prime.ShouldCompactReprimeForEvent(primeCallCount, hookEventName, hookSource)
 
 	contentWithAttribution := withAttributionGuidance("", isLoggedIn, attribution)
 

--- a/cmd/ox/agent_prime_reprime_test.go
+++ b/cmd/ox/agent_prime_reprime_test.go
@@ -113,6 +113,16 @@ func TestPrimeTokenBudget_FullAndCompactStayUnderCeiling(t *testing.T) {
 	// read the old "Required/Automatic" wording as "always attribute" and fabricated
 	// provenance, and the imperative tone re-triggered prompt-injection suspicion
 	// every session. The follow-on prime-slimming work (S1) brings this back down.
+	// Raised 3600 -> 3700 (#880): XML-escaping the placeholders in the guidance
+	// blocks and the two command tables, so the document actually parses — a raw
+	// `<dr.md>` opened an element that never closed and cost every consumer the
+	// remainder of the output. Measured 3653 here, leaving ~47 of headroom, in
+	// line with the buffer the previous raises kept.
+	//
+	// Escaping is TEXT-only (&, <, >) via escapeXMLText, deliberately: quotes are
+	// legal in element content, and escaping them as well cost ~2x the tokens and
+	// turned `ox query "<q>"` into `ox query &quot;&lt;q&gt;&quot;` for the agent
+	// that has to read it.
 	// Raised 3340 -> 3600 (#664): the <commands> table gains verb-mode +
 	// DSL-mode `ox code` rows (defs/callers/callees/refs/log, plus type:pr /
 	// calls: / calledby: intents) so agents discover CodeDB's call-graph,
@@ -123,7 +133,7 @@ func TestPrimeTokenBudget_FullAndCompactStayUnderCeiling(t *testing.T) {
 	// prose moved to `ox code search --help` / .claude/rules/ox-code.md) to hold
 	// the real-usage cost down; this fixture measures the banner-off path.
 	const (
-		fullCeiling    = 3600
+		fullCeiling    = 3700
 		compactCeiling = 400
 	)
 
@@ -159,7 +169,12 @@ func TestRequiredFullPrimeDirectives_PresentInFullOutput(t *testing.T) {
 	xml := renderXML(t, out)
 
 	for _, d := range prime.RequiredFullPrimeDirectives() {
-		if !strings.Contains(xml, d.Marker) {
+		// The manifest marker is the RAW command text, because
+		// TestRequiredFullPrimeDirectives_ConsultFirstReachable matches it
+		// against the capability table. The emitted document escapes
+		// placeholders, so compare against the escaped form rather than
+		// weakening either side to a substring that survives both.
+		if !strings.Contains(xml, escapeXMLText(d.Marker)) {
 			t.Errorf("FULL prime output missing required directive %q (marker %q)", d.Name, d.Marker)
 		}
 	}
@@ -229,7 +244,12 @@ func assertFullRePrime(t *testing.T, xml string) {
 		t.Error("expected FULL prime output, but found mode=\"compact\"")
 	}
 	for _, d := range prime.RequiredFullPrimeDirectives() {
-		if !strings.Contains(xml, d.Marker) {
+		// The manifest marker is the RAW command text, because
+		// TestRequiredFullPrimeDirectives_ConsultFirstReachable matches it
+		// against the capability table. The emitted document escapes
+		// placeholders, so compare against the escaped form rather than
+		// weakening either side to a substring that survives both.
+		if !strings.Contains(xml, escapeXMLText(d.Marker)) {
 			t.Errorf("FULL prime output missing required directive %q (marker %q)", d.Name, d.Marker)
 		}
 	}

--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -248,14 +248,20 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 		sb.WriteString("\nThe you= and you_aliases= attributes identify the current user. Match against ALL aliases (the same person appears under different names in different contexts).\n")
 		sb.WriteString("The current user's own prior work is not a teammate contribution — for it say \"Building on your earlier work on [topic]...\".\n")
 		sb.WriteString("\nPlan footer — add \"> Guided by SageOx\" as the plan's final line only when SageOx team context actually shaped it; otherwise omit it.\n")
-		// PR header — the human-facing TOP-of-body counterpart to the
-		// SageOx-Session: trailer below. Both halves of the PR contract must be
-		// stated HERE, in the XML the agent actually reads: this block is a
-		// hand-maintained sibling of prime.WithAttributionGuidance, and when
-		// only that one gained the header line, agents kept emitting the
-		// trailer (session state, re-sent every prime) and never the header.
-		sb.WriteString("\nPR header — when SageOx context shaped the work, run `ox pr header` (add `--plan <pln_id>` per plan, `--prior-art/--collisions N` for enrichment) and paste its output as the FIRST lines of the PR body, above your summary. It links the session(s) and plan(s). If SageOx did not shape the work, skip it. Keep the `SageOx-Session:` trailer last.\n")
-		sb.WriteString("Save the plan first so the header can link it: `ox plan save --file <plan.html|plan.md>` returns the `pln_` id.\n")
+		// PR header — the TOP-of-body counterpart to the SageOx-Session: trailer.
+		// Gated on attribution being configured, for the same reason the score and
+		// trailer blocks below are: a repo that credits nothing has no use for a
+		// credit line, and the minimal-prime floor (agent_prime_xml_test.go) has
+		// ~5 tokens of headroom — an unconditional line there would buy nothing and
+		// cost every bare prime.
+		//
+		// Stated HERE, in the XML the agent actually reads: this block is a
+		// hand-maintained sibling of prime.WithAttributionGuidance, and when only
+		// that one gained the header line, agents kept emitting the trailer (session
+		// state, re-sent every prime) and never the header.
+		if output.Attribution.PR != "" || output.Attribution.Commit != "" {
+			sb.WriteString("\nPR header — `ox pr header` (`--plan <pln_id>` per saved plan) and paste as the FIRST lines of the PR body; keep the `SageOx-Session:` trailer last. `ox plan save --file <plan>` returns the `pln_` id.\n")
+		}
 		if output.Attribution.Commit != "" {
 			sb.WriteString("\nSageOx contribution score (report only when commit attribution is configured; `none` is the correct, common answer when you worked independently of team context):\n")
 			sb.WriteString("Score reflects how much SageOx team context shaped your work — NOT that a session was recorded.\n")

--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -248,6 +248,14 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 		sb.WriteString("\nThe you= and you_aliases= attributes identify the current user. Match against ALL aliases (the same person appears under different names in different contexts).\n")
 		sb.WriteString("The current user's own prior work is not a teammate contribution — for it say \"Building on your earlier work on [topic]...\".\n")
 		sb.WriteString("\nPlan footer — add \"> Guided by SageOx\" as the plan's final line only when SageOx team context actually shaped it; otherwise omit it.\n")
+		// PR header — the human-facing TOP-of-body counterpart to the
+		// SageOx-Session: trailer below. Both halves of the PR contract must be
+		// stated HERE, in the XML the agent actually reads: this block is a
+		// hand-maintained sibling of prime.WithAttributionGuidance, and when
+		// only that one gained the header line, agents kept emitting the
+		// trailer (session state, re-sent every prime) and never the header.
+		sb.WriteString("\nPR header — when SageOx context shaped the work, run `ox pr header` (add `--plan <pln_id>` per plan, `--prior-art/--collisions N` for enrichment) and paste its output as the FIRST lines of the PR body, above your summary. It links the session(s) and plan(s). If SageOx did not shape the work, skip it. Keep the `SageOx-Session:` trailer last.\n")
+		sb.WriteString("Save the plan first so the header can link it: `ox plan save --file <plan.html|plan.md>` returns the `pln_` id.\n")
 		if output.Attribution.Commit != "" {
 			sb.WriteString("\nSageOx contribution score (report only when commit attribution is configured; `none` is the correct, common answer when you worked independently of team context):\n")
 			sb.WriteString("Score reflects how much SageOx team context shaped your work — NOT that a session was recorded.\n")

--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -158,7 +158,11 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 		// Rendered from the compile-time table (no per-session state) → stays in the
 		// static cache tier, byte-identical across sessions for a given binary.
 		for _, route := range consultRoutes() {
-			fmt.Fprintf(&sb, "- %s → %s\n", route.Cue, route.Command)
+			// escapeXML on BOTH: these are table data, not literals authored
+			// here, and the table legitimately contains placeholders like
+			// `--file <dr.md>`. Written raw, that opens an element that never
+			// closes and the whole <ox-prime> document stops parsing.
+			fmt.Fprintf(&sb, "- %s → %s\n", escapeXMLText(route.Cue), escapeXMLText(route.Command))
 		}
 		sb.WriteString("</consult-first>\n")
 
@@ -169,7 +173,7 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 		// team rules matter, the manual publish workflow) moved to `ox guide
 		// team-rules` — read once, on demand, instead of paid on every prime.
 		sb.WriteString("\n<rule-promotion-guidance>\n")
-		sb.WriteString("When the user adds/edits a project-local rule (.claude/rules/*.md, CLAUDE.md, AGENTS.md, etc.) that looks team-wide rather than repo-specific, ask whether to also publish it to agents/rules/<name>.md in SageOx team context. Default to asking; never silent-publish; skip repo-specific rules. Run `ox guide team-rules` for the file format and workflow.\n")
+		sb.WriteString("When the user adds/edits a project-local rule (.claude/rules/*.md, CLAUDE.md, AGENTS.md, etc.) that looks team-wide rather than repo-specific, ask whether to also publish it to agents/rules/&lt;name&gt;.md in SageOx team context. Default to asking; never silent-publish; skip repo-specific rules. Run `ox guide team-rules` for the file format and workflow.\n")
 		sb.WriteString("Team rules reach every supported AI coding agent (Claude, Codex, Amp, etc.) for teammates running ox; project-local .claude/rules/ reaches only Claude users on this machine.\n")
 		sb.WriteString("</rule-promotion-guidance>\n")
 
@@ -230,7 +234,9 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 			sb.WriteString("| Intent | Command |\n")
 			sb.WriteString("|--------|---------|\n")
 			for _, ic := range output.Guidance.Commands {
-				fmt.Fprintf(&sb, "| %s | `%s` |\n", ic.Intent, ic.Command)
+				// Table DATA, same as the consult-first rows: guidance commands
+				// legitimately carry placeholders like `ox query "<your question>"`.
+				fmt.Fprintf(&sb, "| %s | `%s` |\n", escapeXMLText(ic.Intent), escapeXMLText(ic.Command))
 			}
 			sb.WriteString("</commands>\n")
 		}
@@ -260,7 +266,7 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 		// that one gained the header line, agents kept emitting the trailer (session
 		// state, re-sent every prime) and never the header.
 		if output.Attribution.PR != "" || output.Attribution.Commit != "" {
-			sb.WriteString("\nPR header — `ox pr header` (`--plan <pln_id>` per saved plan) and paste as the FIRST lines of the PR body; keep the `SageOx-Session:` trailer last. `ox plan save --file <plan>` returns the `pln_` id.\n")
+			sb.WriteString("\nPR header — `ox pr header` (`--plan &lt;pln_id&gt;` per saved plan) and paste as the FIRST lines of the PR body; keep the `SageOx-Session:` trailer last. `ox plan save --file &lt;plan&gt;` returns the `pln_` id.\n")
 		}
 		if output.Attribution.Commit != "" {
 			sb.WriteString("\nSageOx contribution score (report only when commit attribution is configured; `none` is the correct, common answer when you worked independently of team context):\n")
@@ -353,7 +359,7 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 					fmt.Fprintf(&sb, "| %s | %s | %s |\n", cw.Name, desc, model)
 				}
 				bk.charge(prime.BudgetSourceTeam)
-				sb.WriteString("\nLoad: `ox coworker load <name>`\n")
+				sb.WriteString("\nLoad: `ox coworker load &lt;name&gt;`\n")
 				sb.WriteString("</coworkers>\n")
 				bk.charge(prime.BudgetSourceSageox)
 			}
@@ -369,7 +375,9 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 					if desc == "" {
 						desc = "(no description)"
 					}
-					fmt.Fprintf(&sb, "| %s | %s | %s |\n", tcmd.Name, tcmd.Trigger, desc)
+					// Team-authored data — the least trustworthy input on this
+					// path, and the one most likely to contain an angle bracket.
+					fmt.Fprintf(&sb, "| %s | %s | %s |\n", escapeXMLText(tcmd.Name), escapeXMLText(tcmd.Trigger), escapeXMLText(desc))
 				}
 				bk.charge(prime.BudgetSourceTeam)
 				sb.WriteString("</team-commands>\n")
@@ -428,7 +436,7 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 		if output.Ledger != nil && output.Ledger.Exists {
 			sb.WriteString("\n<ledger>\n")
 			sb.WriteString("Repo-specific archive of prior AI coworker coding sessions.\n")
-			sb.WriteString("NOT team context. Use `ox session list` to browse, `ox session view <name> --text` to view.\n")
+			sb.WriteString("NOT team context. Use `ox session list` to browse, `ox session view &lt;name&gt; --text` to view.\n")
 			sb.WriteString("Do not read ledger files directly (LFS stubs).\n")
 			sb.WriteString("</ledger>\n")
 		}
@@ -485,7 +493,7 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 				fmt.Fprintf(&sb, "| %s | %s |\n", t.Slug, age)
 			}
 			sb.WriteString("\nList all: `ox teams`\n")
-			sb.WriteString("Read: `ox agent team-ctx <slug>`\n")
+			sb.WriteString("Read: `ox agent team-ctx &lt;slug&gt;`\n")
 			sb.WriteString("</other-teams>\n")
 		}
 
@@ -679,6 +687,23 @@ func escapeXML(s string) string {
 	return xmlEscaper.Replace(s)
 }
 
+// xmlTextEscaper escapes only what ELEMENT TEXT requires: &, < and >. Quotes
+// and apostrophes are legal in text content and are left alone — escaping them
+// there (as escapeXML does, correctly, for attribute values) costs tokens on
+// every prime and turns readable guidance like `ox query "<q>"` into
+// `ox query &quot;&lt;q&gt;&quot;` for the agent that has to read it.
+var xmlTextEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+)
+
+// escapeXMLText is escapeXML for element content. Use it for anything written
+// between tags; use escapeXML for attribute values.
+func escapeXMLText(s string) string {
+	return xmlTextEscaper.Replace(s)
+}
+
 // consultRoutes returns the cue→corpus routing rows for the <consult-first>
 // reminder, sourced from the capability table's floor entries. The table is the
 // single source of truth: the same floor cue set feeds the additive `ox-consult`
@@ -716,11 +741,11 @@ func writePlanEnrichmentGuidance(sb *strings.Builder, agentType string) {
 	sb.WriteString("A plan follows a creed: don't waste human attention, delight them, educate them visually and crisply.\n")
 	// Cross-agent mandate: planning should ALWAYS draw on SageOx conversation
 	// intelligence first, regardless of agent tier.
-	sb.WriteString("Before planning non-trivial work, consult SageOx conversation intelligence: `ox query \"<topic>\"` (discussions+sessions), `ox code search` (code+history) — plans ignoring recent team context get re-litigated.\n")
+	sb.WriteString("Before planning non-trivial work, consult SageOx conversation intelligence: `ox query \"&lt;topic&gt;\"` (discussions+sessions), `ox code search` (code+history) — plans ignoring recent team context get re-litigated.\n")
 	if prime.ClassifyAgentTier(agentType) == prime.TierBronze {
 		// lighter tier: surface the surface, don't promise real-time nudges.
-		sb.WriteString("When you produce a plan: run `ox plan enrich` (JSON) WHILE drafting. For material work author `plan.html`, save it canonically with `ox plan save --file plan.html`, then present it through `ox plan render --file plan.html --open` so ox injects team context without replacing the page. Verify with `ox plan lint <slug> [--strict]`. Browse prior plans: `ox plan list`. Run `ox guide plan-enrichment` for the full workflow.\n")
-		sb.WriteString("Structure it in two layers: a decision layer up top, then exactly one collapsed `<details>` \"Implementation notes\" appendix at the end for the implementer.\n")
+		sb.WriteString("When you produce a plan: run `ox plan enrich` (JSON) WHILE drafting. For material work author `plan.html`, save it canonically with `ox plan save --file plan.html`, then present it through `ox plan render --file plan.html --open` so ox injects team context without replacing the page. Verify with `ox plan lint &lt;slug&gt; [--strict]`. Browse prior plans: `ox plan list`. Run `ox guide plan-enrichment` for the full workflow.\n")
+		sb.WriteString("Structure it in two layers: a decision layer up top, then exactly one collapsed `&lt;details&gt;` \"Implementation notes\" appendix at the end for the implementer.\n")
 		sb.WriteString("</plan-enrichment-guidance>\n")
 		return
 	}
@@ -728,13 +753,13 @@ func writePlanEnrichmentGuidance(sb *strings.Builder, agentType string) {
 	// HTML + review loop are HUMAN-opt-in: the agent recommends, the human runs.
 	// The authored page leads; ox supplies canonical storage, enrichment chrome,
 	// and review without becoming a second renderer or source of truth.
-	sb.WriteString("For a material plan — or a mockup, review sheet, or evidence page, which belong in the ledger too — author a purpose-built `plan.html`, save it as the single record with `ox plan save --file plan.html --kind plan|mockup|review|evidence`, then present it through `ox plan render --file plan.html --open`; ox preserves the page, derives markdown, and injects team context (prior art, collisions, expert routing, knowledge bubbles, team memory), attribution, and review chrome. Never use legacy `--plan + --html`: competing sources can make review discard the authored page. Verify with `ox plan lint --file plan.html` BEFORE the first save, `ox plan lint <slug>` after. After presenting, proactively OFFER the live review loop: on the human's yes, launch `ox plan review <slug>` (they mark up in-browser, you address items live) — never auto-start without the yes. `ox plan list` flags open review items on resume.\n")
+	sb.WriteString("For a material plan — or a mockup, review sheet, or evidence page, which belong in the ledger too — author a purpose-built `plan.html`, save it as the single record with `ox plan save --file plan.html --kind plan|mockup|review|evidence`, then present it through `ox plan render --file plan.html --open`; ox preserves the page, derives markdown, and injects team context (prior art, collisions, expert routing, knowledge bubbles, team memory), attribution, and review chrome. Never use legacy `--plan + --html`: competing sources can make review discard the authored page. Verify with `ox plan lint --file plan.html` BEFORE the first save, `ox plan lint &lt;slug&gt;` after. After presenting, proactively OFFER the live review loop: on the human's yes, launch `ox plan review &lt;slug&gt;` (they mark up in-browser, you address items live) — never auto-start without the yes. `ox plan list` flags open review items on resume.\n")
 	// Two-audience structure: a plan is read by the ~10-min human approver AND
 	// the agent that implements it. Steer agents to layer, not average — detail
 	// relocated to the end, never inlined up top or deleted (see buildGuidance).
-	sb.WriteString("Structure the plan in two layers for its two readers: a minutiae-free decision layer up top (conclusion, tradeoffs, biggest risk, one hero diagram) that a human approves in ~10 min, then exactly one collapsed `<details>` \"Implementation notes\" appendix at the END for the implementing agent (exact files, edits, gotchas) — relocate detail there rather than inlining it up top or dropping it.\n")
+	sb.WriteString("Structure the plan in two layers for its two readers: a minutiae-free decision layer up top (conclusion, tradeoffs, biggest risk, one hero diagram) that a human approves in ~10 min, then exactly one collapsed `&lt;details&gt;` \"Implementation notes\" appendix at the END for the implementing agent (exact files, edits, gotchas) — relocate detail there rather than inlining it up top or dropping it.\n")
 	// Progressive disclosure: authoring aids live on-demand, not inlined here.
-	sb.WriteString("Use `ox viz suggest \"<what needs explaining>\"` for diagrams, charts, layouts, and mockups. The generic markdown renderer is only the quick path for small, low-stakes plans. Never hand-author a SageOx credit or your own footnote/ⓘ markers — ox chrome owns the footer credit and OX context markers; for the rest, use the `ox viz ox-annotation` pattern.\n")
+	sb.WriteString("Use `ox viz suggest \"&lt;what needs explaining&gt;\"` for diagrams, charts, layouts, and mockups. The generic markdown renderer is only the quick path for small, low-stakes plans. Never hand-author a SageOx credit or your own footnote/ⓘ markers — ox chrome owns the footer credit and OX context markers; for the rest, use the `ox viz ox-annotation` pattern.\n")
 	sb.WriteString("</plan-enrichment-guidance>\n")
 }
 
@@ -742,7 +767,7 @@ func writePlanEnrichmentGuidance(sb *strings.Builder, agentType string) {
 // vocabulary, independent of whether it uses SageOx enriched plans.
 func writeVisualizationGuidance(sb *strings.Builder) {
 	sb.WriteString("\n<visualization-guidance>\n")
-	sb.WriteString("Before a material PR description, run `ox viz pr`: no visual if prose answers it; GitHub-safe Mermaid for a 2–5-node flow; rich only for a reviewer question Mermaid cannot answer. For a known question, run `ox viz pr --intent \"<question>\" --json`.\n")
+	sb.WriteString("Before a material PR description, run `ox viz pr`: no visual if prose answers it; GitHub-safe Mermaid for a 2–5-node flow; rich only for a reviewer question Mermaid cannot answer. For a known question, run `ox viz pr --intent \"&lt;question&gt;\" --json`.\n")
 	projectRoot := findGitRoot()
 	if config.PRVisualsRich(projectRoot) {
 		theme := config.PRVisualsTheme(projectRoot)
@@ -750,7 +775,7 @@ func writeVisualizationGuidance(sb *strings.Builder) {
 	} else {
 		sb.WriteString("Generated PNG/SVG PR images are disabled; the ox viz catalog and `ox viz suggest` remain available. For PR text, use GitHub-safe Mermaid only when it helps; enable image generation with `ox config set pr_visuals.rich on`.\n")
 	}
-	sb.WriteString("For architecture, flow, state, sequence, comparison, chronology, or quantitative shape, use `ox viz suggest \"<intent>\"`; the catalog serves plans, docs, PRs, reports, and design notes. Pull `ox viz <id>`; only `ox-render` recipes support `ox viz render`; check SVG/HTML with `ox viz lint`.\n")
+	sb.WriteString("For architecture, flow, state, sequence, comparison, chronology, or quantitative shape, use `ox viz suggest \"&lt;intent&gt;\"`; the catalog serves plans, docs, PRs, reports, and design notes. Pull `ox viz &lt;id&gt;`; only `ox-render` recipes support `ox viz render`; check SVG/HTML with `ox viz lint`.\n")
 	sb.WriteString("</visualization-guidance>\n")
 }
 
@@ -770,8 +795,8 @@ func writeDecisionRecordGuidance(sb *strings.Builder) {
 	}
 	sb.WriteString("\n<decision-record-guidance>\n")
 	sb.WriteString("This repo keeps Decision Records (ADRs/DDRs) — permanent team memory; consult before touching one.\n")
-	sb.WriteString("New DR: `ox decision enrich --topic \"<subject>\"` before drafting. Editing: `ox decision enrich --file <path>`. Both are zero-cost JSON: related decisions, numbering, ready-to-paste citations — re-run after editing (a citation you can't resolve should be deleted, not left dangling).\n")
-	sb.WriteString("Mid-implementation, before a nontrivial design choice: check for a standing constraint first — `ox code search \"<topic>\" --decisions`.\n")
+	sb.WriteString("New DR: `ox decision enrich --topic \"&lt;subject&gt;\"` before drafting. Editing: `ox decision enrich --file &lt;path&gt;`. Both are zero-cost JSON: related decisions, numbering, ready-to-paste citations — re-run after editing (a citation you can't resolve should be deleted, not left dangling).\n")
+	sb.WriteString("Mid-implementation, before a nontrivial design choice: check for a standing constraint first — `ox code search \"&lt;topic&gt;\" --decisions`.\n")
 	sb.WriteString("Paste citation comments VERBATIM, never hand-composed. Run `ox guide decision-records` for the credit and amendment rules.\n")
 	sb.WriteString("</decision-record-guidance>\n")
 }
@@ -797,7 +822,7 @@ func emitTeamRules(sb *strings.Builder, bk *bookkeeper, rules []teamdocs.TeamRul
 		}
 	}
 
-	sb.WriteString("\n<team-rules hint=\"agents/rules/<topic>.md — modular AI-coworker rules. See `ox guide team-rules`.\">\n")
+	sb.WriteString("\n<team-rules hint=\"agents/rules/&lt;topic&gt;.md — modular AI-coworker rules. See `ox guide team-rules`.\">\n")
 	bk.charge(prime.BudgetSourceSageox)
 
 	// always-tier rules: framing is ours, body+name+desc+path are team's

--- a/cmd/ox/agent_prime_xml_test.go
+++ b/cmd/ox/agent_prime_xml_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/xml"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -543,11 +545,11 @@ func TestOutputAgentPrimeXML_ConsultFirst(t *testing.T) {
 		t.Error("consult-first must route recency cues to `ox session list`")
 	}
 	// conceptual cue routes to semantic query
-	if !strings.Contains(xml, `ox query "<question>"`) {
+	if !strings.Contains(xml, `ox query "&lt;question&gt;"`) {
 		t.Error("consult-first must route conceptual cues to `ox query`")
 	}
 	// code-provenance cue routes to code search
-	if !strings.Contains(xml, `ox code search "<pattern>"`) {
+	if !strings.Contains(xml, `ox code search "&lt;pattern&gt;"`) {
 		t.Error("consult-first must route code-provenance cues to `ox code search`")
 	}
 
@@ -1119,12 +1121,16 @@ func TestOutputAgentPrimeXML_SageoxOverheadBudget_Regression(t *testing.T) {
 	// not its mechanics. The rationale still lives on demand in `ox guide
 	// plan-enrichment`.
 	//
+	// Raised 2190 -> 2250 (#880): XML-escaping the guidance placeholders, so the
+	// prime document parses instead of dying at the first `<topic>`. Measured
+	// 2209 — a +19 floor, text-only escaping (&, <, >); escaping quotes too would
+	// have cost roughly double for no correctness gain in element content.
 	// Raised 2150 -> 2190 (#809): the static-tier <attribution> conditional/anti-
 	// fabrication gate plus the <instructions> self-verification pointer add ~32
 	// tokens to the minimal floor. Same #809 correctness rationale as the full-prime
 	// ceiling (see agent_prime_reprime_test.go); the prime-slimming follow-up (S1)
 	// brings it back down.
-	const sageoxOverheadCeiling = 2190
+	const sageoxOverheadCeiling = 2250
 	sageoxTokens := budget.Get(prime.BudgetSourceSageox)
 	if sageoxTokens > sageoxOverheadCeiling {
 		t.Errorf("SageOx overhead floor for minimal prime = %d tokens, exceeds ceiling %d.\n"+
@@ -1423,6 +1429,82 @@ func TestOutputAgentPrimeXML_KnowledgeBubbles_PendingCheckoutNote(t *testing.T) 
 			// the commands stay advertised in every state — they work unmounted
 			if !strings.Contains(xml, "ox kb describe") {
 				t.Errorf("ox kb describe must stay listed:\n%s", xml)
+			}
+		})
+	}
+}
+
+// TestOutputAgentPrimeXML_IsWellFormed parses the whole emitted document rather
+// than grepping it for substrings, which is the gap that let a raw `<pln_id>`
+// placeholder ship inside <attribution>: every other guidance line in this file
+// escapes its placeholders as &lt;...&gt; (see the `ox code defs &lt;name&gt;`
+// block and the session-score line), so a new line that forgets is invisible to
+// every Contains-style assertion while silently opening a tag that never closes.
+//
+// The attribution-configured case is the one that was broken, and it is gated —
+// a bare prime never reaches that branch — so the minimal shape alone would not
+// have caught it. Both shapes are covered for that reason.
+func TestOutputAgentPrimeXML_IsWellFormed(t *testing.T) {
+	tests := []struct {
+		name   string
+		output agentPrimeOutput
+	}{
+		{
+			name:   "minimal",
+			output: agentPrimeOutput{AgentID: "test-agent", Status: "fresh"},
+		},
+		{
+			// PR + commit attribution configured: unlocks the PR-header line,
+			// the plan footer and the contribution-score block.
+			name: "attribution configured",
+			output: agentPrimeOutput{
+				AgentID: "test-agent",
+				Status:  "fresh",
+				Attribution: config.ResolvedAttribution{
+					Commit: "Co-Authored-By: SageOx <ox@sageox.ai>",
+					PR:     "Co-Authored-By: SageOx <ox@sageox.ai>",
+				},
+			},
+		},
+		{
+			// PR-only: the header line is reachable through this branch too.
+			name: "pr attribution only",
+			output: agentPrimeOutput{
+				AgentID:     "test-agent",
+				Status:      "fresh",
+				Attribution: config.ResolvedAttribution{PR: "Co-Authored-By: SageOx <ox@sageox.ai>"},
+			},
+		},
+	}
+
+	// The fully-loaded shape is the one that matters most: it is the only case
+	// that renders the <commands> and <team-commands> tables, whose rows are
+	// DATA (guidance and team-authored) rather than literals written here — and
+	// data is where an angle bracket arrives without anyone reviewing it.
+	tests = append(tests, struct {
+		name   string
+		output agentPrimeOutput
+	}{name: "fully loaded", output: fullyLoadedPrimeFixture()})
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&buf)
+
+			if _, err := outputAgentPrimeXML(cmd, tc.output); err != nil {
+				t.Fatalf("outputAgentPrimeXML() error = %v", err)
+			}
+
+			dec := xml.NewDecoder(bytes.NewReader(buf.Bytes()))
+			for {
+				_, err := dec.Token()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					t.Fatalf("prime output is not well-formed XML: %v\n\n%s", err, buf.String())
+				}
 			}
 		})
 	}

--- a/docs/adr/ADR-029-session-draft-placeholder.md
+++ b/docs/adr/ADR-029-session-draft-placeholder.md
@@ -142,6 +142,48 @@ Every site that reads a possibly-unreadable `meta.json` picks a direction. The r
 | daemon `detectInDir` / `DetectOrphanedForAgent` | **skip** | Falling through reaches `recoverRawFromSessionFile`, which writes real bytes to the tracked `raw.jsonl` and breaks LFS for the team |
 | `ledgersearch.isDraftSession` | not a draft (index it) | Fail-open; a malformed file must not hide a real session from search |
 
+## The contract for consumers outside the CLI
+
+The cost section below counts roughly fifteen CLI call sites. It undercounts. The **SageOx
+server is also a consumer of `meta.json`**, and it renders that file on surfaces the CLI
+never sees — the team home page's session list, a repo's session detail page, and
+`/c/<ses_id>` itself.
+
+That gap shipped a bug. The decision table above names the CLI symptom exactly — *"Without
+it a draft reads as `StatusUploaded`: live recordings render as finished"* — and fixes it
+with a derived `StatusDraft`. Nothing carried the same rule across the API boundary, so the
+identical failure reappeared on the web: a live draft rendered as a finished session, with a
+normal card and an empty transcript.
+
+Any consumer reading `sessions/<name>/meta.json` — in any language, on either side of the
+network — is bound by three rules.
+
+1. **Branch on `draft` before rendering anything as a finished session.** An absent key means
+   not-a-draft (`omitempty`, back-compat), and an unreadable file must also be treated as
+   not-a-draft, matching `IsDraft()`'s nil-safe direction. A draft has no turns, no summary,
+   and no title — not "none loaded yet", none *at all*, structurally, because
+   `lfs.DraftInput` has no field that could hold them. Render it as in-progress, or omit it.
+   Never as an empty finished session.
+
+2. **Do not present `turn_count` as a count.** It advances only every
+   `DraftRefreshEveryTurns` (10) turns, so a live draft reads 2, 12, 22, 32 — never the true
+   number. Its purpose is to show *forward motion*; the meaning is in the first derivative,
+   not the value. Finalize clears it.
+
+3. **`entry_count` is not a turn count.** It counts `raw.jsonl` entries — user messages,
+   assistant messages, and every tool call — so it runs roughly an order of magnitude above
+   `turn_count`. Labeling it "N turns" overstates a session by that factor.
+
+Rules 2 and 3 are the same trap the finalize path already avoids, stated in the `TurnCount`
+doc comment: *"leaving both would invite consumers to disagree about which one means size."*
+Finalize clears `TurnCount` for precisely that reason. **A draft is the one state that ships
+both counters** — so it is the one state where that disagreement is available to have, and a
+consumer duly had it.
+
+The mirror-image obligation belongs to this repo. `meta.json` is a published API, and a field
+whose meaning is recoverable only by reading Go source is not documented. Both counters now
+carry doc comments in `internal/lfs/meta.go`.
+
 ## Consequences
 
 **Good.** `/c/<id>` resolves mid-session, durably and retryably. `ox session status` gains
@@ -159,7 +201,8 @@ by roughly 1 + turns/10 per session.
 its co-staging window routine rather than theoretical, and it should get the same pathspec
 treatment in a follow-up. `pushMurmurCommits` has the secret-gate hole this change declined to
 propagate. `.recording.json` is now gitignored, but that does not untrack markers already
-committed in existing ledgers.
+committed in existing ledgers. Server-side rendering of drafts does not yet honor the
+consumer contract above; that work is owned privately and tracked there.
 
 ## Alternatives considered
 

--- a/docs/adr/ADR-029-session-draft-placeholder.md
+++ b/docs/adr/ADR-029-session-draft-placeholder.md
@@ -170,9 +170,13 @@ network — is bound by three rules.
    number. Its purpose is to show *forward motion*; the meaning is in the first derivative,
    not the value. Finalize clears it.
 
-3. **`entry_count` is not a turn count.** It counts `raw.jsonl` entries — user messages,
+3. **`entry_count` is not a turn count.** It counts CONVERSATION entries — user messages,
    assistant messages, and every tool call — so it runs roughly an order of magnitude above
-   `turn_count`. Labeling it "N turns" overstates a session by that factor.
+   `turn_count`. Labeling it "N turns" overstates a session by that factor. It does **not**
+   count the `type: "header"` / `type: "footer"` records ox writes into `raw.jsonl` itself:
+   the count comes from what the adapter read out of the agent's own session file, so a
+   consumer diffing `entry_count` against `wc -l raw.jsonl` will see a small fixed shortfall
+   and should not treat it as loss.
 
 Rules 2 and 3 are the same trap the finalize path already avoids, stated in the `TurnCount`
 doc comment: *"leaving both would invite consumers to disagree about which one means size."*

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -79,8 +79,13 @@ type SessionMeta struct {
 	Title     string    `json:"title,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 
-	// EntryCount is the number of raw.jsonl entries: user messages, assistant
-	// messages, and every tool call. It is NOT a turn count — one response turn
+	// EntryCount is the number of CONVERSATION entries: user messages, assistant
+	// messages, and every tool call. It counts what the adapter read out of the
+	// agent's own session file, so the type:"header"/type:"footer" records ox
+	// writes into raw.jsonl are NOT included — `wc -l raw.jsonl` runs slightly
+	// ahead of this, and that gap is framing, not loss.
+	//
+	// It is NOT a turn count — one response turn
 	// routinely produces dozens of entries — and it is the authoritative size of
 	// a finished session, which is why finalize clears TurnCount and leaves this
 	// one. A draft is the only state that carries both counters; see ADR-029's

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -74,11 +74,20 @@ type SessionMeta struct {
 	// recording created for the same native coding-agent session.
 	ContinuedFromSessionID string `json:"continued_from_session_id,omitempty"`
 
-	AgentType           string     `json:"agent_type"` // "claude-code", "cursor", etc.
-	Model               string     `json:"model,omitempty"`
-	Title               string     `json:"title,omitempty"`
-	CreatedAt           time.Time  `json:"created_at"`
-	EntryCount          int        `json:"entry_count,omitempty"`
+	AgentType string    `json:"agent_type"` // "claude-code", "cursor", etc.
+	Model     string    `json:"model,omitempty"`
+	Title     string    `json:"title,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+
+	// EntryCount is the number of raw.jsonl entries: user messages, assistant
+	// messages, and every tool call. It is NOT a turn count — one response turn
+	// routinely produces dozens of entries — and it is the authoritative size of
+	// a finished session, which is why finalize clears TurnCount and leaves this
+	// one. A draft is the only state that carries both counters; see ADR-029's
+	// consumer contract for why that pairing is where a reader picks the wrong
+	// "size".
+	EntryCount int `json:"entry_count,omitempty"`
+
 	Summary             string     `json:"summary,omitempty"`
 	StopReason          string     `json:"stop_reason,omitempty"`        // how session ended (session.StopReason* constants)
 	StopDetail          string     `json:"stop_detail,omitempty"`        // human-readable detail (matched message, capped 512B)

--- a/internal/prime/attribution_test.go
+++ b/internal/prime/attribution_test.go
@@ -1,6 +1,7 @@
 package prime
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/sageox/ox/internal/config"
@@ -117,5 +118,33 @@ func TestBuildAttributionTextSection(t *testing.T) {
 				assert.NotContains(t, got, a)
 			}
 		})
+	}
+}
+
+// TestAttributionGuidanceStatesBothHalvesOfThePRContract pins the drift that
+// shipped a PR with the SageOx-Session trailer and no `ox pr header` credit
+// line: the markdown guidance here gained the header directive while the XML
+// renderer's hand-maintained sibling block (cmd/ox/agent_prime_xml.go) did not,
+// and XML is what a Claude Code agent actually reads.
+//
+// A PR body has two attribution ends. The trailer rides session state and is
+// re-emitted on every prime; the header is taught once, in guidance. If only
+// one end is stated, only one end ships — which is exactly what happened.
+func TestAttributionGuidanceStatesBothHalvesOfThePRContract(t *testing.T) {
+	t.Parallel()
+
+	got := WithAttributionGuidance("", true, config.ResolvedAttribution{
+		Commit: "Co-Authored-By: SageOx <ox@sageox.ai>",
+		PR:     "Co-Authored-By: SageOx",
+	})
+
+	for _, want := range []string{
+		"ox pr header",    // the top-of-body half
+		"SageOx-Session:", // the bottom-of-body half
+		"--plan",          // how a saved plan gets linked from the header
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("attribution guidance is missing %q — a PR authored from it can only carry half the contract", want)
+		}
 	}
 }

--- a/internal/prime/reprime.go
+++ b/internal/prime/reprime.go
@@ -19,6 +19,34 @@ func IsForceReprimeSource(source string) bool {
 	return source == "clear" || source == "compact"
 }
 
+// preCompactEventName is Claude Code's compaction hook event. It is a distinct
+// EVENT, not a SessionStart `source` value, which is exactly why it needs its
+// own check — see IsForceReprimeEvent.
+const preCompactEventName = "PreCompact"
+
+// IsForceReprimeEvent is IsForceReprimeSource plus the one signal that field
+// cannot carry: the PreCompact hook.
+//
+// Claude Code fires PreCompact as its own event, and agentx.HookInput documents
+// that `source` is populated "only for session start/end" — so on a PreCompact
+// payload `source` is EMPTY. Reading source alone therefore answers "not a
+// force signal" at the one moment the context window is about to be wiped, and
+// the agent gets the compact delta precisely when it is about to lose
+// everything the full preamble already gave it.
+//
+// That is not theoretical. It is how a PR shipped with the `SageOx-Session:`
+// trailer but no `ox pr header` credit line and no saved plan: the trailer is
+// re-emitted with session state on every prime, while the PR-header guidance
+// and the `ox plan save` teaching live in the static-instructions block the
+// compact delta drops. Half the attribution contract survived compaction; the
+// half that had to be re-read did not.
+//
+// Fails the same direction as its sibling: a redundant full preamble costs a
+// few thousand tokens, a silently dropped directive costs the artifact.
+func IsForceReprimeEvent(hookEventName, source string) bool {
+	return hookEventName == preCompactEventName || IsForceReprimeSource(source)
+}
+
 // ShouldCompactReprime reports whether a prime call should emit the
 // compact re-prime delta (session-state only) instead of the full
 // preamble (static instructions, command reference, team knowledge).
@@ -40,5 +68,13 @@ func IsForceReprimeSource(source string) bool {
 // redundant full preamble is only a wasted few thousand tokens. See bd
 // ox-32f6.
 func ShouldCompactReprime(primeCallCount int, hookSource string) bool {
-	return primeCallCount > 1 && !IsForceReprimeSource(hookSource)
+	return ShouldCompactReprimeForEvent(primeCallCount, "", hookSource)
+}
+
+// ShouldCompactReprimeForEvent is ShouldCompactReprime with the hook EVENT in
+// hand as well as the source field. Prefer it at any call site that has parsed
+// hook stdin; the two-argument form remains for callers that genuinely have
+// only a source (a direct re-invocation with no piped payload).
+func ShouldCompactReprimeForEvent(primeCallCount int, hookEventName, hookSource string) bool {
+	return primeCallCount > 1 && !IsForceReprimeEvent(hookEventName, hookSource)
 }

--- a/internal/prime/reprime_test.go
+++ b/internal/prime/reprime_test.go
@@ -115,3 +115,61 @@ func TestShouldCompactReprime(t *testing.T) {
 		})
 	}
 }
+
+// TestPreCompactForcesFullReprime pins the regression that shipped a PR with a
+// SageOx-Session trailer but no `ox pr header` credit line and no saved plan.
+//
+// Claude Code fires PreCompact as its own event and leaves `source` empty
+// (agentx.HookInput: "Source only for session start/end"). Reading source alone
+// answered "not a force signal" at the exact moment the context window was
+// about to be wiped, so ox emitted the compact delta — which deliberately omits
+// the static-instructions block where the PR-header guidance and the hidden
+// `ox plan save` command are taught. The trailer survived because it rides
+// session state, re-emitted every prime; its top-of-body counterpart did not.
+func TestPreCompactForcesFullReprime(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		primeCalls    int
+		hookEventName string
+		hookSource    string
+		wantCompact   bool
+	}{
+		{"precompact with empty source still forces full", 4, "PreCompact", "", false},
+		{"precompact ignores a stale source value", 4, "PreCompact", "resume", false},
+		{"sessionstart compact forces full", 4, "SessionStart", "compact", false},
+		{"sessionstart clear forces full", 4, "SessionStart", "clear", false},
+		{"first prime is always full", 1, "PreCompact", "", false},
+		// The tier still exists: a redundant same-window re-invocation is the
+		// case it was built for, and must keep getting the delta.
+		{"redundant direct re-invocation stays compact", 4, "", "", true},
+		{"routine sessionstart resume stays compact", 4, "SessionStart", "resume", true},
+		{"userpromptsubmit stays compact", 4, "UserPromptSubmit", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ShouldCompactReprimeForEvent(tc.primeCalls, tc.hookEventName, tc.hookSource)
+			if got != tc.wantCompact {
+				t.Errorf("ShouldCompactReprimeForEvent(%d, %q, %q) = %v, want %v",
+					tc.primeCalls, tc.hookEventName, tc.hookSource, got, tc.wantCompact)
+			}
+		})
+	}
+}
+
+// TestShouldCompactReprimeKeepsTwoArgBehaviour pins the legacy wrapper: a caller
+// with only a source must behave exactly as before.
+func TestShouldCompactReprimeKeepsTwoArgBehaviour(t *testing.T) {
+	t.Parallel()
+
+	if ShouldCompactReprime(4, "compact") {
+		t.Error("source=compact must still force a full preamble")
+	}
+	if !ShouldCompactReprime(4, "resume") {
+		t.Error("source=resume must still take the compact tier")
+	}
+	if ShouldCompactReprime(1, "") {
+		t.Error("a first prime must still be full")
+	}
+}

--- a/internal/skillmanager/manager.go
+++ b/internal/skillmanager/manager.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -178,6 +179,21 @@ func LegacyBundles(repoRoot string, target adapterprotocol.SkillTarget) ([]strin
 		}
 		data, readErr := readNoSymlink(filepath.Join(root, entry.Name(), skills.SkillFileName))
 		if os.IsNotExist(readErr) {
+			continue
+		}
+		// A symlinked or non-regular SKILL.md here belongs to SOMEONE ELSE. This
+		// directory is shared: a repo puts its own skills beside ox's, and some
+		// of them are generated symlinks (the sageox monorepo's agent-parity
+		// mirrors are exactly this). Such a file cannot carry a valid ox stamp,
+		// so it can never be one of ours — skipping it is the correct answer.
+		//
+		// Aborting instead is what made skill rollout silently dead: this loop
+		// exists only to discover which bundles are already installed, and one
+		// foreign symlink returned an error for the WHOLE scan, so `ox doctor`
+		// reported "cannot inspect managed skills" and reconciled nothing. Every
+		// later ox release then failed to reach the repo — which is how a repo
+		// ends up missing ox-pr-header while the guidance points at it.
+		if errors.Is(readErr, ErrNonRegularFile) {
 			continue
 		}
 		if readErr != nil {
@@ -888,7 +904,14 @@ func retiredLegacyFiles(repoRoot string, target adapterprotocol.SkillTarget, des
 		}
 		data, readErr := readRepoFile(repoRoot, path)
 		if readErr != nil {
-			if os.IsNotExist(readErr) {
+			// Same shared-directory reasoning as LegacyBundles: this walks EVERY
+			// skill dir looking for retired ox skills, and a symlinked SKILL.md
+			// belongs to the repo, not to ox. It cannot carry a valid ox stamp, so
+			// it can never be a retirement candidate — skipping it is the answer.
+			// Returning the error instead aborted the entire plan, which is what
+			// made `ox doctor` report "cannot inspect managed skills" and reconcile
+			// nothing for any skill.
+			if os.IsNotExist(readErr) || errors.Is(readErr, ErrNonRegularFile) {
 				continue
 			}
 			return nil, readErr
@@ -915,7 +938,7 @@ func inspectRepoFile(repoRoot, relative string) ([]byte, fs.FileMode, error) {
 		return nil, 0, err
 	}
 	if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return nil, 0, fmt.Errorf("refusing non-regular or symlink skill file %s", path)
+		return nil, 0, fmt.Errorf("%w: %s", ErrNonRegularFile, path)
 	}
 	data, err := os.ReadFile(path)
 	return data, info.Mode(), err
@@ -926,13 +949,22 @@ func readRepoFile(repoRoot, relative string) ([]byte, error) {
 	return data, err
 }
 
+// ErrNonRegularFile marks a path ox declined to read because it is a symlink or
+// otherwise not a regular file. Callers that are INSPECTING A FILE OX MANAGES
+// must treat it as fatal — following a symlink out of the repo is the
+// path-escape this refusal exists to prevent. Callers that are merely SCANNING
+// a shared directory to discover which skills are ox's should skip it: a file
+// ox cannot read is a file ox does not manage, which is an answer, not a
+// failure.
+var ErrNonRegularFile = errors.New("refusing non-regular or symlink file")
+
 func readNoSymlink(path string) ([]byte, error) {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return nil, err
 	}
 	if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("refusing non-regular or symlink file %s", path)
+		return nil, fmt.Errorf("%w: %s", ErrNonRegularFile, path)
 	}
 	return os.ReadFile(path)
 }

--- a/internal/skillmanager/manager_test.go
+++ b/internal/skillmanager/manager_test.go
@@ -351,3 +351,66 @@ func TestSymlinkAndMalformedLockFailWithoutMutation(t *testing.T) {
 	_, err = Plan(symlinkLockRepo, "1.0.0", desiredFor(target), []adapterprotocol.SkillTarget{target})
 	require.ErrorContains(t, err, "symlink")
 }
+
+// TestForeignSymlinkDoesNotAbortSkillDiscovery pins the defect that made ox
+// skill rollout silently dead in any repo that keeps its own skills beside
+// ox's.
+//
+// `.claude/skills/` is SHARED. The sageox monorepo generates agent-parity
+// mirrors there as symlinks, and both whole-directory scans — LegacyBundles
+// (which bundles are installed?) and retiredLegacyFiles (which ox skills should
+// be removed?) — refused to read them and returned the error for the entire
+// scan. `ox doctor` then reported "cannot inspect managed skills" and
+// reconciled nothing, so every later ox release failed to reach the repo. That
+// is how a repo ends up without ox-pr-header while prime tells the agent to
+// "see the ox-pr-header skill".
+//
+// A symlinked SKILL.md cannot carry a valid ox stamp, so it is definitionally
+// not ox's. Skipping it is the correct answer; the hard refusal stays on the
+// write path, where following a symlink is the path-escape this guards.
+func TestForeignSymlinkDoesNotAbortSkillDiscovery(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	root := filepath.Join(repo, ".claude", "skills")
+
+	// One real ox-stamped skill, so discovery has something to find.
+	managed := filepath.Join(root, "ox-plan")
+	if err := os.MkdirAll(managed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("# ox-plan\n")
+	stamped := append([]byte("<!-- ox-hash: "+agentx.ContentHash(body)+" ver: 0.0.1 -->\n"), body...)
+	if err := os.WriteFile(filepath.Join(managed, "SKILL.md"), stamped, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A foreign skill whose SKILL.md is a symlink — the agent-parity shape.
+	foreign := filepath.Join(root, "bdd-compile")
+	if err := os.MkdirAll(foreign, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realFile := filepath.Join(repo, "tests", "bdd", "skills", "bdd-compile", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(realFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(realFile, []byte("# bdd-compile\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realFile, filepath.Join(foreign, "SKILL.md")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	target := adapterprotocol.SkillTarget{
+		Key: "claude", Root: ".claude/skills",
+		Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject,
+		LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+	}
+	bundles, err := LegacyBundles(repo, target)
+	if err != nil {
+		t.Fatalf("LegacyBundles aborted on a foreign symlink: %v", err)
+	}
+	if len(bundles) == 0 {
+		t.Error("discovery skipped the foreign symlink but also lost the real stamped skill beside it")
+	}
+}


### PR DESCRIPTION
## Summary

**Every AI coworker that runs `ox agent prime` has been receiving an ill-formed XML document, and this fixes it.** Placeholders like `<topic>`, `<slug>` and `<dr.md>` were written into the prime output raw, so each one opened an element that never closed. Any consumer that parses the output — rather than treating it as loose text — hits a syntax error partway through and loses everything after it.

This is **pre-existing on `main`**, not introduced here. It surfaced because a review flagged one new instance of the same mistake, and the gate added to prove that fix found the rest.

The PR also carries three smaller correctness fixes and the session-draft documentation it was originally opened for.

## What broke

`cmd/ox/agent_prime_xml.go` writes guidance text into `<ox-prime>`. Most lines already escape their placeholders — `ox code defs &lt;name&gt;`, the session-score line — but several did not:

```mermaid
flowchart LR
    T["capability table<br/>--file &lt;dr.md&gt;"] --> W["Fprintf, unescaped"]
    W --> D["&lt;ox-prime&gt; document"]
    L["guidance literals<br/>&quot;&lt;topic&gt;&quot; · &quot;&lt;slug&gt;&quot; · &quot;&lt;details&gt;&quot;"] --> D
    D --> P{"XML parse"}
    P -->|"before"| E["syntax error at line 29<br/>rest of document lost ❌"]
    P -->|"after"| OK["parses clean ✅"]
```

- **A whole class, at three writers.** The `<consult-first>` rows, the `<commands>` table and the `<team-commands>` table are all *data* — from `prime.OxCapabilities()`, from guidance, and from team-authored config — and all three were `fmt.Fprintf`'d straight into the document. Guidance data legitimately contains placeholders like `--file <dr.md>` and `ox query "<your question>"`. All three now escape, so no future row can break the document, and the team-authored table (the least trustworthy input on this path) is covered too.
- **Ten placeholder instances in guidance literals**, including one inside an attribute value (`<team-rules hint="agents/rules/<topic>.md">`), where a raw `<` is invalid XML rather than merely mis-nested.
- **The instance from review** — `<pln_id>` and `<plan>` in the PR-header directive. Correctly flagged; it was new, but it landed in a document that was already broken.

### Escaping is text-only, and that is the interesting decision

`escapeXML` escapes `&`, `<`, `>`, `"` and `'` — correct for **attribute values**, wrong for element content, where quotes are legal. Using it here cost roughly twice the tokens and turned readable guidance into `ox query &quot;&lt;q&gt;&quot;` for the agent that has to read it.

So this adds `escapeXMLText` (`&`, `<`, `>` only) alongside it, with each documented for its context. Measured difference: the minimal-prime floor lands at **2209 tokens, +19** over the old ceiling, instead of the +34 full escaping cost.

### Token ceilings raised deliberately

This repo guards prime size with regression tests, and their own failure text says to raise the ceiling and explain. Both are raised with the measured numbers:

| Gate | Was | Measured now | New ceiling |
|---|---|---|---|
| Full-prime SageOx budget | 3600 | **3653** | 3700 |
| Minimal-prime SageOx overhead floor | 2190 | **2209** | 2250 |

Headroom is ~47 and ~41, matching the buffer previous raises kept. That is the honest price of a parseable document; it is not free, and the comments say so.

Structural elements (`<attribution>`, `<team-rules>`, `<context-budget>`, and 29 others) are untouched — only non-element placeholders were escaped.

## The gate

`TestOutputAgentPrimeXML_IsWellFormed` **parses** the emitted document instead of grepping it for substrings. That distinction is the whole point: every existing assertion here is `strings.Contains`-shaped, and a placeholder that silently opens a tag is invisible to all of them.

Three shapes, because the branches differ: minimal, PR-only attribution, and PR + commit attribution. The reported bug lives behind an attribution gate that a bare prime never reaches, so the minimal case alone would not have caught it.

**Written before the fix and watched fail.** It failed on all three shapes at `element <dr.md> closed by </consult-first>` — a *different* defect than the one under review, on the always-emitted path. Each subsequent fix moved the failure to the next instance until the document parsed clean.

## Also in this PR

- **`fix(prime)`: `PreCompact` now forces a full re-prime.** `agentx.HookInput` populates `Source` only for session start/end, so a `PreCompact` payload carries an empty `Source` and the compact-vs-full decision could not be made from it. The agent received the compact delta at exactly the moment its context window was about to be wiped. Concretely: a PR shipped with the `SageOx-Session:` trailer but no `ox pr header` credit and no saved plan — the trailer is re-sent every prime, while the guidance that had to be re-read lived in the block the delta drops.
- **`fix(prime)`: the PR-header directive is gated on attribution being configured**, so it fits the minimal-prime token ceiling — a repo that credits nothing has no use for a credit line.
- **`fix(skills)`: a foreign symlink no longer aborts skill discovery.** One unreadable entry used to fail the whole scan.
- **`docs(session)`: the draft consumer contract.** ADR-029 predicted this bug class — *"Without it a draft reads as `StatusUploaded`: live recordings render as finished"* — and fixed it for CLI consumers only. The server reads the same `meta.json` and never got the rule, so the identical failure reappeared on the web: a live draft rendered as a finished session with an empty transcript. The ADR now states the contract for consumers outside this repo, in wire terms they can actually act on (inspect the JSON `draft` field; absent or `false` means not-a-draft), plus the two counter rules — `turn_count` is a 10-turn liveness pulse, not a count, and `entry_count` is not a turn count. `EntryCount` also gained the doc comment it never had, sitting directly beside a 12-line warning on `TurnCount` about exactly this confusion.

## Test Plan

Two independent red-first proofs, both restored green:

| Break | Failure |
|---|---|
| Revert only the reported `<pln_id>` escape | `element <pln_id> closed by </attribution>` — on exactly the two attribution-gated shapes, and not the minimal one |
| Revert the class fix at the consult-first writer | document fails to parse again |

- The gate was **written before any fix** and failed on all four shapes at `element <dr.md> closed by </consult-first>` — a different defect on the always-emitted path than the one under review. Each fix moved the failure to the next instance until it parsed clean.
- Four shapes covered: minimal, PR-only attribution, PR + commit attribution, and fully-loaded. The last is not decoration — it is the only one that renders the two command tables, and it is what caught `ox query "<your question>"`.
- `./cmd/ox`, `./internal/prime`, `./internal/lfs`, `./internal/skillmanager` pass; `gofmt` clean; no double-escaping (`&amp;lt;`) introduced.

Two existing assertions changed, deliberately: the required-directive markers stay **raw** (they are matched against the capability table by `TestRequiredFullPrimeDirectives_ConsultFirstReachable`), so the output-side checks now escape the marker before searching rather than weakening either side to a substring that survives both forms.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — `TestOutputAgentPrimeXML_IsWellFormed`, red-first
- [x] CHANGELOG entry added (if user-facing) — N/A: no command surface or flag changes
- [x] Breaking change documented — none; consumers that tolerated the malformed text still parse the corrected document
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: no auth, IPC, secret-handling, or dependency paths touched

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prime guidance now consistently produces well-formed XML, including dynamic text and placeholders.
  - Pre-compaction events now trigger a complete refresh of guidance instead of a compact refresh.
  - Skill discovery continues when it encounters unsupported links or file types, while unsafe direct file access remains blocked.

- **Documentation**
  - Clarified how draft status is identified by external API consumers.
  - Clarified that session entry counts exclude metadata records and should not be compared with raw log line counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->