### PR TITLE
docs(adr): mark ADR-031 accepted

### DIFF
--- a/docs/adr/ADR-031-cli-skill-rule-inventory.md
+++ b/docs/adr/ADR-031-cli-skill-rule-inventory.md
@@ -1,6 +1,6 @@
 # ADR-031 — The ox CLI skill & rule inventory: reserved namespaces, gitignored materialization
 
-**Status:** Draft (Proposed) — awaiting Ryan's review as path-location and data-ergonomics owner. Two decisions in this ADR trip the `CLAUDE.md` Required-Review gate ("Path locations", "Data access ergonomics"), and one of them has ox writing a commit into a customer's repository. Implementation has landed behind these decisions so the review has running code to judge; it flips to Accepted on approval.
+**Status:** Accepted — approved by Ryan Snodgrass on 2026-09-07 as path-location and data-ergonomics owner. Both gated decisions were ruled on explicitly: **(8)** ox may write the single untrack commit at `FixLevelAuto`, and **(5)** the scoped ox-owned `.gitignore` files are the right home for the ignore rules.
 
 **Date:** 2026-09-07 · **Supersedes:** nothing · **Amends:** ADR-023 (two-layer skill injection), `docs/specs/skill-management.md`
 


### PR DESCRIPTION
ADR-031 no longer blocks the skill-inventory work — the two decisions that needed a human ruling have one, so the ADR matches what already shipped in #882.

## What was decided

- **(8) The one commit ox writes** — approved at `FixLevelAuto`. `ox doctor --fix` may write the single untrack commit into a customer's repository. Ignoring a file does nothing while git still tracks it, and there is no way to untrack without a commit.
- **(5) Scoped ox-owned ignore files** — approved. `.claude/.gitignore`, `.agents/.gitignore`, `.factory/.gitignore`, written as a marked block, only into directories that already exist.

Both were already implemented and running on `main`; the implementation landed behind the decisions deliberately so the review had running code to judge. This PR only flips the status line.

## Why these two needed a ruling

They trip the `CLAUDE.md` Required-Review gate — "Path locations" and "Data access ergonomics" — and one of them has ox writing into a customer's git history.

The alternatives were considered and rejected on the record:

- **Confirm-gating the migration.** A migration a human has to opt into is one that never happens: five orphaned command files survived multiple releases for exactly that reason.
- **`.git/info/exclude` instead of scoped files.** Machine-local and never committed, so a teammate's fresh clone has no rule until ox runs there — precisely the window in which vendor files get committed by accident.

## Test plan

Documentation only; no code change. `make lint` clean.

Closes the `[HUMAN]` gate tracked as `ox-v4cc.22`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791418238&installation_model_id=433550&pr_number=883&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F883&signature=1fd9daed416262eb1fa2c876de7b9bb6e249f5cfc2c393eae1b1717606fc90d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Accepted ADR-031, documenting decisions for automatic fixes and scoped ignore-rule storage.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->