### PR TITLE
fix(daemon): report sync health and preserve data during repair

### DIFF
--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -845,12 +845,9 @@ func openOrCreateBleveIndex(root, path, name string) (bleve.Index, error) {
 		return nil, fmt.Errorf("stat bleve bolt file %s: %w", boltPath, statErr)
 	}
 
-	// bolt file absent or path structure broken — nuke and recreate
-	slog.Error("bleve index corrupt, recreating", "path", path, "err", err)
-	if removeErr := os.RemoveAll(path); removeErr != nil {
-		return nil, fmt.Errorf("remove corrupt bleve index %s: %w", path, removeErr)
-	}
-	return createBleveSubIndex(path, name)
+	// A healer may be recreating this directory. Recheck under its lock before
+	// treating absent metadata or a broken store path as our own repair.
+	return selfHealBleveSubIndex(root, path, name, err)
 }
 
 // selfHealBleveSubIndex recovers from proven mapping/snapshot corruption by
@@ -865,11 +862,8 @@ func openOrCreateBleveIndex(root, path, name string) (bleve.Index, error) {
 // opens cleanly is an acceptable replacement (the healed index is empty and
 // carries the current mapping version).
 //
-// The marker is best-effort: if the marker write fails (disk full, permission
-// denied) the function still returns the empty index — the daemon will see
-// the empty bleve on its next freshness check via different signals (empty
-// search results) but the explicit signal is preferred. Marker failure is
-// logged at warn level.
+// The reindex marker is written before removal so interrupted/failed recreation
+// cannot lose the rebuild signal. If it cannot be written, keep the old index.
 func selfHealBleveSubIndex(root, path, name string, openErr error) (bleve.Index, error) {
 	return rebuildSubIndexLocked(root, path, name, false, openErr)
 }
@@ -981,7 +975,7 @@ func acquireSubIndexHealLock(path string) (*flock.Flock, bool, error) {
 func reclassifyUnderLock(path, name string, requireVersion bool) (bleve.Index, healVerdict) {
 	boltPath := filepath.Join(path, "store", "root.bolt")
 	if _, statErr := os.Stat(boltPath); statErr != nil {
-		if errors.Is(statErr, os.ErrNotExist) {
+		if errors.Is(statErr, os.ErrNotExist) || errors.Is(statErr, syscall.ENOTDIR) {
 			// bolt genuinely absent / path structure broken → needs a (re)build.
 			return nil, healNuke
 		}
@@ -1082,8 +1076,8 @@ func boundedAdoptOpen(path string, timeout time.Duration) (bleve.Index, error) {
 //   - healAdopt → return the replacement the winner created; never nuke it.
 //   - healDefer → return the pre-existing retryable "lock contention" error; a
 //     healthy index is being held open, not corrupt.
-//   - healNuke  → we hold the lock and it is still corrupt/stale: RemoveAll +
-//     recreate empty + write the .needs_reindex marker.
+//   - healNuke  → we hold the lock and it is still corrupt/stale: write the
+//     .needs_reindex marker, then RemoveAll + recreate empty.
 //
 // A destructive rebuild (RemoveAll + recreate) runs ONLY while the heal lock is
 // held. When the lock cannot be acquired — for EITHER reason — we never nuke,
@@ -1122,8 +1116,8 @@ func rebuildSubIndexLocked(root, path, name string, requireVersion bool, openErr
 // applyRebuildVerdict reclassifies the sub-index and acts on the verdict:
 // adopt a concurrent repair, defer to a live writer, or nuke+recreate+marker a
 // still-corrupt/stale index. Callers MUST hold the heal lock — the healNuke path
-// does a destructive RemoveAll, which is safe to run only under cross-process
-// serialization (see rebuildSubIndexLocked; the no-lock paths never reach here).
+// first records the reindex marker, then does a destructive RemoveAll under
+// cross-process serialization (the no-lock paths never reach here).
 func applyRebuildVerdict(root, path, name string, requireVersion bool, openErrForLog error) (bleve.Index, error) {
 	idx, verdict := reclassifyUnderLock(path, name, requireVersion)
 	switch verdict {
@@ -1139,6 +1133,9 @@ func applyRebuildVerdict(root, path, name string, requireVersion bool, openErrFo
 
 	// healNuke: the index is still provably corrupt/stale. The specific trigger
 	// (parse error vs stale mapping version) is in open_err.
+	if markerErr := WriteNeedsReindexMarker(root, name); markerErr != nil {
+		return nil, fmt.Errorf("write reindex marker before rebuilding bleve sub-index %s: %w", name, markerErr)
+	}
 	slog.Warn("bleve sub-index rebuild (nuke + recreate)",
 		"name", name, "path", path, "open_err", openErrForLog)
 	if removeErr := os.RemoveAll(path); removeErr != nil {
@@ -1147,10 +1144,6 @@ func applyRebuildVerdict(root, path, name string, requireVersion bool, openErrFo
 	newIdx, err := createBleveSubIndex(path, name)
 	if err != nil {
 		return nil, fmt.Errorf("recreate empty bleve sub-index %s: %w", path, err)
-	}
-	if markerErr := WriteNeedsReindexMarker(root, name); markerErr != nil {
-		slog.Warn("failed to write needs_reindex marker; daemon may not auto-rebuild",
-			"name", name, "root", root, "err", markerErr)
 	}
 	subIndexRebuildActionHook("nuke")
 	return newIdx, nil

--- a/internal/codedb/store/store_selfheal_concurrent_test.go
+++ b/internal/codedb/store/store_selfheal_concurrent_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blevesearch/bleve/v2"
 	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
@@ -73,6 +74,7 @@ func runSelfHealHelper(root, path, name string) int {
 			return 0
 		}
 		lastErr = err
+		fmt.Fprintf(os.Stderr, "open attempt %d failed: %v\n", attempt, err)
 		time.Sleep(15 * time.Millisecond)
 	}
 	fmt.Fprintf(os.Stderr, "helper never obtained a working index: %v\n", lastErr)
@@ -365,10 +367,109 @@ func TestConcurrentSelfHeal_MultiProcess(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), n)
 	require.True(t, HasNeedsReindexMarker(tmp, "code"),
-		"at least one process must have marked the sub-index for reindex")
+		"at least one process must have marked the sub-index for reindex; process output: %q", outs)
 }
 
 // --- D. Lock unavailable: never nuke racily, recover on retry ---
+
+// A missing-metadata opener must recheck under the heal lock before replacing
+// an index that a competing healer finished in the meantime.
+func TestSelfHeal_MissingMetadataPreservesConcurrentReplacement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + filesystem operations")
+	}
+	for _, heldOpen := range []bool{false, true} {
+		t.Run(fmt.Sprintf("winner_held_open=%t", heldOpen), func(t *testing.T) {
+			installFastCorruptionProbes(t)
+			root := t.TempDir()
+			indexPath := filepath.Join(root, "test-index")
+			require.NoError(t, os.Mkdir(indexPath, 0o700)) // healer's partially recreated directory
+			var winner bleve.Index
+			origHook := subIndexHealLockAcquiredHook
+			t.Cleanup(func() {
+				subIndexHealLockAcquiredHook = origHook
+				if winner != nil {
+					_ = winner.Close()
+				}
+			})
+			hookRan := false
+			subIndexHealLockAcquiredHook = func(string) {
+				hookRan = true
+				// Complete the competing repair before this opener reclassifies.
+				require.NoError(t, os.RemoveAll(indexPath))
+				var err error
+				winner, err = createBleveSubIndex(indexPath, "code")
+				require.NoError(t, err)
+				require.NoError(t, winner.Index("survivor", map[string]string{"content": "keep"}))
+				if !heldOpen {
+					require.NoError(t, winner.Close())
+					winner = nil
+				}
+			}
+			idx, err := openOrCreateBleveIndex(root, indexPath, "code")
+			if idx != nil {
+				defer func() { _ = idx.Close() }()
+			}
+			require.True(t, hookRan, "missing-metadata recovery must acquire the shared heal lock")
+			if heldOpen {
+				require.ErrorContains(t, err, "lock contention")
+				require.Nil(t, idx)
+				idx = winner
+			} else {
+				require.NoError(t, err)
+			}
+			count, err := idx.DocCount()
+			require.NoError(t, err)
+			require.Equal(t, uint64(1), count, "loser must preserve the competing replacement's content")
+			require.False(t, HasNeedsReindexMarker(root, "code"), "adopting or deferring must not rebuild")
+		})
+	}
+}
+
+// A broken store path still needs a locked rebuild, including ENOTDIR.
+func TestSelfHeal_BrokenStoreStructure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + filesystem operations")
+	}
+	root := t.TempDir()
+	indexPath := filepath.Join(root, "test-index")
+	idx, err := createBleveSubIndex(indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, idx.Close())
+	storePath := filepath.Join(indexPath, "store")
+	require.NoError(t, os.RemoveAll(storePath))
+	require.NoError(t, os.WriteFile(storePath, []byte("broken layout"), 0o600))
+	idx, err = openOrCreateBleveIndex(root, indexPath, "code")
+	require.NoError(t, err)
+	defer func() { _ = idx.Close() }()
+	require.True(t, HasNeedsReindexMarker(root, "code"))
+}
+
+// Refuse destructive repair when its durable reindex signal cannot be written.
+func TestSelfHeal_MarkerFailurePreservesCorruptIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + filesystem operations")
+	}
+	root := t.TempDir()
+	indexPath := filepath.Join(root, "test-index")
+	idx, err := createBleveSubIndex(indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, idx.Close())
+	boltPath := filepath.Join(indexPath, "store", "root.bolt")
+	emptyMappingForLatestSnapshot(t, boltPath)
+	before, err := os.ReadFile(boltPath)
+	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(NeedsReindexMarkerPath(root, "code"), 0o700))
+	idx, err = rebuildSubIndexLocked(root, indexPath, "code", false, errors.New("corrupt mapping"))
+	if idx != nil {
+		defer func() { _ = idx.Close() }()
+	}
+	require.ErrorContains(t, err, "reindex marker")
+	require.Nil(t, idx)
+	after, err := os.ReadFile(boltPath)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "marker failure must leave the existing index unchanged")
+}
 
 // TestSelfHeal_LockTimeout_DefersThenRecovers proves the safety valve: when the
 // heal lock cannot be acquired (a live healer holds it), a corrupt-index open

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -1192,6 +1192,8 @@ func TestSelfHealBleveSubIndex_RecreateFailure_ReturnsError(t *testing.T) {
 	emptyMappingForLatestSnapshot(t, boltPath)
 
 	bleveParent := filepath.Join(tmp, "bleve")
+	// Let the repair acquire its lock before failing in the destructive step.
+	require.NoError(t, os.WriteFile(subIndexHealLockPath(filepath.Join(bleveParent, "comment")), nil, 0o600))
 	require.NoError(t, os.Chmod(bleveParent, 0o500), "make bleve parent read-only")
 	t.Cleanup(func() { _ = os.Chmod(bleveParent, 0o700) })
 
@@ -1200,6 +1202,8 @@ func TestSelfHealBleveSubIndex_RecreateFailure_ReturnsError(t *testing.T) {
 	require.Nil(t, idx, "must not return nil index alongside error")
 	require.Contains(t, err.Error(), "bleve sub-index",
 		"error must identify the failing operation, not bubble up a raw EACCES")
+	require.True(t, HasNeedsReindexMarker(tmp, "comment"),
+		"failed destructive repair must retain the signal needed to repopulate the index")
 }
 
 // TestInsights_NeverEmitsCrypticBleveError is the negative regression for

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1549,6 +1549,13 @@ func (s *daemonServiceImpl) Status() *StatusData {
 	if registry := s.d.scheduler.WorkspaceRegistry(); registry != nil {
 		projectTeamID = registry.ProjectTeamID()
 		for _, ws := range registry.GetAllWorkspaces() {
+			// A different daemon may own global sync; its cache is fresher
+			// than this project's config. Only update the status snapshot.
+			if ws.Type == WorkspaceTypeTeamContext {
+				if state := LoadSyncState(ws.Path); state.LastSync.After(ws.ConfigLastSync) {
+					ws.ConfigLastSync = state.LastSync
+				}
+			}
 			wsType := string(ws.Type)
 			// normalize type to match API convention (team_context -> team-context)
 			if wsType == "team_context" {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -4,12 +4,87 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// A follower must observe successful syncs by the shared owner without rewriting
+// config or the owner's cache, including after an upgrade with no usable cache.
+func TestDaemonStatus_SharedTeamContextSync(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("OX_XDG_DISABLE", "")
+	t.Setenv("SAGEOX_ENDPOINT", "https://status.test.invalid")
+	older := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	newer := older.Add(30 * time.Minute)
+	cases := []struct {
+		name       string
+		configSync time.Time
+		sharedSync time.Time
+		corrupt    bool
+		want       time.Time
+	}{
+		{name: "never synced"},
+		{name: "missing cache", configSync: older, want: older},
+		{name: "corrupt cache", configSync: older, corrupt: true, want: older},
+		{name: "shared owner synced", sharedSync: newer, want: newer},
+		{name: "shared cache newer", configSync: older, sharedSync: newer, want: newer},
+		{name: "config newer", configSync: newer, sharedSync: older, want: newer},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.ProjectRoot = t.TempDir()
+			d := New(cfg, nil)
+			d.scheduler = NewSyncScheduler(cfg, d.logger)
+			d.scheduler.SetGlobalSyncLease("", nil)
+			teamPath := t.TempDir()
+			ws := &WorkspaceState{
+				ID: "team_1", Type: WorkspaceTypeTeamContext, Path: teamPath,
+				TeamID: "team_1", TeamName: "Test Team", Exists: true,
+				ConfigLastSync: tc.configSync, LastErr: "local sync failed",
+			}
+			d.scheduler.WorkspaceRegistry().workspaces[ws.ID] = ws
+			statePath := filepath.Join(teamPath, ".sageox", "cache", "sync-state.json")
+			if !tc.sharedSync.IsZero() {
+				require.NoError(t, SaveSyncState(teamPath, &SyncState{LastSync: tc.sharedSync}))
+			}
+			if tc.corrupt {
+				require.NoError(t, os.MkdirAll(filepath.Dir(statePath), 0755))
+				require.NoError(t, os.WriteFile(statePath, []byte("{incomplete"), 0600))
+			}
+			before, beforeErr := os.ReadFile(statePath)
+			svc := &daemonServiceImpl{d: d}
+			status := svc.Status()
+			require.False(t, status.GlobalSyncOwner)
+			require.Len(t, status.Workspaces["team-context"], 1)
+			require.Len(t, status.TeamContexts, 1)
+			assert.Equal(t, tc.want, status.Workspaces["team-context"][0].LastSync)
+			assert.Equal(t, tc.want, status.TeamContexts[0].LastSync)
+			assert.Equal(t, ws.LastErr, status.Workspaces["team-context"][0].LastErr)
+			assert.Equal(t, ws.LastErr, status.TeamContexts[0].LastErr)
+			assert.Equal(t, tc.configSync, ws.ConfigLastSync, "status must not mutate registry state")
+			after, afterErr := os.ReadFile(statePath)
+			assert.Equal(t, before, after, "status must not rewrite shared sync state")
+			if os.IsNotExist(beforeErr) {
+				assert.True(t, os.IsNotExist(afterErr), "status must not create shared sync state")
+			} else {
+				require.NoError(t, afterErr)
+			}
+
+			// The owner updates the shared cache while this follower keeps running.
+			advanced := newer.Add(time.Minute)
+			require.NoError(t, SaveSyncState(teamPath, &SyncState{LastSync: advanced}))
+			status = svc.Status()
+			assert.Equal(t, advanced, status.Workspaces["team-context"][0].LastSync)
+			assert.Equal(t, advanced, status.TeamContexts[0].LastSync)
+			assert.Equal(t, tc.configSync, ws.ConfigLastSync)
+		})
+	}
+}
 
 func TestNew(t *testing.T) {
 	t.Run("with nil config uses defaults", func(t *testing.T) {

--- a/internal/daemon/ipc_status_test.go
+++ b/internal/daemon/ipc_status_test.go
@@ -175,29 +175,27 @@ func TestServer_StatusHandler_NeverBlocks(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	go server.Start(ctx)
-	time.Sleep(100 * time.Millisecond)
+	stop := startRecoveryTestServer(t, server)
+	defer stop()
 
 	// send 100 concurrent status requests
 	const numRequests = 100
-	done := make(chan struct{}, numRequests)
+	done := make(chan error, numRequests)
 
 	overallStart := time.Now()
 	for i := 0; i < numRequests; i++ {
 		go func() {
-			defer func() { done <- struct{}{} }()
 			client := &Client{socketPath: SocketPath(), timeout: 5 * time.Second}
-			_, _ = client.Status()
+			_, err := client.Status()
+			done <- err
 		}()
 	}
 
 	// wait for all to complete
 	for i := 0; i < numRequests; i++ {
 		select {
-		case <-done:
+		case err := <-done:
+			require.NoError(t, err, "status request failed")
 		case <-time.After(5 * time.Second):
 			t.Fatalf("status request %d timed out after 5s", i)
 		}

--- a/internal/daemon/status_display.go
+++ b/internal/daemon/status_display.go
@@ -1044,8 +1044,8 @@ func formatSyncHistory(history []SyncEvent) string {
 
 // determineHealth calculates overall health status.
 func determineHealth(status *StatusData) HealthStatus {
-	// critical: many recent errors or sync very stale
-	if status.RecentErrorCount >= 5 {
+	// Critical issues must take precedence over sync or issue warnings.
+	if status.RecentErrorCount >= 5 || MaxIssueSeverity(status.Issues) == SeverityCritical {
 		return HealthCritical
 	}
 
@@ -1059,8 +1059,8 @@ func determineHealth(status *StatusData) HealthStatus {
 		}
 	}
 
-	// warning: some errors
-	if status.RecentErrorCount > 0 {
+	// A successful sync does not clear outstanding integrity or repair issues.
+	if status.RecentErrorCount > 0 || status.NeedsHelp || len(status.Issues) > 0 {
 		return HealthWarning
 	}
 

--- a/internal/daemon/status_display_test.go
+++ b/internal/daemon/status_display_test.go
@@ -237,6 +237,36 @@ func TestDetermineHealth(t *testing.T) {
 			&StatusData{Running: true, RecentErrorCount: 10},
 			HealthCritical,
 		},
+		{
+			"warning - active integrity issue despite successful sync",
+			&StatusData{LastSync: time.Now(), SyncIntervalRead: time.Minute, Issues: []DaemonIssue{{Severity: SeverityWarning}}},
+			HealthWarning,
+		},
+		{
+			"warning - blocking issue",
+			&StatusData{Issues: []DaemonIssue{{Severity: SeverityError}}},
+			HealthWarning,
+		},
+		{
+			"critical - highest issue severity wins",
+			&StatusData{Issues: []DaemonIssue{{Severity: SeverityWarning}, {Severity: SeverityCritical}, {Severity: SeverityError}}},
+			HealthCritical,
+		},
+		{
+			"critical - issue takes precedence over stale sync warning",
+			&StatusData{LastSync: time.Now().Add(-time.Hour), SyncIntervalRead: time.Minute, Issues: []DaemonIssue{{Severity: SeverityCritical}}},
+			HealthCritical,
+		},
+		{
+			"critical - sync errors take precedence over issue warning",
+			&StatusData{RecentErrorCount: 5, Issues: []DaemonIssue{{Severity: SeverityWarning}}},
+			HealthCritical,
+		},
+		{
+			"warning - needs help without issue details",
+			&StatusData{NeedsHelp: true},
+			HealthWarning,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/daemon/sync_bubbles_scale_test.go
+++ b/internal/daemon/sync_bubbles_scale_test.go
@@ -3,12 +3,17 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/stretchr/testify/require"
 )
 
 // --- Scale tests for KB sync ---
@@ -93,10 +98,10 @@ func TestKBSync_NoFDLeak_AtScale(t *testing.T) {
 		numKBs, firstPass, secondPass, delta, baseline, final)
 }
 
-// TestKBSync_SecondPass_IsFastAndIdempotent verifies that a second
-// reconcile pass over already-cloned KBs is substantially cheaper than the
-// initial clone pass. A linear-in-N regression on the steady-state path
-// would make every sync cycle as expensive as the cold-start.
+// TestKBSync_SecondPass_IsFastAndIdempotent verifies that a second reconcile
+// preserves existing clones and skips fetches. Timing remains diagnostic:
+// the steady path still checks remote refs and reapplies sparse checkout,
+// so its wall-time ratio to cloning varies with subprocess scheduling.
 //
 // Failure prevented: a user with N>>1 KBs has their daemon spend
 // significant wall time on each sync tick, blocking the team-context
@@ -131,38 +136,31 @@ func TestKBSync_SecondPass_IsFastAndIdempotent(t *testing.T) {
 	s.syncBubbles(context.Background())
 	clonePass := time.Since(start)
 
-	// Second pass: every KB already cloned, FETCH_HEAD recent enough that
-	// the daemon should skip the network entirely.
+	// Snapshot the actual fetch state and add a local marker that a re-clone
+	// would lose. This tests the work avoided without inferring it from timing.
+	fetchTimes := make(map[string]time.Time, numKBs)
+	for _, b := range bubbles {
+		target := paths.KBDir(endpoint.Get(), b.KBID)
+		require.NoError(t, os.WriteFile(filepath.Join(target, ".git", "steady-pass-sentinel"), []byte("keep"), 0o600))
+		info, err := os.Stat(filepath.Join(target, ".git", "FETCH_HEAD"))
+		require.NoError(t, err)
+		fetchTimes[target] = info.ModTime()
+	}
+
+	// Second pass: remote-ref checks are expected, but no clone or fetch.
 	start = time.Now()
 	s.syncBubbles(context.Background())
 	steadyPass := time.Since(start)
 
 	t.Logf("KB sync timing at N=%d: clone=%v, steady=%v", numKBs, clonePass, steadyPass)
 
-	// On very fast runners, both passes can finish under tens of
-	// milliseconds and the ratio is dominated by scheduler/GC noise
-	// instead of the actual work. Skip the strict gate in that regime —
-	// a real re-clone-every-tick regression would push clonePass into
-	// the hundreds-of-ms range, well above the floor.
-	const minCloneForRatioCheck = 300 * time.Millisecond
-	if clonePass < minCloneForRatioCheck {
-		t.Logf("clone pass under %v (got %v) — skipping ratio assertion to avoid CI flake",
-			minCloneForRatioCheck, clonePass)
-		return
-	}
-
-	// Steady-state must be at least 2x cheaper than the clone pass. The
-	// real reduction is bigger (typically 4-5x: clone runs git clone +
-	// initial checkout per repo, steady runs an fstat dedup + cheap
-	// FETCH_HEAD check), but a 2x ratio is enough to catch a
-	// re-clone-on-every-tick regression while leaving slack for CI noise
-	// and the per-KB constant work that genuinely happens on steady-state
-	// (fstat, manifest read, registry update). If the ratio collapses to
-	// ~1x, the daemon is paying the clone cost on every sync.
-	if steadyPass*2 > clonePass {
-		t.Errorf("steady-state pass (%v) not measurably cheaper than clone pass (%v) at N=%d — "+
-			"suspect re-clone-every-tick or per-KB network call on steady path",
-			steadyPass, clonePass, numKBs)
+	for target, before := range fetchTimes {
+		marker, err := os.ReadFile(filepath.Join(target, ".git", "steady-pass-sentinel"))
+		require.NoError(t, err, "steady pass must preserve existing clone %s", target)
+		require.Equal(t, "keep", string(marker))
+		info, err := os.Stat(filepath.Join(target, ".git", "FETCH_HEAD"))
+		require.NoError(t, err)
+		require.Equal(t, before, info.ModTime(), "steady pass must not fetch %s", target)
 	}
 
 	// And the API should be called exactly twice — once per syncBubbles

--- a/internal/daemon/twin_clone_test.go
+++ b/internal/daemon/twin_clone_test.go
@@ -91,7 +91,7 @@ func TestTwoPhaseClone_BasicTeamContext(t *testing.T) {
 	require.Contains(t, result.ManifestConfig.Denies, "secrets/")
 
 	// sparse paths include expected entries
-	require.Contains(t, result.SparsePaths, ".sageox/")
+	require.Contains(t, result.SparsePaths, "/.sageox/")
 }
 
 // --- B. Unshallow enables pull --rebase ---

--- a/internal/daemon/workspace_registry.go
+++ b/internal/daemon/workspace_registry.go
@@ -694,13 +694,15 @@ func (r *WorkspaceRegistry) GetLedgerPath() string {
 // GetTeamContextStatus returns team context status in the legacy format.
 // This provides backward compatibility with existing status display code.
 func (r *WorkspaceRegistry) GetTeamContextStatus() []TeamContextSyncStatus {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
 	var result []TeamContextSyncStatus
-	for _, ws := range r.workspaces {
+	for _, ws := range r.GetAllWorkspaces() {
 		if ws.Type != WorkspaceTypeTeamContext {
 			continue
+		}
+		// Read the shared owner's progress without changing registry/config
+		// state or holding the registry lock during disk reads.
+		if state := LoadSyncState(ws.Path); state.LastSync.After(ws.ConfigLastSync) {
+			ws.ConfigLastSync = state.LastSync
 		}
 		result = append(result, TeamContextSyncStatus{
 			TeamID:   ws.TeamID,

--- a/internal/doctor/autofix/default_checks.go
+++ b/internal/doctor/autofix/default_checks.go
@@ -374,8 +374,12 @@ func repairLedgerSessionTitles(sessionsDir, repoPath string) CheckResult {
 		return CheckResult{Status: StatusClean, Repo: repoPath}
 	}
 	if recovered > 0 || flipped > 0 {
+		status := StatusFixed
+		if errored > 0 {
+			status = StatusFound // partial progress must not clear unresolved errors
+		}
 		return CheckResult{
-			Status:  StatusFixed,
+			Status:  status,
 			Repo:    repoPath,
 			Summary: fmt.Sprintf("session meta titles: recovered=%d flipped_terminal=%d bumped=%d errored=%d", recovered, flipped, bumped, errored),
 		}

--- a/internal/doctor/autofix/sacred_deletion.go
+++ b/internal/doctor/autofix/sacred_deletion.go
@@ -31,8 +31,9 @@ const commitMarker = "\x1e"
 // files under a sacred prefix.
 //
 // DETECTION ONLY — it never restores. Per ADR-024 sacred-data deletion needs
-// explicit human approval, and the content is always recoverable from history,
-// so a hit is surfaced as StatusFound and alerted for a human to recover. This
+// explicit human approval, so a hit is surfaced as StatusFound for review.
+// A file-count threshold cannot establish intent: even one intentionally
+// removed plan/session may contain enough artifacts to trigger it. This
 // is the belt to the commit-time guard's suspenders: it fires even when the
 // guard never ran (old binary) or was bypassed (force-push).
 func checkLedgerSacredDeletion(ctx context.Context, repoPath string) CheckResult {
@@ -111,8 +112,8 @@ func scanLedgerSacredDeletions(ctx context.Context, ledgerPath, repoPath string)
 			sample = append(sample, fmt.Sprintf("%s(%d)", shortSHA(h.commit), h.count))
 		}
 	}
-	// Loud alert: a data-loss event is sitting in history right now.
-	slog.ErrorContext(ctx, "ALERT: sacred mass-deletion found in ledger history",
+	// Keep every threshold hit visible; commit messages do not prove consent.
+	slog.ErrorContext(ctx, "ALERT: plan/session deletions found in ledger history",
 		"repo", repoPath,
 		"ledger", ledgerPath,
 		"wipe_commits", len(hits),
@@ -122,7 +123,7 @@ func scanLedgerSacredDeletions(ctx context.Context, ledgerPath, repoPath string)
 	return CheckResult{
 		Status: StatusFound,
 		Repo:   repoPath,
-		Summary: fmt.Sprintf("sacred mass-deletion in ledger history: %d commit(s) deleting %d plan/session files (e.g. %s) — recover from history; do NOT auto-delete (ADR-024)",
+		Summary: fmt.Sprintf("plan/session deletion history: %d commit(s) deleting %d plan/session files (e.g. %s) — verify intent before recovery; do NOT auto-delete (ADR-024)",
 			len(hits), total, strings.Join(sample, ", ")),
 	}
 }

--- a/internal/doctor/autofix/sacred_deletion_test.go
+++ b/internal/doctor/autofix/sacred_deletion_test.go
@@ -50,7 +50,48 @@ func TestScanLedgerSacredDeletions_FlagsHistoricalWipe(t *testing.T) {
 
 	res := scanLedgerSacredDeletions(context.Background(), repo, "/fake/repo")
 	assert.Equal(t, StatusFound, res.Status, "a historical sacred wipe must be surfaced")
-	assert.Contains(t, res.Summary, "sacred mass-deletion")
+	assert.Contains(t, res.Summary, "plan/session deletion history")
+}
+
+// One session can contain six artifacts. Keep the warning and safety threshold,
+// but do not call it a confirmed mass wipe or instruct customers to undo it.
+func TestScanLedgerSacredDeletions_ReportsFactsWithoutChangingHistory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git history")
+	}
+	for _, message := range []string{"Delete session example", "github: sync PRs"} {
+		t.Run(message, func(t *testing.T) {
+			repo := newSacredTestRepo(t)
+			dir := filepath.Join(repo, "sessions", "example")
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+			for _, name := range []string{"meta.json", "raw.jsonl", "summary.json", "summary.md", "session.md", "context-trace.jsonl"} {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("preserved in history\n"), 0o600))
+			}
+			afGit(t, repo, "add", "sessions")
+			afGit(t, repo, "commit", "-m", "record session")
+			afGit(t, repo, "rm", "-r", "sessions/example")
+			afGit(t, repo, "commit", "-m", message)
+			head := afGit(t, repo, "rev-parse", "HEAD")
+			// An unrelated uncommitted edit must also survive the scan.
+			dirty := filepath.Join(repo, "base.txt")
+			require.NoError(t, os.WriteFile(dirty, []byte("customer edit\n"), 0o600))
+			status := afGit(t, repo, "status", "--porcelain")
+			for range 2 {
+				res := scanLedgerSacredDeletions(context.Background(), repo, "/fake/repo")
+				require.Equal(t, StatusFound, res.Status, "commit messages are not proof of authorization")
+				assert.Contains(t, res.Summary, "1 commit(s) deleting 6 plan/session files")
+				assert.Contains(t, res.Summary, "verify intent before recovery")
+				assert.NotContains(t, res.Summary, "mass-deletion")
+			}
+			assert.Equal(t, head, afGit(t, repo, "rev-parse", "HEAD"))
+			assert.Equal(t, status, afGit(t, repo, "status", "--porcelain"))
+			assert.NoDirExists(t, dir, "scanning must not restore intentionally deleted data")
+			assert.Equal(t, "preserved in history", afGit(t, repo, "show", "HEAD^:sessions/example/raw.jsonl"))
+			content, err := os.ReadFile(dirty)
+			require.NoError(t, err)
+			assert.Equal(t, "customer edit\n", string(content))
+		})
+	}
 }
 
 // TestScanLedgerSacredDeletions_CleanWhenNoWipe: a ledger that only ever added

--- a/internal/doctor/autofix/session_meta_titles_test.go
+++ b/internal/doctor/autofix/session_meta_titles_test.go
@@ -131,3 +131,26 @@ func TestRepairLedgerSessionTitles_BumpsOnlyReportFound(t *testing.T) {
 	assert.Equal(t, StatusFound, res.Status, "pure-bump pass must surface as Found, not Fixed")
 	assert.Contains(t, res.Summary, "bumped=1")
 }
+
+// Successful repairs must not clear the warning for remaining corrupt sessions.
+func TestRepairLedgerSessionTitles_PartialRepairKeepsWarning(t *testing.T) {
+	sessionsDir := t.TempDir()
+	seedSession(t, sessionsDir, "recoverable", &lfs.SessionMeta{}, "Recovered title")
+	corruptDir := filepath.Join(sessionsDir, "corrupt")
+	require.NoError(t, os.Mkdir(corruptDir, 0o700))
+	corruptPath := filepath.Join(corruptDir, "meta.json")
+	const corrupt = "{\n<<<<<<< HEAD\n"
+	require.NoError(t, os.WriteFile(corruptPath, []byte(corrupt), 0o600))
+
+	res := repairLedgerSessionTitles(sessionsDir, "/fake/repo")
+	assert.Equal(t, StatusFound, res.Status, "one successful repair must not hide another session's error")
+	assert.Contains(t, res.Summary, "recovered=1")
+	assert.Contains(t, res.Summary, "errored=1")
+	assert.Equal(t, StatusFound, repairLedgerSessionTitles(sessionsDir, "/fake/repo").Status)
+	meta, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "recoverable"))
+	require.NoError(t, err)
+	assert.Equal(t, "Recovered title", meta.Title)
+	bytes, err := os.ReadFile(corruptPath)
+	require.NoError(t, err)
+	assert.Equal(t, corrupt, string(bytes))
+}

--- a/internal/lfs/meta_repair.go
+++ b/internal/lfs/meta_repair.go
@@ -1,6 +1,7 @@
 package lfs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sageox/ox/internal/fileutil"
 )
 
 // MetaRepairOutcome reports what RecoverEmptyTitleMeta did to a single
@@ -30,9 +33,10 @@ type MetaRepairOutcome struct {
 // SummaryAttempts and, at MaxSummaryAttempts, flips status to
 // unrecoverable so future calls early-exit.
 //
-// This is the daemon-safe core of the empty-title repair flow. Both
-// the CLI `ox session repair-meta-summary` tool and the autofix
-// scheduler delegate to this so the on-disk behavior is identical.
+// This is the daemon-safe empty-title repair. The explicit CLI
+// `ox session repair-meta-summary` also repairs non-empty leaky titles.
+// Automatic repair preserves healthy titles and patches only its five
+// fields under the shared metadata lock, retaining all other JSON data.
 //
 // Idempotency contract: running this repeatedly on a healthy meta is a
 // no-op (Skipped=true, no write). Running it repeatedly on an
@@ -43,77 +47,144 @@ type MetaRepairOutcome struct {
 func RecoverEmptyTitleMeta(sessionDir string, dryRun bool) MetaRepairOutcome {
 	name := filepath.Base(sessionDir)
 	out := MetaRepairOutcome{SessionName: name}
+	metaPath := filepath.Join(sessionDir, metaFilename)
 
-	meta, err := ReadSessionMeta(sessionDir)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
+	repair := func(meta *SessionMeta) (*SessionMeta, error) {
+		if meta == nil {
 			out.Skipped = true
-			return out
+			return nil, nil
 		}
-		out.Error = err.Error()
-		return out
-	}
 
-	// A draft placeholder legitimately has no title (ADR-029): it is a
-	// meta.json-only marker for a LIVE recording, not a session whose
-	// summarization failed. Without this skip, every autofix tick would treat
-	// the empty title as a fault, bump SummaryAttempts, and at
-	// MaxSummaryAttempts stamp summary_status="unrecoverable" into a session
-	// that is still being recorded — which the daemon's finalize (a
-	// preserve-unowned-fields RMW) would then carry into the finished session,
-	// permanently marking real work as unsummarizable. It would also dirty the
-	// ledger worktree mid-recording for a file the CLI is about to purge.
-	if meta.IsDraft() {
-		out.Skipped = true
-		return out
-	}
-
-	// Healthy or terminal — nothing to do. We treat any non-empty
-	// trimmed title as "healthy" because that's what the web UI will
-	// render; we don't second-guess whether the title is good.
-	if strings.TrimSpace(meta.Title) != "" {
-		out.Skipped = true
-		return out
-	}
-	// Terminal failure — daemon already exhausted MaxSummaryAttempts on
-	// this session. Stop trying. The session is teammate-visible (LFS
-	// upload happened) and the row title falls back to the session-name
-	// slug in the UI.
-	if meta.SummaryStatus == "unrecoverable" {
-		out.Skipped = true
-		return out
-	}
-
-	// Try to recover a clean title from summary.json. The daemon may
-	// have written a failure-stub summary.json with title="" too — in
-	// which case readSummaryJSONTitle returns "" and we fall through to
-	// the bump-attempts path.
-	if cleanTitle := readSummaryJSONTitle(sessionDir); cleanTitle != "" {
-		meta.Title = cleanTitle
-		// Mirror title into summary if summary.json doesn't carry a
-		// distinct one. Keeps the two fields consistent for older
-		// readers that prefer Summary over Title.
-		if strings.TrimSpace(meta.Summary) == "" {
-			meta.Summary = cleanTitle
+		// A draft placeholder legitimately has no title (ADR-029): it is a
+		// meta.json-only marker for a LIVE recording, not a session whose
+		// summarization failed. Without this skip, every autofix tick would treat
+		// the empty title as a fault, bump SummaryAttempts, and at
+		// MaxSummaryAttempts stamp summary_status="unrecoverable" into a session
+		// that is still being recorded — which the daemon's finalize (a
+		// preserve-unowned-fields RMW) would then carry into the finished session,
+		// permanently marking real work as unsummarizable. It would also dirty the
+		// ledger worktree mid-recording for a file the CLI is about to purge.
+		if meta.IsDraft() {
+			out.Skipped = true
+			return nil, nil
 		}
-		meta.SummaryStatus = "ok"
-		meta.ValidationError = ""
-		meta.SummaryAttempts = 0
-		out.RecoveredFromJSON = true
-	} else {
-		meta.SummaryAttempts++
-		out.BumpedAttempts = true
-		if meta.SummaryAttempts >= MaxSummaryAttempts {
-			meta.SummaryStatus = "unrecoverable"
-			out.FlippedTerminal = true
+
+		// Healthy or terminal — nothing to do. We treat any non-empty
+		// trimmed title as "healthy" because that's what the web UI will
+		// render; we don't second-guess whether the title is good.
+		if strings.TrimSpace(meta.Title) != "" {
+			out.Skipped = true
+			return nil, nil
 		}
+		// Terminal failure — daemon already exhausted MaxSummaryAttempts on
+		// this session. Stop trying. The session is teammate-visible (LFS
+		// upload happened) and the row title falls back to the session-name
+		// slug in the UI.
+		if meta.SummaryStatus == "unrecoverable" {
+			out.Skipped = true
+			return nil, nil
+		}
+
+		// Older CLIs persisted error prose in Summary. Move it to the diagnostic
+		// field before writing: otherwise validation rejects every repair attempt.
+		// Preserve both diagnostics when a different one is already present.
+		leakySummary := IsLeakySummaryString(meta.Summary)
+		if leakySummary {
+			if meta.ValidationError == "" {
+				meta.ValidationError = meta.Summary
+			} else if !strings.Contains(meta.ValidationError, meta.Summary) {
+				meta.ValidationError += "\n" + meta.Summary
+			}
+			meta.Summary = ""
+		}
+
+		// Try to recover a clean title from summary.json. The daemon may
+		// have written a failure-stub summary.json with title="" too — in
+		// which case readSummaryJSONTitle returns "" and we fall through to
+		// the bump-attempts path.
+		if cleanTitle := readSummaryJSONTitle(sessionDir); cleanTitle != "" {
+			meta.Title = cleanTitle
+			// Mirror title into summary if summary.json doesn't carry a
+			// distinct one. Keeps the two fields consistent for older
+			// readers that prefer Summary over Title.
+			if strings.TrimSpace(meta.Summary) == "" {
+				meta.Summary = cleanTitle
+			}
+			meta.SummaryStatus = "ok"
+			// Repairing a display title is not a new summary generation;
+			// retain diagnostics, including ones moved by an earlier pass.
+			meta.SummaryAttempts = 0
+			out.RecoveredFromJSON = true
+		} else {
+			meta.SummaryAttempts++
+			out.BumpedAttempts = true
+			if meta.SummaryAttempts >= MaxSummaryAttempts {
+				meta.SummaryStatus = "unrecoverable"
+				out.FlippedTerminal = true
+			}
+		}
+
+		if err := meta.Validate(); err != nil {
+			return nil, fmt.Errorf("repaired session meta failed invariant: %w", err)
+		}
+		info, err := os.Lstat(metaPath)
+		if err != nil {
+			return nil, err
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("refusing to repair non-regular meta.json")
+		}
+		data, err := os.ReadFile(metaPath)
+		if err != nil {
+			return nil, err
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(data, &fields); err != nil {
+			return nil, err
+		}
+		if fields == nil {
+			return nil, fmt.Errorf("meta.json must contain a JSON object")
+		}
+		if dryRun {
+			return nil, nil
+		}
+		// Patch only the repair-owned fields. Rewriting the typed manifest would
+		// drop fields from older/newer producers, including nested file metadata.
+		for key, value := range map[string]any{
+			"title": meta.Title, "summary": meta.Summary,
+			"summary_status": meta.SummaryStatus, "summary_attempts": meta.SummaryAttempts,
+			"validation_error": meta.ValidationError,
+		} {
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				return nil, err
+			}
+			fields[key] = encoded
+		}
+		data, err = json.MarshalIndent(fields, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		// MutateSessionMeta holds the shared metadata lock; return nil so it
+		// does not replace this lossless patch with a typed-manifest rewrite.
+		return nil, fileutil.AtomicWriteBytes(metaPath, data, info.Mode().Perm())
 	}
 
+	var err error
 	if dryRun {
-		return out
+		var meta *SessionMeta
+		meta, err = ReadSessionMeta(sessionDir)
+		if errors.Is(err, fs.ErrNotExist) {
+			err = nil
+		}
+		if err == nil {
+			_, err = repair(meta)
+		}
+	} else {
+		err = MutateSessionMeta(context.Background(), sessionDir, repair)
 	}
-	if err := WriteSessionMetaOnly(sessionDir, meta); err != nil {
-		out.Error = "write meta.json: " + err.Error()
+	if err != nil {
+		return MetaRepairOutcome{SessionName: name, Error: err.Error()}
 	}
 	return out
 }

--- a/internal/lfs/meta_repair_test.go
+++ b/internal/lfs/meta_repair_test.go
@@ -1,15 +1,211 @@
 package lfs
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Upgrading must repair legacy error summaries without losing session identity,
+// content references, extension fields, diagnostics, or customer-authored text.
+func TestRecoverEmptyTitleMeta_PreservesLegacyData(t *testing.T) {
+	const diagnostic = "Summary generation failed: legacy timeout"
+	for _, tc := range []struct {
+		name       string
+		title      string
+		summary    string
+		status     string
+		diagnostic string
+		recovery   string
+		draft      bool
+		dryRun     bool
+		skip       bool
+	}{
+		{name: "recover legacy error", summary: diagnostic, recovery: "Recovered title"},
+		{name: "bound legacy error retries", summary: diagnostic},
+		{name: "preserve both diagnostics", summary: diagnostic, diagnostic: "Earlier validation failure"},
+		{name: "preserve valid summary", summary: "Customer-written summary", recovery: "Recovered title"},
+		{name: "healthy title", title: "Customer-written title", summary: "Customer-written summary", recovery: "Stale title", skip: true},
+		{name: "terminal metadata", summary: diagnostic, status: "unrecoverable", skip: true},
+		{name: "live draft", draft: true, skip: true},
+		{name: "dry run", summary: diagnostic, recovery: "Recovered title", dryRun: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			original := map[string]any{
+				"version": "1.0", "session_name": "legacy-session", "session_id": "ses_preserve",
+				"created_at": "2026-04-01T00:00:00Z", "title": tc.title, "summary": tc.summary,
+				"summary_status": tc.status, "validation_error": tc.diagnostic, "draft": tc.draft,
+				"files":           map[string]any{"raw.jsonl": map[string]any{"oid": "sha256:abc", "size": 123, "future_storage_field": "keep"}},
+				"future_metadata": map[string]any{"large_id": json.Number("9007199254740993"), "value": "keep"},
+			}
+			if tc.draft {
+				delete(original, "files")
+			}
+			// Write the legacy shape directly: today's writer rejects the very
+			// error strings that an older CLI persisted.
+			before, err := json.MarshalIndent(original, "", "  ")
+			require.NoError(t, err)
+			metaPath := filepath.Join(dir, "meta.json")
+			require.NoError(t, os.WriteFile(metaPath, before, 0o600))
+			writeTestSummary(t, dir, tc.recovery)
+			summaryBefore, err := os.ReadFile(filepath.Join(dir, "summary.json"))
+			require.NoError(t, err)
+			raw := []byte("version https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 123\n")
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"), raw, 0o600))
+
+			out := RecoverEmptyTitleMeta(dir, tc.dryRun)
+			require.Empty(t, out.Error)
+			assert.Equal(t, tc.skip, out.Skipped)
+			after, err := os.ReadFile(metaPath)
+			require.NoError(t, err)
+			if tc.skip || tc.dryRun {
+				assert.Equal(t, before, after, "ineligible and dry-run metadata must stay byte-identical")
+			} else {
+				meta, err := ReadSessionMeta(dir)
+				require.NoError(t, err)
+				require.NoError(t, meta.Validate())
+				if tc.recovery != "" {
+					assert.Equal(t, tc.recovery, meta.Title)
+					assert.True(t, out.RecoveredFromJSON)
+				} else {
+					assert.True(t, out.BumpedAttempts)
+					assert.Equal(t, 1, meta.SummaryAttempts)
+				}
+				if tc.summary == diagnostic {
+					assert.Contains(t, meta.ValidationError, diagnostic, "moving an error out of display fields must preserve it")
+					assert.Contains(t, meta.ValidationError, tc.diagnostic)
+				} else {
+					assert.Equal(t, tc.summary, meta.Summary)
+				}
+				var oldFields, newFields map[string]json.RawMessage
+				require.NoError(t, json.Unmarshal(before, &oldFields))
+				require.NoError(t, json.Unmarshal(after, &newFields))
+				for _, field := range []string{"title", "summary", "summary_status", "summary_attempts", "validation_error"} {
+					delete(oldFields, field)
+					delete(newFields, field)
+				}
+				assert.Equal(t, oldFields, newFields, "repair must preserve all unowned fields, including unknown nested fields")
+				info, err := os.Stat(metaPath)
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+				for range MaxSummaryAttempts {
+					require.Empty(t, RecoverEmptyTitleMeta(dir, false).Error)
+				}
+				stable, err := os.ReadFile(metaPath)
+				require.NoError(t, err)
+				assert.True(t, RecoverEmptyTitleMeta(dir, false).Skipped)
+				again, err := os.ReadFile(metaPath)
+				require.NoError(t, err)
+				assert.Equal(t, stable, again, "repeated upgrade repairs must converge to a no-op")
+			}
+			summaryAfter, err := os.ReadFile(filepath.Join(dir, "summary.json"))
+			require.NoError(t, err)
+			assert.Equal(t, summaryBefore, summaryAfter)
+			rawAfter, err := os.ReadFile(filepath.Join(dir, "raw.jsonl"))
+			require.NoError(t, err)
+			assert.Equal(t, raw, rawAfter, "repair must never rewrite content or LFS stubs")
+		})
+	}
+}
+
+// Invalid historical JSON must remain available for deliberate recovery.
+func TestRecoverEmptyTitleMeta_PreservesCorruptMetadata(t *testing.T) {
+	for _, content := range []string{"{\n<<<<<<< HEAD\n\"title\": \"A\"\n=======\n\"title\": \"B\"\n>>>>>>> other\n}", `{"title":`, `null`} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "meta.json")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		writeTestSummary(t, dir, "Available title")
+		for _, dryRun := range []bool{true, false, false} {
+			require.NotEmpty(t, RecoverEmptyTitleMeta(dir, dryRun).Error)
+		}
+		after, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, content, string(after))
+	}
+}
+
+// Repair must not replace a metadata symlink or rewrite its target on upgrade.
+func TestRecoverEmptyTitleMeta_PreservesSymlink(t *testing.T) {
+	targetDir := t.TempDir()
+	writeTestMeta(t, targetDir, &SessionMeta{})
+	target := filepath.Join(targetDir, "meta.json")
+	before, err := os.ReadFile(target)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	link := filepath.Join(dir, "meta.json")
+	require.NoError(t, os.Symlink(target, link))
+	writeTestSummary(t, dir, "Recovered title")
+	for _, dryRun := range []bool{true, false} {
+		assert.Contains(t, RecoverEmptyTitleMeta(dir, dryRun).Error, "non-regular")
+	}
+	gotTarget, err := os.Readlink(link)
+	require.NoError(t, err)
+	assert.Equal(t, target, gotTarget)
+	after, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+}
+
+// Recovery after an earlier cleanup pass must not discard the moved diagnostic.
+func TestRecoverEmptyTitleMeta_DelayedRecoveryKeepsDiagnostic(t *testing.T) {
+	dir := t.TempDir()
+	const diagnostic = "Summary generation failed: legacy timeout"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"),
+		[]byte(`{"summary":"`+diagnostic+`","validation_error":"Earlier failure"}`), 0o600))
+	require.Empty(t, RecoverEmptyTitleMeta(dir, false).Error)
+	writeTestSummary(t, dir, "Recovered title")
+	out := RecoverEmptyTitleMeta(dir, false)
+	require.Empty(t, out.Error)
+	assert.True(t, out.RecoveredFromJSON)
+	meta, err := ReadSessionMeta(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "Recovered title", meta.Title)
+	assert.Contains(t, meta.ValidationError, diagnostic)
+	assert.Contains(t, meta.ValidationError, "Earlier failure")
+}
+
+// A repair must wait for a cooperating writer and reread its latest metadata.
+func TestRecoverEmptyTitleMeta_CoordinatesWithConcurrentWriter(t *testing.T) {
+	dir := t.TempDir()
+	writeTestMeta(t, dir, &SessionMeta{})
+	writeTestSummary(t, dir, "Stale recovery title")
+	done := make(chan MetaRepairOutcome, 1)
+	err := fileutil.WithFileLock(context.Background(), filepath.Join(dir, "meta.json"), func() error {
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			done <- RecoverEmptyTitleMeta(dir, false)
+		}()
+		<-started
+		select {
+		case <-done:
+			t.Error("repair bypassed the metadata lock")
+		case <-time.After(100 * time.Millisecond):
+		}
+		return WriteSessionMetaOnly(dir, &SessionMeta{Title: "Concurrent customer edit", SessionID: "ses_preserve"})
+	})
+	require.NoError(t, err)
+	select {
+	case out := <-done:
+		require.Empty(t, out.Error)
+		assert.True(t, out.Skipped)
+	case <-time.After(time.Second):
+		t.Fatal("repair did not finish after releasing the metadata lock")
+	}
+	meta, err := ReadSessionMeta(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "Concurrent customer edit", meta.Title)
+	assert.Equal(t, "ses_preserve", meta.SessionID)
+}
 
 // writeTestMeta is a small helper used by the recovery tests. It
 // writes a minimal SessionMeta to <dir>/meta.json so each test reads
@@ -98,7 +294,8 @@ func TestRecoverEmptyTitleMeta_RecoversFromSummaryJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Recovered Title From summary.json", got.Title)
 	assert.Equal(t, "ok", got.SummaryStatus, "status must transition failed_validation → ok")
-	assert.Empty(t, got.ValidationError, "stale ops diagnostic must be cleared")
+	assert.Equal(t, "content validation failed: title too short", got.ValidationError,
+		"automatic title repair must retain historical diagnostics")
 	assert.Equal(t, 0, got.SummaryAttempts, "attempt counter must reset on success")
 }
 

--- a/internal/sacred/sacred.go
+++ b/internal/sacred/sacred.go
@@ -19,9 +19,9 @@ var Prefixes = []string{"data/plans/", "sessions/"}
 
 // MassDeleteThreshold is the maximum number of sacred-path files a single ledger
 // commit may delete before it is treated as a suspected wipe. Set deliberately
-// tight: a routine `ox plan` delete or session removal touches one dir (its ~5
-// artifact files) and passes; removing two or more plans/sessions at once trips
-// it. Per ADR-024 sacred deletion needs explicit human approval, so err toward
+// tight: a single plan or session can exceed this file-count threshold. A hit
+// is a safety backstop, not proof of a mass wipe or unintended deletion.
+// Per ADR-024 sacred deletion needs explicit human approval, so err toward
 // refusing. The 2026-08-25 incident staged 1000+ sacred deletions in one commit.
 const MassDeleteThreshold = 5
 


### PR DESCRIPTION
## What broke

- **Shared sync status:** A follower daemon reported team contexts as “not synced” even when the global-sync owner had successfully synced them.
- **Legacy metadata repair:** Error text left in `summary` caused the metadata writer to reject the same empty-title repair repeatedly.
- **Health reporting:** The top-level “Healthy” label ignored outstanding integrity issues, and partial repairs could clear a warning while corrupt sessions remained.
- **Code-index repair race:** A missing-metadata fallback bypassed the repair lock, interfered with concurrent recreation, and could lose the reindex signal.
- **Deletion wording:** One plan or session can contain six files, so exceeding the five-file safety threshold does not establish that a mass wipe occurred or that recovery is appropriate.

## What this PR ships

- **Accurate status:** Read the existing shared sync cache for both daemon status APIs, retaining newer local timestamps and existing errors. Status reads do not change config or shared state.
- **Conservative automatic repair:** Use the existing metadata lock and atomic writer; patch only the five repair-owned fields. Preserve session IDs, content references, unknown top-level/nested fields, numeric precision, diagnostics, and file permissions.
- **Visible remaining problems:** Keep partial-repair warnings active and include outstanding issue severity in overall health.
- **Serialized code-index repair:** Route missing-metadata recovery through the existing repair lock, recheck before replacing an index, and save the rebuild signal before replacement. If the signal cannot be saved, preserve the existing index and return an error.
- **Reliable regression tests:** Check bubble clone/fetch preservation directly, wait for the IPC server to become ready, and correct the sparse-checkout assertion.
- **Factual deletion warnings:** Ask coworkers to verify intent before recovery. The deletion threshold and commit-blocking protections are unchanged.

```mermaid
flowchart LR
    A["Session metadata"] --> B{"Readable and eligible?"}
    B -->|No| C["Keep original metadata"]
    B -->|Yes| D["Lock and patch repair fields"]
    D --> E["Preserve other fields and content"]
```

## Upgrade safety

- **Derived-cache safety:** Code-index repairs retain their existing corruption checks and now share the same lock. The rebuild signal survives interrupted recreation; ledger/session files and git history are outside this repair path.

- **No ledger/session migrations, automatic deletion, or history restoration.** Healthy sessions, live drafts, terminal sessions, malformed/null JSON, and symlinked metadata are preserved. Repeated repairs converge to a no-op.
- **Observed-data verification:** Run the updated repair on isolated copies of the affected ledger metadata: all 37 legacy-error cases repaired, all 25 conflict-damaged files preserved unchanged. The live ledger was not repaired or rewritten.
- **Regression proof:** New regressions failed against the original implementation and passed with the fixes; an independent review checked the upgrade behavior.

## Test Plan

- [x] `make lint`
- [x] `go build ./cmd/ox`
- [x] Targeted race tests for metadata repair, shared sync status, health aggregation, and deletion-history reporting
- [x] Existing commit-time sacred-deletion guard tests
- [x] Copied-customer-metadata repair and preservation check
- [x] `make test-all` on the final commit in GitHub CI
- [x] Compiled-binary acceptance, digital-twin suites, package/changed-line coverage gates, and Codecov patch check in GitHub CI
- [x] Preflight guards for LFS subprocesses, raw-session writes, metadata locking, and CodeDB access
- [x] Focused slow clone tests after correcting a pre-existing assertion for root-anchored sparse paths
- [x] Slow-suite validation: other packages passed in `make test-slow`; the complete daemon package passed after the assertion fixes (`go test -tags=slow -race -count=1 -p 1 -parallel 1 -timeout=20m ./internal/daemon`)
- [x] Bubble regressions detect forced re-clone/fetch; corrected scale and dedup tests pass three race repetitions
- [x] IPC regression reproduces delayed-start failure; corrected test passes with delayed startup and 30 race repetitions
- [x] Code-index repair regressions (verified red/green), full store package with race detection, and 50/50 cross-process race repetitions

SageOx-Session: https://sageox.ai/c/ses_01a07e46-00fd-70f6-98e4-f755a4be8912
