### PR TITLE
fix(session): capture and upload Codex sessions in Conductor

### DIFF
--- a/cmd/ox-adapter-codex/session.go
+++ b/cmd/ox-adapter-codex/session.go
@@ -1,9 +1,9 @@
 // session.go — session reading, parsing, discovery, and types for codex adapter.
 //
 // Codex CLI stores sessions as JSONL in ~/.codex/sessions/<session-id>.jsonl.
-// Each line is a JSON object with "type" field: "user", "assistant",
-// "function_call", "function_call_output". Tool entries have "name",
-// "arguments" (JSON string), and "call_id" for correlation. Real sessions
+// Message and tool entries are wrapped in response_item JSON objects.
+// Tool calls use "arguments" for function_call or "input" for custom_tool_call,
+// with "name" and "call_id" for correlation. Real sessions
 // routinely fire several function_calls before any of their
 // function_call_outputs return (parallel/back-to-back tool use), so pairs
 // are rarely adjacent in the stream. mergeToolEntries() pairs them by
@@ -44,8 +44,9 @@ type codexPayload struct {
 	Content    []codexContentBlock `json:"content"`
 	Name       string              `json:"name"`
 	Arguments  string              `json:"arguments"`
+	Input      string              `json:"input"`
 	CallID     string              `json:"call_id"`
-	Output     string              `json:"output"`
+	Output     json.RawMessage     `json:"output"`
 	// event_msg fields
 	Message string `json:"message,omitempty"`
 }
@@ -158,17 +159,39 @@ func parseResponseItem(p *codexPayload, ts string) ([]adapterprotocol.RawEntry, 
 	switch p.ItemType {
 	case "message":
 		return parseCodexMessage(p, ts)
-	case "function_call":
+	case "function_call", "custom_tool_call":
 		if p.Name == "" {
 			return nil, nil
 		}
+		input := p.Arguments
+		if p.ItemType == "custom_tool_call" {
+			input = p.Input
+		}
 		return []adapterprotocol.RawEntry{
-			adapterruntime.ToolUseWithID(parseTS(ts), p.Name, p.Arguments, p.CallID),
+			adapterruntime.ToolUseWithID(parseTS(ts), p.Name, input, p.CallID),
 		}, nil
-	case "function_call_output":
-		isErr := isCodexToolError(p.Output)
+	case "function_call_output", "custom_tool_call_output":
+		var output string
+		if len(p.Output) > 0 {
+			if err := json.Unmarshal(p.Output, &output); err != nil {
+				// Codex also writes tool output as content blocks. Preserve text
+				// and leave image payloads out of the session's text representation.
+				var blocks []codexContentBlock
+				if err := json.Unmarshal(p.Output, &blocks); err != nil {
+					return nil, fmt.Errorf("parse tool output: %w", err)
+				}
+				var parts []string
+				for _, block := range blocks {
+					if block.Text != "" {
+						parts = append(parts, block.Text)
+					}
+				}
+				output = strings.Join(parts, "\n")
+			}
+		}
+		isErr := isCodexToolError(output)
 		return []adapterprotocol.RawEntry{
-			adapterruntime.ToolResultWithID(parseTS(ts), p.Output, isErr, p.CallID),
+			adapterruntime.ToolResultWithID(parseTS(ts), output, isErr, p.CallID),
 		}, nil
 	}
 
@@ -237,7 +260,7 @@ func classifyCodexUserContent(blocks []codexContentBlock) (string, bool) {
 	return text, false
 }
 
-// isCodexToolError reports whether a function_call_output represents a
+// isCodexToolError reports whether a tool result represents a
 // failed command. Real exec_command/write_stdin output embeds "Process
 // exited with code N" as one line within a multi-line block ("Command:
 // ...\nChunk ID: ...\nWall time: ...\nProcess exited with code N\n..."), not
@@ -257,7 +280,7 @@ func isCodexToolError(output string) bool {
 	return false
 }
 
-// mergeToolEntries pairs function_call / function_call_output entries by
+// mergeToolEntries pairs function and custom tool calls with their results by
 // call_id regardless of how far apart they land in the parsed stream. Codex
 // routinely fires several tool calls before any of their results return, so
 // requiring strict adjacency (the previous implementation) missed most pairs
@@ -320,7 +343,7 @@ func mergeToolEntries(entries []adapterprotocol.RawEntry, pending map[string]ada
 			continue
 		}
 
-		// tool result: ToolName == "" here (function_call_output never sets it).
+		// tool result: ToolName == "" here (output entries never set it).
 		if _, ok := callIdx[e.CallID]; ok {
 			// its call is in this same batch and already carries the
 			// output from the block above — drop the now-redundant
@@ -356,10 +379,9 @@ func findCodexSession(repoRoot, agentID, since, agentSessionID string) (string, 
 		if err := adapterruntime.ValidateSessionID(agentSessionID); err != nil {
 			return "", err
 		}
-		if path, err := findCodexBySessionID(sessionsDir, agentSessionID); err == nil {
-			return path, nil
-		}
-		// fall through to timestamp-based scanning
+		// The requested file may not exist yet. Wait for that session instead
+		// of attaching this recording to another conversation in the workspace.
+		return findCodexBySessionID(sessionsDir, agentSessionID)
 	}
 
 	sinceTime := time.Time{}

--- a/cmd/ox-adapter-codex/session_test.go
+++ b/cmd/ox-adapter-codex/session_test.go
@@ -1,15 +1,127 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/sageox/ox/pkg/adapterruntime"
 )
+
+// TestToolCallsSurviveReadCommands covers the string and content-block outputs
+// written by Codex 0.153.2 in Conductor. Custom calls were silently omitted;
+// array outputs failed JSON decoding even for ordinary function calls.
+func TestToolCallsSurviveReadCommands(t *testing.T) {
+	for _, call := range []struct {
+		kind     string
+		inputKey string
+		input    string
+	}{
+		{kind: "function_call", inputKey: "arguments", input: `{"cmd":"go test ./..."}`},
+		{kind: "custom_tool_call", inputKey: "input", input: "text(await tools.exec_command({cmd: 'go test ./...'}));"},
+	} {
+		for _, output := range []struct {
+			name    string
+			json    string
+			text    string
+			isError bool
+		}{
+			{name: "string", json: `"Script completed\nPASS"`, text: "Script completed\nPASS"},
+			{name: "empty string", json: `""`},
+			{name: "empty content blocks", json: `[]`},
+			{
+				name: "content blocks",
+				json: `[{"type":"input_text","text":"Script failed"},{"type":"input_image","image_url":"data:image/png;base64,AAAA"},{"type":"input_text","text":"Process exited with code 1\nFAIL"}]`,
+				text: "Script failed\nProcess exited with code 1\nFAIL", isError: true,
+			},
+		} {
+			for _, command := range []string{"read", "read-from-offset"} {
+				t.Run(call.kind+"/"+output.name+"/"+command, func(t *testing.T) {
+					path := filepath.Join(t.TempDir(), "session.jsonl")
+					content := fmt.Sprintf(`{"timestamp":"2026-09-07T16:50:00Z","type":"response_item","payload":{"type":%q,"name":"exec","call_id":"call-1",%q:%q}}
+{"timestamp":"2026-09-07T16:50:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Checking the tests."}]}}
+{"timestamp":"2026-09-07T16:50:02Z","type":"response_item","payload":{"type":%q,"call_id":"call-1","output":%s}}
+`, call.kind, call.inputKey, call.input, call.kind+"_output", output.json)
+					if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					var buf bytes.Buffer
+					args := []string{command, "--session-file", path}
+					if command == "read-from-offset" {
+						args = append(args, "--offset", "0")
+					}
+					if err := adapterruntime.RunWithArgs(adapterConfig, args, nil, &buf); err != nil {
+						t.Fatal(err)
+					}
+					var result adapterprotocol.ReadFromOffsetResult
+					if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+						t.Fatal(err)
+					}
+					if len(result.Entries) != 2 {
+						t.Fatalf("entries = %+v, want paired tool call and assistant message", result.Entries)
+					}
+					tool := result.Entries[0]
+					if tool.Role != adapterprotocol.RoleTool || tool.ToolName != "exec" || tool.CallID != "call-1" || tool.ToolInput != call.input || tool.ToolOutput != output.text || tool.IsError != output.isError {
+						t.Fatalf("tool = %+v, want call-1 with input %q, output %q, is_error=%v", tool, call.input, output.text, output.isError)
+					}
+					if command == "read-from-offset" && result.NewOffset != int64(len(content)) {
+						t.Fatalf("offset = %d, want %d", result.NewOffset, len(content))
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestCustomToolResultsPairAcrossReads prevents delayed custom tool results
+// losing their name and input when calls and results arrive in separate polls.
+func TestCustomToolResultsPairAcrossReads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	calls := `{"timestamp":"2026-09-07T16:50:00Z","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"custom-1","input":"text(await tools.exec_command({cmd: 'go test ./...'}));"}}
+{"timestamp":"2026-09-07T16:50:01Z","type":"response_item","payload":{"type":"function_call","name":"write_stdin","call_id":"function-1","arguments":"{\"session_id\":123}"}}
+`
+	if err := os.WriteFile(path, []byte(calls), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pending := newPendingCallStore()
+	entries, offset, err := readCodexFromOffset(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := pending.merge(path, entries)
+	if len(first) != 2 || first[0].ToolName != "exec" || first[1].ToolName != "write_stdin" {
+		t.Fatalf("first read = %+v, want both pending calls", first)
+	}
+	outputs := `{"timestamp":"2026-09-07T16:50:02Z","type":"response_item","payload":{"type":"function_call_output","call_id":"function-1","output":[{"type":"input_text","text":"tests still running"}]}}
+{"timestamp":"2026-09-07T16:50:03Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"custom-1","output":[{"type":"input_text","text":"Script completed"},{"type":"input_text","text":"PASS"}]}}
+`
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, writeErr := f.WriteString(outputs)
+	closeErr := f.Close()
+	if writeErr != nil || closeErr != nil {
+		t.Fatalf("append outputs: write=%v close=%v", writeErr, closeErr)
+	}
+	entries, newOffset, err := readCodexFromOffset(path, offset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := pending.merge(path, entries)
+	if len(second) != 2 || second[0].ToolName != "write_stdin" || second[0].ToolInput != `{"session_id":123}` || second[0].ToolOutput != "tests still running" || second[1].ToolName != "exec" || second[1].ToolInput != "text(await tools.exec_command({cmd: 'go test ./...'}));" || second[1].ToolOutput != "Script completed\nPASS" {
+		t.Fatalf("second read = %+v, want results paired with earlier calls", second)
+	}
+	if newOffset != int64(len(calls)+len(outputs)) {
+		t.Fatalf("offset = %d, want %d", newOffset, len(calls)+len(outputs))
+	}
+}
 
 // --- A. Direct lookup via agent_session_id ---
 
@@ -47,10 +159,8 @@ func TestFindCodexSession_DirectLookup(t *testing.T) {
 	}
 }
 
-// TestFindCodexSession_DirectLookup_InvalidFallsBack verifies that a
-// non-matching session ID gracefully falls back to CWD-based scanning.
-// Failure prevented: error instead of fallback when session ID doesn't match any file.
-func TestFindCodexSession_DirectLookup_InvalidFallsBack(t *testing.T) {
+// A delayed native session must not bind its recording to a sibling conversation.
+func TestFindCodexSession_DirectLookup_WaitsForRequestedSession(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -62,21 +172,46 @@ func TestFindCodexSession_DirectLookup_InvalidFallsBack(t *testing.T) {
 	}
 
 	repoRoot := "/tmp/test-repo"
-	sessionFile := filepath.Join(dateDir, "session-001.jsonl")
+	siblingFile := filepath.Join(dateDir, "session-sibling.jsonl")
 	content := fmt.Sprintf(
-		`{"timestamp":"2026-04-02T10:00:00Z","type":"session_meta","payload":{"id":"real-id","cwd":"%s","cli_version":"0.107.0"}}`+"\n",
+		`{"timestamp":"2026-04-02T10:00:00Z","type":"session_meta","payload":{"id":"sibling-id","cwd":"%s","cli_version":"0.107.0"}}`+"\n",
 		repoRoot,
 	)
-	if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(siblingFile, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := findCodexSession(repoRoot, "", "", "nonexistent-session-id")
+	sessionID := "019d2c0d-ac3c-7b72-bb1d-0f246ad1f0d0"
+	since := now.Add(-5 * time.Minute).Format(time.RFC3339)
+	got, err := findCodexSession(repoRoot, "", since, sessionID)
+	if err == nil || got != "" {
+		t.Fatalf("missing native session = %q, %v; must wait instead of selecting %q", got, err, siblingFile)
+	}
+
+	sessionFile := filepath.Join(dateDir, "session-requested.jsonl")
+	content = fmt.Sprintf(`{"type":"session_meta","payload":{"id":%q,"cwd":%q}}`+"\n", sessionID, repoRoot)
+	if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = findCodexSession(repoRoot, "", since, sessionID)
 	if err != nil {
-		t.Fatalf("findCodexSession: %v", err)
+		t.Fatalf("discover delayed native session: %v", err)
 	}
 	if got != sessionFile {
-		t.Errorf("got %q, want %q (fallback)", got, sessionFile)
+		t.Errorf("got %q, want requested session %q", got, sessionFile)
+	}
+}
+
+// Malformed native identities are rejected rather than triggering a heuristic lookup.
+func TestFindCodexSession_DirectLookup_RejectsMalformedID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, id := range []string{"../session", "/absolute", "nested/session", `nested\session`} {
+		t.Run(id, func(t *testing.T) {
+			got, err := findCodexSession("/tmp/test-repo", "", "", id)
+			if err == nil || got != "" || !strings.Contains(err.Error(), "invalid session ID") {
+				t.Fatalf("malformed native session ID %q = %q, %v; want error", id, got, err)
+			}
+		})
 	}
 }
 

--- a/cmd/ox-adapter-codex/session_test.go
+++ b/cmd/ox-adapter-codex/session_test.go
@@ -79,6 +79,33 @@ func TestToolCallsSurviveReadCommands(t *testing.T) {
 	}
 }
 
+// An invalid tool payload must not create a bogus result or prevent later messages from being read.
+func TestMalformedToolOutputDoesNotDiscardFollowingMessages(t *testing.T) {
+	for _, kind := range []string{"function_call_output", "custom_tool_call_output"} {
+		for _, output := range []string{`{"text":"unexpected object"}`, `42`, `[{"type":"input_text","text":17}]`} {
+			t.Run(kind+"/"+output, func(t *testing.T) {
+				malformed := fmt.Sprintf(`{"timestamp":"2026-09-07T16:50:00Z","type":"response_item","payload":{"type":%q,"call_id":"bad-output","output":%s}}`, kind, output)
+				entries, err := parseCodexLine([]byte(malformed))
+				if err == nil || !strings.Contains(err.Error(), "parse tool output") || len(entries) != 0 {
+					t.Fatalf("malformed tool output = %+v, %v; want a parse error and no entries", entries, err)
+				}
+				path := filepath.Join(t.TempDir(), "session.jsonl")
+				content := malformed + "\n" + `{"timestamp":"2026-09-07T16:50:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Following message survives."}]}}` + "\n"
+				if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				result, err := handleRead(adapterprotocol.ReadParams{SessionFile: path})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(result.Entries) != 1 || result.Entries[0].Content != "Following message survives." {
+					t.Fatalf("session after malformed output = %+v; want the following message", result.Entries)
+				}
+			})
+		}
+	}
+}
+
 // TestCustomToolResultsPairAcrossReads prevents delayed custom tool results
 // losing their name and input when calls and results arrive in separate polls.
 func TestCustomToolResultsPairAcrossReads(t *testing.T) {

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -629,9 +629,10 @@ func handleAfterTool(ctx *HookContext) error {
 			repoRoot = ctx.ProjectRoot
 		}
 		sf, findErr := adapter.FindSessionFile(adapters.SessionLookup{
-			RepoRoot: repoRoot,
-			AgentID:  agentID,
-			Since:    state.StartedAt,
+			RepoRoot:       repoRoot,
+			AgentID:        agentID,
+			AgentSessionID: state.AgentSessionID,
+			Since:          state.StartedAt.Add(-5 * time.Minute),
 		})
 		if findErr != nil || sf == "" {
 			slog.Info("hook: session file not found", "agentID", agentID, "adapter", state.AdapterName, "repo", repoRoot, "err", findErr)
@@ -658,9 +659,10 @@ func handleAfterTool(ctx *HookContext) error {
 			repoRoot = ctx.ProjectRoot
 		}
 		sf, findErr := adapter.FindSessionFile(adapters.SessionLookup{
-			RepoRoot: repoRoot,
-			AgentID:  agentID,
-			Since:    state.StartedAt,
+			RepoRoot:       repoRoot,
+			AgentID:        agentID,
+			AgentSessionID: state.AgentSessionID,
+			Since:          state.StartedAt.Add(-5 * time.Minute),
 		})
 		if findErr == nil && sf != "" && sf != state.SessionFile {
 			slog.Info("hook: rediscovered session file", "old", state.SessionFile, "new", sf)
@@ -888,9 +890,14 @@ func startSessionRecordingIfConfigured(ctx *HookContext) {
 	}
 
 	agentID := ""
+	agentSessionID := ""
 	if ctx.Marker != nil {
 		agentID = ctx.Marker.AgentID
+		agentSessionID = ctx.Marker.AgentSessionID
+	}
+	if ctx.Input != nil && ctx.Input.SessionID != "" {
+		agentSessionID = ctx.Input.SessionID
 	}
 
-	startSessionRecording(ctx.ProjectRoot, agentID, ctx.AgentType, "", recordingSessionIDFromMarker(ctx.Marker))
+	startSessionRecording(ctx.ProjectRoot, agentID, ctx.AgentType, "", recordingSessionIDFromMarker(ctx.Marker), agentSessionID)
 }

--- a/cmd/ox/agent_hook_test.go
+++ b/cmd/ox/agent_hook_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/agentx"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/stretchr/testify/assert"
@@ -129,8 +132,8 @@ func setupHandleAfterToolTest(t *testing.T) (projectRoot string, agentID string,
 	return projectRoot, agentID, sourceFile
 }
 
-// Hook discovery must capture its own native conversation, including files created before prime.
-func TestHandleAfterTool_CodexDiscoveryUsesRecordingIdentity(t *testing.T) {
+func buildCodexCaptureAdapter(t *testing.T) string {
+	t.Helper()
 	if testing.Short() {
 		t.Skip("short: builds and invokes the real Codex adapter")
 	}
@@ -139,6 +142,12 @@ func TestHandleAfterTool_CodexDiscoveryUsesRecordingIdentity(t *testing.T) {
 	build.Dir = findModuleRoot(t)
 	buildOutput, err := build.CombinedOutput()
 	require.NoError(t, err, "%s", buildOutput)
+	return adapterBin
+}
+
+// Hook discovery must capture its own native conversation, including files created before prime.
+func TestHandleAfterTool_CodexDiscoveryUsesRecordingIdentity(t *testing.T) {
+	adapterBin := buildCodexCaptureAdapter(t)
 
 	for _, sourceState := range []string{"undiscovered", "missing", "truncated"} {
 		for _, knownIdentity := range []bool{true, false} {
@@ -209,6 +218,63 @@ func TestHandleAfterTool_CodexDiscoveryUsesRecordingIdentity(t *testing.T) {
 				assert.NotContains(t, string(raw), "sibling conversation")
 			})
 		}
+	}
+}
+
+// Current hook input must override an older marker when selecting the native conversation.
+func TestHookStart_UsesCurrentNativeSessionIdentity(t *testing.T) {
+	adapterBin := buildCodexCaptureAdapter(t)
+	const nativeID = "codex-test-session"
+	for _, tt := range []struct {
+		name     string
+		markerID string
+		input    *agentx.HookInput
+	}{
+		{name: "marker only", markerID: nativeID},
+		{name: "empty input retains marker", markerID: nativeID, input: &agentx.HookInput{}},
+		{name: "input overrides stale marker", markerID: "stale-native-session", input: &agentx.HookInput{SessionID: nativeID}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_DATA_HOME", t.TempDir())
+			t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+			t.Setenv("OX_XDG_DISABLE", "")
+			f := newDraftLedgerFixture(t)
+			t.Chdir(f.projectRoot)
+			defaultLedger, err := ledger.DefaultPath()
+			require.NoError(t, err)
+			require.NoError(t, os.MkdirAll(filepath.Dir(defaultLedger), 0o755))
+			runGit(t, f.projectRoot, "clone", "--quiet", f.barePath, defaultLedger)
+			oldCfg := cfg
+			cfg = &config.Config{}
+			t.Cleanup(func() { cfg = oldCfg })
+			oxConfigSetRepo(t, "session_recording", "auto")
+			adapter, err := adapters.NewExternalAdapter(adapterBin)
+			require.NoError(t, err)
+			adapters.Register(adapter)
+			t.Cleanup(func() {
+				adapters.Unregister("codex")
+				_ = adapter.Close()
+			})
+			source := writeCodexSessionFile(t, os.Getenv("HOME"), f.projectRoot)
+			data, err := os.ReadFile(source)
+			require.NoError(t, err)
+			sibling := filepath.Join(filepath.Dir(source), "stale-session.jsonl")
+			require.NoError(t, os.WriteFile(sibling, []byte(strings.ReplaceAll(string(data), nativeID, "stale-native-session")), 0o600))
+
+			const agentID = "OxHookNative"
+			startSessionRecordingIfConfigured(&HookContext{
+				AgentType: "codex", ProjectRoot: f.projectRoot, Input: tt.input,
+				Marker: &SessionMarker{AgentID: agentID, AgentSessionID: tt.markerID, RecordingSessionID: draftTestSessionID},
+			})
+			state, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+			require.NoError(t, err)
+			require.NotNil(t, state)
+			assert.Equal(t, nativeID, state.AgentSessionID)
+			assert.Equal(t, source, state.SessionFile, "hook startup must attach to the current native conversation")
+			assert.Equal(t, draftTestSessionID, state.ContinuedFromSessionID)
+			assert.FileExists(t, filepath.Join(state.SessionPath, "raw.jsonl"))
+		})
 	}
 }
 

--- a/cmd/ox/agent_hook_test.go
+++ b/cmd/ox/agent_hook_test.go
@@ -4,7 +4,9 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -125,6 +127,89 @@ func setupHandleAfterToolTest(t *testing.T) (projectRoot string, agentID string,
 	require.NoError(t, writeRawHeader(projectRoot, state))
 
 	return projectRoot, agentID, sourceFile
+}
+
+// Hook discovery must capture its own native conversation, including files created before prime.
+func TestHandleAfterTool_CodexDiscoveryUsesRecordingIdentity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: builds and invokes the real Codex adapter")
+	}
+	adapterBin := filepath.Join(t.TempDir(), "ox-adapter-codex")
+	build := exec.Command("go", "build", "-o", adapterBin, "./cmd/ox-adapter-codex")
+	build.Dir = findModuleRoot(t)
+	buildOutput, err := build.CombinedOutput()
+	require.NoError(t, err, "%s", buildOutput)
+
+	for _, sourceState := range []string{"undiscovered", "missing", "truncated"} {
+		for _, knownIdentity := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/native_id=%t", sourceState, knownIdentity), func(t *testing.T) {
+				t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+				t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+				t.Setenv("OX_XDG_DISABLE", "")
+				projectRoot, agentID, previousSource := setupHandleAfterToolTest(t)
+				t.Chdir(projectRoot)
+				adapter, err := adapters.NewExternalAdapter(adapterBin)
+				require.NoError(t, err)
+				adapters.Register(adapter)
+				t.Cleanup(func() {
+					adapters.Unregister("codex")
+					_ = adapter.Close()
+				})
+
+				state, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+				require.NoError(t, err)
+				require.NotNil(t, state)
+				nativeID := "019d2c0d-ac3c-7b72-bb1d-0f246ad1f0d0"
+				now := time.Now()
+				dateDir := filepath.Join(os.Getenv("HOME"), ".codex", "sessions", now.Format("2006"), now.Format("01"), now.Format("02"))
+				require.NoError(t, os.MkdirAll(dateDir, 0o755))
+				sourceFile := filepath.Join(dateDir, "requested.jsonl")
+				content := fmt.Sprintf("{\"type\":\"session_meta\",\"payload\":{\"id\":%q,\"cwd\":%q}}\n"+
+					"{\"timestamp\":%q,\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"requested conversation\"}]}}\n",
+					nativeID, projectRoot, state.StartedAt.Add(time.Second).Format(time.RFC3339Nano))
+				require.NoError(t, os.WriteFile(sourceFile, []byte(content), 0o600))
+				beforePrime := state.StartedAt.Add(-time.Minute)
+				require.NoError(t, os.Chtimes(sourceFile, beforePrime, beforePrime))
+				if knownIdentity {
+					// A newer sibling makes ignoring the persisted identity capture the wrong source.
+					sibling := strings.ReplaceAll(content, nativeID, "sibling-session")
+					sibling = strings.ReplaceAll(sibling, "requested conversation", "sibling conversation")
+					require.NoError(t, os.WriteFile(filepath.Join(dateDir, "sibling.jsonl"), []byte(sibling), 0o600))
+				}
+				require.NoError(t, session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
+					s.AdapterName = "codex"
+					s.WorkspacePath = projectRoot
+					if knownIdentity {
+						s.AgentSessionID = nativeID
+					}
+					switch sourceState {
+					case "undiscovered":
+						s.SessionFile = ""
+					case "missing":
+						s.SessionFile = filepath.Join(dateDir, "missing.jsonl")
+					case "truncated":
+						s.SessionFile = previousSource
+						s.SourceOffset = 1024
+					}
+				}))
+
+				require.NoError(t, handleAfterTool(&HookContext{
+					Phase: phaseAfterTool, AgentType: "codex", ProjectRoot: projectRoot,
+					Marker: &SessionMarker{AgentID: agentID},
+				}))
+				captured, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+				require.NoError(t, err)
+				require.NotNil(t, captured)
+				assert.Equal(t, sourceFile, captured.SessionFile)
+				assert.Equal(t, int64(len(content)), captured.SourceOffset)
+				assert.Equal(t, 1, captured.EntryCount)
+				raw, err := os.ReadFile(filepath.Join(captured.SessionPath, "raw.jsonl"))
+				require.NoError(t, err)
+				assert.Contains(t, string(raw), "requested conversation")
+				assert.NotContains(t, string(raw), "sibling conversation")
+			})
+		}
+	}
 }
 
 func TestHandleAfterTool_WritesEntriesToRawJSONL(t *testing.T) {

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -441,7 +441,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	// attempt to start session recording if enabled (local, no auth needed)
 	phaseStart = time.Now()
 	continuedFromSessionID := recordingSessionIDFromMarker(existingMarker)
-	sessionStat := startSessionRecording(projectRoot, agentID, agentType, parentAgentID, continuedFromSessionID)
+	sessionStat := startSessionRecording(projectRoot, agentID, agentType, parentAgentID, continuedFromSessionID, agentSessionID)
 	recordingSessionID := recordingSessionIDForMarker(projectRoot, agentID, continuedFromSessionID)
 	timing["session_start"] = time.Since(phaseStart).Milliseconds()
 
@@ -1220,7 +1220,7 @@ func recordingSessionIDForMarker(projectRoot, agentID, prior string) string {
 	return ""
 }
 
-func startSessionRecording(projectRoot, agentID, agentType, parentAgentID, continuedFromSessionID string) *sessionStatus {
+func startSessionRecording(projectRoot, agentID, agentType, parentAgentID, continuedFromSessionID, agentSessionID string) *sessionStatus {
 	// resolve session mode from the config hierarchy. Sessions record into
 	// the project ledger; Knowledge Bubbles play no part (ox ADR-028).
 	resolved := config.ResolveSessionRecording(projectRoot)
@@ -1244,7 +1244,12 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID, conti
 	}
 
 	// respect explicit session stop — user ran ox agent session stop, don't auto-restart
-	if session.ConsumeExplicitStop(projectRoot, agentID) {
+	if session.HasExplicitStop(projectRoot, agentID) {
+		// A stop in progress or awaiting retry still owns the recording.
+		// Keep its signal until processing clears the state.
+		if state, err := session.LoadRecordingStateForAgent(projectRoot, agentID); err == nil && state == nil {
+			session.ConsumeExplicitStop(projectRoot, agentID)
+		}
 		return nil
 	}
 
@@ -1275,6 +1280,17 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID, conti
 
 	// check if already recording
 	if existing, err := session.LoadRecordingStateForAgent(projectRoot, agentID); err == nil && existing != nil {
+		if existing.WatchMode == "tail" && existing.SessionFile == "" {
+			if agentSessionID != "" && existing.AgentSessionID != agentSessionID {
+				if err := session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
+					s.AgentSessionID = agentSessionID
+				}); err != nil {
+					slog.Warn("failed to persist native session identity", "agent_id", agentID, "error", err)
+				}
+				existing.AgentSessionID = agentSessionID
+			}
+			sendSessionWatchStart(existing, projectRoot)
+		}
 		return &sessionStatus{
 			Recording: true,
 			File:      existing.SessionFile,
@@ -1303,6 +1319,7 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID, conti
 
 	opts := session.StartRecordingOptions{
 		AgentID:                agentID,
+		AgentSessionID:         agentSessionID,
 		AdapterName:            agentType,
 		OutputFile:             outputFile,
 		FilterMode:             resolved.Mode,
@@ -1442,9 +1459,10 @@ func sendSessionWatchStart(state *session.RecordingState, projectRoot string) {
 			repoRoot = projectRoot
 		}
 		sf, err := adapter.FindSessionFile(adapters.SessionLookup{
-			RepoRoot: repoRoot,
-			AgentID:  state.AgentID,
-			Since:    state.StartedAt,
+			RepoRoot:       repoRoot,
+			AgentID:        state.AgentID,
+			AgentSessionID: state.AgentSessionID,
+			Since:          state.StartedAt.Add(-5 * time.Minute),
 		})
 		if err != nil {
 			slog.Debug("tail-mode: session file not found yet, daemon will discover later",
@@ -1454,7 +1472,9 @@ func sendSessionWatchStart(state *session.RecordingState, projectRoot string) {
 		sessionFile = sf
 		// persist the discovered session file so daemon can find it via DetectAndRestart
 		state.SessionFile = sf
-		if saveErr := session.SaveRecordingState(projectRoot, state); saveErr != nil {
+		if saveErr := session.UpdateRecordingStateForAgent(projectRoot, state.AgentID, func(s *session.RecordingState) {
+			s.SessionFile = sf
+		}); saveErr != nil {
 			slog.Warn("failed to save session file to recording state", "error", saveErr)
 		}
 	}

--- a/cmd/ox/agent_prime_e2e_test.go
+++ b/cmd/ox/agent_prime_e2e_test.go
@@ -9,7 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/ledger"
+	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/sageox/ox/internal/skillmanager"
 	"github.com/sageox/ox/pkg/adapterprotocol"
 
@@ -140,4 +145,102 @@ func TestRunAgentPrime_ReconcilesWhenTheRecordedRevisionIsStale(t *testing.T) {
 		"a stale recorded revision must make prime rebuild the inventory, restoring the missing skill")
 	assert.Contains(t, buf.String(), "skills_reconciled",
 		"prime must report how many files it wrote when the reconcile actually did work")
+}
+
+// A source created after prime must join the existing recording, including after a state-write failure.
+func TestPrimeCodexRecording_ReprimeDiscoversDelayedSource(t *testing.T) {
+	adapterBin := buildCodexCaptureAdapter(t)
+	for _, readOnlyState := range []bool{false, true} {
+		name := "writable state"
+		if readOnlyState {
+			name = "state write recovers"
+		}
+		t.Run(name, func(t *testing.T) {
+			if readOnlyState && os.Geteuid() == 0 {
+				t.Skip("root can write files despite read-only permissions")
+			}
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_DATA_HOME", t.TempDir())
+			t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+			t.Setenv("OX_XDG_DISABLE", "")
+			f := newDraftLedgerFixture(t)
+			t.Chdir(f.projectRoot)
+			defaultLedger, err := ledger.DefaultPath()
+			require.NoError(t, err)
+			require.NoError(t, os.MkdirAll(filepath.Dir(defaultLedger), 0o755))
+			runGit(t, f.projectRoot, "clone", "--quiet", f.barePath, defaultLedger)
+			oldCfg := cfg
+			cfg = &config.Config{}
+			t.Cleanup(func() { cfg = oldCfg })
+			oxConfigSetRepo(t, "session_recording", "auto")
+			adapter, err := adapters.NewExternalAdapter(adapterBin)
+			require.NoError(t, err)
+			adapters.Register(adapter)
+			t.Cleanup(func() {
+				adapters.Unregister("codex")
+				_ = adapter.Close()
+			})
+
+			const agentID, nativeID = "OxCodexLate", "codex-test-session"
+			firstStatus := startSessionRecording(f.projectRoot, agentID, "codex", "", "", "")
+			require.NotNil(t, firstStatus)
+			require.True(t, firstStatus.Recording)
+			first, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+			require.NoError(t, err)
+			require.NotNil(t, first)
+			require.Equal(t, "tail", first.WatchMode)
+			require.Empty(t, first.SessionFile)
+			rawBefore, err := os.ReadFile(filepath.Join(first.SessionPath, "raw.jsonl"))
+			require.NoError(t, err)
+			markerPath := filepath.Join(first.SessionPath, ".recording.json")
+			if readOnlyState {
+				require.NoError(t, os.Chmod(markerPath, 0o400))
+				t.Cleanup(func() { _ = os.Chmod(markerPath, 0o600) })
+			}
+
+			// Learn the native ID while its file is still unavailable. Keep it for daemon discovery.
+			require.NotNil(t, startSessionRecording(f.projectRoot, agentID, "codex", "", "", nativeID))
+			waiting, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+			require.NoError(t, err)
+			require.NotNil(t, waiting)
+			if readOnlyState {
+				assert.Empty(t, waiting.AgentSessionID, "failed state writes must leave the prior recording intact")
+			} else {
+				assert.Equal(t, nativeID, waiting.AgentSessionID)
+				// A subsequent environment without a native ID must not erase the saved one.
+				require.NotNil(t, startSessionRecording(f.projectRoot, agentID, "codex", "", "", ""))
+			}
+			assert.Empty(t, waiting.SessionFile)
+			assert.Equal(t, first.SessionID, waiting.SessionID)
+
+			source := writeCodexSessionFile(t, os.Getenv("HOME"), f.projectRoot)
+			beforePrime := first.StartedAt.Add(-time.Minute)
+			require.NoError(t, os.Chtimes(source, beforePrime, beforePrime))
+			data, err := os.ReadFile(source)
+			require.NoError(t, err)
+			sibling := filepath.Join(filepath.Dir(source), "newer-sibling.jsonl")
+			require.NoError(t, os.WriteFile(sibling, []byte(strings.ReplaceAll(string(data), nativeID, "sibling-session")), 0o600))
+
+			foundStatus := startSessionRecording(f.projectRoot, agentID, "codex", "", "", nativeID)
+			require.NotNil(t, foundStatus)
+			assert.Equal(t, source, foundStatus.File)
+			if readOnlyState {
+				pending, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+				require.NoError(t, err)
+				require.NotNil(t, pending)
+				assert.Empty(t, pending.SessionFile, "discovery must preserve a recording when its source path cannot yet be saved")
+				require.NoError(t, os.Chmod(markerPath, 0o600))
+				require.NotNil(t, startSessionRecording(f.projectRoot, agentID, "codex", "", "", nativeID))
+			}
+			found, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+			require.NoError(t, err)
+			require.NotNil(t, found)
+			assert.Equal(t, nativeID, found.AgentSessionID)
+			assert.Equal(t, source, found.SessionFile)
+			assert.Equal(t, first.SessionID, found.SessionID, "re-prime must recover the existing recording")
+			rawAfter, err := os.ReadFile(filepath.Join(found.SessionPath, "raw.jsonl"))
+			require.NoError(t, err)
+			assert.Equal(t, rawBefore, rawAfter, "discovery must not replace the recording's captured data")
+		})
+	}
 }

--- a/cmd/ox/agent_prime_e2e_test.go
+++ b/cmd/ox/agent_prime_e2e_test.go
@@ -209,6 +209,10 @@ func TestPrimeCodexRecording_ReprimeDiscoversDelayedSource(t *testing.T) {
 				assert.Equal(t, nativeID, waiting.AgentSessionID)
 				// A subsequent environment without a native ID must not erase the saved one.
 				require.NotNil(t, startSessionRecording(f.projectRoot, agentID, "codex", "", "", ""))
+				waiting, err = session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+				require.NoError(t, err)
+				require.NotNil(t, waiting)
+				assert.Equal(t, nativeID, waiting.AgentSessionID, "an empty native ID must not erase the saved one")
 			}
 			assert.Empty(t, waiting.SessionFile)
 			assert.Equal(t, first.SessionID, waiting.SessionID)

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/doctor"
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/identity"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/plan"
@@ -122,6 +123,10 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 	title := parseTitle(args)
 
 	agentType := canonicalAgentType(inst.AgentType)
+	var agentSessionID string
+	if agent, ok := agentx.DefaultRegistry.Get(agentx.AgentType(agentType)); ok && agent.SupportsSession() {
+		agentSessionID = agent.SessionID(agentx.NewSystemEnvironment())
+	}
 	adapterName := ""          // canonical adapter name for GetAdapter() lookup
 	agentTypeName := agentType // original type for metadata
 	sessionFile := ""
@@ -136,9 +141,10 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 		}
 		since := time.Now().Add(-5 * time.Minute)
 		sf, findErr := codexAdapter.FindSessionFile(adapters.SessionLookup{
-			RepoRoot: projectRoot,
-			AgentID:  inst.AgentID,
-			Since:    since,
+			RepoRoot:       projectRoot,
+			AgentID:        inst.AgentID,
+			AgentSessionID: agentSessionID,
+			Since:          since,
 		})
 		if findErr != nil {
 			if errors.Is(findErr, adapters.ErrSessionNotFound) {
@@ -226,17 +232,18 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 
 	// start recording with agent ID from session
 	opts := session.StartRecordingOptions{
-		AgentID:       inst.AgentID,
-		AdapterName:   adapterName,
-		AgentType:     agentTypeName,
-		SessionFile:   sessionFile,
-		Title:         title,
-		Username:      identity.AttributionUsername(endpoint.GetForProject(projectRoot), config.GetDisplayName()),
-		WorkspacePath: projectRoot,
-		Branch:        repotools.GetCurrentBranch(projectRoot),
-		ParentPID:     parentPID,
-		StartOffset:   startOffset,
-		WatchMode:     "hook", // CLI-started sessions use hook mode (CLI hooks drive recording)
+		AgentID:        inst.AgentID,
+		AgentSessionID: agentSessionID,
+		AdapterName:    adapterName,
+		AgentType:      agentTypeName,
+		SessionFile:    sessionFile,
+		Title:          title,
+		Username:       identity.AttributionUsername(endpoint.GetForProject(projectRoot), config.GetDisplayName()),
+		WorkspacePath:  projectRoot,
+		Branch:         repotools.GetCurrentBranch(projectRoot),
+		ParentPID:      parentPID,
+		StartOffset:    startOffset,
+		WatchMode:      sessionWatchMode(adapterName),
 	}
 
 	state, err := session.StartRecording(projectRoot, opts)
@@ -257,6 +264,9 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 
 	// register-at-start so /c/<session_id> resolves from t=0 (fire-and-forget)
 	notifySessionStartedAsync(projectRoot, state)
+	if state.WatchMode == "tail" {
+		sendSessionWatchStart(state, projectRoot)
+	}
 
 	// build output once, render based on mode
 	output := buildSessionStartOutput(inst.AgentID, adapterName, sessionFile, title, notice, state.StartedAt)
@@ -441,7 +451,9 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 
 	// mark explicit stop BEFORE daemon RPC so anti-entropy cannot restart
 	// the watcher in the window between RPC and mark
-	_ = session.MarkExplicitStop(projectRoot, inst.AgentID)
+	if err := session.MarkExplicitStop(projectRoot, inst.AgentID); err != nil {
+		return fmt.Errorf("mark session stopped: %w", err)
+	}
 
 	// for tail-mode sessions: tell the daemon to stop tailing before we process
 	if state.WatchMode == "tail" {
@@ -465,9 +477,10 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 				repoRoot = projectRoot // fallback for legacy states without WorkspacePath
 			}
 			lookup := adapters.SessionLookup{
-				RepoRoot: repoRoot,
-				AgentID:  state.AgentID,
-				Since:    state.StartedAt,
+				RepoRoot:       repoRoot,
+				AgentID:        state.AgentID,
+				AgentSessionID: state.AgentSessionID,
+				Since:          state.StartedAt.Add(-5 * time.Minute),
 			}
 			if sf, findErr := adapter.FindSessionFile(lookup); findErr == nil {
 				slog.Info("session file discovered at stop time", "file", sf, "adapter", state.AdapterName)
@@ -479,9 +492,10 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 				pathVariants := sessionPathVariants(repoRoot)
 				for _, variant := range pathVariants {
 					retryLookup := adapters.SessionLookup{
-						RepoRoot: variant,
-						AgentID:  state.AgentID,
-						Since:    state.StartedAt,
+						RepoRoot:       variant,
+						AgentID:        state.AgentID,
+						AgentSessionID: state.AgentSessionID,
+						Since:          state.StartedAt.Add(-5 * time.Minute),
 					}
 					if sf, retryErr := adapter.FindSessionFile(retryLookup); retryErr == nil {
 						slog.Info("session file discovered via path variant", "file", sf, "original_root", repoRoot, "variant", variant)
@@ -519,7 +533,27 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 	var processResult *agentSessionResult
 	if state.SessionFile != "" {
 		processStart := time.Now()
-		processResult, err = processAgentSession(projectRoot, state)
+		if state.WatchMode == "tail" {
+			// IPC stop is advisory. Wait for the writer's file lock and reload
+			// its final cursor before draining, so an in-flight batch is not
+			// captured twice. A lock failure preserves the recording for retry.
+			err = fileutil.WithFileLock(context.Background(), filepath.Join(state.SessionPath, "raw.jsonl"), func() error {
+				latest, loadErr := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
+				if loadErr != nil {
+					return loadErr
+				}
+				if latest == nil {
+					return session.ErrNotRecording
+				}
+				latest.SessionFile = state.SessionFile
+				state = latest
+				var processErr error
+				processResult, processErr = processAgentSession(projectRoot, state)
+				return processErr
+			})
+		} else {
+			processResult, err = processAgentSession(projectRoot, state)
+		}
 		timing["process_ms"] = time.Since(processStart).Milliseconds()
 		if err != nil {
 			// set marker so future ox agent prime knows doctor is needed

--- a/cmd/ox/agent_session_incremental.go
+++ b/cmd/ox/agent_session_incremental.go
@@ -108,7 +108,7 @@ func finalizeIncrementalSession(projectRoot string, state *session.RecordingStat
 
 		entries, newOffset, readErr := reader.ReadFromOffset(state.SessionFile, readOffset)
 		if readErr != nil {
-			slog.Debug("finalize: incremental read failed", "error", readErr)
+			return nil, fmt.Errorf("read final session entries: %w", readErr)
 		} else if len(entries) > 0 {
 			slog.Info("finalize: drain result", "entries_read", len(entries), "new_offset", newOffset)
 
@@ -132,7 +132,7 @@ func finalizeIncrementalSession(projectRoot string, state *session.RecordingStat
 				drainEntries := session.ConvertRawEntries(entries)
 
 				if appendErr := appendRedactedEntries(rawPath, drainEntries); appendErr != nil {
-					slog.Debug("finalize: append entries failed", "error", appendErr)
+					return nil, fmt.Errorf("append final session entries: %w", appendErr)
 				} else {
 					// only advance offset/count after successful append;
 					// leaving them unchanged lets the next drain retry these entries

--- a/cmd/ox/agent_session_incremental_test.go
+++ b/cmd/ox/agent_session_incremental_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/agentinstance"
+	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/stretchr/testify/assert"
@@ -852,4 +854,85 @@ func TestFinalizeIncrementalSession_EmptySession(t *testing.T) {
 	assert.Equal(t, rawPath, got.RawPath, "RawPath should still be set even for empty sessions")
 	assert.Empty(t, got.SummaryMDPath, "no summary should be generated for empty session")
 	assert.Empty(t, got.SessionMDPath, "no session markdown should be generated for empty session")
+}
+
+// A failed final Codex drain must preserve its captured prefix and cursor for retry.
+func TestCodexSessionStop_FinalDrainFailurePreservesRecording(t *testing.T) {
+	for _, failure := range []string{"read", "append"} {
+		t.Run(failure, func(t *testing.T) {
+			if failure == "append" && os.Geteuid() == 0 {
+				t.Skip("root can write files despite read-only permissions")
+			}
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+			t.Setenv("OX_XDG_DISABLE", "")
+			t.Setenv("SAGEOX_DAEMON", "false")
+			projectRoot := setupIncrementalTest(t)
+			t.Chdir(projectRoot)
+			previousCfg := cfg
+			cfg = &config.Config{Text: true}
+			t.Cleanup(func() { cfg = previousCfg })
+
+			adapter := &testCodexAdapter{}
+			adapters.Register(adapter)
+			t.Cleanup(func() { adapters.Unregister("codex") })
+			sourceFile := writeCodexSessionFile(t, os.Getenv("HOME"), projectRoot)
+			inst := &agentinstance.Instance{AgentID: "OxDrainRetry", AgentType: "codex"}
+			state, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+				AgentID: inst.AgentID, AdapterName: "codex", SessionFile: sourceFile,
+				WorkspacePath: projectRoot, WatchMode: "tail", ParentPID: os.Getpid(),
+			})
+			require.NoError(t, err)
+			require.NoError(t, writeRawHeader(projectRoot, state))
+			rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
+			appendCodexMessage(t, sourceFile, "user", "captured prefix")
+			prefix, offset, err := adapter.ReadFromOffset(sourceFile, 0)
+			require.NoError(t, err)
+			require.Len(t, prefix, 1)
+			require.NoError(t, appendRedactedEntries(rawPath, session.ConvertRawEntries(prefix)))
+			require.NoError(t, session.UpdateRecordingStateForAgent(projectRoot, inst.AgentID, func(s *session.RecordingState) {
+				s.SourceOffset = offset
+				s.EntryCount = len(prefix)
+			}))
+			before, err := os.ReadFile(rawPath)
+			require.NoError(t, err)
+			appendCodexMessage(t, sourceFile, "assistant", "final Codex response")
+			if failure == "read" {
+				require.NoError(t, os.Rename(sourceFile, sourceFile+".unavailable"))
+			} else {
+				require.NoError(t, os.Chmod(rawPath, 0o400))
+				t.Cleanup(func() { _ = os.Chmod(rawPath, 0o600) })
+			}
+
+			err = runAgentSessionStop(inst)
+			require.Error(t, err, "stop must not finalize only the captured prefix")
+			assert.Contains(t, err.Error(), "recording state preserved")
+			preserved, err := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
+			require.NoError(t, err)
+			require.NotNil(t, preserved)
+			assert.Equal(t, offset, preserved.SourceOffset)
+			assert.Equal(t, 1, preserved.EntryCount)
+			after, err := os.ReadFile(rawPath)
+			require.NoError(t, err)
+			assert.Equal(t, before, after, "a failed drain must preserve already captured content")
+
+			if failure == "read" {
+				require.NoError(t, os.Rename(sourceFile+".unavailable", sourceFile))
+			} else {
+				require.NoError(t, os.Chmod(rawPath, 0o600))
+			}
+			require.NoError(t, runAgentSessionStop(inst))
+			cleared, err := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
+			require.NoError(t, err)
+			assert.Nil(t, cleared)
+			stored, err := session.ReadSessionFromPath(rawPath)
+			require.NoError(t, err)
+			var contents []any
+			for _, entry := range stored.Entries {
+				contents = append(contents, entry["content"])
+			}
+			assert.Equal(t, []any{"captured prefix", "final Codex response"}, contents,
+				"retry must retain the prefix and capture the final turn exactly once")
+		})
+	}
 }

--- a/cmd/ox/agent_session_manual_publish_test.go
+++ b/cmd/ox/agent_session_manual_publish_test.go
@@ -2,16 +2,20 @@ package main
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/sageox/ox/internal/agentinstance"
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/daemon/agentwork"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/stretchr/testify/require"
@@ -35,8 +39,33 @@ type agentSessionFixture struct {
 	// the isolated test environment and returns a handle/path for follow-up writes.
 	createSessionSource func(t *testing.T, homeDir, cwd string) string
 
-	// appendQuery appends a user query to the agent source after session start.
-	appendQuery func(t *testing.T, sourcePath, query string)
+	// appendMessage appends a native message after session start.
+	appendMessage func(t *testing.T, sourcePath, role, content string)
+
+	stopDuringCapture bool
+}
+
+// blockingStopCodexAdapter holds the watcher's final native read in flight while
+// the CLI starts stopping. Only that first read blocks; an unlocked CLI drain
+// can still run, exposing duplicate capture instead of hiding it behind the test.
+type blockingStopCodexAdapter struct {
+	testCodexAdapter
+	response string
+	entered  chan struct{}
+	release  chan struct{}
+	blocked  atomic.Bool
+}
+
+func (a *blockingStopCodexAdapter) ReadFromOffset(path string, offset int64) ([]adapters.RawEntry, int64, error) {
+	entries, next, err := a.testCodexAdapter.ReadFromOffset(path, offset)
+	for _, entry := range entries {
+		if entry.Content == a.response && a.blocked.CompareAndSwap(false, true) {
+			close(a.entered)
+			<-a.release
+			break
+		}
+	}
+	return entries, next, err
 }
 
 func TestManualPublishingSessionCapture_Matrix(t *testing.T) {
@@ -62,7 +91,14 @@ func TestManualPublishingSessionCapture_Matrix(t *testing.T) {
 			name:                "codex",
 			agentType:           "codex",
 			createSessionSource: writeCodexSessionFile,
-			appendQuery:         appendCodexUserQuery,
+			appendMessage:       appendCodexMessage,
+		},
+		{
+			name:                "codex_stop_during_capture",
+			agentType:           "codex",
+			createSessionSource: writeCodexSessionFile,
+			appendMessage:       appendCodexMessage,
+			stopDuringCapture:   true,
 		},
 	}
 
@@ -75,6 +111,10 @@ func TestManualPublishingSessionCapture_Matrix(t *testing.T) {
 }
 
 func runManualPublishingSessionCaptureTest(t *testing.T, fixture agentSessionFixture) {
+	if fixture.stopDuringCapture && testing.Short() {
+		t.Skip("short: waits for native recording polls and concurrent CLI stop")
+	}
+
 	// Fast local HTTP endpoint for auth/access checks (checkUploadAccess fail-open path).
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
@@ -85,7 +125,11 @@ func runManualPublishingSessionCaptureTest(t *testing.T, fixture agentSessionFix
 	t.Setenv("OX_XDG_ENABLE", "1")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SAGEOX_DAEMON", "false")
 
 	projectRoot := createInitializedProjectWithConfig(t, &config.ProjectConfig{
 		RepoID:    "test-repo-manual-publish",
@@ -102,6 +146,7 @@ func runManualPublishingSessionCaptureTest(t *testing.T, fixture agentSessionFix
 	require.NoError(t, os.Chdir(projectRoot))
 	actualProjectCWD, err := os.Getwd()
 	require.NoError(t, err)
+	require.Nil(t, daemon.TryConnect(), "fixture must not connect to a live daemon")
 
 	// runAgentSessionStart/Stop read output mode from global cfg, which is normally
 	// initialized by Cobra PersistentPreRun in CLI execution.
@@ -153,23 +198,109 @@ func runManualPublishingSessionCaptureTest(t *testing.T, fixture agentSessionFix
 	require.NoError(t, err)
 	require.NoError(t, store.Add(inst))
 	require.NoError(t, runAgentSessionStart(inst, nil))
+	state, err := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, "tail", state.WatchMode, "manual Codex start without hooks must start tail capture")
 
 	// (d) append pre-canned query after recording start so it survives timestamp filtering.
 	preCannedQuery := "PRE-CANNED-QUERY: verify manual publishing captures this"
-	fixture.appendQuery(t, sourcePath, preCannedQuery)
+	fixture.appendMessage(t, sourcePath, "user", preCannedQuery)
 
 	// (e) stop session and gather stored session data.
-	require.NoError(t, runAgentSessionStop(inst))
+	const finalResponse = "FINAL-CODEX-RESPONSE: the recording contains the completed work"
+	if fixture.stopDuringCapture {
+		// Failure prevented: stopping between a source read and its persisted
+		// cursor used to make the CLI drain that same batch a second time.
+		blocking := &blockingStopCodexAdapter{
+			response: finalResponse, entered: make(chan struct{}), release: make(chan struct{}),
+		}
+		previousAdapter, err := adapters.GetAdapter("codex")
+		require.NoError(t, err)
+		adapters.Unregister("codex")
+		adapters.Register(blocking)
+		t.Cleanup(func() {
+			adapters.Unregister("codex")
+			adapters.Register(previousAdapter)
+		})
+		manager := agentwork.NewSessionWatcherManager(slog.Default())
+		manager.SetHomeDirForTest(os.Getenv("HOME"))
+		t.Cleanup(func() {
+			select {
+			case <-blocking.release:
+			default:
+				close(blocking.release)
+			}
+			manager.StopAll()
+		})
+		ledgerPath := deriveLedgerPath(state.SessionPath)
+		require.NotEmpty(t, ledgerPath)
+		require.Equal(t, 1, manager.DetectAndRestart(ledgerPath))
+		firstBatch, err := os.Stat(sourcePath)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			current, err := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
+			return err == nil && current != nil && current.SourceOffset == firstBatch.Size() && current.EntryCount == 1
+		}, 8*time.Second, 10*time.Millisecond, "first prompt must be captured before the final read")
 
-	// Read latest saved raw session from local cache store.
-	contextPath := session.GetContextPath("test-repo-manual-publish")
-	require.NotEmpty(t, contextPath)
-	s, err := session.NewStore(contextPath)
-	require.NoError(t, err)
-	latest, err := s.GetLatestRaw()
-	require.NoError(t, err)
-	stored, err := s.ReadSessionRaw(latest.SessionName)
-	require.NoError(t, err)
+		fixture.appendMessage(t, sourcePath, "assistant", finalResponse)
+		select {
+		case <-blocking.entered:
+		case <-time.After(8 * time.Second):
+			t.Fatal("watcher did not begin the final native read")
+		}
+		stopResult := make(chan error, 1)
+		stopFinished := make(chan struct{})
+		go func() {
+			defer close(stopFinished)
+			stopResult <- runAgentSessionStop(inst)
+		}()
+		t.Cleanup(func() {
+			select {
+			case <-blocking.release:
+			default:
+				close(blocking.release)
+			}
+			select {
+			case <-stopFinished:
+			case <-time.After(15 * time.Second):
+				t.Error("CLI stop did not finish during cleanup")
+			}
+		})
+		require.Eventually(t, func() bool {
+			return session.HasExplicitStop(projectRoot, inst.AgentID)
+		}, 3*time.Second, 10*time.Millisecond, "CLI must mark explicit stop before waiting for the watcher")
+		close(blocking.release)
+		select {
+		case err := <-stopResult:
+			require.NoError(t, err)
+		case <-time.After(15 * time.Second):
+			t.Fatal("CLI stop did not finish without daemon IPC")
+		}
+		require.Eventually(t, func() bool { return len(manager.ActiveSessions()) == 0 }, 3*time.Second, 10*time.Millisecond,
+			"watcher must observe explicit stop without IPC")
+		require.NoFileExists(t, filepath.Join(state.SessionPath, ".recording.json"))
+		require.Zero(t, manager.DetectAndRestart(ledgerPath), "stopped recording must not restart")
+	} else {
+		require.NoError(t, runAgentSessionStop(inst))
+	}
+
+	var stored *session.StoredSession
+	if fixture.stopDuringCapture {
+		// Incremental stop finalizes the existing recording cache in place.
+		stored, err = session.ReadSessionFromPath(filepath.Join(state.SessionPath, "raw.jsonl"))
+		require.NoError(t, err)
+	} else {
+		// A session with no live capture is reconstructed into the store.
+		contextPath := session.GetContextPath("test-repo-manual-publish")
+		require.NotEmpty(t, contextPath)
+		s, err := session.NewStore(contextPath)
+		require.NoError(t, err)
+		latest, err := s.GetLatestRaw()
+		require.NoError(t, err)
+		stored, err = s.ReadSessionRaw(latest.SessionName)
+		require.NoError(t, err)
+	}
 
 	// (f) assert session contains the pre-canned query.
 	found := false
@@ -180,6 +311,16 @@ func runManualPublishingSessionCaptureTest(t *testing.T, fixture agentSessionFix
 		}
 	}
 	require.True(t, found, "expected stored session to contain pre-canned query")
+	if fixture.stopDuringCapture {
+		counts := make(map[string]int)
+		for _, entry := range stored.Entries {
+			if content, ok := entry["content"].(string); ok {
+				counts[content]++
+			}
+		}
+		require.Equal(t, 1, counts[preCannedQuery], "initial prompt must remain captured once")
+		require.Equal(t, 1, counts[finalResponse], "final response must be drained exactly once")
+	}
 }
 
 func writeCodexSessionFile(t *testing.T, homeDir, cwd string) string {
@@ -215,24 +356,28 @@ func writeCodexSessionFile(t *testing.T, homeDir, cwd string) string {
 	return sessionPath
 }
 
-func appendCodexUserQuery(t *testing.T, sessionPath, query string) {
+func appendCodexMessage(t *testing.T, sessionPath, role, content string) {
 	t.Helper()
 
 	f, err := os.OpenFile(sessionPath, os.O_APPEND|os.O_WRONLY, 0o644)
 	require.NoError(t, err)
 	defer f.Close()
 
+	contentType := "input_text"
+	if role == "assistant" {
+		contentType = "output_text"
+	}
 	enc := json.NewEncoder(f)
 	require.NoError(t, enc.Encode(map[string]any{
 		"timestamp": time.Now().Add(2 * time.Second).UTC().Format(time.RFC3339Nano),
 		"type":      "response_item",
 		"payload": map[string]any{
 			"type": "message",
-			"role": "user",
+			"role": role,
 			"content": []map[string]any{
 				{
-					"type": "input_text",
-					"text": query,
+					"type": contentType,
+					"text": content,
 				},
 			},
 		},

--- a/cmd/ox/config_settings_e2e_test.go
+++ b/cmd/ox/config_settings_e2e_test.go
@@ -141,7 +141,7 @@ func TestConfigE2E_SessionRecordingGateControlsRecording(t *testing.T) {
 
 	// Disabled via the real command: the gate creates no recording.
 	oxConfigSetRepo(t, "session_recording", "disabled")
-	assert.Nil(t, startSessionRecording(f.projectRoot, agentID, "claude-code", "", ""),
+	assert.Nil(t, startSessionRecording(f.projectRoot, agentID, "claude-code", "", "", ""),
 		"session_recording=disabled must not start a recording")
 	st, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
 	require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestConfigE2E_SessionRecordingGateControlsRecording(t *testing.T) {
 
 	// Auto via the real command: the gate creates a recording with a transcript.
 	oxConfigSetRepo(t, "session_recording", "auto")
-	status := startSessionRecording(f.projectRoot, agentID, "claude-code", "", "")
+	status := startSessionRecording(f.projectRoot, agentID, "claude-code", "", "", "")
 	require.NotNil(t, status, "session_recording=auto must start a recording")
 	assert.True(t, status.Recording, "auto must actually record")
 	st2, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
@@ -180,7 +180,7 @@ func TestConfigE2E_ResumeLinksNewRecordingToPriorSession(t *testing.T) {
 	)
 	t.Cleanup(func() { _ = DeleteSessionMarker(agentSessionID) })
 
-	firstStatus := startSessionRecording(f.projectRoot, agentID, "claude-code", "", "")
+	firstStatus := startSessionRecording(f.projectRoot, agentID, "claude-code", "", "", agentSessionID)
 	require.NotNil(t, firstStatus)
 	first, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
 	require.NoError(t, err)
@@ -203,11 +203,12 @@ func TestConfigE2E_ResumeLinksNewRecordingToPriorSession(t *testing.T) {
 	resumedMarker, err := ReadSessionMarker(agentSessionID)
 	require.NoError(t, err)
 	continuedFrom := recordingSessionIDFromMarker(resumedMarker)
-	secondStatus := startSessionRecording(f.projectRoot, agentID, "claude-code", "", continuedFrom)
+	secondStatus := startSessionRecording(f.projectRoot, agentID, "claude-code", "", continuedFrom, agentSessionID)
 	require.NotNil(t, secondStatus)
 	second, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
 	require.NoError(t, err)
 	require.NotNil(t, second)
+	assert.Equal(t, agentSessionID, second.AgentSessionID, "native identity must survive daemon restart")
 
 	assert.NotEqual(t, first.SessionID, second.SessionID, "each finalized half keeps its own identity")
 	assert.Equal(t, first.SessionID, second.ContinuedFromSessionID)
@@ -217,6 +218,36 @@ func TestConfigE2E_ResumeLinksNewRecordingToPriorSession(t *testing.T) {
 	require.NotNil(t, stored.Meta)
 	assert.Equal(t, first.SessionID, stored.Meta.ContinuedFromSessionID,
 		"continuation must survive loss of the ephemeral recording state")
+}
+
+// A failed Codex stop retains its recording for retry. Re-prime must not
+// consume the stop signal and let daemon discovery restart that recording.
+func TestConfigE2E_CodexReprimePreservesPendingStop(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	t.Chdir(f.projectRoot)
+	oldCfg := cfg
+	cfg = &config.Config{}
+	t.Cleanup(func() { cfg = oldCfg })
+	oxConfigSetRepo(t, "session_recording", "auto")
+	const agentID = "OxCodexStop"
+	require.NotNil(t, startSessionRecording(f.projectRoot, agentID, "codex", "", "", "codex-stop-retry"))
+	state, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.NoError(t, session.MarkExplicitStop(f.projectRoot, agentID))
+
+	for range 2 {
+		require.Nil(t, startSessionRecording(f.projectRoot, agentID, "codex", "", "", "codex-stop-retry"))
+		require.True(t, session.HasExplicitStop(f.projectRoot, agentID), "pending stop must remain durable across re-prime")
+		current, err := session.LoadRecordingStateForAgent(f.projectRoot, agentID)
+		require.NoError(t, err)
+		require.NotNil(t, current)
+		require.Equal(t, state.SessionID, current.SessionID)
+	}
+
+	require.NoError(t, session.ClearRecordingStateForAgent(f.projectRoot, agentID))
+	require.Nil(t, startSessionRecording(f.projectRoot, agentID, "codex", "", "", "codex-stop-retry"))
+	require.False(t, session.HasExplicitStop(f.projectRoot, agentID), "completed stop retains its existing one-prime skip")
 }
 
 // TestConfigE2E_CloudQueryGateControlsTheNetworkDecision proves the privacy

--- a/internal/daemon/agentwork/manager.go
+++ b/internal/daemon/agentwork/manager.go
@@ -434,6 +434,11 @@ func (m *Manager) runSessionCleanup() {
 	sw := m.sessionWatcher
 	m.mu.Unlock()
 
+	// Quiesce finished watchers before cleanup or finalization reads their cursor.
+	if sw != nil {
+		sw.Cleanup()
+	}
+
 	if ok {
 		if sfh, ok := h.(*SessionFinalizeHandler); ok {
 			sfh.Cleanup(m.ledgerPath)
@@ -443,7 +448,6 @@ func (m *Manager) runSessionCleanup() {
 	// tail-mode watcher anti-entropy: restart orphaned watchers, stop finished ones
 	if sw != nil {
 		sw.DetectAndRestart(m.ledgerPath)
-		sw.Cleanup()
 	}
 }
 

--- a/internal/daemon/agentwork/manager_test.go
+++ b/internal/daemon/agentwork/manager_test.go
@@ -2,14 +2,18 @@ package agentwork
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +73,61 @@ func newTestManager(runner Runner, cfgFn func() *config.AgentWorkerConfig) (*Man
 }
 
 // --- tests ---
+
+func TestManager_ForceDetect_QuiescesFinishedCaptureWhenDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: waits for capture polling before cleanup")
+	}
+	for _, finished := range []string{"stopped", "dead"} {
+		t.Run(finished, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+			t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+			watcher := newTestWatcherManager(t)
+			t.Cleanup(watcher.StopAll)
+			m, _ := newTestManager(NewMockRunner(false), disabledConfig)
+			m.ledgerPath = t.TempDir()
+			m.SetSessionWatcher(watcher)
+			m.RegisterHandler(NewSessionFinalizeHandlerForTest(nil))
+
+			source := watcher.codexSessionPath(t, "finished.jsonl")
+			content := []byte("Keep this captured response.\n")
+			require.NoError(t, os.WriteFile(source, content, 0600))
+			state := session.RecordingState{
+				AgentID: "OxFinish", WorkspacePath: t.TempDir(),
+				SessionPath: filepath.Join(m.ledgerPath, ".sageox", "cache", "sessions", "finished"),
+				AdapterName: "codex", WatchMode: "tail", SessionFile: source,
+				ParentPID: os.Getpid(), StartedAt: time.Now(),
+			}
+			require.NoError(t, session.SaveRecordingState(state.WorkspacePath, &state))
+			require.NoError(t, watcher.StartWatch("finished", source, "codex", m.ledgerPath, state.SessionPath))
+			recPath := filepath.Join(state.SessionPath, recordingMarker)
+			require.Eventually(t, func() bool {
+				data, err := os.ReadFile(recPath)
+				var current session.RecordingState
+				return err == nil && json.Unmarshal(data, &current) == nil && current.SourceOffset == int64(len(content))
+			}, 5*time.Second, 10*time.Millisecond, "watcher must capture before the session finishes")
+			data, err := os.ReadFile(recPath)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(data, &state))
+			if finished == "stopped" {
+				stoppedAt := time.Now()
+				state.StoppedAt = &stoppedAt
+			} else {
+				state.ParentPID = 99999999
+			}
+			require.NoError(t, session.SaveRecordingState(state.WorkspacePath, &state))
+
+			assert.Zero(t, m.ForceDetect(), "disabled workers must not queue summary generation")
+			assert.Empty(t, watcher.ActiveSessions(), "capture must stop even when summary generation is disabled")
+			assert.FileExists(t, recPath, "cleanup must retain the cursor for later finalization")
+			assert.Equal(t, 1, countRawJSONLEntries(t, filepath.Join(state.SessionPath, "raw.jsonl")))
+			assert.Zero(t, watcher.DetectAndRestart(m.ledgerPath), "finished sessions must not restart")
+		})
+	}
+}
 
 func TestManager_StartStop(t *testing.T) {
 	runner := NewMockRunner(true)

--- a/internal/daemon/agentwork/session_capture_upload_test.go
+++ b/internal/daemon/agentwork/session_capture_upload_test.go
@@ -1,0 +1,258 @@
+package agentwork
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/session/adapters"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionCapture_UploadsNativeEntries verifies that native messages and tool
+// calls survive recording, a watcher restart, finalization, LFS upload, and git
+// push. Failure prevented: Codex recordings remain empty or lose custom tools
+// while isolated parser and upload tests continue to pass.
+func TestSessionCapture_UploadsNativeEntries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: builds adapters, polls recordings, and pushes to a local git remote")
+	}
+
+	repoRoot, err := filepath.Abs("../../..")
+	require.NoError(t, err)
+	binDir := t.TempDir()
+	for _, name := range []string{"codex", "claude-code"} {
+		cmd := exec.Command("go", "build", "-o", filepath.Join(binDir, "ox-adapter-"+name), "./cmd/ox-adapter-"+name)
+		cmd.Dir = repoRoot
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "build %s: %s", name, out)
+	}
+
+	// Keep every credential and cache write inside the fixture. The production
+	// LFS client still loads credentials normally, using a loopback endpoint.
+	for _, variable := range []string{"XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME"} {
+		t.Setenv(variable, t.TempDir())
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	previousConfigDir := gitserver.TestSetConfigDirOverride(t.TempDir())
+	t.Cleanup(func() { gitserver.TestSetConfigDirOverride(previousConfigDir) })
+	previousFileStorage := gitserver.TestSetForceFileStorage(true)
+	t.Cleanup(func() { gitserver.TestSetForceFileStorage(previousFileStorage) })
+
+	const userPrompt = "Verify that native conversation messages and tool calls survive recording, daemon restart, finalization, and upload to the team ledger."
+	const firstResponse = "The initial capture contains the requested conversation and tool activity."
+	const finalResponse = "The resumed recording is complete and all session content is ready for upload."
+	for _, tc := range []struct {
+		name           string
+		sourceRelative string
+		firstBatch     string
+		lastBatch      string
+		entryCount     int
+	}{
+		{
+			name:           "codex",
+			sourceRelative: ".codex/sessions/2026/09/07/session.jsonl",
+			firstBatch: `{"type":"response_item","timestamp":"STAMP","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"PROMPT"}]}}
+{"type":"response_item","timestamp":"STAMP","payload":{"type":"custom_tool_call","name":"functions.exec","input":"text(\"capture canary\")","call_id":"call_capture"}}
+{"type":"response_item","timestamp":"STAMP","payload":{"type":"custom_tool_call_output","output":"capture canary","call_id":"call_capture"}}
+{"type":"response_item","timestamp":"STAMP","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"FIRST"}]}}
+`,
+			lastBatch: `{"type":"response_item","timestamp":"STAMP","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Continue the same recording after the watcher restarts."}]}}
+{"type":"response_item","timestamp":"STAMP","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"FINAL"}]}}
+`,
+			entryCount: 5,
+		},
+		{
+			name:           "claude-code",
+			sourceRelative: ".claude/projects/test/session.jsonl",
+			firstBatch: `{"type":"user","timestamp":"STAMP","message":{"role":"user","content":"PROMPT"}}
+{"type":"assistant","timestamp":"STAMP","message":{"role":"assistant","content":[{"type":"tool_use","id":"call_capture","name":"functions.exec","input":{"code":"text(\"capture canary\")"}}]}}
+{"type":"user","timestamp":"STAMP","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_capture","content":"capture canary"}]}}
+{"type":"assistant","timestamp":"STAMP","message":{"role":"assistant","content":[{"type":"text","text":"FIRST"}]}}
+`,
+			lastBatch: `{"type":"user","timestamp":"STAMP","message":{"role":"user","content":"Continue the same recording after the watcher restarts."}}
+{"type":"assistant","timestamp":"STAMP","message":{"role":"assistant","content":[{"type":"text","text":"FINAL"}]}}
+`,
+			entryCount: 6,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter, err := adapters.NewExternalAdapter(filepath.Join(binDir, "ox-adapter-"+tc.name))
+			require.NoError(t, err)
+			var previousAdapter adapters.Adapter
+			for _, name := range adapters.ListAdapters() {
+				if name == tc.name {
+					previousAdapter, err = adapters.GetAdapter(name)
+					require.NoError(t, err)
+				}
+			}
+			adapters.Unregister(tc.name)
+			adapters.Register(adapter)
+			t.Cleanup(func() {
+				_ = adapter.Close()
+				adapters.Unregister(tc.name)
+				if previousAdapter != nil {
+					adapters.Register(previousAdapter)
+				}
+			})
+
+			// Reuse the real git fixture; only LFS HTTP is supplied locally. Git
+			// pushes use a separate file:// push URL and never contact a service.
+			barePath, ledgerPath := setupBareAndCloneLedger(t)
+			var uploaded sync.Map
+			var serverURL string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/ledger.git/info/lfs/objects/batch":
+					var request struct {
+						Operation string            `json:"operation"`
+						Objects   []lfs.BatchObject `json:"objects"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					response := lfs.BatchResponse{Transfer: "basic"}
+					for _, object := range request.Objects {
+						action := &lfs.Action{Href: serverURL + "/objects/" + object.OID}
+						result := lfs.BatchResponseObject{OID: object.OID, Size: object.Size, Actions: &lfs.Actions{}}
+						if request.Operation == "upload" {
+							result.Actions.Upload = action
+						} else if _, ok := uploaded.Load(object.OID); ok {
+							result.Actions.Download = action
+						} else {
+							result.Error = &lfs.ObjectError{Code: 404, Message: "not uploaded"}
+						}
+						response.Objects = append(response.Objects, result)
+					}
+					w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
+					_ = json.NewEncoder(w).Encode(response)
+				case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/objects/"):
+					content, err := io.ReadAll(r.Body)
+					if err != nil || lfs.ComputeOID(content) != filepath.Base(r.URL.Path) {
+						http.Error(w, "invalid uploaded content", http.StatusBadRequest)
+						return
+					}
+					uploaded.Store(filepath.Base(r.URL.Path), content)
+					w.WriteHeader(http.StatusOK)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(server.Close)
+			serverURL = server.URL
+			t.Setenv("SAGEOX_ENDPOINT", serverURL)
+			require.NoError(t, gitserver.SaveCredentialsForEndpoint(serverURL, gitserver.GitCredentials{
+				Username: "testuser", Token: "test-token", ServerURL: serverURL,
+				ExpiresAt: time.Now().Add(time.Hour),
+			}))
+			runGitCmd(t, ledgerPath, "remote", "set-url", "origin", serverURL+"/ledger.git")
+			runGitCmd(t, ledgerPath, "remote", "set-url", "--push", "origin", "file://"+barePath)
+
+			projectRoot := t.TempDir()
+			sessionHome := t.TempDir()
+			source := filepath.Join(sessionHome, filepath.FromSlash(tc.sourceRelative))
+			require.NoError(t, os.MkdirAll(filepath.Dir(source), 0o755))
+			require.NoError(t, os.WriteFile(source, nil, 0o600))
+			state, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+				AgentID: "OxCapture", AdapterName: tc.name, AgentType: tc.name,
+				SessionFile: source, Username: "testuser", WorkspacePath: projectRoot,
+				RepoContextPath: filepath.Join(ledgerPath, ".sageox", "cache"),
+				ParentPID:       os.Getpid(), WatchMode: "tail",
+			})
+			require.NoError(t, err)
+			sessionName := filepath.Base(state.SessionPath)
+			require.Equal(t, filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName), state.SessionPath)
+			rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
+			writer, err := session.NewRawWriter(rawPath, projectRoot)
+			require.NoError(t, err)
+			require.NoError(t, writer.WriteRaw(map[string]any{
+				"type": "header",
+				"metadata": &session.StoreMeta{
+					Version: "1.0", SessionID: state.SessionID, AgentID: state.AgentID,
+					AgentType: tc.name, Username: "testuser", CreatedAt: state.StartedAt,
+				},
+			}))
+			require.NoError(t, writer.CloseAndSync())
+
+			var sourceContent string
+			for _, batch := range []string{tc.firstBatch, tc.lastBatch} {
+				sourceContent += strings.NewReplacer(
+					"STAMP", time.Now().UTC().Format(time.RFC3339Nano),
+					"PROMPT", userPrompt, "FIRST", firstResponse, "FINAL", finalResponse,
+				).Replace(batch)
+				require.NoError(t, os.WriteFile(source, []byte(sourceContent), 0o600))
+				manager := NewSessionWatcherManager(slog.Default())
+				manager.SetHomeDirForTest(sessionHome)
+				t.Cleanup(manager.StopAll)
+				require.Equal(t, 1, manager.DetectAndRestart(ledgerPath), "recording created by StartRecording must be discoverable")
+				require.Eventually(t, func() bool {
+					data, err := os.ReadFile(filepath.Join(state.SessionPath, recordingMarker))
+					var recorded session.RecordingState
+					return err == nil && json.Unmarshal(data, &recorded) == nil && recorded.SourceOffset == int64(len(sourceContent))
+				}, 10*time.Second, 25*time.Millisecond, "native entries must reach the recording cache")
+				manager.StopAll()
+			}
+
+			captured, err := session.ReadSessionFromPath(rawPath)
+			require.NoError(t, err)
+			require.Len(t, captured.Entries, tc.entryCount, "restart must preserve all entries without duplicates")
+			// The finalizer owns the finished cache after the recording marker is
+			// removed, as in the explicit stop/SessionEnd handoff.
+			require.NoError(t, os.Remove(filepath.Join(state.SessionPath, recordingMarker)))
+			handler := NewSessionFinalizeHandler(slog.Default())
+			handler.SetProjectRoot(projectRoot)
+			handler.SetLedgerMu(&sync.Mutex{})
+			items, err := handler.Detect(ledgerPath)
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+			request, err := handler.BuildPrompt(items[0])
+			require.NoError(t, err)
+			require.False(t, request.SkipLLM, "substantive native conversation must reach normal finalization")
+			// Only the summary response is supplied: artifact generation, LFS
+			// upload, pointer publication, and git push use production code.
+			require.NoError(t, handler.ProcessResult(items[0], &RunResult{Output: `{"title":"Native session capture and upload","summary":"Verified native conversation and tool capture across watcher restart, then finalized the session into the team ledger.","key_actions":["Captured native messages and tools","Resumed recording from its persisted cursor","Uploaded session artifacts"],"outcome":"success","topics_found":["session capture"],"quality_score":0.9,"score_reason":"Verified the complete session recording and upload lifecycle"}`}))
+
+			verifyClone := filepath.Join(t.TempDir(), "verify")
+			runGitCmd(t, t.TempDir(), "clone", "file://"+barePath, verifyClone)
+			publishedDir := filepath.Join(verifyClone, "sessions", sessionName)
+			meta, err := lfs.ReadSessionMeta(publishedDir)
+			require.NoError(t, err)
+			require.Equal(t, state.SessionID, meta.SessionID)
+			require.Equal(t, tc.name, meta.AgentType)
+			for _, name := range []string{"raw.jsonl", "session.md", "summary.md"} {
+				ref, err := lfs.ReadPointerFile(filepath.Join(publishedDir, name))
+				require.NoError(t, err, "%s must be an LFS pointer in a fresh clone", name)
+				require.Equal(t, meta.Files[name], ref)
+				blob, ok := uploaded.Load(ref.BareOID())
+				require.True(t, ok, "%s must reference an uploaded object", name)
+				require.Equal(t, ref.Size, int64(len(blob.([]byte))))
+				if name == "raw.jsonl" {
+					content := string(blob.([]byte))
+					for _, expected := range []string{userPrompt, firstResponse, finalResponse, "functions.exec"} {
+						assert.Equal(t, 1, strings.Count(content, expected), "%q must be uploaded once", expected)
+					}
+					assert.Contains(t, content, "capture canary", "tool input must survive upload")
+				}
+			}
+			assert.NoDirExists(t, state.SessionPath, "cache is pruned only after successful publication")
+			remaining, err := handler.Detect(ledgerPath)
+			require.NoError(t, err)
+			assert.Empty(t, remaining, "the completed upload must not be queued again")
+		})
+	}
+}

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -433,7 +433,9 @@ func (h *SessionFinalizeHandler) detectInDir(sessionsDir, ledgerPath string) ([]
 			// entries written after the watcher's last poll. Never write content
 			// into the git-tracked ledger path.
 			if sessionsDir != filepath.Join(ledgerPath, "sessions") {
-				recoverErr := fileutil.WithFileLock(context.Background(), rawPath, func() error {
+				// A busy capture writer can be retried on the next detect pass;
+				// keep one session from blocking the scan for the default 10s.
+				recoverErr := fileutil.WithFileLockTimeout(context.Background(), rawPath, 250*time.Millisecond, func() error {
 					var err error
 					hasRaw, err = recoverRawFromSessionFile(h.logger, recPath, sessionDir, rawPath)
 					if err != nil {
@@ -698,7 +700,7 @@ func (h *SessionFinalizeHandler) DetectOrphanedForAgent(ledgerPath, agentID stri
 			}
 
 			if sessionsDir != filepath.Join(ledgerPath, "sessions") {
-				recoverErr := fileutil.WithFileLock(context.Background(), rawPath, func() error {
+				recoverErr := fileutil.WithFileLockTimeout(context.Background(), rawPath, 250*time.Millisecond, func() error {
 					var err error
 					hasRaw, err = recoverRawFromSessionFile(h.logger, recPath, sessionDir, rawPath)
 					if err != nil {

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/lfs"
@@ -427,20 +429,34 @@ func (h *SessionFinalizeHandler) detectInDir(sessionsDir, ledgerPath string) ([]
 				h.logger.Debug("skipping session with active recording", "session", name)
 				continue
 			}
-			if !hasRaw {
-				// attempt recovery from adapter source file (#184)
-				if recoverRawFromSessionFile(h.logger, recPath, sessionDir, rawPath) {
-					hasRaw = true
-				} else {
-					h.logger.Warn("stale recording unrecoverable, clearing marker",
-						"session", name,
-						"recording_age", recAge.Round(time.Hour),
-					)
-					if rmErr := os.Remove(recPath); rmErr != nil {
-						h.logger.Warn("failed to remove unrecoverable recording marker", "err", rmErr)
+			// Recovery also fills an eager header and drains the final native
+			// entries written after the watcher's last poll. Never write content
+			// into the git-tracked ledger path.
+			if sessionsDir != filepath.Join(ledgerPath, "sessions") {
+				recoverErr := fileutil.WithFileLock(context.Background(), rawPath, func() error {
+					var err error
+					hasRaw, err = recoverRawFromSessionFile(h.logger, recPath, sessionDir, rawPath)
+					if err != nil {
+						return err
 					}
-					continue
+					// A queued watcher must observe the cleared marker before it
+					// acquires this lock and tries to resume the old cursor.
+					return os.Remove(recPath)
+				})
+				if recoverErr != nil {
+					h.logger.Warn("stale recording recovery deferred", "session", name, "err", recoverErr)
+					continue // preserve raw and the cursor so a later pass can retry
 				}
+			} else if err := os.Remove(recPath); err != nil {
+				h.logger.Warn("failed to remove stale recording marker", "session", name, "err", err)
+				continue
+			}
+			if !hasRaw {
+				h.logger.Warn("stale recording unrecoverable, clearing marker",
+					"session", name,
+					"recording_age", recAge.Round(time.Hour),
+				)
+				continue
 			}
 			// stale recording with raw.jsonl: clear the marker so we can finalize
 			h.logger.Info("clearing stale recording for anti-entropy finalization",
@@ -448,10 +464,6 @@ func (h *SessionFinalizeHandler) detectInDir(sessionsDir, ledgerPath string) ([]
 				"recording_age", recAge.Round(time.Hour),
 				"detection_method", method,
 			)
-			if err := os.Remove(recPath); err != nil {
-				h.logger.Warn("failed to remove stale recording marker", "session", name, "err", err)
-				continue
-			}
 		}
 
 		if !hasRaw {
@@ -679,30 +691,40 @@ func (h *SessionFinalizeHandler) DetectOrphanedForAgent(ledgerPath, agentID stri
 			rawPath := filepath.Join(sessionDir, artifactRaw)
 			hasRaw := false
 			if _, statErr := os.Stat(rawPath); statErr == nil {
+				if lfs.IsPointerFile(rawPath) {
+					continue
+				}
 				hasRaw = true
 			}
 
-			if !hasRaw {
-				// attempt recovery from adapter source file
-				if recoverRawFromSessionFile(h.logger, recPath, sessionDir, rawPath) {
-					hasRaw = true
-				} else {
-					h.logger.Warn("orphaned recording unrecoverable for agent",
-						"session", name, "agent_id", agentID,
-					)
-					_ = os.Remove(recPath)
+			if sessionsDir != filepath.Join(ledgerPath, "sessions") {
+				recoverErr := fileutil.WithFileLock(context.Background(), rawPath, func() error {
+					var err error
+					hasRaw, err = recoverRawFromSessionFile(h.logger, recPath, sessionDir, rawPath)
+					if err != nil {
+						return err
+					}
+					return os.Remove(recPath)
+				})
+				if recoverErr != nil {
+					h.logger.Warn("orphaned recording recovery deferred", "session", name, "err", recoverErr)
 					continue
 				}
+			} else if err := os.Remove(recPath); err != nil {
+				h.logger.Warn("failed to remove orphaned recording marker", "session", name, "err", err)
+				continue
+			}
+			if !hasRaw {
+				h.logger.Warn("orphaned recording unrecoverable for agent",
+					"session", name, "agent_id", agentID,
+				)
+				continue
 			}
 
 			// clear the recording marker so finalization can proceed
 			h.logger.Info("clearing orphaned recording for agent exit finalization",
 				"session", name, "agent_id", agentID,
 			)
-			if err := os.Remove(recPath); err != nil {
-				h.logger.Warn("failed to remove orphaned recording marker", "session", name, "err", err)
-				continue
-			}
 
 			if !session.HasSubstantiveEntries(rawPath) {
 				continue
@@ -2233,51 +2255,122 @@ func validateStoredEntries(entries []map[string]any, logger *slog.Logger) []stri
 	return warnings
 }
 
-// recoverRawFromSessionFile attempts to generate raw.jsonl from the adapter's
-// source file when a stale recording has no raw.jsonl. Handles the case where
-// an agent crashed before any hooks fired but the source file still exists.
-func recoverRawFromSessionFile(logger *slog.Logger, recPath, sessionDir, rawPath string) bool {
-	// read .recording.json
+// recoverRawFromSessionFile recovers missing capture and drains a dead tail
+// recording from its persisted cursor. The watcher must be stopped first.
+// false, nil means the source was verified empty; errors leave the marker and
+// captured data intact so finalization can retry without losing the native tail.
+func recoverRawFromSessionFile(logger *slog.Logger, recPath, sessionDir, rawPath string) (bool, error) {
 	data, err := os.ReadFile(recPath)
 	if err != nil {
-		logger.Warn("recovery: cannot read recording state", "path", recPath, "err", err)
-		return false
+		return false, fmt.Errorf("read recording state: %w", err)
 	}
 	var state session.RecordingState
 	if err := json.Unmarshal(data, &state); err != nil {
-		logger.Warn("recovery: invalid recording state", "path", recPath, "err", err)
-		return false
+		return false, fmt.Errorf("parse recording state: %w", err)
 	}
 
-	// check SessionFile exists and has content
-	if state.SessionFile == "" {
-		logger.Info("recovery: no session file path in recording state", "session_dir", sessionDir)
-		return false
+	hasRaw := session.HasSubstantiveEntries(rawPath)
+	if state.StoppedAt != nil || (hasRaw && state.WatchMode != "tail") {
+		return hasRaw, nil // CLI stop already selected and masked the recording
 	}
-	info, err := os.Stat(state.SessionFile)
-	if err != nil || info.Size() == 0 {
-		logger.Info("recovery: session file missing or empty",
-			"session_file", state.SessionFile,
-			"exists", err == nil,
-		)
-		return false
+	if lfs.IsPointerFile(rawPath) {
+		return false, fmt.Errorf("cannot recover into an LFS pointer")
 	}
 
-	// get adapter
+	// Keep every existing metadata/entry field. A decoder error is fatal:
+	// silently skipping malformed captured data would lose it on the rewrite.
+	var header, footer map[string]any
+	var captured []map[string]any
+	if f, openErr := os.Open(rawPath); openErr == nil {
+		defer f.Close()
+		dec := json.NewDecoder(f)
+		for {
+			var entry map[string]any
+			if err := dec.Decode(&entry); errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				return false, fmt.Errorf("read captured session: %w", err)
+			}
+			if _, isMeta := entry["_meta"]; isMeta || entry["type"] == "header" {
+				header = entry
+			} else if entry["type"] == "footer" {
+				footer = entry
+			} else {
+				captured = append(captured, entry)
+			}
+		}
+		if err := f.Close(); err != nil {
+			return false, fmt.Errorf("close captured session: %w", err)
+		}
+	} else if !errors.Is(openErr, os.ErrNotExist) {
+		return false, fmt.Errorf("open captured session: %w", openErr)
+	}
+
+	meta, _ := header["_meta"].(map[string]any)
+	if header["type"] == "header" {
+		meta, _ = header["metadata"].(map[string]any)
+	}
+	if recovered, _ := meta["recovered"].(bool); recovered {
+		// Recovery atomically committed its content and mask before a crash
+		// left the old marker behind. Do not import or mask those entries twice.
+		return len(captured) > 0, nil
+	}
+	if state.AdapterName == "" {
+		return hasRaw, nil
+	}
 	adapter, err := adapters.GetAdapter(state.AdapterName)
 	if err != nil {
-		logger.Warn("recovery: unknown adapter", "adapter", state.AdapterName, "err", err)
-		return false
+		return false, fmt.Errorf("resolve recovery adapter: %w", err)
+	}
+	if state.SessionFile == "" {
+		if state.WatchMode != "tail" {
+			return hasRaw, nil
+		}
+		state.SessionFile, err = adapter.FindSessionFile(adapters.SessionLookup{
+			RepoRoot: state.WorkspacePath, AgentID: state.AgentID,
+			Since: state.StartedAt.Add(-5 * time.Minute), AgentSessionID: state.AgentSessionID,
+		})
+		if err != nil {
+			return false, fmt.Errorf("find native session for recovery: %w", err)
+		}
+		if state.SessionFile == "" {
+			return false, adapters.ErrSessionNotFound
+		}
+	}
+	if state.WatchMode == "tail" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return false, fmt.Errorf("resolve session source home: %w", err)
+		}
+		state.SessionFile, err = adapters.SafeSessionFilePath(state.AdapterName, state.SessionFile, home)
+		if err != nil {
+			return false, fmt.Errorf("validate recovery source: %w", err)
+		}
 	}
 
-	// read all entries from source
-	rawEntries, err := adapter.Read(state.SessionFile)
+	var rawEntries []adapters.RawEntry
+	if reader, ok := adapter.(adapters.IncrementalReader); ok {
+		offset := state.StartOffset
+		if len(captured) > 0 {
+			if state.SourceOffset <= state.StartOffset {
+				return false, fmt.Errorf("captured session has no reliable native recovery cursor")
+			}
+			offset = state.SourceOffset
+		}
+		var nextOffset int64
+		rawEntries, nextOffset, err = reader.ReadFromOffset(state.SessionFile, offset)
+		if err == nil && (nextOffset < offset || (len(rawEntries) > 0 && nextOffset == offset)) {
+			return false, fmt.Errorf("native recovery cursor did not advance: offset=%d returned=%d", offset, nextOffset)
+		}
+	} else if len(captured) == 0 {
+		rawEntries, err = adapter.Read(state.SessionFile)
+	} else {
+		return false, fmt.Errorf("adapter does not support incremental recovery")
+	}
 	if err != nil {
-		logger.Warn("recovery: failed to read session file", "path", state.SessionFile, "err", err)
-		return false
+		return false, fmt.Errorf("read native session: %w", err)
 	}
 
-	// filter entries by StartedAt
 	var filtered []adapters.RawEntry
 	for _, e := range rawEntries {
 		if !e.Timestamp.IsZero() && e.Timestamp.Before(state.StartedAt) {
@@ -2285,99 +2378,81 @@ func recoverRawFromSessionFile(logger *slog.Logger, recPath, sessionDir, rawPath
 		}
 		filtered = append(filtered, e)
 	}
-
-	if len(filtered) == 0 {
-		logger.Info("recovery: no entries after session start time",
-			"session_file", state.SessionFile,
-			"started_at", state.StartedAt,
-			"total_entries", len(rawEntries),
-		)
-		return false
-	}
-
-	// convert to session entries
 	entries := session.ConvertRawEntries(filtered)
-
-	// redact secrets
-	projectRoot := state.WorkspacePath
-	if projectRoot != "" {
-		redactor, _ := session.NewRedactorWithCustomRules(projectRoot)
-		if redactor != nil {
-			redactor.RedactEntries(entries)
-		}
+	ranges := session.BuildSegmentRanges(state.Lifecycle)
+	if len(entries) == 0 && len(ranges) == 0 {
+		return len(captured) > 0, nil
 	}
 
-	// write to a temp file first so a partial write never leaves a corrupt
-	// raw.jsonl that a future Detect cycle would treat as valid
+	if header == nil {
+		meta = map[string]any{
+			"schema_version": "1", "agent_id": state.AgentID,
+			"agent_type": state.AdapterName, "started_at": state.StartedAt,
+		}
+		if state.SessionID != "" {
+			meta["session_id"] = state.SessionID
+		}
+		if state.ContinuedFromSessionID != "" {
+			meta["continued_from_session_id"] = state.ContinuedFromSessionID
+		}
+		header = map[string]any{"_meta": meta}
+	}
+	if meta == nil {
+		return false, fmt.Errorf("captured session has an invalid metadata header")
+	}
+	meta["recovered"] = true
+
+	// Atomic replacement preserves the captured prefix on any source or write
+	// failure. All newly imported content passes through RawWriter's full
+	// command, built-in, custom and extra-detector redaction stack.
 	tmpPath := rawPath + ".tmp"
-	f, err := os.Create(tmpPath)
+	rw, err := session.NewRawWriterTruncate(tmpPath, state.WorkspacePath)
 	if err != nil {
-		logger.Warn("recovery: cannot create temp file", "path", tmpPath, "err", err)
-		return false
+		return false, err
 	}
-	defer func() {
-		f.Close()
-		os.Remove(tmpPath) // no-op after successful rename
-	}()
-
-	enc := json.NewEncoder(f)
-
-	// write header. state.SessionID (when present — post rollout, minted at
-	// StartRecording) MUST be carried into the reconstructed header: this
-	// raw.jsonl is the crash-safe carrier every later finalize path reads
-	// via ReadHeaderSessionID/ParseStoreMeta. Dropping it here would make
-	// writeMetaAndUploadLFS treat the session as having no durable ID and
-	// mint a fresh one, rotating away from an identity that may already be
-	// circulated (commit trailers, PR bodies) or cached server-side.
-	metaFields := map[string]any{
-		"schema_version": "1",
-		"agent_id":       state.AgentID,
-		"agent_type":     state.AdapterName,
-		"started_at":     state.StartedAt,
-		"recovered":      true,
+	defer rw.Close()
+	defer os.Remove(tmpPath)
+	if err := rw.WriteRaw(header); err != nil {
+		return false, err
 	}
-	if state.SessionID != "" {
-		metaFields["session_id"] = state.SessionID
+	written := 0
+	for i, entry := range captured {
+		if session.IsSeqExcluded(i, ranges) {
+			continue
+		}
+		if err := rw.WriteRaw(entry); err != nil {
+			return false, err
+		}
+		written++
 	}
-	if state.ContinuedFromSessionID != "" {
-		metaFields["continued_from_session_id"] = state.ContinuedFromSessionID
+	for i := range entries {
+		if session.IsSeqExcluded(len(captured)+i, ranges) {
+			continue
+		}
+		if err := rw.WriteEntry(&entries[i]); err != nil {
+			return false, err
+		}
+		written++
 	}
-	header := map[string]any{
-		"_meta": metaFields,
-	}
-	if err := enc.Encode(header); err != nil {
-		logger.Warn("recovery: failed to write header", "err", err)
-		return false
-	}
-
-	for _, entry := range entries {
-		if err := enc.Encode(entry); err != nil {
-			logger.Warn("recovery: failed to write entry", "err", err)
-			return false
+	if footer != nil {
+		if err := rw.WriteRaw(footer); err != nil {
+			return false, err
 		}
 	}
-
-	if err := f.Sync(); err != nil {
-		logger.Warn("recovery: fsync failed", "err", err)
-		return false
+	if err := rw.CloseAndSync(); err != nil {
+		return false, err
 	}
-
-	if err := f.Close(); err != nil {
-		logger.Warn("recovery: close failed", "err", err)
-		return false
+	// Abort or stop may have removed/updated the marker while the adapter
+	// read its source. Never resurrect an aborted session or replace CLI work.
+	current, err := os.ReadFile(recPath)
+	if err != nil || !bytes.Equal(data, current) {
+		return false, fmt.Errorf("recording changed during native recovery")
 	}
-
 	if err := os.Rename(tmpPath, rawPath); err != nil {
-		logger.Warn("recovery: atomic rename failed", "err", err)
-		return false
+		return false, fmt.Errorf("replace recovered session: %w", err)
 	}
-
-	logger.Info("recovery: raw.jsonl recovered from session file",
-		"session_dir", sessionDir,
-		"entries", len(entries),
-		"source", state.SessionFile,
-	)
-	return true
+	logger.Info("recovered native session", "session_dir", sessionDir, "entries", written, "source", state.SessionFile)
+	return written > 0, nil
 }
 
 // isPIDAlive checks if a process with the given PID exists.

--- a/internal/daemon/agentwork/session_finalize_misc_test.go
+++ b/internal/daemon/agentwork/session_finalize_misc_test.go
@@ -140,7 +140,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			StartedAt:   startedAt,
 		})
 
-		result := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath)
+		result, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath)
 		if !result {
 			t.Fatal("expected recovery to succeed")
 		}
@@ -190,7 +190,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			StartedAt:   time.Now().Add(-2 * time.Hour),
 		})
 
-		if recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+		if recovered, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath); recovered {
 			t.Error("expected recovery to fail for empty session file")
 		}
 	})
@@ -207,7 +207,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			StartedAt:   time.Now().Add(-2 * time.Hour),
 		})
 
-		if recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+		if recovered, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath); recovered {
 			t.Error("expected recovery to fail for missing session file")
 		}
 	})
@@ -223,7 +223,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			StartedAt:   time.Now().Add(-2 * time.Hour),
 		})
 
-		if recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+		if recovered, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath); recovered {
 			t.Error("expected recovery to fail when no session file in state")
 		}
 	})
@@ -237,7 +237,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+		if recovered, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath); recovered {
 			t.Error("expected recovery to fail for invalid recording JSON")
 		}
 	})
@@ -257,7 +257,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			StartedAt:   time.Now().Add(-2 * time.Hour),
 		})
 
-		if recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+		if recovered, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath); recovered {
 			t.Error("expected recovery to fail for unknown adapter")
 		}
 	})
@@ -283,7 +283,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			StartedAt:   startedAt,
 		})
 
-		result := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath)
+		result, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath)
 		if !result {
 			t.Fatal("expected recovery to succeed")
 		}
@@ -327,7 +327,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			SessionID:   durableID,
 		})
 
-		if !recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+		if recovered, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath); !recovered {
 			t.Fatal("expected recovery to succeed")
 		}
 
@@ -357,7 +357,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			// SessionID intentionally empty
 		})
 
-		if !recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+		if recovered, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath); !recovered {
 			t.Fatal("expected recovery to succeed")
 		}
 
@@ -385,7 +385,7 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 			StartedAt:   startedAt,
 		})
 
-		if recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+		if recovered, _ := recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath); recovered {
 			t.Error("expected recovery to fail when all entries are before start time")
 		}
 	})

--- a/internal/daemon/agentwork/session_finalize_recovery_test.go
+++ b/internal/daemon/agentwork/session_finalize_recovery_test.go
@@ -5,12 +5,16 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/sageox/ox/internal/fileutil"
+	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -154,11 +158,111 @@ func TestNativeRecovery_WaitsForCaptureLock(t *testing.T) {
 	}
 }
 
+// One busy capture writer must not stall the detector for ten seconds per
+// session. Deferral preserves the recording so the next pass can finish it.
+func TestNativeRecovery_BusyCaptureDefersWithoutLosingState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: checks lock-acquisition deadlines for both detectors")
+	}
+	for _, detector := range []string{"anti-entropy", "agent-exit"} {
+		t.Run(detector, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+			ledgerPath := t.TempDir()
+			sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "recovery-OxBusy")
+			require.NoError(t, os.MkdirAll(sessionDir, 0700))
+			sourceDir := filepath.Join(home, ".codex", "sessions")
+			require.NoError(t, os.MkdirAll(sourceDir, 0700))
+			source := filepath.Join(sourceDir, "native.jsonl")
+			require.NoError(t, os.WriteFile(source, []byte("recover after release\n"), 0600))
+			state := session.RecordingState{
+				AgentID: "OxBusy", AdapterName: "codex", WatchMode: "tail",
+				SessionFile: source, SessionPath: sessionDir, ParentPID: 99999999,
+				StartedAt: time.Now().Add(-time.Hour),
+			}
+			recPath := filepath.Join(sessionDir, recordingMarker)
+			writeRecordingState(t, recPath, state)
+			recBefore, err := os.ReadFile(recPath)
+			require.NoError(t, err)
+			rawPath := filepath.Join(sessionDir, artifactRaw)
+			const raw = "{\"_meta\":{\"agent_type\":\"codex\"}}\n"
+			require.NoError(t, os.WriteFile(rawPath, []byte(raw), 0600))
+
+			locked, release, holderDone := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			releaseLock := sync.OnceFunc(func() { close(release) })
+			var holderErr error
+			go func() {
+				defer close(holderDone)
+				holderErr = fileutil.WithFileLock(context.Background(), rawPath, func() error {
+					close(locked)
+					<-release
+					return nil
+				})
+			}()
+			t.Cleanup(func() {
+				releaseLock()
+				<-holderDone
+			})
+			select {
+			case <-locked:
+			case <-holderDone:
+				require.NoError(t, holderErr)
+				t.Fatal("capture lock was not acquired")
+			}
+
+			handler := NewSessionFinalizeHandlerForTest(nil)
+			for attempt := range 2 {
+				done := make(chan struct{})
+				var items []*WorkItem
+				var detectErr error
+				go func() {
+					defer close(done)
+					if detector == "anti-entropy" {
+						items, detectErr = handler.Detect(ledgerPath)
+					} else {
+						items = handler.DetectOrphanedForAgent(ledgerPath, state.AgentID, state.ParentPID)
+					}
+				}()
+				t.Cleanup(func() {
+					releaseLock()
+					<-done
+				})
+				select {
+				case <-done:
+				case <-time.After(time.Second):
+					t.Fatal("one busy session stalled the detector instead of deferring to the next pass")
+				}
+				require.NoError(t, detectErr)
+				if attempt == 0 {
+					require.Empty(t, items)
+					recAfter, err := os.ReadFile(recPath)
+					require.NoError(t, err)
+					assert.Equal(t, recBefore, recAfter)
+					rawAfter, err := os.ReadFile(rawPath)
+					require.NoError(t, err)
+					assert.Equal(t, raw, string(rawAfter))
+					releaseLock()
+					<-holderDone
+					require.NoError(t, holderErr)
+				} else {
+					require.Len(t, items, 1)
+					stored, err := session.ReadSessionFromPath(rawPath)
+					require.NoError(t, err)
+					require.Len(t, stored.Entries, 1)
+					assert.Equal(t, "recover after release", stored.Entries[0]["content"])
+					assert.NoFileExists(t, recPath)
+				}
+			}
+		})
+	}
+}
+
 // A missed watcher poll must recover before cleanup or either finalization detector
 // drops the recording marker, including the header eagerly written by prime.
 func TestNativeRecovery_ReachesFinalization(t *testing.T) {
 	for _, detector := range []string{"anti-entropy", "agent-exit"} {
-		for _, rawState := range []string{"missing", "header", "partial", "caught-up"} {
+		for _, rawState := range []string{"missing", "header", "partial", "caught-up", "legacy"} {
 			t.Run(detector+"/"+rawState, func(t *testing.T) {
 				home := t.TempDir()
 				t.Setenv("HOME", home)
@@ -176,11 +280,15 @@ func TestNativeRecovery_ReachesFinalization(t *testing.T) {
 					AgentID: "OxTail", SessionID: "ses_01890a5d-ac96-774b-bcce-b302099a8057",
 					AdapterName: "codex", WatchMode: "tail", SessionFile: source,
 					SessionPath: sessionDir, ParentPID: 99999999,
-					StartedAt: time.Now().Add(-72 * time.Hour),
+					StartedAt:              time.Now().Add(-72 * time.Hour),
+					ContinuedFromSessionID: "ses_01890a5d-ac96-774b-bcce-b302099a8000",
 				}
-				header := `{"_meta":{"schema_version":"1","agent_id":"OxTail","agent_type":"codex","session_id":"` + state.SessionID + `","username":"coworker","model":"gpt-test"}}` + "\n"
+				header := `{"_meta":{"schema_version":"1","agent_id":"OxTail","agent_type":"codex","session_id":"` + state.SessionID + `","continued_from_session_id":"` + state.ContinuedFromSessionID + `","username":"coworker","model":"gpt-test"}}` + "\n"
+				if rawState == "legacy" {
+					header = strings.Replace(header, `"_meta":`, `"type":"header","metadata":`, 1)
+				}
 				raw := header
-				if rawState == "partial" || rawState == "caught-up" {
+				if rawState == "partial" || rawState == "caught-up" || rawState == "legacy" {
 					raw += `{"type":"assistant","content":"first captured response","seq":1}` + "\n"
 					state.SourceOffset = int64(len(first))
 					state.EntryCount = 1
@@ -189,6 +297,9 @@ func TestNativeRecovery_ReachesFinalization(t *testing.T) {
 					raw += `{"type":"assistant","content":"last response before process exit","seq":2}` + "\n"
 					state.SourceOffset += int64(len(last))
 					state.EntryCount++
+				}
+				if rawState == "legacy" {
+					raw += `{"type":"footer","exit_reason":"interrupted"}` + "\n"
 				}
 				rawPath := filepath.Join(sessionDir, artifactRaw)
 				if rawState != "missing" {
@@ -216,18 +327,24 @@ func TestNativeRecovery_ReachesFinalization(t *testing.T) {
 				assert.Equal(t, "first captured response", stored.Entries[0]["content"])
 				assert.Equal(t, "last response before process exit", stored.Entries[1]["content"])
 				assert.Equal(t, state.SessionID, stored.Meta.SessionID)
+				assert.Equal(t, state.ContinuedFromSessionID, stored.Meta.ContinuedFromSessionID)
 				assert.NoFileExists(t, recPath)
 				if rawState != "missing" {
 					assert.Equal(t, "coworker", stored.Meta.Username, "existing metadata must survive recovery")
 					assert.Equal(t, "gpt-test", stored.Meta.Model)
-					if rawState == "partial" || rawState == "caught-up" {
+					if rawState == "partial" || rawState == "caught-up" || rawState == "legacy" {
 						assert.Equal(t, map[string]any{"type": "assistant", "content": "first captured response", "seq": float64(1)}, stored.Entries[0], "all fields of the captured prefix must survive")
 					}
+				}
+				if rawState == "legacy" {
+					assert.Equal(t, "interrupted", stored.Footer["exit_reason"], "legacy footer metadata must survive")
 				}
 				items, err = handler.Detect(ledgerPath)
 				require.NoError(t, err)
 				require.Len(t, items, 1)
-				assert.Equal(t, 2, countRawJSONLEntries(t, rawPath), "a later detect must not append duplicates")
+				after, err := session.ReadSessionFromPath(rawPath)
+				require.NoError(t, err)
+				assert.Len(t, after.Entries, 2, "a later detect must not append duplicates")
 			})
 		}
 	}
@@ -237,7 +354,7 @@ func TestNativeRecovery_ReachesFinalization(t *testing.T) {
 // cursor instead of uploading an incomplete session and destroying the retry state.
 func TestNativeRecovery_SourceFailurePreservesRecording(t *testing.T) {
 	for _, detector := range []string{"anti-entropy", "agent-exit"} {
-		for _, sourceState := range []string{"missing", "outside-root", "deferred-discovery"} {
+		for _, sourceState := range []string{"missing", "outside-root", "deferred-discovery", "malformed-capture", "unreadable-capture", "missing-cursor", "regressed-cursor", "invalid-header", "blocked-temp", "pointer", "nonincremental"} {
 			t.Run(detector+"/"+sourceState, func(t *testing.T) {
 				home := t.TempDir()
 				t.Setenv("HOME", home)
@@ -249,24 +366,60 @@ func TestNativeRecovery_SourceFailurePreservesRecording(t *testing.T) {
 				require.NoError(t, os.MkdirAll(sourceDir, 0700))
 				source := filepath.Join(sourceDir, "missing.jsonl")
 				switch sourceState {
+				case "missing":
 				case "outside-root":
 					source = filepath.Join(home, "private.jsonl")
 					require.NoError(t, os.WriteFile(source, []byte("private data\n"), 0600))
 				case "deferred-discovery":
 					source = ""
+				default:
+					require.NoError(t, os.WriteFile(source, []byte("prefix line\nnative tail\n"), 0600))
 				}
 				state := session.RecordingState{
 					AgentID: "OxRetry", AdapterName: "codex", WatchMode: "tail",
 					SessionFile: source, SessionPath: sessionDir, ParentPID: 99999999,
 					StartedAt: time.Now().Add(-time.Hour), SourceOffset: 12, EntryCount: 1,
 				}
+				switch sourceState {
+				case "missing-cursor":
+					state.SourceOffset = 0
+				case "regressed-cursor":
+					state.SourceOffset = 100000
+				case "nonincremental":
+					original, err := adapters.GetAdapter("codex")
+					require.NoError(t, err)
+					adapters.Unregister("codex")
+					// A third-party adapter may expose only Adapter, without the
+					// incremental-reader contract needed to merge a captured prefix.
+					adapters.Register(struct{ adapters.Adapter }{original})
+					t.Cleanup(func() {
+						adapters.Unregister("codex")
+						adapters.Register(original)
+					})
+				}
 				recPath := filepath.Join(sessionDir, recordingMarker)
 				writeRecordingState(t, recPath, state)
 				recBefore, err := os.ReadFile(recPath)
 				require.NoError(t, err)
 				rawPath := filepath.Join(sessionDir, artifactRaw)
-				const raw = "{\"_meta\":{\"agent_type\":\"codex\"}}\n{\"type\":\"assistant\",\"content\":\"captured\"}\n"
+				raw := "{\"_meta\":{\"agent_type\":\"codex\"}}\n{\"type\":\"assistant\",\"content\":\"captured\"}\n"
+				switch sourceState {
+				case "malformed-capture":
+					raw += "{torn entry"
+				case "invalid-header":
+					raw = strings.Replace(raw, `{"agent_type":"codex"}`, `"damaged"`, 1)
+				case "blocked-temp":
+					require.NoError(t, os.Mkdir(rawPath+".tmp", 0700))
+				case "pointer":
+					raw = lfs.FormatPointer("sha256:"+strings.Repeat("a", 64), 2048)
+				}
 				require.NoError(t, os.WriteFile(rawPath, []byte(raw), 0600))
+				if sourceState == "unreadable-capture" {
+					if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+						t.Skip("requires enforced Unix file permissions")
+					}
+					require.NoError(t, os.Chmod(rawPath, 0000))
+				}
 				handler := NewSessionFinalizeHandlerForTest(nil)
 				var items []*WorkItem
 				if detector == "anti-entropy" {
@@ -279,11 +432,155 @@ func TestNativeRecovery_SourceFailurePreservesRecording(t *testing.T) {
 				recAfter, err := os.ReadFile(recPath)
 				require.NoError(t, err)
 				assert.Equal(t, recBefore, recAfter)
+				if sourceState == "unreadable-capture" {
+					require.NoError(t, os.Chmod(rawPath, 0600))
+				}
 				rawAfter, err := os.ReadFile(rawPath)
 				require.NoError(t, err)
 				assert.Equal(t, raw, string(rawAfter))
 			})
 		}
+	}
+}
+
+// Recovery can be invoked directly by repair code as well as after detection.
+// Missing identity, a missing marker, or a remote pointer must never cause the
+// repair path to replace already captured or remotely stored content.
+func TestNativeRecovery_RefusesUnsafeRepairInputs(t *testing.T) {
+	for _, input := range []string{"missing-marker", "pointer", "missing-home", "unknown-source"} {
+		t.Run(input, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			sessionDir := t.TempDir()
+			rawPath := filepath.Join(sessionDir, artifactRaw)
+			recPath := filepath.Join(sessionDir, recordingMarker)
+			state := session.RecordingState{
+				AgentID: "OxRepair", WatchMode: "tail", AdapterName: "codex",
+				SessionFile: filepath.Join(home, ".codex", "sessions", "native.jsonl"),
+			}
+			raw := "{\"_meta\":{\"agent_type\":\"codex\"}}\n{\"type\":\"assistant\",\"content\":\"keep captured content\"}\n"
+			switch input {
+			case "pointer":
+				raw = lfs.FormatPointer("sha256:"+strings.Repeat("a", 64), 2048)
+			case "unknown-source":
+				state.AdapterName = ""
+			case "missing-home":
+				if runtime.GOOS == "windows" {
+					t.Skip("Unix home lookup uses HOME")
+				}
+				t.Setenv("HOME", "")
+			}
+			require.NoError(t, os.WriteFile(rawPath, []byte(raw), 0600))
+			if input != "missing-marker" {
+				writeRecordingState(t, recPath, state)
+			}
+			handler := NewSessionFinalizeHandlerForTest(nil)
+			recovered, err := recoverRawFromSessionFile(handler.logger, recPath, sessionDir, rawPath)
+			if input == "unknown-source" {
+				require.NoError(t, err)
+				assert.True(t, recovered, "legacy captured content is usable without a native adapter")
+			} else {
+				require.Error(t, err)
+				assert.False(t, recovered)
+			}
+			after, err := os.ReadFile(rawPath)
+			require.NoError(t, err)
+			assert.Equal(t, raw, string(after))
+			if input == "missing-marker" {
+				assert.NoFileExists(t, recPath, "repair must not recreate a cleared recording")
+			} else {
+				assert.FileExists(t, recPath)
+			}
+		})
+	}
+}
+
+// Native lookup can overlap a user ending or aborting a session. Recovery must
+// preserve those later choices and retain existing content if replacement fails.
+func TestNativeRecovery_DiscoveryAndInterruptedRepair(t *testing.T) {
+	for _, lookup := range []string{"found", "empty-result", "aborted", "stopped", "destination-replaced"} {
+		t.Run(lookup, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+			ledgerPath := t.TempDir()
+			sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "recovery-OxLookup")
+			require.NoError(t, os.MkdirAll(sessionDir, 0700))
+			sourceDir := filepath.Join(home, ".codex", "sessions")
+			require.NoError(t, os.MkdirAll(sourceDir, 0700))
+			source := filepath.Join(sourceDir, "native.jsonl")
+			const first = "captured prefix\n"
+			require.NoError(t, os.WriteFile(source, []byte(first+"recovered tail\n"), 0600))
+			state := session.RecordingState{
+				AgentID: "OxLookup", AgentSessionID: "matching-native-session",
+				WorkspacePath: t.TempDir(), AdapterName: "codex", WatchMode: "tail",
+				SessionPath: sessionDir, ParentPID: 99999999,
+				StartedAt: time.Now().Add(-time.Hour), SourceOffset: int64(len(first)), EntryCount: 1,
+			}
+			recPath := filepath.Join(sessionDir, recordingMarker)
+			writeRecordingState(t, recPath, state)
+			rawPath := filepath.Join(sessionDir, artifactRaw)
+			const raw = "{\"_meta\":{\"agent_type\":\"codex\"}}\n{\"type\":\"assistant\",\"content\":\"captured prefix\"}\n"
+			require.NoError(t, os.WriteFile(rawPath, []byte(raw), 0600))
+			original, err := adapters.GetAdapter("codex")
+			require.NoError(t, err)
+			adapters.Unregister("codex")
+			adapters.Register(&testAdapter{name: "codex", find: func(query adapters.SessionLookup) (string, error) {
+				assert.Equal(t, state.WorkspacePath, query.RepoRoot)
+				assert.Equal(t, state.AgentID, query.AgentID)
+				assert.Equal(t, state.AgentSessionID, query.AgentSessionID)
+				assert.True(t, state.StartedAt.Add(-5*time.Minute).Equal(query.Since), "discovery must retain the recording's time window")
+				switch lookup {
+				case "empty-result":
+					return "", nil
+				case "aborted":
+					require.NoError(t, os.Remove(recPath))
+				case "stopped":
+					next := state
+					stopped := time.Now()
+					next.StoppedAt = &stopped
+					writeRecordingState(t, recPath, next)
+				case "destination-replaced":
+					require.NoError(t, os.Remove(rawPath))
+					require.NoError(t, os.Mkdir(rawPath, 0700))
+					require.NoError(t, os.WriteFile(filepath.Join(rawPath, "keep"), []byte("concurrent data"), 0600))
+				}
+				return source, nil
+			}})
+			t.Cleanup(func() {
+				adapters.Unregister("codex")
+				adapters.Register(original)
+			})
+
+			handler := NewSessionFinalizeHandlerForTest(nil)
+			items := handler.DetectOrphanedForAgent(ledgerPath, state.AgentID, state.ParentPID)
+			if lookup == "found" {
+				require.Len(t, items, 1)
+				stored, err := session.ReadSessionFromPath(rawPath)
+				require.NoError(t, err)
+				require.Len(t, stored.Entries, 2)
+				assert.Equal(t, "captured prefix", stored.Entries[0]["content"])
+				assert.Equal(t, "recovered tail", stored.Entries[1]["content"])
+				assert.NoFileExists(t, recPath)
+			} else {
+				assert.Empty(t, items)
+				if lookup == "destination-replaced" {
+					data, err := os.ReadFile(filepath.Join(rawPath, "keep"))
+					require.NoError(t, err)
+					assert.Equal(t, "concurrent data", string(data))
+				} else {
+					after, err := os.ReadFile(rawPath)
+					require.NoError(t, err)
+					assert.Equal(t, raw, string(after))
+				}
+				if lookup == "aborted" {
+					assert.NoFileExists(t, recPath)
+				} else {
+					assert.FileExists(t, recPath)
+				}
+			}
+			assert.NoFileExists(t, rawPath+".tmp", "failed recovery must not leave partial output for the next pass")
+		})
 	}
 }
 

--- a/internal/daemon/agentwork/session_finalize_recovery_test.go
+++ b/internal/daemon/agentwork/session_finalize_recovery_test.go
@@ -1,0 +1,392 @@
+package agentwork
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/fileutil"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A watcher in another daemon may still flush after local cleanup. Both
+// detectors must wait for its raw lock, then reload the final capture cursor.
+func TestNativeRecovery_WaitsForCaptureLock(t *testing.T) {
+	for _, detector := range []string{"anti-entropy", "agent-exit"} {
+		t.Run(detector, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+			ledgerPath := t.TempDir()
+			sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "recovery-OxLocked")
+			require.NoError(t, os.MkdirAll(sessionDir, 0700))
+			sourceDir := filepath.Join(home, ".codex", "sessions")
+			require.NoError(t, os.MkdirAll(sourceDir, 0700))
+			source := filepath.Join(sourceDir, "native.jsonl")
+			const first = "first response\n"
+			const second = "watcher flush\n"
+			const last = "final unread response\n"
+			require.NoError(t, os.WriteFile(source, []byte(first+second+last), 0600))
+			state := session.RecordingState{
+				AgentID: "OxLocked", AdapterName: "codex", WatchMode: "tail",
+				SessionFile: source, SessionPath: sessionDir, ParentPID: 99999999,
+				StartedAt: time.Now().Add(-time.Hour), SourceOffset: int64(len(first)), EntryCount: 1,
+			}
+			recPath := filepath.Join(sessionDir, recordingMarker)
+			writeRecordingState(t, recPath, state)
+			rawPath := filepath.Join(sessionDir, artifactRaw)
+			const raw = "{\"_meta\":{\"agent_type\":\"codex\"}}\n{\"type\":\"assistant\",\"content\":\"first response\"}\n"
+			require.NoError(t, os.WriteFile(rawPath, []byte(raw), 0600))
+
+			locked, flush, flushed := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			release, holderDone := make(chan struct{}), make(chan struct{})
+			releaseLock := sync.OnceFunc(func() { close(release) })
+			var holderErr error
+			go func() {
+				defer close(holderDone)
+				holderErr = fileutil.WithFileLock(context.Background(), rawPath, func() error {
+					close(locked)
+					select {
+					case <-flush:
+					case <-release:
+						return nil
+					}
+					rw, err := session.NewRawWriter(rawPath, "")
+					if err != nil {
+						return err
+					}
+					defer rw.Close()
+					if err := rw.WriteEntry(&session.Entry{Type: session.EntryTypeAssistant, Content: "watcher flush"}); err != nil {
+						return err
+					}
+					if err := rw.CloseAndSync(); err != nil {
+						return err
+					}
+					next := state
+					next.SourceOffset += int64(len(second))
+					next.EntryCount++
+					data, err := json.Marshal(next)
+					if err != nil {
+						return err
+					}
+					if err := os.WriteFile(recPath, data, 0600); err != nil {
+						return err
+					}
+					close(flushed)
+					<-release
+					return nil
+				})
+			}()
+			t.Cleanup(func() {
+				releaseLock()
+				<-holderDone
+			})
+			select {
+			case <-locked:
+			case <-holderDone:
+				require.NoError(t, holderErr)
+				t.Fatal("capture lock was not acquired")
+			}
+
+			handler := NewSessionFinalizeHandlerForTest(nil)
+			started, done := make(chan struct{}), make(chan struct{})
+			var items []*WorkItem
+			var detectErr error
+			go func() {
+				defer close(done)
+				close(started)
+				if detector == "anti-entropy" {
+					items, detectErr = handler.Detect(ledgerPath)
+				} else {
+					items = handler.DetectOrphanedForAgent(ledgerPath, state.AgentID, state.ParentPID)
+				}
+			}()
+			t.Cleanup(func() {
+				releaseLock()
+				<-done
+			})
+			<-started
+			// This deadline asserts the blocking contract; channel handshakes
+			// establish lock ownership and control the writer's final flush.
+			select {
+			case <-done:
+				t.Fatal("finalization completed while another capture writer held the raw lock")
+			case <-time.After(100 * time.Millisecond):
+			}
+			require.FileExists(t, recPath, "a pending writer still owns the recording marker")
+			beforeFlush, err := os.ReadFile(rawPath)
+			require.NoError(t, err)
+			assert.Equal(t, raw, string(beforeFlush), "recovery must not replace a writer's captured prefix")
+
+			close(flush)
+			select {
+			case <-flushed:
+			case <-holderDone:
+				require.NoError(t, holderErr)
+				t.Fatal("capture writer did not flush")
+			}
+			require.FileExists(t, recPath)
+			assert.Equal(t, 2, countRawJSONLEntries(t, rawPath))
+			releaseLock()
+			<-holderDone
+			require.NoError(t, holderErr)
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("finalization did not resume after capture released the raw lock")
+			}
+			require.NoError(t, detectErr)
+			require.Len(t, items, 1)
+			stored, err := session.ReadSessionFromPath(rawPath)
+			require.NoError(t, err)
+			require.Len(t, stored.Entries, 3, "recovery must reload the flushed cursor and capture each entry once")
+			assert.Equal(t, "first response", stored.Entries[0]["content"])
+			assert.Equal(t, "watcher flush", stored.Entries[1]["content"])
+			assert.Equal(t, "final unread response", stored.Entries[2]["content"])
+			assert.NoFileExists(t, recPath)
+		})
+	}
+}
+
+// A missed watcher poll must recover before cleanup or either finalization detector
+// drops the recording marker, including the header eagerly written by prime.
+func TestNativeRecovery_ReachesFinalization(t *testing.T) {
+	for _, detector := range []string{"anti-entropy", "agent-exit"} {
+		for _, rawState := range []string{"missing", "header", "partial", "caught-up"} {
+			t.Run(detector+"/"+rawState, func(t *testing.T) {
+				home := t.TempDir()
+				t.Setenv("HOME", home)
+				t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+				ledgerPath := t.TempDir()
+				sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "recovery-OxTail")
+				require.NoError(t, os.MkdirAll(sessionDir, 0700))
+				sourceDir := filepath.Join(home, ".codex", "sessions")
+				require.NoError(t, os.MkdirAll(sourceDir, 0700))
+				source := filepath.Join(sourceDir, "native.jsonl")
+				const first = "first captured response\n"
+				const last = "last response before process exit\n"
+				require.NoError(t, os.WriteFile(source, []byte(first+last), 0600))
+				state := session.RecordingState{
+					AgentID: "OxTail", SessionID: "ses_01890a5d-ac96-774b-bcce-b302099a8057",
+					AdapterName: "codex", WatchMode: "tail", SessionFile: source,
+					SessionPath: sessionDir, ParentPID: 99999999,
+					StartedAt: time.Now().Add(-72 * time.Hour),
+				}
+				header := `{"_meta":{"schema_version":"1","agent_id":"OxTail","agent_type":"codex","session_id":"` + state.SessionID + `","username":"coworker","model":"gpt-test"}}` + "\n"
+				raw := header
+				if rawState == "partial" || rawState == "caught-up" {
+					raw += `{"type":"assistant","content":"first captured response","seq":1}` + "\n"
+					state.SourceOffset = int64(len(first))
+					state.EntryCount = 1
+				}
+				if rawState == "caught-up" {
+					raw += `{"type":"assistant","content":"last response before process exit","seq":2}` + "\n"
+					state.SourceOffset += int64(len(last))
+					state.EntryCount++
+				}
+				rawPath := filepath.Join(sessionDir, artifactRaw)
+				if rawState != "missing" {
+					require.NoError(t, os.WriteFile(rawPath, []byte(raw), 0600))
+				}
+				recPath := filepath.Join(sessionDir, recordingMarker)
+				writeRecordingState(t, recPath, state)
+				require.NoError(t, os.Chtimes(sessionDir, state.StartedAt, state.StartedAt))
+
+				handler := NewSessionFinalizeHandlerForTest(nil)
+				handler.Cleanup(ledgerPath)
+				require.FileExists(t, recPath, "cleanup must leave recoverable native sessions for the detector")
+				var items []*WorkItem
+				if detector == "anti-entropy" {
+					var err error
+					items, err = handler.Detect(ledgerPath)
+					require.NoError(t, err)
+				} else {
+					items = handler.DetectOrphanedForAgent(ledgerPath, state.AgentID, state.ParentPID)
+				}
+				require.Len(t, items, 1)
+				stored, err := session.ReadSessionFromPath(rawPath)
+				require.NoError(t, err)
+				require.Len(t, stored.Entries, 2, "capture and recovery must include each native entry once")
+				assert.Equal(t, "first captured response", stored.Entries[0]["content"])
+				assert.Equal(t, "last response before process exit", stored.Entries[1]["content"])
+				assert.Equal(t, state.SessionID, stored.Meta.SessionID)
+				assert.NoFileExists(t, recPath)
+				if rawState != "missing" {
+					assert.Equal(t, "coworker", stored.Meta.Username, "existing metadata must survive recovery")
+					assert.Equal(t, "gpt-test", stored.Meta.Model)
+					if rawState == "partial" || rawState == "caught-up" {
+						assert.Equal(t, map[string]any{"type": "assistant", "content": "first captured response", "seq": float64(1)}, stored.Entries[0], "all fields of the captured prefix must survive")
+					}
+				}
+				items, err = handler.Detect(ledgerPath)
+				require.NoError(t, err)
+				require.Len(t, items, 1)
+				assert.Equal(t, 2, countRawJSONLEntries(t, rawPath), "a later detect must not append duplicates")
+			})
+		}
+	}
+}
+
+// An unreadable native source must retain the captured prefix and its recovery
+// cursor instead of uploading an incomplete session and destroying the retry state.
+func TestNativeRecovery_SourceFailurePreservesRecording(t *testing.T) {
+	for _, detector := range []string{"anti-entropy", "agent-exit"} {
+		for _, sourceState := range []string{"missing", "outside-root", "deferred-discovery"} {
+			t.Run(detector+"/"+sourceState, func(t *testing.T) {
+				home := t.TempDir()
+				t.Setenv("HOME", home)
+				t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+				ledgerPath := t.TempDir()
+				sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "recovery-OxRetry")
+				require.NoError(t, os.MkdirAll(sessionDir, 0700))
+				sourceDir := filepath.Join(home, ".codex", "sessions")
+				require.NoError(t, os.MkdirAll(sourceDir, 0700))
+				source := filepath.Join(sourceDir, "missing.jsonl")
+				switch sourceState {
+				case "outside-root":
+					source = filepath.Join(home, "private.jsonl")
+					require.NoError(t, os.WriteFile(source, []byte("private data\n"), 0600))
+				case "deferred-discovery":
+					source = ""
+				}
+				state := session.RecordingState{
+					AgentID: "OxRetry", AdapterName: "codex", WatchMode: "tail",
+					SessionFile: source, SessionPath: sessionDir, ParentPID: 99999999,
+					StartedAt: time.Now().Add(-time.Hour), SourceOffset: 12, EntryCount: 1,
+				}
+				recPath := filepath.Join(sessionDir, recordingMarker)
+				writeRecordingState(t, recPath, state)
+				recBefore, err := os.ReadFile(recPath)
+				require.NoError(t, err)
+				rawPath := filepath.Join(sessionDir, artifactRaw)
+				const raw = "{\"_meta\":{\"agent_type\":\"codex\"}}\n{\"type\":\"assistant\",\"content\":\"captured\"}\n"
+				require.NoError(t, os.WriteFile(rawPath, []byte(raw), 0600))
+				handler := NewSessionFinalizeHandlerForTest(nil)
+				var items []*WorkItem
+				if detector == "anti-entropy" {
+					items, err = handler.Detect(ledgerPath)
+					require.NoError(t, err)
+				} else {
+					items = handler.DetectOrphanedForAgent(ledgerPath, state.AgentID, state.ParentPID)
+				}
+				assert.Empty(t, items)
+				recAfter, err := os.ReadFile(recPath)
+				require.NoError(t, err)
+				assert.Equal(t, recBefore, recAfter)
+				rawAfter, err := os.ReadFile(rawPath)
+				require.NoError(t, err)
+				assert.Equal(t, raw, string(rawAfter))
+			})
+		}
+	}
+}
+
+// Catch-up must compose with the same pause mask and credential redaction as
+// normal session stop, including a final unread entry during an open pause.
+func TestNativeRecovery_HonorsPauseAndRedaction(t *testing.T) {
+	for _, paused := range []bool{false, true} {
+		t.Run(map[bool]string{false: "redaction", true: "pause"}[paused], func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+			ledgerPath := t.TempDir()
+			sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "recovery-OxPrivacy")
+			require.NoError(t, os.MkdirAll(sessionDir, 0700))
+			sourceDir := filepath.Join(home, ".codex", "sessions")
+			require.NoError(t, os.MkdirAll(sourceDir, 0700))
+			source := filepath.Join(sourceDir, "native.jsonl")
+			const public = "public response\n"
+			const private = "paused content\n"
+			const secret = "ghp_1234567890abcdefghijklmnopqrstuvwxyz1234"
+			require.NoError(t, os.WriteFile(source, []byte(public+private+secret+"\n"), 0600))
+			state := session.RecordingState{
+				AgentID: "OxPrivacy", AdapterName: "codex", WatchMode: "tail",
+				SessionFile: source, SessionPath: sessionDir, ParentPID: 99999999,
+				StartedAt: time.Now().Add(-time.Hour), SourceOffset: int64(len(public + private)), EntryCount: 2,
+			}
+			if paused {
+				at := time.Now().Add(-time.Minute)
+				state.SuspendedAt = &at
+				state.Lifecycle = []session.LifecycleEvent{{Action: session.LifecycleActionPause, At: at, Seq: 1}}
+			}
+			writeRecordingState(t, filepath.Join(sessionDir, recordingMarker), state)
+			rawPath := filepath.Join(sessionDir, artifactRaw)
+			raw := "{\"_meta\":{\"agent_type\":\"codex\"}}\n{\"type\":\"assistant\",\"content\":\"public response\"}\n{\"type\":\"assistant\",\"content\":\"paused content\"}\n"
+			require.NoError(t, os.WriteFile(rawPath, []byte(raw), 0600))
+			handler := NewSessionFinalizeHandlerForTest(nil)
+			// Simulate a crash after the recovered raw was committed but before
+			// the old recording marker was removed. Retrying cannot mask twice.
+			recovered, err := recoverRawFromSessionFile(handler.logger, filepath.Join(sessionDir, recordingMarker), sessionDir, rawPath)
+			require.NoError(t, err)
+			require.True(t, recovered)
+			beforeRetry, err := os.ReadFile(rawPath)
+			require.NoError(t, err)
+			items := handler.DetectOrphanedForAgent(ledgerPath, state.AgentID, state.ParentPID)
+			require.Len(t, items, 1)
+			data, err := os.ReadFile(rawPath)
+			require.NoError(t, err)
+			assert.Equal(t, beforeRetry, data, "retry must not import or mask the same entries twice")
+			assert.NotContains(t, string(data), secret)
+			if paused {
+				assert.NotContains(t, string(data), "paused content")
+				assert.Equal(t, 1, countRawJSONLEntries(t, rawPath))
+			} else {
+				assert.Contains(t, string(data), "REDACTED")
+				assert.Equal(t, 3, countRawJSONLEntries(t, rawPath))
+			}
+		})
+	}
+}
+
+// Stopped recordings already applied masks and selected the recording window;
+// recovery must never import later native activity back into them.
+func TestNativeRecovery_LeavesStoppedRecordingUnchanged(t *testing.T) {
+	ledgerPath := t.TempDir()
+	sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "stopped-OxStop")
+	require.NoError(t, os.MkdirAll(sessionDir, 0700))
+	stopped := time.Now()
+	state := session.RecordingState{AgentID: "OxStop", AdapterName: "codex", WatchMode: "tail", StoppedAt: &stopped}
+	writeRecordingState(t, filepath.Join(sessionDir, recordingMarker), state)
+	const raw = "{\"_meta\":{\"agent_type\":\"codex\"}}\n{\"type\":\"assistant\",\"content\":\"captured\"}\n"
+	rawPath := filepath.Join(sessionDir, artifactRaw)
+	require.NoError(t, os.WriteFile(rawPath, []byte(raw), 0600))
+	handler := NewSessionFinalizeHandlerForTest(nil)
+	require.Len(t, handler.DetectOrphanedForAgent(ledgerPath, state.AgentID, 0), 1)
+	data, err := os.ReadFile(rawPath)
+	require.NoError(t, err)
+	assert.Equal(t, raw, string(data))
+}
+
+// A successful read proving the native log empty must still release the stub
+// for cleanup; preserving recoverable recordings must not create immortals.
+func TestNativeRecovery_EmptySourceCanBeCleaned(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	ledgerPath := t.TempDir()
+	sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "empty-OxEmpty")
+	require.NoError(t, os.MkdirAll(sessionDir, 0700))
+	sourceDir := filepath.Join(home, ".codex", "sessions")
+	require.NoError(t, os.MkdirAll(sourceDir, 0700))
+	source := filepath.Join(sourceDir, "empty.jsonl")
+	require.NoError(t, os.WriteFile(source, nil, 0600))
+	state := session.RecordingState{AgentID: "OxEmpty", AdapterName: "codex", WatchMode: "tail", SessionFile: source, SessionPath: sessionDir, ParentPID: 99999999, StartedAt: time.Now().Add(-72 * time.Hour)}
+	writeRecordingState(t, filepath.Join(sessionDir, recordingMarker), state)
+	header, err := json.Marshal(map[string]any{"_meta": map[string]any{"agent_type": "codex"}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, artifactRaw), append(header, '\n'), 0600))
+	handler := NewSessionFinalizeHandlerForTest(nil)
+	items, err := handler.Detect(ledgerPath)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+	assert.NoFileExists(t, filepath.Join(sessionDir, recordingMarker))
+	require.NoError(t, os.Chtimes(sessionDir, state.StartedAt, state.StartedAt))
+	handler.Cleanup(ledgerPath)
+	assert.NoDirExists(t, sessionDir)
+}

--- a/internal/daemon/agentwork/session_watcher.go
+++ b/internal/daemon/agentwork/session_watcher.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 )
@@ -46,10 +47,13 @@ type SessionWatcherManager struct {
 // activeWatcher tracks a running TailWatcher goroutine.
 type activeWatcher struct {
 	cancel      context.CancelFunc
+	done        chan struct{}
 	sessionName string
 	adapterName string
 	sessionFile string
 	cachePath   string
+	projectRoot string
+	agentID     string
 	ledgerPath  string
 	startOffset int64 // byte offset in source file to resume from (0 for fresh start)
 	startedAt   time.Time
@@ -92,7 +96,7 @@ func (m *SessionWatcherManager) StartWatch(
 }
 
 // startWatchAt is the internal start method that accepts a starting offset.
-// offset=0 means start from current EOF (fresh start from IPC).
+// offset=0 means catch up from the beginning of the native session.
 // offset>0 means catch up from that position first (daemon restart recovery).
 func (m *SessionWatcherManager) startWatchAt(
 	sessionName, sessionFile, adapterName, ledgerPath, cachePath string, offset int64,
@@ -139,14 +143,29 @@ func (m *SessionWatcherManager) startWatchAt(
 	}
 
 	rawPath := filepath.Join(cachePath, "raw.jsonl")
+	var state session.RecordingState
+	data, err := os.ReadFile(filepath.Join(cachePath, recordingMarker))
+	if err != nil {
+		return fmt.Errorf("read recording state: %w", err)
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("read recording state: %w", err)
+	}
+	if state.StoppedAt != nil || session.HasExplicitStop(state.WorkspacePath, state.AgentID) {
+		return fmt.Errorf("session recording has stopped")
+	}
+	offset = max(offset, state.SourceOffset, state.StartOffset)
 
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is stored in activeWatcher.cancel, called by StopWatch/StopAll
 	aw := &activeWatcher{
 		cancel:      cancel,
+		done:        make(chan struct{}),
 		sessionName: sessionName,
 		adapterName: adapterName,
 		sessionFile: sessionFile,
 		cachePath:   cachePath,
+		projectRoot: state.WorkspacePath,
+		agentID:     state.AgentID,
 		ledgerPath:  ledgerPath,
 		startOffset: offset,
 		startedAt:   time.Now(),
@@ -168,13 +187,11 @@ func (m *SessionWatcherManager) startWatchAt(
 func (m *SessionWatcherManager) StopWatch(sessionName string) {
 	m.mu.Lock()
 	aw, ok := m.watchers[sessionName]
-	if ok {
-		delete(m.watchers, sessionName)
-	}
 	m.mu.Unlock()
 
 	if ok {
 		aw.cancel()
+		<-aw.done
 		m.logger.Info("session watcher stopped", "session", sessionName)
 	}
 }
@@ -215,7 +232,7 @@ func (m *SessionWatcherManager) ActiveSessions() []string {
 // On restart, reads the persisted SourceOffset from .recording.json so the
 // catch-up read recovers entries written while the daemon was down.
 func (m *SessionWatcherManager) DetectAndRestart(ledgerPath string) int {
-	sessionsDir := filepath.Join(ledgerPath, "sessions")
+	sessionsDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions")
 	entries, err := os.ReadDir(sessionsDir)
 	if err != nil {
 		return 0
@@ -248,15 +265,42 @@ func (m *SessionWatcherManager) DetectAndRestart(ledgerPath string) int {
 		if err := json.Unmarshal(data, &state); err != nil {
 			continue
 		}
-		if state.WatchMode != "tail" || state.StoppedAt != nil {
+		if state.WatchMode != "tail" || state.StoppedAt != nil || session.HasExplicitStop(state.WorkspacePath, state.AgentID) {
 			continue
 		}
-		if state.SessionFile == "" || state.AdapterName == "" {
+		if state.AdapterName == "" {
 			continue
 		}
 		// don't restart watchers for dead agents — let session_finalize handle them
 		if !state.IsAgentAlive() {
 			continue
+		}
+		if state.SessionFile == "" {
+			adapter, err := resolveAdapter(state.AdapterName)
+			if err != nil {
+				continue
+			}
+			source, err := adapter.FindSessionFile(adapters.SessionLookup{
+				RepoRoot:       state.WorkspacePath,
+				AgentID:        state.AgentID,
+				AgentSessionID: state.AgentSessionID,
+				Since:          state.StartedAt.Add(-5 * time.Minute),
+			})
+			if err != nil {
+				m.logger.Debug("session source not available yet", "session", sessionName, "error", err)
+				continue
+			}
+			if _, err := adapters.SafeSessionFilePath(state.AdapterName, source, m.homeDir()); err != nil {
+				m.logger.Warn("refusing discovered session source", "session", sessionName, "error", err)
+				continue
+			}
+			if err := session.UpdateRecordingStateForAgent(state.WorkspacePath, state.AgentID, func(s *session.RecordingState) {
+				s.SessionFile = source
+			}); err != nil {
+				m.logger.Warn("failed to persist discovered session source", "session", sessionName, "error", err)
+				continue
+			}
+			state.SessionFile = source
 		}
 
 		cachePath := filepath.Join(sessionsDir, sessionName)
@@ -308,6 +352,7 @@ func (m *SessionWatcherManager) runWatcher(
 	adapter adapters.Adapter, rawPath string,
 ) {
 	defer m.wg.Done()
+	defer close(aw.done)
 	defer func() {
 		m.mu.Lock()
 		// skip cleanup if StopAll already ran (prevents re-inserting into cleared map)
@@ -319,95 +364,126 @@ func (m *SessionWatcherManager) runWatcher(
 		m.mu.Unlock()
 	}()
 
-	// Per ox-h20u: ALL raw.jsonl writes go through session.RawWriter. The
-	// writer constructs and applies the three-layer redaction stack
-	// (CommandRedactor → built-in Redactor → gitleaks extras). There is no
-	// way to call WriteEntry without redaction running first. Adapters can
-	// only emit RawEntry JSON on stdout — they have no write access to
-	// raw.jsonl.
-	rw, err := session.NewRawWriter(rawPath, "")
-	if err != nil {
-		m.logger.Error("failed to open raw.jsonl for writing",
-			"session", aw.sessionName, "path", rawPath, "error", err)
-		return
-	}
-	defer rw.Close()
-
-	// cursor is where recording resumes from. It starts at the persisted
-	// offset and must be carried through catch-up into the poll loop —
-	// re-deriving it from aw.startOffset later would re-read and duplicate
-	// everything catch-up just recovered.
-	cursor := aw.startOffset
-
-	// catch-up: read entries between the persisted offset and now
-	if reader, ok := adapter.(adapters.IncrementalReader); ok && cursor > 0 {
-		entries, newOffset, readErr := reader.ReadFromOffset(aw.sessionFile, cursor)
-		switch {
-		case readErr != nil:
-			m.logger.Warn("catch-up read failed; continuing from the persisted offset",
-				"session", aw.sessionName, "offset", cursor, "error", readErr)
-		case len(entries) > 0:
-			converted := session.ConvertRawEntries(entries)
-			if writeErr := writeEntries(rw, converted); writeErr != nil {
-				// the cursor must NOT advance past entries that never reached
-				// the ledger: doing so marks them consumed and they are gone
-				// for good. Leaving it where it is costs a re-read.
-				m.logger.Error("catch-up write failed; leaving the cursor in place so the entries can be recovered",
-					"session", aw.sessionName, "offset", cursor, "error", writeErr)
-				return
-			}
-			cursor = newOffset
-			m.persistOffset(aw, cursor, len(converted))
-			m.logger.Info("catch-up read recovered entries",
-				"session", aw.sessionName,
-				"entries", len(entries),
-				"from_offset", aw.startOffset,
-				"to_offset", cursor,
-			)
+	// Serialize with CLI stop independently of IPC. The stop breadcrumb makes
+	// the poll loop release this lock; the CLI then reloads the final cursor.
+	err := fileutil.WithFileLock(ctx, rawPath, func() error {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-	}
+		data, err := os.ReadFile(filepath.Join(aw.cachePath, recordingMarker))
+		if err != nil {
+			return err
+		}
+		var state session.RecordingState
+		if err := json.Unmarshal(data, &state); err != nil {
+			return err
+		}
+		if state.StoppedAt != nil || session.HasExplicitStop(state.WorkspacePath, state.AgentID) {
+			return nil
+		}
 
-	// Record through the adapter's own incremental reader whenever it has one.
-	//
-	// The alternative, adapter.Watch, delivers entries with NO cursor, so any
-	// resume offset has to be inferred from the file afterwards — and both
-	// ways of being wrong lose data. Infer high (file size, or a boundary
-	// scanned after the write) and a record the agent appended in between is
-	// marked consumed but never written. Infer low and a restart re-reads and
-	// duplicates. Database-backed adapters cannot even infer: their offset is
-	// a row count nothing outside the adapter can compute.
-	//
-	// ReadFromOffset returns the cursor it actually consumed to, so there is
-	// nothing to infer.
-	if reader, ok := adapter.(adapters.IncrementalReader); ok {
-		m.pollSession(ctx, aw, reader, rw, cursor)
-		return
-	}
+		// Per ox-h20u: ALL raw.jsonl writes go through session.RawWriter. The
+		// writer constructs and applies the three-layer redaction stack
+		// (CommandRedactor → built-in Redactor → gitleaks extras). There is no
+		// way to call WriteEntry without redaction running first. Adapters can
+		// only emit RawEntry JSON on stdout — they have no write access to
+		// raw.jsonl.
+		rw, err := session.NewRawWriter(rawPath, aw.projectRoot)
+		if err != nil {
+			m.logger.Error("failed to open raw.jsonl for writing",
+				"session", aw.sessionName, "path", rawPath, "error", err)
+			return nil
+		}
+		defer rw.Close()
 
-	// Fallback for an adapter with no incremental reader: tail for entries and
-	// accept that the session cannot be resumed. Every shipped adapter now
-	// implements ReadFromOffset (enforced by tests/adapters), so this path is
-	// for third-party adapters only.
-	ch, err := adapter.Watch(ctx, aw.sessionFile)
-	if err != nil {
-		m.logger.Error("failed to start tail watcher",
-			"session", aw.sessionName, "error", err)
-		return
-	}
-	m.logger.Warn("adapter has no incremental reader; this session cannot resume after a daemon restart",
-		"session", aw.sessionName, "adapter", aw.adapterName)
+		// cursor is where recording resumes from. It starts at the persisted
+		// offset and must be carried through catch-up into the poll loop —
+		// re-deriving it from aw.startOffset later would re-read and duplicate
+		// everything catch-up just recovered.
+		cursor := max(aw.startOffset, state.SourceOffset, state.StartOffset)
 
-	for entry := range ch {
-		converted := session.ConvertRawEntries([]adapters.RawEntry{entry})
-		for i := range converted {
-			if encErr := rw.WriteEntry(&converted[i]); encErr != nil {
-				m.logger.Warn("failed to write entry to raw.jsonl",
-					"session", aw.sessionName, "error", encErr)
+		// catch-up: read entries between the persisted offset and now
+		if reader, ok := adapter.(adapters.IncrementalReader); ok && cursor > 0 {
+			entries, newOffset, readErr := reader.ReadFromOffset(aw.sessionFile, cursor)
+			switch {
+			case readErr != nil:
+				m.logger.Warn("catch-up read failed; continuing from the persisted offset",
+					"session", aw.sessionName, "offset", cursor, "error", readErr)
+			case len(entries) > 0:
+				converted := session.ConvertRawEntries(entries)
+				if writeErr := writeEntries(rw, converted); writeErr != nil {
+					// the cursor must NOT advance past entries that never reached
+					// the ledger: doing so marks them consumed and they are gone
+					// for good. Leaving it where it is costs a re-read.
+					m.logger.Error("catch-up write failed; leaving the cursor in place so the entries can be recovered",
+						"session", aw.sessionName, "offset", cursor, "error", writeErr)
+					return nil
+				}
+				cursor = newOffset
+				m.persistOffset(aw, cursor, len(converted))
+				m.logger.Info("catch-up read recovered entries",
+					"session", aw.sessionName,
+					"entries", len(entries),
+					"from_offset", aw.startOffset,
+					"to_offset", cursor,
+				)
 			}
 		}
-		// no offset is persisted: Watch delivers entries with no cursor, and
-		// every way of guessing one from the file loses data in one direction
-		// or the other — see pollSession
+
+		// Record through the adapter's own incremental reader whenever it has one.
+		//
+		// The alternative, adapter.Watch, delivers entries with NO cursor, so any
+		// resume offset has to be inferred from the file afterwards — and both
+		// ways of being wrong lose data. Infer high (file size, or a boundary
+		// scanned after the write) and a record the agent appended in between is
+		// marked consumed but never written. Infer low and a restart re-reads and
+		// duplicates. Database-backed adapters cannot even infer: their offset is
+		// a row count nothing outside the adapter can compute.
+		//
+		// ReadFromOffset returns the cursor it actually consumed to, so there is
+		// nothing to infer.
+		if reader, ok := adapter.(adapters.IncrementalReader); ok {
+			m.pollSession(ctx, aw, reader, rw, cursor)
+			return nil
+		}
+
+		// Fallback for an adapter with no incremental reader: tail for entries and
+		// accept that the session cannot be resumed. Every shipped adapter now
+		// implements ReadFromOffset (enforced by tests/adapters), so this path is
+		// for third-party adapters only.
+		ch, err := adapter.Watch(ctx, aw.sessionFile)
+		if err != nil {
+			m.logger.Error("failed to start tail watcher",
+				"session", aw.sessionName, "error", err)
+			return nil
+		}
+		m.logger.Warn("adapter has no incremental reader; this session cannot resume after a daemon restart",
+			"session", aw.sessionName, "adapter", aw.adapterName)
+
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-ticker.C:
+				if session.HasExplicitStop(aw.projectRoot, aw.agentID) {
+					return nil
+				}
+			case entry, ok := <-ch:
+				if !ok || session.HasExplicitStop(aw.projectRoot, aw.agentID) {
+					return nil
+				}
+				converted := session.ConvertRawEntries([]adapters.RawEntry{entry})
+				if err := writeEntries(rw, converted); err != nil {
+					return err
+				}
+				// Watch has no cursor to persist; see pollSession.
+			}
+		}
+	})
+	if err != nil && !errors.Is(err, context.Canceled) {
+		m.logger.Warn("session watcher ended", "session", aw.sessionName, "error", err)
 	}
 }
 
@@ -434,6 +510,9 @@ func (m *SessionWatcherManager) pollSession(
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+		}
+		if session.HasExplicitStop(aw.projectRoot, aw.agentID) {
+			return
 		}
 
 		entries, newOffset, err := reader.ReadFromOffset(aw.sessionFile, offset)

--- a/internal/daemon/agentwork/session_watcher_handle_test.go
+++ b/internal/daemon/agentwork/session_watcher_handle_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 )
 
@@ -47,8 +48,15 @@ func piSessionsRoot(t *testing.T) (home, sessions string) {
 func startWatch(t *testing.T, m *SessionWatcherManager, sessionFile, adapter string) error {
 	t.Helper()
 	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache")
+	if err := os.MkdirAll(cachePath, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeRecordingState(t, filepath.Join(cachePath, recordingMarker), session.RecordingState{
+		WatchMode: "tail", AdapterName: adapter, SessionFile: sessionFile, ParentPID: os.Getpid(),
+	})
 	return m.StartWatch("sess", sessionFile, adapter,
-		filepath.Join(dir, "ledger"), filepath.Join(dir, "cache"))
+		filepath.Join(dir, "ledger"), cachePath)
 }
 
 // TestStartWatch_AcceptsOpaqueHandles: opencode and goose read from a SQLite

--- a/internal/daemon/agentwork/session_watcher_test.go
+++ b/internal/daemon/agentwork/session_watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
@@ -25,8 +27,9 @@ import (
 // watcher manager tests to exercise catch-up reads and live tailing without
 // requiring real external adapter binaries.
 type testAdapter struct {
-	name string
-	find func(adapters.SessionLookup) (string, error)
+	name  string
+	find  func(adapters.SessionLookup) (string, error)
+	watch func(context.Context, string) (<-chan adapters.RawEntry, error)
 }
 
 func (a *testAdapter) Name() string { return a.name }
@@ -43,6 +46,9 @@ func (a *testAdapter) ReadMetadata(_ string) (*adapters.SessionMetadata, error) 
 }
 
 func (a *testAdapter) Watch(ctx context.Context, path string) (<-chan adapters.RawEntry, error) {
+	if a.watch != nil {
+		return a.watch(ctx, path)
+	}
 	tw := adapters.NewTailWatcher(path, 0, testParseLine)
 	return tw.Watch(ctx)
 }
@@ -115,6 +121,139 @@ func (m *SessionWatcherManager) codexSessionPath(t *testing.T, name string) stri
 }
 
 // --- A. Lifecycle ---
+
+// A queued start can pass validation before CLI stop finishes under the raw lock.
+// It must recheck the marker after acquiring that lock and leave capture closed.
+func TestSessionWatcherManager_QueuedStartRechecksRecording(t *testing.T) {
+	for _, change := range []string{"removed", "corrupt", "stopped", "explicit-stop", "raw-directory"} {
+		t.Run(change, func(t *testing.T) {
+			mgr := newTestWatcherManager(t)
+			t.Cleanup(mgr.StopAll)
+			t.Setenv("XDG_DATA_HOME", t.TempDir())
+			t.Setenv("XDG_CACHE_HOME", t.TempDir())
+			t.Setenv("OX_XDG_DISABLE", "")
+			projectRoot := t.TempDir()
+			require.NoError(t, config.SaveProjectConfig(projectRoot, &config.ProjectConfig{RepoID: "repo_queued_start", Endpoint: "https://test.sageox.ai"}))
+			cachePath := t.TempDir()
+			source := mgr.codexSessionPath(t, "queued.jsonl")
+			require.NoError(t, os.WriteFile(source, []byte("must not be captured\n"), 0600))
+			rawPath := filepath.Join(cachePath, "raw.jsonl")
+			recPath := filepath.Join(cachePath, recordingMarker)
+			state := session.RecordingState{
+				AgentID: "OxQueued", WorkspacePath: projectRoot, SessionPath: cachePath,
+				SessionFile: source, AdapterName: "codex", WatchMode: "tail", ParentPID: os.Getpid(),
+			}
+			writeRecordingState(t, recPath, state)
+			require.NoError(t, fileutil.WithFileLock(context.Background(), rawPath, func() error {
+				require.NoError(t, mgr.StartWatch("queued", source, "codex", "/ledger", cachePath))
+				switch change {
+				case "removed":
+					return os.Remove(recPath)
+				case "corrupt":
+					return os.WriteFile(recPath, []byte("{invalid"), 0600)
+				case "stopped":
+					now := time.Now()
+					state.StoppedAt = &now
+					writeRecordingState(t, recPath, state)
+				case "explicit-stop":
+					return session.MarkExplicitStop(projectRoot, state.AgentID)
+				case "raw-directory":
+					return os.Mkdir(rawPath, 0700)
+				}
+				return nil
+			}))
+			require.Eventually(t, func() bool { return len(mgr.ActiveSessions()) == 0 }, time.Second, time.Millisecond)
+			mgr.StopAll()
+			if change == "raw-directory" {
+				assert.DirExists(t, rawPath, "an unwritable capture must be preserved for repair")
+				assert.FileExists(t, recPath, "opening failure must remain retryable")
+			} else {
+				assert.NoFileExists(t, rawPath, "late start must not recreate finalized capture")
+			}
+			if change == "explicit-stop" {
+				assert.True(t, session.HasExplicitStop(projectRoot, state.AgentID))
+			}
+		})
+	}
+}
+
+// Stream-only adapters must still capture, stop without IPC, and release the
+// raw lock when their stream ends or fails. Incremental adapters obey the same stop.
+func TestSessionWatcherManager_CaptureReleasesLock(t *testing.T) {
+	for _, end := range []string{"stream-close", "cancel", "explicit-stop", "watch-error", "incremental-stop"} {
+		t.Run(end, func(t *testing.T) {
+			if testing.Short() && (end == "explicit-stop" || end == "incremental-stop") {
+				t.Skip("short: durable stop detected on polling interval")
+			}
+			mgr := newTestWatcherManager(t)
+			t.Cleanup(mgr.StopAll)
+			t.Setenv("XDG_DATA_HOME", t.TempDir())
+			t.Setenv("XDG_CACHE_HOME", t.TempDir())
+			t.Setenv("OX_XDG_DISABLE", "")
+			projectRoot := t.TempDir()
+			require.NoError(t, config.SaveProjectConfig(projectRoot, &config.ProjectConfig{RepoID: "repo_capture_stop", Endpoint: "https://test.sageox.ai"}))
+			cachePath := t.TempDir()
+			source := mgr.codexSessionPath(t, "stream.jsonl")
+			require.NoError(t, os.WriteFile(source, nil, 0600))
+			state := session.RecordingState{
+				AgentID: "OxStream", WorkspacePath: projectRoot, SessionPath: cachePath,
+				SessionFile: source, AdapterName: "codex", WatchMode: "tail", ParentPID: os.Getpid(),
+			}
+			writeRecordingState(t, filepath.Join(cachePath, recordingMarker), state)
+			original, err := adapters.GetAdapter("codex")
+			require.NoError(t, err)
+			entries := make(chan adapters.RawEntry, 1)
+			if end != "incremental-stop" {
+				// Embedding the Adapter interface exposes Watch but hides the fake's
+				// IncrementalReader, exercising the supported stream-only fallback.
+				adapter := struct{ adapters.Adapter }{&testAdapter{name: "codex", watch: func(context.Context, string) (<-chan adapters.RawEntry, error) {
+					if end == "watch-error" {
+						return nil, errors.New("native session watch unavailable")
+					}
+					return entries, nil
+				}}}
+				adapters.Unregister("codex")
+				adapters.Register(adapter)
+				t.Cleanup(func() {
+					mgr.StopAll()
+					adapters.Unregister("codex")
+					adapters.Register(original)
+				})
+			}
+			rawPath := filepath.Join(cachePath, "raw.jsonl")
+			require.NoError(t, mgr.StartWatch("stream", source, "codex", "/ledger", cachePath))
+			if end == "incremental-stop" {
+				require.Eventually(t, func() bool { _, err := os.Stat(rawPath); return err == nil }, time.Second, time.Millisecond)
+			} else if end != "watch-error" {
+				entries <- adapters.RawEntry{Role: "assistant", Content: "captured before stop", Timestamp: time.Now()}
+				require.Eventually(t, func() bool {
+					data, err := os.ReadFile(rawPath)
+					return err == nil && strings.Contains(string(data), "captured before stop")
+				}, time.Second, time.Millisecond)
+			}
+			switch end {
+			case "stream-close":
+				close(entries)
+			case "cancel":
+				mgr.StopWatch("stream")
+			case "explicit-stop", "incremental-stop":
+				require.NoError(t, session.MarkExplicitStop(projectRoot, state.AgentID))
+			}
+			require.Eventually(t, func() bool { return len(mgr.ActiveSessions()) == 0 }, 2*pollInterval, 10*time.Millisecond)
+			mgr.StopAll()
+			require.NoError(t, fileutil.WithFileLockTimeout(context.Background(), rawPath, 100*time.Millisecond, func() error { return nil }),
+				"CLI finalization must be able to acquire the capture lock")
+			data, err := os.ReadFile(rawPath)
+			require.NoError(t, err)
+			if end == "watch-error" || end == "incremental-stop" {
+				assert.Empty(t, data)
+			} else {
+				assert.Equal(t, 1, strings.Count(string(data), "captured before stop"))
+			}
+			assert.FileExists(t, filepath.Join(cachePath, recordingMarker), "capture must leave finalization state intact")
+		})
+	}
+}
 
 // A queued start IPC can arrive after stop removed or closed the recording.
 // It must not recreate capture, overwrite finalized content, or consume the
@@ -381,6 +520,64 @@ func TestSessionWatcherManager_DetectAndRestart_RetriesMissingSource(t *testing.
 	assert.Equal(t, source, after.SessionFile)
 	assert.Equal(t, "native-thread", after.AgentSessionID)
 	assert.Zero(t, mgr.DetectAndRestart(ledgerPath), "repeated detection must not duplicate capture")
+}
+
+// Failed discovery must not start capture from another file or lose the native
+// identity needed to retry when Conductor eventually writes the session.
+func TestSessionWatcherManager_DetectAndRestart_RejectsUnavailableSource(t *testing.T) {
+	for _, failure := range []string{"no-adapter", "unknown-adapter", "unsafe-source", "removed-recording"} {
+		t.Run(failure, func(t *testing.T) {
+			mgr := newTestWatcherManager(t)
+			t.Cleanup(mgr.StopAll)
+			t.Setenv("XDG_DATA_HOME", t.TempDir())
+			t.Setenv("XDG_CACHE_HOME", t.TempDir())
+			t.Setenv("OX_XDG_DISABLE", "")
+			projectRoot := t.TempDir()
+			cfg := &config.ProjectConfig{RepoID: "repo_discovery_failure", Endpoint: "https://test.sageox.ai"}
+			require.NoError(t, config.SaveProjectConfig(projectRoot, cfg))
+			adapterName := "codex"
+			switch failure {
+			case "no-adapter":
+				adapterName = ""
+			case "unknown-adapter":
+				adapterName = "missing-session-adapter"
+			}
+			state, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+				AgentID: "OxDiscovery", AgentSessionID: "native-thread", AdapterName: adapterName,
+				WorkspacePath: projectRoot, WatchMode: "tail", ParentPID: os.Getpid(),
+			})
+			require.NoError(t, err)
+			source := mgr.codexSessionPath(t, "discovered.jsonl")
+			if failure == "unsafe-source" {
+				source = filepath.Join(t.TempDir(), "private.jsonl")
+			}
+			require.NoError(t, os.WriteFile(source, []byte("must not be uploaded\n"), 0600))
+			original, err := adapters.GetAdapter("codex")
+			require.NoError(t, err)
+			adapters.Unregister("codex")
+			adapters.Register(&testAdapter{name: "codex", find: func(lookup adapters.SessionLookup) (string, error) {
+				assert.Equal(t, state.AgentSessionID, lookup.AgentSessionID)
+				if failure == "removed-recording" {
+					return source, os.Remove(filepath.Join(state.SessionPath, recordingMarker))
+				}
+				return source, nil
+			}})
+			t.Cleanup(func() {
+				mgr.StopAll()
+				adapters.Unregister("codex")
+				adapters.Register(original)
+			})
+			assert.Zero(t, mgr.DetectAndRestart(paths.LedgersDataDir(cfg.RepoID, cfg.Endpoint)))
+			assert.Empty(t, mgr.ActiveSessions())
+			if failure != "removed-recording" {
+				after, err := session.LoadRecordingStateForAgent(projectRoot, state.AgentID)
+				require.NoError(t, err)
+				require.NotNil(t, after)
+				assert.Empty(t, after.SessionFile)
+				assert.Equal(t, "native-thread", after.AgentSessionID)
+			}
+		})
+	}
 }
 
 // TestSessionWatcherManager_DetectAndRestart_SkipsHookMode verifies hook-mode

--- a/internal/daemon/agentwork/session_watcher_test.go
+++ b/internal/daemon/agentwork/session_watcher_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/stretchr/testify/assert"
@@ -24,11 +26,15 @@ import (
 // requiring real external adapter binaries.
 type testAdapter struct {
 	name string
+	find func(adapters.SessionLookup) (string, error)
 }
 
 func (a *testAdapter) Name() string { return a.name }
 func (a *testAdapter) Detect() bool { return false }
-func (a *testAdapter) FindSessionFile(_ adapters.SessionLookup) (string, error) {
+func (a *testAdapter) FindSessionFile(lookup adapters.SessionLookup) (string, error) {
+	if a.find != nil {
+		return a.find(lookup)
+	}
 	return "", adapters.ErrSessionNotFound
 }
 func (a *testAdapter) Read(_ string) ([]adapters.RawEntry, error) { return nil, nil }
@@ -110,6 +116,52 @@ func (m *SessionWatcherManager) codexSessionPath(t *testing.T, name string) stri
 
 // --- A. Lifecycle ---
 
+// A queued start IPC can arrive after stop removed or closed the recording.
+// It must not recreate capture, overwrite finalized content, or consume the
+// durable stop breadcrumb that also protects against a later auto-start.
+func TestSessionWatcherManager_StartWatch_RequiresLiveRecording(t *testing.T) {
+	for _, marker := range []string{"missing", "corrupt", "stopped", "explicit-stop"} {
+		t.Run(marker, func(t *testing.T) {
+			mgr := newTestWatcherManager(t)
+			t.Cleanup(mgr.StopAll)
+			t.Setenv("XDG_DATA_HOME", filepath.Join(t.TempDir(), "data"))
+			t.Setenv("XDG_CACHE_HOME", filepath.Join(t.TempDir(), "cache"))
+			t.Setenv("OX_XDG_DISABLE", "")
+			projectRoot := t.TempDir()
+			cfg := &config.ProjectConfig{RepoID: "repo_closed_recording", Endpoint: "https://test.sageox.ai"}
+			require.NoError(t, config.SaveProjectConfig(projectRoot, cfg))
+			cachePath := t.TempDir()
+			source := mgr.codexSessionPath(t, "closed.jsonl")
+			require.NoError(t, os.WriteFile(source, []byte("must not be captured\n"), 0600))
+			state := session.RecordingState{
+				AgentID: "OxClosed", WorkspacePath: projectRoot, SessionPath: cachePath,
+				SessionFile: source, AdapterName: "codex", WatchMode: "tail", ParentPID: os.Getpid(),
+			}
+			recPath := filepath.Join(cachePath, recordingMarker)
+			switch marker {
+			case "corrupt":
+				require.NoError(t, os.WriteFile(recPath, []byte("{invalid"), 0600))
+			case "stopped":
+				stopped := time.Now()
+				state.StoppedAt = &stopped
+				writeRecordingState(t, recPath, state)
+			case "explicit-stop":
+				writeRecordingState(t, recPath, state)
+				require.NoError(t, session.MarkExplicitStop(projectRoot, state.AgentID))
+			}
+
+			err := mgr.StartWatch("closed", source, "codex", paths.LedgersDataDir(cfg.RepoID, cfg.Endpoint), cachePath)
+			assert.Error(t, err, "a delayed IPC must be rejected when the recording is no longer live")
+			assert.Empty(t, mgr.ActiveSessions())
+			mgr.StopAll()
+			assert.NoFileExists(t, filepath.Join(cachePath, "raw.jsonl"), "rejected starts must not write capture data")
+			if marker == "explicit-stop" {
+				assert.True(t, session.ConsumeExplicitStop(projectRoot, state.AgentID), "watcher validation must not consume the explicit-stop breadcrumb")
+			}
+		})
+	}
+}
+
 // TestSessionWatcherManager_StartWatch_Idempotent verifies that starting a
 // watcher twice for the same session is a no-op (not an error or double-start).
 // Failure prevented: duplicate goroutines tailing the same file.
@@ -125,6 +177,9 @@ func TestSessionWatcherManager_StartWatch_Idempotent(t *testing.T) {
 	sessionFile := mgr.codexSessionPath(t, "session.jsonl")
 	require.NoError(t, os.WriteFile(sessionFile, []byte{}, 0644))
 
+	writeRecordingState(t, filepath.Join(dir, recordingMarker), session.RecordingState{
+		WatchMode: "tail", AdapterName: "codex", SessionFile: sessionFile, ParentPID: os.Getpid(),
+	})
 	err := mgr.StartWatch("test-session", sessionFile, "codex", "/ledger", dir)
 	require.NoError(t, err)
 
@@ -150,6 +205,9 @@ func TestSessionWatcherManager_StopWatch_RemovesWatcher(t *testing.T) {
 	sessionFile := mgr.codexSessionPath(t, "session.jsonl")
 	require.NoError(t, os.WriteFile(sessionFile, []byte{}, 0644))
 
+	writeRecordingState(t, filepath.Join(dir, recordingMarker), session.RecordingState{
+		WatchMode: "tail", AdapterName: "codex", SessionFile: sessionFile, ParentPID: os.Getpid(),
+	})
 	require.NoError(t, mgr.StartWatch("s1", sessionFile, "codex", "/ledger", dir))
 	assert.Len(t, mgr.ActiveSessions(), 1)
 
@@ -178,7 +236,12 @@ func TestSessionWatcherManager_StopAll_CleansUp(t *testing.T) {
 	for _, name := range []string{"s1", "s2", "s3"} {
 		f := mgr.codexSessionPath(t, name+".jsonl")
 		require.NoError(t, os.WriteFile(f, []byte{}, 0644))
-		require.NoError(t, mgr.StartWatch(name, f, "codex", "/ledger", dir))
+		cachePath := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(cachePath, 0700))
+		writeRecordingState(t, filepath.Join(cachePath, recordingMarker), session.RecordingState{
+			WatchMode: "tail", AdapterName: "codex", SessionFile: f, ParentPID: os.Getpid(),
+		})
+		require.NoError(t, mgr.StartWatch(name, f, "codex", "/ledger", cachePath))
 	}
 	assert.Len(t, mgr.ActiveSessions(), 3)
 
@@ -247,7 +310,7 @@ func TestSessionWatcherManager_DetectAndRestart_FindsTailRecordings(t *testing.T
 	defer mgr.StopAll()
 
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 
 	// create a tail-mode recording
 	sessionDir := filepath.Join(sessionsDir, "2026-03-31T10-00-test")
@@ -269,13 +332,64 @@ func TestSessionWatcherManager_DetectAndRestart_FindsTailRecordings(t *testing.T
 	assert.Len(t, mgr.ActiveSessions(), 1)
 }
 
+// A source file that appears after prime must be discovered without restarting
+// the coworker, using its persisted native ID rather than another session's file.
+func TestSessionWatcherManager_DetectAndRestart_RetriesMissingSource(t *testing.T) {
+	mgr := newTestWatcherManager(t)
+	t.Cleanup(mgr.StopAll)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(t.TempDir(), "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(t.TempDir(), "cache"))
+	t.Setenv("OX_XDG_DISABLE", "")
+	projectRoot := t.TempDir()
+	cfg := &config.ProjectConfig{RepoID: "repo_delayed_source", Endpoint: "https://test.sageox.ai"}
+	require.NoError(t, config.SaveProjectConfig(projectRoot, cfg))
+	ledgerPath := paths.LedgersDataDir(cfg.RepoID, cfg.Endpoint)
+	state, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+		AgentID: "OxLate", AgentSessionID: "native-thread", AdapterName: "codex",
+		WorkspacePath: projectRoot, WatchMode: "tail", ParentPID: os.Getpid(),
+	})
+	require.NoError(t, err)
+	source := mgr.codexSessionPath(t, "late.jsonl")
+	original, err := adapters.GetAdapter("codex")
+	require.NoError(t, err)
+	adapters.Unregister("codex")
+	adapters.Register(&testAdapter{name: "codex", find: func(lookup adapters.SessionLookup) (string, error) {
+		assert.Equal(t, state.AgentID, lookup.AgentID)
+		assert.Equal(t, "native-thread", lookup.AgentSessionID)
+		assert.Equal(t, projectRoot, lookup.RepoRoot)
+		if _, err := os.Stat(source); err != nil {
+			return "", err
+		}
+		return source, nil
+	}})
+	t.Cleanup(func() {
+		mgr.StopAll()
+		adapters.Unregister("codex")
+		adapters.Register(original)
+	})
+
+	assert.Zero(t, mgr.DetectAndRestart(ledgerPath), "missing source must remain retryable")
+	before, err := session.LoadRecordingStateForAgent(projectRoot, state.AgentID)
+	require.NoError(t, err)
+	require.NotNil(t, before)
+	assert.Empty(t, before.SessionFile)
+	require.NoError(t, os.WriteFile(source, []byte("late message\n"), 0o600))
+	require.Equal(t, 1, mgr.DetectAndRestart(ledgerPath))
+	after, err := session.LoadRecordingStateForAgent(projectRoot, state.AgentID)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	assert.Equal(t, source, after.SessionFile)
+	assert.Equal(t, "native-thread", after.AgentSessionID)
+	assert.Zero(t, mgr.DetectAndRestart(ledgerPath), "repeated detection must not duplicate capture")
+}
+
 // TestSessionWatcherManager_DetectAndRestart_SkipsHookMode verifies hook-mode
 // recordings are not picked up by detection.
 // Failure prevented: daemon starts duplicate watcher for hook-driven sessions.
 func TestSessionWatcherManager_DetectAndRestart_SkipsHookMode(t *testing.T) {
 	mgr := newTestWatcherManager(t)
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 
 	sessionDir := filepath.Join(sessionsDir, "hook-session")
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
@@ -294,7 +408,7 @@ func TestSessionWatcherManager_DetectAndRestart_SkipsHookMode(t *testing.T) {
 func TestSessionWatcherManager_DetectAndRestart_SkipsStopped(t *testing.T) {
 	mgr := newTestWatcherManager(t)
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 
 	sessionDir := filepath.Join(sessionsDir, "stopped-session")
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
@@ -320,7 +434,7 @@ func TestSessionWatcherManager_DetectAndRestart_SkipsStopped(t *testing.T) {
 func TestSessionWatcherManager_DetectAndRestart_SkipsDeadPID(t *testing.T) {
 	mgr := newTestWatcherManager(t)
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 
 	sessionDir := filepath.Join(sessionsDir, "dead-agent")
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
@@ -349,7 +463,7 @@ func TestSessionWatcherManager_DetectAndRestart_SkipsAlreadyWatched(t *testing.T
 	mgr := newTestWatcherManager(t)
 
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 	sessionDir := filepath.Join(sessionsDir, "active-session")
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
 
@@ -403,7 +517,7 @@ func TestSessionWatcherManager_DetectAndRestart_CatchUpFromPersistedOffset(t *te
 	defer mgr.StopAll()
 
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 	sessionDir := filepath.Join(sessionsDir, "catchup-session")
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
 
@@ -476,7 +590,7 @@ func TestSessionWatcherManager_WritePath_RedactsCredentials(t *testing.T) {
 	defer mgr.StopAll()
 
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 	sessionDir := filepath.Join(sessionsDir, "canary-session")
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
 
@@ -564,7 +678,7 @@ func TestSessionWatcherManager_WritePath_WholeOutputRedactsAwsSso(t *testing.T) 
 	defer mgr.StopAll()
 
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 	sessionDir := filepath.Join(sessionsDir, "aws-sso-session")
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
 
@@ -856,6 +970,9 @@ func TestSessionWatcherManager_Cleanup_StopsStopped(t *testing.T) {
 	dir := t.TempDir()
 	sessionFile := mgr.codexSessionPath(t, "session.jsonl")
 	require.NoError(t, os.WriteFile(sessionFile, []byte{}, 0644))
+	writeRecordingState(t, filepath.Join(dir, recordingMarker), session.RecordingState{
+		WatchMode: "tail", AdapterName: "codex", SessionFile: sessionFile, ParentPID: os.Getpid(),
+	})
 	require.NoError(t, mgr.StartWatch("s1", sessionFile, "codex", "/ledger", dir))
 
 	// write a stopped recording marker
@@ -885,9 +1002,13 @@ func TestSessionWatcherManager_Cleanup_StopsOrphaned(t *testing.T) {
 	dir := t.TempDir()
 	sessionFile := mgr.codexSessionPath(t, "session.jsonl")
 	require.NoError(t, os.WriteFile(sessionFile, []byte{}, 0644))
+	writeRecordingState(t, filepath.Join(dir, recordingMarker), session.RecordingState{
+		WatchMode: "tail", AdapterName: "codex", SessionFile: sessionFile, ParentPID: os.Getpid(),
+	})
 	require.NoError(t, mgr.StartWatch("s1", sessionFile, "codex", "/ledger", dir))
 
-	// no .recording.json in dir → orphaned
+	// marker removed after startup → orphaned
+	require.NoError(t, os.Remove(filepath.Join(dir, recordingMarker)))
 	mgr.Cleanup()
 
 	require.Eventually(t, func() bool {
@@ -908,7 +1029,14 @@ func TestSessionWatcherManager_Cleanup_SkipsCorruptRecording(t *testing.T) {
 	dir := t.TempDir()
 	sessionFile := mgr.codexSessionPath(t, "session.jsonl")
 	require.NoError(t, os.WriteFile(sessionFile, []byte{}, 0644))
+	writeRecordingState(t, filepath.Join(dir, recordingMarker), session.RecordingState{
+		WatchMode: "tail", AdapterName: "codex", SessionFile: sessionFile, ParentPID: os.Getpid(),
+	})
 	require.NoError(t, mgr.StartWatch("s1", sessionFile, "codex", "/ledger", dir))
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(dir, "raw.jsonl"))
+		return err == nil
+	}, time.Second, 10*time.Millisecond, "wait for capture to open before corrupting the marker")
 
 	// overwrite .recording.json with garbage
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".recording.json"), []byte("{{not json"), 0644))
@@ -959,7 +1087,7 @@ func TestSessionWatcherManager_DetectAndRestart_OffsetBeyondEOF(t *testing.T) {
 	mgr := newTestWatcherManager(t)
 
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 	sessionDir := filepath.Join(sessionsDir, "truncated-session")
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
 
@@ -1001,7 +1129,7 @@ func TestSessionWatcherManager_CatchUpReadFailure_LiveTailStillStarts(t *testing
 	mgr := newTestWatcherManager(t)
 
 	ledgerDir := t.TempDir()
-	sessionsDir := filepath.Join(ledgerDir, "sessions")
+	sessionsDir := filepath.Join(ledgerDir, ".sageox", "cache", "sessions")
 	sessionDir := filepath.Join(sessionsDir, "catchup-fail-session")
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
 
@@ -1052,6 +1180,10 @@ func TestSessionWatcherManager_PersistOffset_MissingRecordingJSON(t *testing.T) 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".recording.json"), recData, 0644))
 
 	require.NoError(t, mgr.StartWatch("s1", sessionFile, "codex", "/ledger", dir))
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(dir, "raw.jsonl"))
+		return err == nil
+	}, time.Second, 10*time.Millisecond, "wait for capture to open before removing the marker")
 
 	// delete .recording.json while watcher is active
 	require.NoError(t, os.Remove(filepath.Join(dir, ".recording.json")))
@@ -1063,6 +1195,10 @@ func TestSessionWatcherManager_PersistOffset_MissingRecordingJSON(t *testing.T) 
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
+	require.Eventually(t, func() bool {
+		info, err := os.Stat(filepath.Join(dir, "raw.jsonl"))
+		return err == nil && info.Size() > 0
+	}, 5*time.Second, 10*time.Millisecond, "capture must reach persistOffset with the marker absent")
 	// watcher should still be running (persistOffset didn't crash)
 	require.Eventually(t, func() bool {
 		return len(mgr.ActiveSessions()) == 1
@@ -1092,6 +1228,10 @@ func TestSessionWatcherManager_PersistOffset_CorruptRecordingJSON(t *testing.T) 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".recording.json"), recData, 0644))
 
 	require.NoError(t, mgr.StartWatch("s1", sessionFile, "codex", "/ledger", dir))
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(dir, "raw.jsonl"))
+		return err == nil
+	}, time.Second, 10*time.Millisecond, "wait for capture to open before corrupting the marker")
 
 	// corrupt .recording.json while watcher is active
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".recording.json"), []byte("%%%CORRUPT%%%"), 0644))
@@ -1103,6 +1243,10 @@ func TestSessionWatcherManager_PersistOffset_CorruptRecordingJSON(t *testing.T) 
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
+	require.Eventually(t, func() bool {
+		info, err := os.Stat(filepath.Join(dir, "raw.jsonl"))
+		return err == nil && info.Size() > 0
+	}, 5*time.Second, 10*time.Millisecond, "capture must reach persistOffset with a corrupt marker")
 	// watcher should still be running (persistOffset didn't crash)
 	require.Eventually(t, func() bool {
 		return len(mgr.ActiveSessions()) == 1

--- a/internal/daemon/agentwork/session_watcher_test.go
+++ b/internal/daemon/agentwork/session_watcher_test.go
@@ -239,7 +239,7 @@ func TestSessionWatcherManager_CaptureReleasesLock(t *testing.T) {
 			case "explicit-stop", "incremental-stop":
 				require.NoError(t, session.MarkExplicitStop(projectRoot, state.AgentID))
 			}
-			require.Eventually(t, func() bool { return len(mgr.ActiveSessions()) == 0 }, 2*pollInterval, 10*time.Millisecond)
+			require.Eventually(t, func() bool { return len(mgr.ActiveSessions()) == 0 }, 5*time.Second, 10*time.Millisecond)
 			mgr.StopAll()
 			require.NoError(t, fileutil.WithFileLockTimeout(context.Background(), rawPath, 100*time.Millisecond, func() error { return nil }),
 				"CLI finalization must be able to acquire the capture lock")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -283,6 +283,9 @@ func (d *Daemon) checkDeadAgentsAndFinalize() {
 			)
 
 			if d.sessionFinalizeHandler != nil {
+				if d.sessionWatcher != nil {
+					d.sessionWatcher.Cleanup()
+				}
 				items := d.sessionFinalizeHandler.DetectOrphanedForAgent(d.config.LedgerPath, agentID, pid)
 				for _, item := range items {
 					if d.agentWorker.Enqueue(item) {
@@ -1911,7 +1914,7 @@ func (s *daemonServiceImpl) SessionWatchStart(payload SessionWatchStartPayload) 
 	}
 	// derive paths server-side; never trust client-supplied destinations
 	ledgerPath := s.d.config.LedgerPath
-	cachePath := filepath.Join(ledgerPath, "sessions", payload.SessionName)
+	cachePath := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", payload.SessionName)
 	if err := s.d.sessionWatcher.StartWatch(
 		payload.SessionName, payload.SessionFile,
 		payload.AdapterName, ledgerPath, cachePath,

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,14 +2,126 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	projectconfig "github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon/agentwork"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDaemon_DeadAgentQuiescesCaptureBeforeFinalizing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: builds the Codex adapter")
+	}
+	binaryPath := filepath.Join(t.TempDir(), "ox-adapter-codex")
+	build := exec.Command("go", "build", "-o", binaryPath, "./cmd/ox-adapter-codex")
+	build.Dir = supFindRepoRoot(t)
+	out, err := build.CombinedOutput()
+	require.NoError(t, err, "build Codex adapter: %s", out)
+	adapter, err := adapters.NewExternalAdapter(binaryPath)
+	require.NoError(t, err)
+	adapters.Register(adapter)
+	t.Cleanup(func() {
+		adapters.Unregister("codex")
+		_ = adapter.Close()
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("OX_XDG_DISABLE", "")
+	projectRoot := t.TempDir()
+	cfg := &projectconfig.ProjectConfig{RepoID: "repo_dead_capture", Endpoint: "https://test.sageox.ai"}
+	require.NoError(t, projectconfig.SaveProjectConfig(projectRoot, cfg))
+	ledgerPath := paths.LedgersDataDir(cfg.RepoID, cfg.Endpoint)
+	source := filepath.Join(home, ".codex", "sessions", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(source), 0700))
+	first := `{"timestamp":"2026-09-07T16:50:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Remember the initial Codex request."}]}}` + "\n"
+	last := `{"timestamp":"2026-09-07T16:51:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Preserve the final Codex response."}]}}` + "\n"
+	require.NoError(t, os.WriteFile(source, []byte(first), 0600))
+	state, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+		AgentID: "OxDeadCapture", AdapterName: "codex", SessionFile: source,
+		WorkspacePath: projectRoot, ParentPID: os.Getpid(), WatchMode: "tail",
+	})
+	require.NoError(t, err)
+	state.StartedAt = time.Date(2026, time.September, 7, 16, 49, 0, 0, time.UTC)
+	require.NoError(t, session.SaveRecordingState(projectRoot, state))
+	rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
+	writer, err := session.NewRawWriter(rawPath, projectRoot)
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteRaw(map[string]any{"type": "header", "metadata": map[string]any{"agent_id": state.AgentID}}))
+	require.NoError(t, writer.Close())
+
+	d := New(&Config{LedgerPath: ledgerPath}, nil)
+	d.heartbeat = NewHeartbeatHandler(d.logger)
+	d.agentWorker = agentwork.NewManager(agentwork.NewMockRunner(false), d.logger, func() *projectconfig.AgentWorkerConfig {
+		return &projectconfig.AgentWorkerConfig{Agent: "none"}
+	}, nil, ledgerPath, projectRoot)
+	d.sessionFinalizeHandler = agentwork.NewSessionFinalizeHandlerForTest(d.logger)
+	d.sessionWatcher = agentwork.NewSessionWatcherManager(d.logger)
+	t.Cleanup(d.sessionWatcher.StopAll)
+	require.NoError(t, d.sessionWatcher.StartWatch(filepath.Base(state.SessionPath), source, "codex", ledgerPath, state.SessionPath))
+	recPath := filepath.Join(state.SessionPath, ".recording.json")
+	require.Eventually(t, func() bool {
+		data, readErr := os.ReadFile(recPath)
+		var current session.RecordingState
+		return readErr == nil && json.Unmarshal(data, &current) == nil && current.SourceOffset == int64(len(first))
+	}, 5*time.Second, 10*time.Millisecond, "capture must own the raw writer before process death")
+	data, err := os.ReadFile(recPath)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, state))
+	state.ParentPID = 99999999
+	require.NoError(t, session.SaveRecordingState(projectRoot, state))
+	f, err := os.OpenFile(source, os.O_APPEND|os.O_WRONLY, 0600)
+	require.NoError(t, err)
+	_, err = f.WriteString(last)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	d.heartbeat.agentPID[state.AgentID] = state.ParentPID
+	d.heartbeat.GetAgentActivity().RecordAt(state.AgentID, time.Now().Add(-IdleThreshold-time.Second))
+
+	done := make(chan struct{})
+	go func() {
+		d.checkDeadAgentsAndFinalize()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		d.sessionWatcher.StopAll()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("dead-agent finalization did not finish after releasing capture")
+		}
+	})
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("finalization must stop the watcher before waiting for its raw writer lock")
+	}
+
+	assert.Empty(t, d.sessionWatcher.ActiveSessions())
+	assert.Equal(t, 1, d.agentWorker.Status().QueueDepth, "the complete session must be queued for summary and upload")
+	assert.NoFileExists(t, recPath)
+	assert.Zero(t, d.heartbeat.GetAgentPID(state.AgentID))
+	assert.NotContains(t, d.heartbeat.GetAgentActivity().Keys(), state.AgentID)
+	data, err = os.ReadFile(rawPath)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(string(data), "Remember the initial Codex request."))
+	assert.Equal(t, 1, strings.Count(string(data), "Preserve the final Codex response."))
+}
 
 func TestNew(t *testing.T) {
 	t.Run("with nil config uses defaults", func(t *testing.T) {

--- a/internal/daemon/ipc_handlers_session_watch_test.go
+++ b/internal/daemon/ipc_handlers_session_watch_test.go
@@ -3,12 +3,93 @@ package daemon
 import (
 	"encoding/json"
 	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	projectconfig "github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon/agentwork"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestSessionWatchStart_CapturesInRecordingCache reproduces Conductor's IPC
+// startup with the real Codex reader and StartRecording's directory layout.
+// Previously the service opened ledger/sessions/raw.jsonl, either failing to
+// record anything or writing conversation bytes into a published session folder.
+func TestSessionWatchStart_CapturesInRecordingCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: builds Codex adapter and waits for session polling")
+	}
+	binaryPath := filepath.Join(t.TempDir(), "ox-adapter-codex")
+	build := exec.Command("go", "build", "-o", binaryPath, "./cmd/ox-adapter-codex")
+	build.Dir = supFindRepoRoot(t)
+	out, err := build.CombinedOutput()
+	require.NoError(t, err, "build Codex adapter: %s", out)
+	adapter, err := adapters.NewExternalAdapter(binaryPath)
+	require.NoError(t, err)
+	adapters.Register(adapter)
+	t.Cleanup(func() { adapters.Unregister("codex") })
+
+	for _, publishedDirExists := range []bool{false, true} {
+		name := "before publication"
+		if publishedDirExists {
+			name = "published folder exists"
+		}
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+			t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+			t.Setenv("OX_XDG_DISABLE", "")
+			projectRoot := t.TempDir()
+			cfg := &projectconfig.ProjectConfig{RepoID: "repo_ipc_watch", Endpoint: "https://test.sageox.ai"}
+			require.NoError(t, projectconfig.SaveProjectConfig(projectRoot, cfg))
+			ledgerPath := paths.LedgersDataDir(cfg.RepoID, cfg.Endpoint)
+			source := filepath.Join(home, ".codex", "sessions", "session.jsonl")
+			require.NoError(t, os.MkdirAll(filepath.Dir(source), 0o755))
+			require.NoError(t, os.WriteFile(source, []byte(`{"timestamp":"2026-09-07T16:50:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Capture this Codex session through IPC."}]}}`+"\n"), 0o600))
+			state, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+				AgentID: "OxIPC1", AdapterName: "codex", SessionFile: source,
+				WorkspacePath: projectRoot, ParentPID: os.Getpid(), WatchMode: "tail",
+			})
+			require.NoError(t, err)
+			sessionName := filepath.Base(state.SessionPath)
+			require.Equal(t, filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName), state.SessionPath)
+			rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
+			writer, err := session.NewRawWriter(rawPath, projectRoot)
+			require.NoError(t, err)
+			require.NoError(t, writer.WriteRaw(map[string]any{"type": "header", "metadata": map[string]any{"agent_id": state.AgentID}}))
+			require.NoError(t, writer.Close())
+			publishedPath := filepath.Join(ledgerPath, "sessions", sessionName)
+			if publishedDirExists {
+				require.NoError(t, os.MkdirAll(publishedPath, 0o755))
+			}
+			publishedRaw := filepath.Join(publishedPath, "raw.jsonl")
+
+			logger := slog.New(slog.NewTextHandler(testWriter{t}, nil))
+			d := New(&Config{LedgerPath: ledgerPath}, logger)
+			d.sessionWatcher = agentwork.NewSessionWatcherManager(logger)
+			defer d.sessionWatcher.StopAll()
+			svc := &daemonServiceImpl{d: d}
+			svc.SessionWatchStart(SessionWatchStartPayload{
+				SessionName: sessionName, SessionFile: source, AdapterName: "codex",
+			})
+			require.Eventually(t, func() bool {
+				return session.HasSubstantiveEntries(rawPath) || session.RawJSONLHasData(publishedPath) || len(d.sessionWatcher.ActiveSessions()) == 0
+			}, 5*time.Second, 10*time.Millisecond, "watcher did not capture the source")
+			assert.True(t, session.HasSubstantiveEntries(rawPath), "IPC must write into the active recording cache")
+			assert.NoFileExists(t, publishedRaw, "live capture must not write hydrated bytes into tracked ledger sessions")
+		})
+	}
+}
 
 // --- A. session_watch_start handler ---
 

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -62,6 +62,9 @@ type LifecycleEvent struct {
 // Stored in sessions/<session-name>/.recording.json
 type RecordingState struct {
 	AgentID string `json:"agent_id"`
+	// AgentSessionID identifies the native session independently of its file's
+	// modification time, including when the daemon retries discovery later.
+	AgentSessionID string `json:"agent_session_id,omitempty"`
 	// SessionID is the durable ses_<UUIDv7> recording identity, minted once at
 	// StartRecording and reused verbatim by every finalize path (stop, recover,
 	// daemon). It exists from t=0 so conversation URLs (/c/<ses_id>) circulated
@@ -551,6 +554,20 @@ func resolveSessionsWritePath(projectRoot string) string {
 
 const explicitStopMarker = ".session_stopped"
 
+// HasExplicitStop checks the stop breadcrumb without consuming it. Tail watchers
+// use it to stop even when the CLI cannot reach the daemon over IPC.
+func HasExplicitStop(projectRoot, agentID string) bool {
+	if projectRoot == "" || agentID == "" {
+		return false
+	}
+	for _, dir := range sessionsSearchPaths(projectRoot) {
+		if _, err := os.Stat(filepath.Join(dir, explicitStopMarker+"."+agentID)); !os.IsNotExist(err) {
+			return true
+		}
+	}
+	return false
+}
+
 // MarkExplicitStop writes a per-agent breadcrumb indicating the user explicitly
 // stopped recording. This prevents the next auto-start cycle (e.g. from /clear
 // hook re-prime) from silently restarting the session for this specific agent.
@@ -701,6 +718,11 @@ func cleanupStaleEmptyRecordings(projectRoot string) {
 		if state.SessionPath == "" {
 			continue
 		}
+		// A native log can hold the session even when the watcher never wrote
+		// an entry. Let finalization read it before classifying this as empty.
+		if state.AdapterName != "" && (state.SessionFile != "" || state.WatchMode == "tail") {
+			continue
+		}
 		// only clean phantom stubs — a header-only or missing raw.jsonl. Since
 		// eager writes at recording start (ses_/c link, header, context-trace),
 		// an abandoned session leaves a dir with content, so a plain os.Stat
@@ -783,6 +805,9 @@ func cleanupGhosts(states []*RecordingState) GhostCleanupResult {
 		// immediately; give the recording time to establish before cleanup.
 		if !state.StartedAt.IsZero() && time.Since(state.StartedAt) < GhostGracePeriod {
 			continue
+		}
+		if state.AdapterName != "" && (state.SessionFile != "" || state.WatchMode == "tail") {
+			continue // native source must be checked by finalization first
 		}
 
 		// parent is dead — check if there's any recoverable data. Classify
@@ -917,6 +942,9 @@ func CleanupOrphanedStubsInDir(cacheSessionsDir string) GhostCleanupResult {
 			if json.Unmarshal(data, &state) != nil || state.IsAgentAlive() {
 				continue // unreadable-as-JSON or still alive → keep
 			}
+			if state.AdapterName != "" && (state.SessionFile != "" || state.WatchMode == "tail") {
+				continue // native source must be checked by finalization first
+			}
 			// parsed cleanly and the PID is dead → eligible; fall through.
 		} else if !os.IsNotExist(readErr) {
 			// marker present but the read itself failed (permission/transient) → keep.
@@ -974,6 +1002,7 @@ func loadRecordingStatesFromDir(sessionsDir string) ([]*RecordingState, error) {
 // StartRecordingOptions contains options for starting a recording.
 type StartRecordingOptions struct {
 	AgentID          string
+	AgentSessionID   string
 	AdapterName      string
 	SessionFile      string // source file from adapter (Claude Code JSONL)
 	OutputFile       string // output file being recorded
@@ -1112,6 +1141,7 @@ func StartRecording(projectRoot string, opts StartRecordingOptions) (*RecordingS
 
 	state := &RecordingState{
 		AgentID:                opts.AgentID,
+		AgentSessionID:         opts.AgentSessionID,
 		SessionID:              sessionid.GenerateSessionID(),
 		ContinuedFromSessionID: continuedFromSessionID,
 		AdapterName:            opts.AdapterName,

--- a/internal/session/recording_cleanup_test.go
+++ b/internal/session/recording_cleanup_test.go
@@ -210,6 +210,42 @@ func TestCleanupStaleEmptyRecordings_RemovesEmptyDir(t *testing.T) {
 
 // --- Ghost session cleanup tests ---
 
+// Source discovery and capture can both lag prime. All cleanup paths must give
+// native recovery a chance before deleting an old header-only recording.
+func TestRecordingCleanup_PreservesNativeRecoveryState(t *testing.T) {
+	for _, cleanup := range []string{"stale", "ghost", "orphan"} {
+		for _, source := range []string{"known", "pending"} {
+			t.Run(cleanup+"/"+source, func(t *testing.T) {
+				projectRoot, sessionsBase := setupRecordingTestWithSessionsBase(t, t.TempDir())
+				sessionPath := filepath.Join(sessionsBase, "2026-01-01T00-00-user-OxNative")
+				require.NoError(t, os.MkdirAll(sessionPath, 0700))
+				state := &RecordingState{
+					AgentID: "OxNative", SessionPath: sessionPath,
+					ParentPID: 99999999, StartedAt: time.Now().Add(-72 * time.Hour),
+					AdapterName: "codex", WatchMode: "tail",
+				}
+				if source == "known" {
+					state.SessionFile = filepath.Join(t.TempDir(), "native.jsonl")
+					require.NoError(t, os.WriteFile(state.SessionFile, []byte("native conversation\n"), 0600))
+				}
+				require.NoError(t, SaveRecordingState(projectRoot, state))
+				require.NoError(t, os.WriteFile(filepath.Join(sessionPath, "raw.jsonl"), []byte("{\"type\":\"header\"}\n"), 0600))
+				require.NoError(t, os.Chtimes(sessionPath, state.StartedAt, state.StartedAt))
+				switch cleanup {
+				case "stale":
+					cleanupStaleEmptyRecordings(projectRoot)
+				case "ghost":
+					assert.Zero(t, CleanupGhostSessionsInDir(sessionsBase).Removed)
+				case "orphan":
+					assert.Zero(t, CleanupOrphanedStubsInDir(sessionsBase).Removed)
+				}
+				assert.FileExists(t, filepath.Join(sessionPath, recordingFile))
+				assert.FileExists(t, filepath.Join(sessionPath, "raw.jsonl"))
+			})
+		}
+	}
+}
+
 func TestCleanupGhostSessionsInDir_RemovesDeadPIDNoData(t *testing.T) {
 	sessionsDir := filepath.Join(t.TempDir(), "sessions")
 	sessionPath := filepath.Join(sessionsDir, "2026-01-01T00-00-user-OxDead")

--- a/internal/session/recording_cleanup_test.go
+++ b/internal/session/recording_cleanup_test.go
@@ -11,6 +11,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestHasExplicitStop_PreservesPerAgentBreadcrumb(t *testing.T) {
+	projectRoot, sessionsBase := setupRecordingTestWithSessionsBase(t, t.TempDir())
+	assert.False(t, HasExplicitStop("", "OxStopA"))
+	assert.False(t, HasExplicitStop(projectRoot, ""))
+	assert.False(t, HasExplicitStop(projectRoot, "OxStopA"))
+
+	require.NoError(t, MarkExplicitStop(projectRoot, "OxStopA"))
+	for range 2 {
+		assert.True(t, HasExplicitStop(projectRoot, "OxStopA"), "watcher checks must not consume the breadcrumb")
+		assert.False(t, HasExplicitStop(projectRoot, "OxStopB"), "stopping one coworker must not stop another")
+	}
+	assert.FileExists(t, filepath.Join(sessionsBase, explicitStopMarker+".OxStopA"))
+
+	require.NoError(t, MarkExplicitStop(projectRoot, "OxStopB"))
+	assert.True(t, ConsumeExplicitStop(projectRoot, "OxStopA"))
+	assert.False(t, HasExplicitStop(projectRoot, "OxStopA"))
+	assert.True(t, HasExplicitStop(projectRoot, "OxStopB"))
+	assert.True(t, ConsumeExplicitStop(projectRoot, "OxStopB"))
+	assert.False(t, HasExplicitStop(projectRoot, "OxStopB"))
+}
+
 func TestClearRecordingState(t *testing.T) {
 	t.Run("clears existing state from session folder", func(t *testing.T) {
 		cacheDir := t.TempDir()


### PR DESCRIPTION
## What broke

Conductor's GPT/Codex sessions could stay header-only and never reach normal ox upload, while Claude Code hook capture worked.

- **Capture destination:** daemon startup and restart discovery used the tracked `sessions/` directory instead of the recording cache created by `StartRecording`.
- **Native session selection:** discovery could miss a source created before prime, never retry a delayed file, or select another conversation when the requested native ID was unavailable.
- **Codex tools:** custom tool calls were omitted, and tool output stored as content blocks could fail decoding.
- **Finalization:** cleanup could delete recoverable stubs; the last unread batch could be lost or duplicated during stop/recovery.

## What this PR ships

- **Capture and discovery:** persist the native session ID, retry missing sources, and use the canonical recording cache for daemon capture. Explicit Codex starts select tail capture when hooks are absent.
- **Codex parsing:** retain custom tool inputs/results and normalize both string and content-block outputs using the existing call-ID pairing.
- **Safe handoff:** serialize capture, CLI stop, and daemon recovery with the existing file lock; reload the final cursor; retain stop intent and recovery state after failures.
- **Recovery:** recover missing/header-only recordings and unread final entries while preserving session identity, pause exclusions, redaction, and source-path validation. Busy capture locks defer after 250 ms so detection can continue.

```mermaid
flowchart LR
    A[Native Codex session] --> B[Codex adapter]
    B --> C[Recording cache: raw.jsonl and cursor]
    C --> D[Stop or process-exit recovery under file lock]
    D --> E[Existing finalization and LFS upload]
    E --> F[Ledger: metadata and LFS pointers]
```

## Test Plan

- **Local gates:** `make format`, `make lint`, `make test`, `make build`, and `make docs-check`.
- **Codex regressions:** native-ID selection, delayed discovery, real adapter hook capture, custom tools and content-block outputs, stop during an in-flight batch without IPC, failed final-drain retry, and re-prime while stop is pending.
- **Capture/upload integration:** compiled Codex and Claude adapters through recording, watcher restart, finalization, the production LFS client, and a local Git remote. A fresh clone verifies pointers reference the uploaded session content.
- **Recovery and race checks:** both daemon finalization paths, process-death cleanup, delayed starts after stop, lock-contention deferral/retry, stream-only adapter fallback, malformed capture preservation, cursor preservation, pause/redaction behavior, and targeted `-race` runs.
- **Changed-code coverage:** 95.8% (317/331 statements) in CI; native session discovery, hook identity selection, and Codex parser changes each have 100% coverage. Existing thresholds and exclusions are unchanged.
- **Regression verification:** removing individual fixes reproduces empty capture, sibling-session selection, omitted tools, duplicate final responses, and unsafe recovery.
- **Live parsing smoke test:** the rebuilt Codex adapter successfully parsed this Conductor conversation. The upload test uses an isolated local endpoint.

## Review

- **Ryan required:** the daemon capture destination changes to the existing canonical recording cache.
- **Scope:** no new dependencies or configuration variables. Full session content stays local until LFS upload; the tracked Ledger receives pointers.

SageOx-Session: https://sageox.ai/c/ses_01a07e46-8ddd-765c-8eb2-0d00c29df476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex session capture for function and custom tool calls, including multiline outputs and content blocks.
  - Session discovery now selects the requested conversation and preserves native session identity.
  - Improved recording recovery after interruptions, delayed data, source failures, and watcher restarts.
  - Explicit stops now complete reliably and prevent unintended recording restarts.
  - Prevented duplicate entries while preserving captured content, metadata, redaction, and recording state.
  - Improved watcher shutdown and cleanup for completed or disconnected sessions.
  - Preserved recordings during temporary failures so final responses can be captured on retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->