### PR TITLE
fix(daemon): keep status responsive when code index is unavailable

### DIFF
--- a/cmd/ox/incremental_e2e_test.go
+++ b/cmd/ox/incremental_e2e_test.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -518,12 +519,22 @@ func oxEnv(env e2eEnv) []string {
 	return result
 }
 
+// runOx returns stdout so stderr warnings cannot contaminate JSON results.
 func runOx(t *testing.T, oxBin string, env e2eEnv, agentID string, args ...string) string {
 	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
 	fullArgs := append([]string{"agent", agentID}, args...)
-	out, exitCode, _ := testguard.RunOx(t, oxBin, env.workspace, oxEnv(env), fullArgs...)
-	require.Equal(t, 0, exitCode, "ox agent %s %v failed:\n%s", agentID, args, out)
-	return out
+	cmd := testguard.OxCmdContext(t, ctx, oxBin, env.workspace, oxEnv(env), fullArgs...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if stderr.Len() > 0 {
+		t.Logf("ox agent %s %v stderr:\n%s", agentID, args, stderr.String())
+	}
+	require.NoError(t, err, "ox agent %s %v failed:\n%s", agentID, args, out)
+	return string(out)
 }
 
 func runOxHook(t *testing.T, oxBin string, env e2eEnv, agentID, event, sessionID string) string {

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -1020,82 +1020,29 @@ func (m *CodeDBManager) RefreshDirtyOverlay(ctx context.Context) {
 }
 
 // Stats returns current index statistics.
-// Returns cached stats from the last index run to avoid blocking on SQLite
-// during active indexing. Only queries the DB on cold start (no cached stats
-// and not currently indexing).
+// Counts come from the last successful index run. Never open the database here:
+// cold starts and failed indexing can leave SQLite or Bleve unavailable, and
+// status IPC requests must remain responsive in those states.
 func (m *CodeDBManager) Stats() CodeDBStats {
 	m.mu.Lock()
-	indexing := m.indexing
-	lastIndex := m.lastIndex
-	lastErr := m.lastErr
-	cached := m.stats
-	ledgerIndexing := m.ledgerIndexing
-	ledgerStats := m.ledgerStats
+	result := m.stats
+	result.IndexingNow = m.indexing
+	result.LastIndexed = m.lastIndex
+	result.LastError = ""
+	if m.lastErr != nil {
+		result.LastError = m.lastErr.Error()
+	}
+	result.LedgerIndexingNow = m.ledgerIndexing
+	result.LedgerExists = m.ledgerStats.IndexExists
+	result.LedgerCommits = m.ledgerStats.Commits
 	m.mu.Unlock()
 
-	dataDir := m.resolveSharedDataDir()
-
-	// merge ledger index fields into result
-	mergeLedger := func(s *CodeDBStats) {
-		s.LedgerIndexingNow = ledgerIndexing
-		s.LedgerExists = ledgerStats.IndexExists
-		s.LedgerCommits = ledgerStats.Commits
+	result.DataDir = m.resolveSharedDataDir()
+	if !result.IndexExists {
+		_, err := os.Stat(result.DataDir)
+		result.IndexExists = err == nil
 	}
 
-	// if we have cached stats, return them with live metadata
-	if cached.IndexExists {
-		cached.IndexingNow = indexing
-		cached.LastIndexed = lastIndex
-		cached.DataDir = dataDir
-		cached.LastError = ""
-		if lastErr != nil {
-			cached.LastError = lastErr.Error()
-		}
-		mergeLedger(&cached)
-		return cached
-	}
-
-	// no cached stats yet — cold start before first index completes
-	result := CodeDBStats{
-		DataDir:     dataDir,
-		IndexingNow: indexing,
-		LastIndexed: lastIndex,
-	}
-	if lastErr != nil {
-		result.LastError = lastErr.Error()
-	}
-
-	// if indexing is active, don't try to open the DB (it will block)
-	if indexing {
-		if _, err := os.Stat(dataDir); err == nil {
-			result.IndexExists = true
-		}
-		mergeLedger(&result)
-		return result
-	}
-
-	// not indexing and no cache: try a quick read to populate initial stats
-	if _, err := os.Stat(dataDir); err == nil {
-		result.IndexExists = true
-
-		db, err := codedb.Open(dataDir)
-		if err == nil {
-			defer db.Close()
-			result = queryStatsFromDB(db, dataDir)
-			result.IndexingNow = indexing
-			result.LastIndexed = lastIndex
-			if lastErr != nil {
-				result.LastError = lastErr.Error()
-			}
-
-			// cache for future calls
-			m.mu.Lock()
-			m.stats = result
-			m.mu.Unlock()
-		}
-	}
-
-	mergeLedger(&result)
 	return result
 }
 

--- a/internal/daemon/ipc_status_test.go
+++ b/internal/daemon/ipc_status_test.go
@@ -3,12 +3,14 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/codedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,6 +35,88 @@ func TestStatusData_JSON(t *testing.T) {
 	assert.Equal(t, status.Running, decoded.Running)
 	assert.Equal(t, status.Pid, decoded.Pid)
 	assert.Equal(t, status.LedgerPath, decoded.LedgerPath)
+}
+
+// Status must remain responsive when a cold or failed index has no cached stats
+// and another writer holds the database open. Exercise both real IPC handlers.
+func TestServerClient_StatusWithLockedCodeDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real code databases and IPC servers")
+	}
+
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_RUNTIME_DIR", recoveryRuntimeDir(t, "ox-ipc-stats-"))
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	for _, tt := range []struct {
+		name     string
+		indexing bool
+		cached   bool
+		lastErr  error
+	}{
+		{name: "cold start"},
+		{name: "failed initial index", lastErr: errors.New("code index is corrupt")},
+		{name: "active initial index", indexing: true},
+		{name: "failed refresh preserves stats", cached: true, lastErr: errors.New("refresh failed")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			seedCodeDB(t, dataDir)
+			// Keep Bleve's real writer lock held throughout the status requests.
+			db, err := codedb.Open(dataDir)
+			require.NoError(t, err)
+			defer db.Close()
+
+			cfg := DefaultConfig()
+			cfg.ProjectRoot = t.TempDir()
+			d := New(cfg, nil)
+			d.scheduler = NewSyncScheduler(cfg, d.logger)
+			d.codedb = NewCodeDBManager(cfg.ProjectRoot, d.logger, nil)
+			d.codedb.dataDir = dataDir
+			d.codedb.indexing = tt.indexing
+			d.codedb.lastErr = tt.lastErr
+			d.codedb.ledgerStats = CodeDBStats{IndexExists: true, Commits: 7}
+			if tt.cached {
+				d.codedb.stats = queryStatsFromDB(db, dataDir)
+				d.codedb.lastIndex = time.Now().Add(-time.Minute).UTC()
+			}
+
+			server := NewServerWithService(d.logger, &daemonServiceImpl{d: d})
+			stop := startRecoveryTestServer(t, server)
+			defer func() {
+				// Release a blocked old implementation before draining handlers.
+				require.NoError(t, db.Close())
+				stop()
+			}()
+
+			client := &Client{socketPath: SocketPath(), timeout: 250 * time.Millisecond}
+			for range 2 {
+				status, err := client.Status()
+				require.NoError(t, err, "daemon status must not wait for the code database")
+				require.NotNil(t, status.CodeDB)
+				assert.True(t, status.Running)
+				codeStatus, err := client.CodeStatus()
+				require.NoError(t, err, "code status must not wait for the code database")
+				assert.Equal(t, status.CodeDB, codeStatus)
+				assert.True(t, codeStatus.IndexExists)
+				assert.Equal(t, tt.indexing, codeStatus.IndexingNow)
+				assert.Equal(t, dataDir, codeStatus.DataDir)
+				assert.True(t, codeStatus.LedgerExists)
+				assert.Equal(t, 7, codeStatus.LedgerCommits)
+				if tt.lastErr != nil {
+					assert.Equal(t, tt.lastErr.Error(), codeStatus.LastError)
+				} else {
+					assert.Empty(t, codeStatus.LastError)
+				}
+				if tt.cached {
+					assert.Equal(t, 3, codeStatus.Commits)
+					assert.Len(t, codeStatus.Repos, 2)
+					assert.Equal(t, d.codedb.lastIndex, codeStatus.LastIndexed)
+				}
+			}
+		})
+	}
 }
 
 // --- Regression tests: IPC status must remain responsive during long-running operations ---

--- a/internal/daemon/ipc_status_test.go
+++ b/internal/daemon/ipc_status_test.go
@@ -114,6 +114,10 @@ func TestServerClient_StatusWithLockedCodeDB(t *testing.T) {
 					assert.Equal(t, 3, codeStatus.Commits)
 					assert.Len(t, codeStatus.Repos, 2)
 					assert.Equal(t, d.codedb.lastIndex, codeStatus.LastIndexed)
+				} else {
+					assert.Zero(t, codeStatus.Commits)
+					assert.Empty(t, codeStatus.Repos)
+					assert.True(t, codeStatus.LastIndexed.IsZero())
 				}
 			}
 		})

--- a/internal/daemon/ipc_status_test.go
+++ b/internal/daemon/ipc_status_test.go
@@ -37,8 +37,9 @@ func TestStatusData_JSON(t *testing.T) {
 	assert.Equal(t, status.LedgerPath, decoded.LedgerPath)
 }
 
-// Status must remain responsive when a cold or failed index has no cached stats
-// and another writer holds the database open. Exercise both real IPC handlers.
+// TestServerClient_StatusWithLockedCodeDB verifies both status IPC handlers stay
+// responsive when a cold or failed index has no cached stats and another writer
+// holds the database open.
 func TestServerClient_StatusWithLockedCodeDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short: real code databases and IPC servers")


### PR DESCRIPTION
## What broke

- **Trigger:** A cold start or failed initial index leaves no cached statistics, while the code database is locked or unavailable.
- **Impact:** `ox daemon status` synchronously opened SQLite and Bleve to collect counts. The request could stall even while daemon pings and ledger syncs worked, then report the generic `daemon is busy (likely syncing)` timeout.
- **Observed:** On the affected daemon, ping responded immediately while code-index status exceeded 25 seconds.
- **Acceptance gate:** The session test helper decoded combined stdout/stderr, so a legitimate upload warning arriving after the JSON response could fail coverage CI.

## What this PR ships

- **Responsive status:** Read counts from the existing cache populated by successful background indexing. Remove database opening and queries from `CodeDBManager.Stats()`.
- **Preserved state:** Combine cached counts with current indexing flags, the last indexing error, ledger metadata, and the existing directory-existence fallback.
- **Startup behavior:** Counts remain unavailable until background indexing populates the cache. Status remains usable when indexing fails; this change does not repair the underlying index.
- **Reliable acceptance tests:** Capture stdout separately in the existing session test helper, retaining stderr diagnostics and the 60-second timeout.

```mermaid
flowchart LR
    A[Status request] --> B[Cached counts and current index state]
    B --> C[Status response]
    D[Background indexer] -->|Updates after successful indexing| B
```

## Test Plan

- **Regression reproduced:** The new IPC test failed against the original code with a status read timeout while a real Bleve writer lock was held.
- **Regression fixed:** Race-enabled tests pass for cold start, failed initial indexing, active indexing, and failed refresh with cached counts. Both IPC status handlers are checked repeatedly, including zero worktree counts and timestamps before initial indexing succeeds.
- **Local checks passed:** `make format`, `make lint`, `make test` (18,494 passed; 1,021 skipped after the rebase), and `go build -o .context/ox-daemon-status ./cmd/ox`.
- **Full local suite:** `make test-preflight` passed lint and the full test suite (20,971 tests; 28 skipped). Its slow suite had one stale sparse-checkout assertion failure; all other executed slow tests passed.
- **Upstream correction verified:** Rebased onto #884, which corrects that sparse-checkout expectation. Reran the failed slow test, the locked-CodeDB regression, and the concurrent status test together with race detection; all passed.
- **Stream-order regression verified:** Replaying the real instrumented binary's stderr after stdout reproduced the CI JSON parse failure before the helper fix and passed afterward. The stderr warning remains visible in test diagnostics.
- **Coverage acceptance passed:** `make test-acceptance-cover` passed all 8 integration journeys and both compiled-binary session journeys, including the previously failing test.
- **Latest upstream correction verified:** Coverage CI exposed the capture-lock timing race introduced by #888. Rebased onto #890, which fixes that test's wait budget. Both native-recovery lock tests pass with race detection and coverage; the locked-CodeDB regression passes again with race detection, and lint reports zero issues. The PR's own changes remain limited to the three files described above.

SageOx-Session: https://sageox.ai/c/ses_01a07e88-a089-7d27-a2c0-d3b153eefb9a
