### PR TITLE
fix(agentwork): stop the capture-lock wait and defer tests racing one budget

### DIFF
--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -161,7 +161,22 @@ type SessionFinalizeHandler struct {
 	// after each emit. Single-threaded by construction: judge and emit
 	// both run synchronously inside ProcessResult.
 	lastJudgeResult *summaryeval.JudgeResult
+	// captureLockWait bounds how long recovery waits for a busy capture
+	// writer's raw-file lock before deferring the session to a later detect
+	// pass. Defaults to defaultCaptureLockWait.
+	//
+	// A field rather than a constant because two tests assert opposite halves
+	// of this contract — that a busy writer causes a deferral, and that
+	// recovery resumes once that writer releases the lock. Pinning both to one
+	// wall-clock budget makes them race each other: on a loaded runner the
+	// second test's flush handshake outlives the budget, recovery defers, and
+	// the test fails on a timing accident rather than a real regression.
+	captureLockWait time.Duration
 }
+
+// defaultCaptureLockWait keeps one busy session from blocking the whole detect
+// scan for the file lock's default 10s.
+const defaultCaptureLockWait = 250 * time.Millisecond
 
 // NewSessionFinalizeHandler creates a handler with the given logger.
 func NewSessionFinalizeHandler(logger *slog.Logger) *SessionFinalizeHandler {
@@ -172,6 +187,7 @@ func NewSessionFinalizeHandler(logger *slog.Logger) *SessionFinalizeHandler {
 		logger:                  logger,
 		qualityUploadThreshold:  0.3,
 		qualityDiscardThreshold: 0.1,
+		captureLockWait:         defaultCaptureLockWait,
 	}
 }
 
@@ -433,9 +449,8 @@ func (h *SessionFinalizeHandler) detectInDir(sessionsDir, ledgerPath string) ([]
 			// entries written after the watcher's last poll. Never write content
 			// into the git-tracked ledger path.
 			if sessionsDir != filepath.Join(ledgerPath, "sessions") {
-				// A busy capture writer can be retried on the next detect pass;
-				// keep one session from blocking the scan for the default 10s.
-				recoverErr := fileutil.WithFileLockTimeout(context.Background(), rawPath, 250*time.Millisecond, func() error {
+				// A busy capture writer can be retried on the next detect pass.
+				recoverErr := fileutil.WithFileLockTimeout(context.Background(), rawPath, h.captureLockWait, func() error {
 					var err error
 					hasRaw, err = recoverRawFromSessionFile(h.logger, recPath, sessionDir, rawPath)
 					if err != nil {
@@ -700,7 +715,7 @@ func (h *SessionFinalizeHandler) DetectOrphanedForAgent(ledgerPath, agentID stri
 			}
 
 			if sessionsDir != filepath.Join(ledgerPath, "sessions") {
-				recoverErr := fileutil.WithFileLockTimeout(context.Background(), rawPath, 250*time.Millisecond, func() error {
+				recoverErr := fileutil.WithFileLockTimeout(context.Background(), rawPath, h.captureLockWait, func() error {
 					var err error
 					hasRaw, err = recoverRawFromSessionFile(h.logger, recPath, sessionDir, rawPath)
 					if err != nil {

--- a/internal/daemon/agentwork/session_finalize_recovery_test.go
+++ b/internal/daemon/agentwork/session_finalize_recovery_test.go
@@ -99,6 +99,16 @@ func TestNativeRecovery_WaitsForCaptureLock(t *testing.T) {
 			}
 
 			handler := NewSessionFinalizeHandlerForTest(nil)
+			// This test asserts the WAIT half of the capture-lock contract: the
+			// detector must still be blocked when the writer finally releases.
+			// The default 250ms budget is the DEFER half, asserted by
+			// TestNativeRecovery_BusyCaptureDefersWithoutLosingState. Sharing one
+			// budget makes the two race: the flush handshake below is not bounded
+			// under 250ms, so on a loaded runner recovery deferred, returned zero
+			// items, and this test failed on a timing accident. Give the wait a
+			// budget the handshake cannot outlive; the deadline assertions below
+			// still prove it blocks.
+			handler.captureLockWait = 30 * time.Second
 			started, done := make(chan struct{}), make(chan struct{})
 			var items []*WorkItem
 			var detectErr error


### PR DESCRIPTION
Coverage runs stop failing for reasons that have nothing to do with the change under review. Right now every PR that reaches the `coverage` job can fail on a session-recovery test that races itself, which costs a reviewer a re-run and a few minutes of "is this mine?" before they conclude it isn't.

## What broke

`SessionFinalizeHandler` gave stale-recording recovery a single hardcoded 250 ms budget to acquire a busy capture writer's raw-file lock before deferring the session to a later detect pass. Two sibling tests assert **opposite halves** of that one constant:

- **`TestNativeRecovery_BusyCaptureDefersWithoutLosingState`** — a busy writer must cause a deferral, so one wedged session cannot stall the whole scan. Needs the budget to be *short*.
- **`TestNativeRecovery_WaitsForCaptureLock`** — recovery must still be blocked when the writer finally releases, then resume and return the session. Needs the budget to outlast the test's flush handshake.

Nothing bounds that handshake under 250 ms. On an unloaded runner the second test wins the race; on a loaded one recovery defers, `Detect` returns zero items, and the test fails:

```
session_finalize_recovery_test.go:149:
    Error: "[]" should have 1 item(s), but has 0
    Test:  TestNativeRecovery_WaitsForCaptureLock/anti-entropy
```

immediately preceded in the log by the deferral it was not supposed to take:

```
WARN stale recording recovery deferred session=recovery-OxLocked
     err="acquire advisory lock ...: timed out after 249.998397ms"
INFO session finalize detect complete items=0
```

**Production behavior is correct.** The deferral is the intended design — only the test's assumption about the budget is wrong.

```mermaid
sequenceDiagram
    participant W as capture writer
    participant D as Detect (recovery)
    W->>W: acquire raw lock
    D->>D: blocked, waiting for lock
    Note over D: budget expires at 250ms
    D--xD: defers, returns 0 items
    W->>W: flush handshake completes
    W->>W: release lock
    Note over D: test asserts 1 item — but Detect already gave up
```

## What this PR ships

- **`captureLockWait` becomes a handler field**, defaulting to `defaultCaptureLockWait` (250 ms, unchanged). Both recovery call sites read it.
- **`TestNativeRecovery_WaitsForCaptureLock` sets its own generous budget**, so it asserts the wait contract without racing the deferral contract. Its existing deadline assertions still prove `Detect` blocks — the budget change removes the timing accident, not the assertion.
- **A field, not a package var**, so nothing in the package is mutated across tests and the race detector stays quiet.

Widening the shared 250 ms would only move the flake to a slower runner. Splitting the budget removes it.

## Test Plan

- **Red-first:** set the wait test's budget to `1 * time.Millisecond` — both subtests fail with the exact CI assertion (`should have 1 item(s), but has 0`), confirming the budget is what governs the outcome and not incidental timing. Restore it: green.
- **Both halves together:** `go test ./internal/daemon/agentwork -run 'TestNativeRecovery_WaitsForCaptureLock|TestNativeRecovery_BusyCaptureDefersWithoutLosingState' -race` — passes, so the deferral contract is still asserted at 250 ms.
- `make lint` — 0 issues.

## Observed impact

The same failure appeared on unrelated branches, so this is not specific to one change:

| Run | Branch | Failure |
|---|---|---|
| 34182402765 | `ryan/fix-test-binary-reexec` | `TestNativeRecovery_WaitsForCaptureLock` |
| 34179449501 | `fix-daemon-busy-status` | `TestNativeRecovery_WaitsForCaptureLock` |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791432150&installation_model_id=433550&pr_number=890&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F890&signature=c73b93c6e88fe37b6b87ec73163122e81d28c924d02432954025cbd629e30075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale recording recovery by allowing the capture lock wait period to be configured, reducing failures when the system is under load.
  * Recovery detection now consistently honors the configured lock-wait duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->