### PR TITLE
fix(test): use t.Chdir so trace test compiles in the short tier

### DIFF
--- a/cmd/ox/agent_prime_context_trace_test.go
+++ b/cmd/ox/agent_prime_context_trace_test.go
@@ -106,8 +106,7 @@ func TestEmitProvidedContextTrace_NilTeamCtx(t *testing.T) {
 // the agent happened to be run from — inside the user's repo.
 func TestEmitProvidedContextTrace_EmptySessionDir(t *testing.T) {
 	cwd := t.TempDir()
-	restore := changeToDir(t, cwd)
-	defer restore()
+	t.Chdir(cwd)
 
 	// MemoryContent must be non-empty: it is what makes the writer append an
 	// event at all. With an empty struct nothing is ever written and the test


### PR DESCRIPTION
## What broke

- **Symptom:** every push-to-main CI run since #845 fails in the `Fast tests` step with `cmd/ox [build failed]`.
- **Error:** `cmd/ox/agent_prime_context_trace_test.go:109:13: undefined: changeToDir`
- **Cause:** the fast tier runs with `-tags short`. The new trace test is untagged, but the `changeToDir` helper it called lives in `doctor_sageox_helpers_test.go`, which is tagged `//go:build !short`. Under the fast tier the helper is excluded and the test package no longer compiles.
- **Why the PR gate missed it:** pull requests run the full suite without the tag, so the package compiled and the PR merged green. Only the post-merge push job hit the short tier.

```mermaid
flowchart LR
    PR[PR gate<br/>full suite, no tag] -->|helper present| Green[compiles ✓]
    Push[push to main<br/>-tags short] -->|helper excluded| Red[undefined: changeToDir ✗]
```

## What this PR ships

- Replace the `changeToDir` call with the standard library `t.Chdir`, which every other untagged test in `cmd/ox` already uses. Two lines changed, same behavior, restore is automatic.

## Test Plan

- [x] `go vet -tags short ./...` passes (was failing on `cmd/ox`)
- [x] `go vet ./cmd/ox/` passes
- [x] `go test -tags short ./cmd/ox/ -run TestEmitProvidedContextTrace` passes
- [x] `go test ./cmd/ox/ -run TestEmitProvidedContextTrace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRukT5PesWm9T5XX2J9sk9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791494853&installation_model_id=433550&pr_number=895&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F895&signature=f8e816f0c6198c560b14a28c05120dda02a2a0d4bb7f04703d13f0bb6ff20849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup and cleanup when running the empty-session-directory test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->