### PR TITLE
fix(codex): install SessionEnd hook so sessions finalize on close

### DIFF
--- a/cmd/ox-adapter-codex/hooks.go
+++ b/cmd/ox-adapter-codex/hooks.go
@@ -21,13 +21,20 @@ const (
 	codexConfigFile    = "config.toml"
 )
 
-// all Codex CLI hook events ox should install handlers for
+// all Codex CLI hook events ox should install handlers for.
+//
+// SessionEnd is what finalizes a recording without an explicit `session stop`:
+// Codex fires it when the conversation is archived or deleted, when Codex
+// closes normally, or after 30 minutes idle with no connected client. ox maps
+// it to the end phase (handleEnd), the same path Claude Code and Gemini use.
+// Stop only marks the end of a turn.
 var codexHookEvents = []string{
 	"SessionStart",
 	"PreToolUse",
 	"PostToolUse",
 	"UserPromptSubmit",
 	"Stop",
+	"SessionEnd",
 }
 
 // hookCommand returns the shell command for a given event.

--- a/cmd/ox-adapter-codex/hooks_test.go
+++ b/cmd/ox-adapter-codex/hooks_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -269,4 +270,40 @@ func TestHandleDiagnose_CodexProjectMissingHooks(t *testing.T) {
 	require.Len(t, result.Issues, 1)
 	assert.Equal(t, "codex:hooks-missing", result.Issues[0].Slug)
 	assert.True(t, result.Issues[0].FixSafe)
+}
+
+// Installs written by older ox versions carry five events. Doctor's check must
+// flag them, and a re-install must add SessionEnd without touching the rest,
+// or Codex sessions on upgraded machines keep waiting for a manual stop.
+func TestHandleInstallHooks_AddsSessionEndToExistingInstall(t *testing.T) {
+	repoRoot := t.TempDir()
+	hooksPath := filepath.Join(repoRoot, codexProjectPath, codexHooksFileName)
+	legacy := map[string][]codexHookEntry{}
+	for _, event := range []string{"SessionStart", "PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"} {
+		legacy[event] = mergeHookEntries(nil, hookCommand(event), event)
+	}
+	legacy["Stop"] = append(legacy["Stop"], codexHookEntry{Hooks: []codexHook{{Type: "command", Command: "echo user-hook"}}})
+	require.NoError(t, writeHooksFile(hooksPath, legacy, map[string]json.RawMessage{}, "project"))
+
+	check, err := handleCheckHooks(adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	assert.False(t, check.Installed, "a five-event install predates SessionEnd and must be reported incomplete")
+
+	response, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	assert.Equal(t, codexHookEvents, response.Hooks)
+
+	hooksMap, _, err := readHooksFile(hooksPath)
+	require.NoError(t, err)
+	require.Len(t, hooksMap["SessionEnd"], 1)
+	require.Len(t, hooksMap["SessionEnd"][0].Hooks, 1)
+	assert.Equal(t, hookCommand("SessionEnd"), hooksMap["SessionEnd"][0].Hooks[0].Command)
+	assert.Contains(t, hooksMap["SessionEnd"][0].Hooks[0].Command, "ox agent hook SessionEnd")
+	assert.Empty(t, hooksMap["SessionEnd"][0].Hooks[0].StatusMessage, "only SessionStart shows a status message")
+	require.Len(t, hooksMap["Stop"], 2, "the user's own Stop hook must survive the re-install")
+	assert.Equal(t, "echo user-hook", hooksMap["Stop"][1].Hooks[0].Command)
+
+	check, err = handleCheckHooks(adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	assert.True(t, check.Installed)
 }

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -138,14 +138,26 @@ func runAgentHook(args []string) error {
 	return dispatchPhase(ctx)
 }
 
-// localEventPhases supplements agentx registry with phase mappings for agents
-// not yet defined in agentx (pending module release).
+// localEventPhases supplements the agentx registry with phase mappings for
+// agents whose agentx definition does not implement LifecycleEventMapper yet.
+// Without an entry here such an agent resolves through the "try all maps"
+// fallback in resolvePhase, which works only while every agent spells its
+// events the same way.
 var localEventPhases = map[string]map[agentx.HookEvent]agentx.Phase{
 	"gemini": {
 		"SessionStart": agentx.PhaseStart,
 		"BeforeAgent":  agentx.PhasePrompt,
 		"AfterTool":    agentx.PhaseAfterTool,
 		"SessionEnd":   agentx.PhaseEnd,
+	},
+	// the six events cmd/ox-adapter-codex installs (codexHookEvents)
+	"codex": {
+		"SessionStart":     agentx.PhaseStart,
+		"PreToolUse":       agentx.PhaseBeforeTool,
+		"PostToolUse":      agentx.PhaseAfterTool,
+		"UserPromptSubmit": agentx.PhasePrompt,
+		"Stop":             agentx.PhaseStop,
+		"SessionEnd":       agentx.PhaseEnd,
 	},
 }
 

--- a/cmd/ox/agent_hook_test.go
+++ b/cmd/ox/agent_hook_test.go
@@ -39,6 +39,9 @@ func TestResolvePhase(t *testing.T) {
 		{"claude alias resolves", "claudecode", "SessionStart", phaseStart},
 		{"claude short alias resolves", "claude", "SessionStart", phaseStart},
 		{"unknown agent falls back", "codex", "SessionStart", phaseStart},
+		// the Codex adapter installs SessionEnd; auto-finalize depends on this
+		// resolving to the end phase through the cross-agent fallback.
+		{"codex SessionEnd finalizes", "codex", "SessionEnd", phaseEnd},
 		{"unknown agent unknown event", "codex", "FooBar", ""},
 	}
 

--- a/cmd/ox/agent_hook_test.go
+++ b/cmd/ox/agent_hook_test.go
@@ -38,11 +38,16 @@ func TestResolvePhase(t *testing.T) {
 		{"claude unknown event", "claude-code", "SubagentStop", ""},
 		{"claude alias resolves", "claudecode", "SessionStart", phaseStart},
 		{"claude short alias resolves", "claude", "SessionStart", phaseStart},
-		{"unknown agent falls back", "codex", "SessionStart", phaseStart},
-		// the Codex adapter installs SessionEnd; auto-finalize depends on this
-		// resolving to the end phase through the cross-agent fallback.
+		// every event cmd/ox-adapter-codex installs has an explicit local mapping
+		{"codex SessionStart", "codex", "SessionStart", phaseStart},
+		{"codex PreToolUse", "codex", "PreToolUse", phaseBeforeTool},
+		{"codex PostToolUse", "codex", "PostToolUse", phaseAfterTool},
+		{"codex UserPromptSubmit", "codex", "UserPromptSubmit", phasePrompt},
+		{"codex Stop", "codex", "Stop", phaseStop},
 		{"codex SessionEnd finalizes", "codex", "SessionEnd", phaseEnd},
-		{"unknown agent unknown event", "codex", "FooBar", ""},
+		{"codex unknown event", "codex", "FooBar", ""},
+		{"unregistered agent falls back", "some-new-agent", "SessionStart", phaseStart},
+		{"unregistered agent unknown event", "some-new-agent", "FooBar", ""},
 	}
 
 	for _, tt := range tests {

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Codex sessions now finalize on their own** — archiving or deleting a Codex conversation, or closing Codex, publishes the recording the same way closing Claude Code does. Until now a Codex session stayed in the local cache until someone ran `ox agent <id> session stop` or the daemon's stale sweep noticed the exited process. Existing installs pick up the new hook on the next `ox doctor`.
 - **Claude Code and Codex session recording continues after individual commands finish** — interrupted uploads remain recoverable, with secret redaction preserved before publication.
 - **A read-only code index is no longer mistaken for a corrupt one and deleted** — ox read "cannot write this database" as "this database is damaged" and tried to delete it; only the read-only filesystem stopped it. The same misreading on writable media would have destroyed a healthy index that costs minutes to rebuild.
 - **`ox code status` no longer reports an index it could not open as an empty one** — it answered zeros under `index_exists: true`, which reads exactly like a warm index holding nothing. It now shows `✗ unreadable` with the reason (`open_error` in `--json`), and labels a read-only index as such.

--- a/docs/guides/agent-compatibility.md
+++ b/docs/guides/agent-compatibility.md
@@ -156,8 +156,13 @@ directory up to the repo root, so context primes even before hooks are installed
   `OX_PROJECT_ROOT` to the absolute repo root rather than relying on the cwd walk.
 - **Gemini, Droid**: no `SessionStart` hook, so priming depends on the instruction
   file marker rather than firing automatically.
-- **Codex**: no `SessionEnd` hook, so sessions do not auto-finalize; they close on
-  the next `ox agent <id> session stop` or daemon sweep.
+- **Codex**: sessions auto-finalize through `SessionEnd`, which Codex fires when a
+  conversation is archived or deleted, when Codex closes normally, or after 30
+  minutes idle with no connected client. A hard kill of the Codex process skips
+  the hook; the daemon's dead-process sweep finalizes those recordings instead.
+  Project-scope hooks (`.codex/hooks.json`) load only once the project `.codex/`
+  layer is trusted via `/hooks`; user-scope `~/.codex/hooks.json` needs no per-repo
+  trust. Installs made before `SessionEnd` was added are completed by `ox doctor`.
 - **Pi**: instruction-file marker only, no lifecycle hooks. Session recording also only
   understands transcript format version 3. Pi 0.84+ introduced a v4 lane-based session
   model that ox does not yet parse — `ox doctor` reports `pi:format-unsupported` when it

--- a/docs/specs/agent-support-matrix.md
+++ b/docs/specs/agent-support-matrix.md
@@ -30,9 +30,9 @@ Agent-specific hooks (`ox integrate install --<agent>`) are *additive* — they 
 | Pull whispers (`ox agent whisper`) | Yes | Yes | Yes | Yes | Yes |
 | AGENTS.md / CLAUDE.md marker | Yes (universal) | Yes (universal) | Yes (universal) | Yes (universal + Amp-specific block) | Yes (universal; OpenCode reads AGENTS.md natively) |
 | **Silver: Hooks** | | | | | |
-| Native hook/plugin events | 6 (SessionStart, PreCompact, PostToolUse, Stop, SessionEnd, UserPromptSubmit) | 4 (SessionStart, BeforeAgent, AfterTool, SessionEnd) | 2 (SessionStart, SessionEnd) | 2 (tool:pre-execute, tool:post-execute — experimental) | 27+ (session.*, message.*, tool.*, file.*, command.*, permission.*, lsp.*, server.*, tui.*, shell.*, todo.*) |
-| ox-used hook events | 6 | 4 | 2 | 0 (AGENTS.md marker only) | 1 (session.created) |
-| Phase mapping (agentx) | Full (in agentx) | Local fallback (pending agentx) | Full (in agentx) | N/A | N/A |
+| Native hook/plugin events | 6 (SessionStart, PreCompact, PostToolUse, Stop, SessionEnd, UserPromptSubmit) | 4 (SessionStart, BeforeAgent, AfterTool, SessionEnd) | 12 (SessionStart, SessionEnd, SubagentStart, PreToolUse, PermissionRequest, PostToolUse, PreCompact, PostCompact, UserPromptSubmit, SubagentStop, Stop, Interrupt) | 2 (tool:pre-execute, tool:post-execute — experimental) | 27+ (session.*, message.*, tool.*, file.*, command.*, permission.*, lsp.*, server.*, tui.*, shell.*, todo.*) |
+| ox-used hook events | 6 | 4 | 6 (SessionStart, PreToolUse, PostToolUse, UserPromptSubmit, Stop, SessionEnd) | 0 (AGENTS.md marker only) | 1 (session.created) |
+| Phase mapping (agentx) | Full (in agentx) | Local fallback (pending agentx) | Local fallback (pending agentx) | N/A | N/A |
 | Startup banner (JSON stdout) | Yes | Yes | No | No | No |
 | Hook install/uninstall | `ox integrate install` | `ox integrate install --gemini` | `ox integrate install --codex` | `ox integrate install --amp` |
 | `ox doctor` detection + auto-fix | Yes | Yes | Yes | Yes | Yes |


### PR DESCRIPTION
## What broke

- **Codex sessions never finalized on their own.** The Codex adapter installs five hook events (SessionStart, PreToolUse, PostToolUse, UserPromptSubmit, Stop) and omits `SessionEnd`. In Codex, `Stop` only marks the end of a turn.
- **Result:** a Codex recording stayed in the local cache until someone ran `ox agent <id> session stop`, or until the daemon's stale sweep noticed the exited Codex process (10-minute grace, then the next 5-minute scan). Claude Code, Gemini, and Goose already finalize through `SessionEnd`.

## What this PR ships

- **One more hook event.** `SessionEnd` joins `codexHookEvents`. The `ox agent hook SessionEnd` command it installs resolves to the end phase, so `handleEnd` stamps the recording as stopped and hands finalization to the daemon, exactly as for Claude Code.
- **Explicit Codex phase map (`97154e55`).** Codex previously resolved every event through `resolvePhase`'s "try all maps" fallback because its agentx definition has no `EventPhases`. `localEventPhases` now carries a `codex` entry for the six installed events, mirroring the existing Gemini entry, and `TestResolvePhase` covers each one plus an unknown event. The canonical home for this map is agentx's `CodexAgent`; a follow-up there lets ox drop the local entry.
- **When it fires.** Per OpenAI's Codex hooks docs: when the conversation is archived or deleted, when Codex closes normally, or after 30 minutes idle with no connected client. A hard kill still falls back to the daemon's dead-PID sweep.
- **Upgrade path.** The adapter's check treats a five-event install as incomplete, and `ox doctor`'s Codex hooks fix re-runs the install, which merges the missing event and preserves user-authored hooks.
- **Release note** under Fixed.

```mermaid
flowchart LR
    A[Codex archives / deletes / closes conversation] --> B[SessionEnd hook: ox agent hook SessionEnd]
    B --> C[handleEnd: StoppedAt set, recording cleared]
    C --> D[Daemon IPC finalize]
    D --> E[Pointer-first commit and push]
    A -. hard kill, no hook .-> F[Daemon dead-PID sweep, 10m grace + 5m scan]
    F --> D
```

## Test Plan

- [x] `TestResolvePhase`: `codex` + `SessionEnd` resolves to the end phase through the cross-agent fallback, which is what the new hook relies on.
- [x] `TestHandleInstallHooks_AddsSessionEndToExistingInstall`: a five-event `hooks.json` is reported incomplete by the check, a re-install adds only `SessionEnd` with the `ox agent hook SessionEnd` command and no status message, and a user's own `Stop` hook survives.
- [x] Existing adapter tests compare against `codexHookEvents` and pass with six events.
- [x] `make lint` zero issues; `go test ./cmd/ox-adapter-codex/` and the `cmd/ox` hook tests green.
- [ ] Manual: install hooks in a Codex workspace (`ox-adapter-codex install-hooks --repo-root <ws> --scope project`, trust the project `.codex/` layer via `/hooks`), run a session, archive it in Conductor, and confirm the ledger gains a single `session:` commit without a manual stop.

Note for reviewers: project-local Codex hooks load only once the project's `.codex/` layer is trusted, and `.codex/hooks.json` is not tracked in this repo, so a fresh Conductor workspace still needs a one-time install or a user-scope `~/.codex/hooks.json`. That is unchanged by this PR.

SageOx-Session: https://sageox.ai/c/ses_01a08266-004b-7119-ab69-566380cdb1c5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791497171&installation_model_id=433550&pr_number=896&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F896&signature=c91cde6459c66c5edd8f3115a2e77302014f1a89828cadaa8e453371204cb5a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex sessions now finalize automatically when conversations are archived, deleted, or closed.
  * Codex session-end events are handled consistently with other supported lifecycle events.
  * Finalized Codex sessions publish recordings alongside recordings from other supported clients.

* **Bug Fixes**
  * Existing Codex hook installations are recognized as incomplete when missing session-end support.
  * Reinstalling hooks adds the missing event while preserving existing user-defined hooks.
  * Existing installations receive the update after running `ox doctor`.

* **Documentation**
  * Updated Codex compatibility guidance to describe automatic finalization and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
