### PR TITLE
fix(codedb): self-heal empty Bleve mappings

### DIFF
--- a/cmd/ox/doctor_codedb.go
+++ b/cmd/ox/doctor_codedb.go
@@ -64,6 +64,10 @@ func checkCodeIndexAtDir(dataDir string, fix bool) checkResult {
 		// --fix would otherwise delete a healthy index that costs minutes to
 		// rebuild.
 		if !errors.Is(err, store.ErrCorrupt) {
+			if store.IsBleveMappingParseError(err) {
+				return WarningCheck("Code index", fmt.Sprintf("could not open index: %v", err),
+					"run 'ox code index --full' to rebuild; nothing was removed")
+			}
 			return WarningCheck("Code index", fmt.Sprintf("could not open index: %v", err),
 				"nothing was removed; resolve the condition above and rerun 'ox doctor'")
 		}

--- a/cmd/ox/doctor_codedb_test.go
+++ b/cmd/ox/doctor_codedb_test.go
@@ -137,6 +137,53 @@ func TestCheckCodeIndexAtDir_CorruptMapping_TargetedRebuild(t *testing.T) {
 	require.NoError(t, db2.Close())
 }
 
+// TestCheckCodeIndexAtDir_MappingOpenErrorRecommendsFullReindex verifies that
+// doctor turns Bleve's otherwise opaque mapping-parse failure into the recovery
+// command known to work. The blocked heal-lock fixture keeps the open error
+// visible long enough for doctor to report it instead of repairing it inline.
+//
+// Failure prevented: doctor reports only a misleading lock-contention warning,
+// leaving users to discover `ox code index --full` from daemon logs.
+func TestCheckCodeIndexAtDir_MappingOpenErrorRecommendsFullReindex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: SQLite + Bleve operations")
+	}
+
+	dataDir := t.TempDir()
+	db, err := codedb.Open(dataDir)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	boltPath := filepath.Join(dataDir, "bleve", "comment", "store", "root.bolt")
+	corruptCommentMapping(t, boltPath)
+
+	// Put an unknown entry after the real snapshot. Bleve skips it and reaches
+	// the empty mapping; the lightweight corruption peek remains inconclusive.
+	bolt, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: time.Second})
+	require.NoError(t, err)
+	require.NoError(t, bolt.Update(func(tx *bbolt.Tx) error {
+		snapshots := tx.Bucket([]byte{'s'})
+		require.NotNil(t, snapshots, "snapshots bucket missing — Bleve layout changed")
+		return snapshots.Put([]byte{0xff}, []byte("unknown snapshot entry"))
+	}))
+	require.NoError(t, bolt.Close())
+
+	// Point the heal lock through a regular file so opening the lock fails with
+	// ENOTDIR. The store correctly refuses a lockless destructive repair,
+	// allowing doctor to exercise its open-error remediation path.
+	notDir := filepath.Join(dataDir, "not-a-directory")
+	require.NoError(t, os.WriteFile(notDir, []byte("block lock creation"), 0o600))
+	healLock := filepath.Join(dataDir, "bleve", "comment.heal.lock")
+	if err := os.Symlink(filepath.Join(notDir, "lock"), healLock); err != nil {
+		t.Skipf("symlink unavailable; cannot isolate heal-lock setup failure: %v", err)
+	}
+
+	result := checkCodeIndexAtDir(dataDir, false)
+	assert.True(t, result.warning, "an unhealed mapping error must be visible")
+	assert.Contains(t, result.message, "error parsing mapping JSON")
+	assert.Contains(t, result.detail, "ox code index --full")
+}
+
 // corruptCommentMapping zeroes the latest snapshot's mapping doc in the
 // comment sub-index — same on-disk state observed in production.
 func corruptCommentMapping(t *testing.T, boltPath string) {

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -769,13 +769,13 @@ func removeSQLiteFiles(dbPath string) {
 // daemon indexing pass does a full rebuild. Returns the empty index with no
 // error — callers see a working but empty bleve, not a typed error.
 //
-// True lock contention (another writer holds bbolt's exclusive flock) is
-// preserved as the pre-existing "lock contention" error: the corruption peek
-// retries a read-only open (100ms timeout per attempt) a few times before
-// giving up, so a live exclusive lock blocks the peek and we stay in the safe
-// wait-and-retry path — but a transient hold that clears within the retry
-// budget no longer permanently masks provable corruption (see
-// isBleveIndexCorrupt).
+// True lock contention (another writer holds bbolt's exclusive flock) remains
+// non-destructive: the corruption peek retries a read-only open (100ms timeout
+// per attempt) a few times before giving up. If Bleve already proved its
+// mapping is invalid, the locked self-heal path rechecks and reports a distinct
+// deferral while the writer remains; other open errors retain the direct
+// "lock contention" diagnosis. A transient hold that clears within the retry
+// budget no longer permanently masks provable corruption.
 //
 // path is the bleve sub-index dir (e.g. <root>/bleve/code); root is the
 // codedb dataDir (needed to locate the marker file).
@@ -839,6 +839,14 @@ func openOrCreateBleveIndex(root, path, name string) (bleve.Index, error) {
 		if boltCorruptOnExclusiveOpen(boltPath) {
 			return selfHealBleveSubIndex(root, path, name, err)
 		}
+		// Bleve reached the persisted mapping and proved it cannot parse it.
+		// The narrower bbolt peek above can be inconclusive when it encounters
+		// an entry Bleve skips while selecting a usable snapshot. Route the
+		// definitive Bleve error through the locked recheck instead of relabeling
+		// it as contention; the recheck still refuses to nuke a live-held index.
+		if IsBleveMappingParseError(err) {
+			return selfHealBleveSubIndex(root, path, name, err)
+		}
 		return nil, fmt.Errorf("bleve index appears to be in use (lock contention): %w", err)
 	} else if !os.IsNotExist(statErr) && !errors.Is(statErr, syscall.ENOTDIR) {
 		// permission/IO errors are transient — nuking would cause data loss
@@ -883,7 +891,7 @@ const (
 	healNuke
 	// healDefer: the index cannot be reopened but is NOT provably corrupt — a
 	// live writer holds its exclusive bbolt lock. Never nuke a healthy-but-held
-	// index; surface the pre-existing retryable "lock contention" error.
+	// index; surface a distinct retryable self-heal deferral.
 	healDefer
 )
 
@@ -1009,6 +1017,13 @@ func reclassifyUnderLock(path, name string, requireVersion bool) (bleve.Index, h
 	_ = db.Close()
 	idx, openErr := boundedAdoptOpen(path, bleveExclusiveProbeTimeout)
 	if openErr != nil {
+		// This is a fresh error from the index currently on disk, after the
+		// bounded exclusive probe proved no writer held root.bolt. Bleve's own
+		// mapping parser is authoritative when the lightweight bbolt inspection
+		// could not identify the snapshot Bleve ultimately selected.
+		if IsBleveMappingParseError(openErr) {
+			return nil, healNuke
+		}
 		// Raced away between probe and open, timed out on a late writer, or a
 		// non-corruption open failure — defer rather than nuke a possibly-healthy
 		// index.
@@ -1074,8 +1089,8 @@ func boundedAdoptOpen(path string, timeout time.Duration) (bleve.Index, error) {
 //
 // Flow: acquire the per-sub-index heal lock, then reclassify under it:
 //   - healAdopt → return the replacement the winner created; never nuke it.
-//   - healDefer → return the pre-existing retryable "lock contention" error; a
-//     healthy index is being held open, not corrupt.
+//   - healDefer → return a retryable self-heal deferral; a healthy index is
+//     being held open or the current state could not be confirmed.
 //   - healNuke  → we hold the lock and it is still corrupt/stale: write the
 //     .needs_reindex marker, then RemoveAll + recreate empty.
 //
@@ -1128,7 +1143,7 @@ func applyRebuildVerdict(root, path, name string, requireVersion bool, openErrFo
 		return idx, nil
 	case healDefer:
 		subIndexRebuildActionHook("defer")
-		return nil, fmt.Errorf("bleve index appears to be in use (lock contention): %w", openErrForLog)
+		return nil, fmt.Errorf("bleve sub-index %s self-heal deferred (index busy or state unconfirmed): %w", name, openErrForLog)
 	}
 
 	// healNuke: the index is still provably corrupt/stale. The specific trigger
@@ -1462,6 +1477,14 @@ func safeOpenBleve(path string) (idx bleve.Index, err error) {
 		}
 	}()
 	return bleve.Open(path)
+}
+
+// IsBleveMappingParseError reports whether Bleve opened an index far enough to
+// read its persisted mapping but could not decode that mapping. Bleve exposes
+// no typed error for this condition, so matching its stable error prefix is the
+// only way to distinguish proven mapping corruption from a generic open error.
+func IsBleveMappingParseError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "error parsing mapping JSON:")
 }
 
 // --- SQL convenience methods ---

--- a/internal/codedb/store/store_selfheal_concurrent_test.go
+++ b/internal/codedb/store/store_selfheal_concurrent_test.go
@@ -53,11 +53,11 @@ func TestMain(m *testing.M) {
 
 // runSelfHealHelper is the child-process body for the real multi-process race
 // test. It drives the actual production entry point (openOrCreateBleveIndex) on
-// a shared, already-corrupted sub-index, retrying on the retryable "lock
-// contention" verdict exactly as a real daemon/CLI caller would, and exits 0
-// once it holds a working index. Any process that permanently fails to get a
-// working index exits non-zero — which the parent treats as the #828 race
-// destroying the replacement.
+// a shared, already-corrupted sub-index, retrying on the retryable open verdict
+// exactly as a real daemon/CLI caller would, and exits 0 once it holds a working
+// index. Any process that permanently fails to get a working index exits
+// non-zero — which the parent treats as the #828 race destroying the
+// replacement.
 func runSelfHealHelper(root, path, name string) int {
 	if root == "" || path == "" || name == "" {
 		fmt.Fprintf(os.Stderr, "bad helper spec root=%q path=%q name=%q\n", root, path, name)
@@ -211,12 +211,60 @@ func TestRebuildSubIndexLocked_HeldOpen_Defers(t *testing.T) {
 		fmt.Errorf("simulated corrupt open"))
 	require.Nil(t, idx)
 	require.Error(t, err, "a healthy-but-held index must not be healed")
-	require.Contains(t, err.Error(), "lock contention",
-		"held index must surface the retryable contention error")
+	require.Contains(t, err.Error(), "self-heal deferred",
+		"held index must surface the retryable deferred-heal error")
+	require.NotContains(t, err.Error(), "appears to be in use (lock contention)",
+		"deferred healing must be distinguishable from a direct open contention error")
 	require.Equal(t, 1, counter.get("defer"))
 	require.Equal(t, 0, counter.get("nuke"),
 		"a live-locked healthy index must never be nuked")
 	require.False(t, HasNeedsReindexMarker(tmp, "test"))
+}
+
+// TestOpenOrCreateBleveIndex_MappingParseErrorSurvivesInconclusivePeek covers
+// the field state where Bleve can select an empty-mapping snapshot that the
+// lightweight corruption peek does not identify. Bleve skips malformed entries
+// while walking snapshots newest-to-oldest; the peek must not turn Bleve's
+// definitive mapping-parse error into a lock-contention diagnosis merely
+// because its narrower inspection was inconclusive.
+//
+// Failure prevented: a free, corrupt index retries forever as "in use (lock
+// contention)" and never writes the marker that triggers a full rebuild.
+func TestOpenOrCreateBleveIndex_MappingParseErrorSurvivesInconclusivePeek(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+	installFastCorruptionProbes(t)
+
+	root := t.TempDir()
+	indexPath := filepath.Join(root, "test-index")
+	idx, err := openOrCreateBleveIndex(root, indexPath, "code")
+	require.NoError(t, err)
+	require.NoError(t, idx.Close())
+
+	boltPath := filepath.Join(indexPath, "store", "root.bolt")
+	emptyMappingForLatestSnapshot(t, boltPath)
+
+	// Bleve walks backward past entries it cannot decode as snapshot epochs.
+	// isBleveIndexCorrupt currently inspects only the final cursor entry, so this
+	// realistic unknown-entry shape makes its result inconclusive while Bleve
+	// continues to the real snapshot and reports the empty mapping.
+	db, err := bbolt.Open(boltPath, 0o600, &bbolt.Options{Timeout: time.Second})
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		snapshots := tx.Bucket([]byte{'s'})
+		require.NotNil(t, snapshots, "snapshots bucket missing — Bleve layout changed")
+		return snapshots.Put([]byte{0xff}, []byte("unknown snapshot entry"))
+	}))
+	require.NoError(t, db.Close())
+	require.False(t, isBleveIndexCorrupt(boltPath),
+		"precondition: the lightweight peek must be inconclusive for this fixture")
+
+	healed, err := openOrCreateBleveIndex(root, indexPath, "code")
+	require.NoError(t, err, "Bleve's mapping-parse error must trigger safe self-heal")
+	require.NoError(t, healed.Close())
+	require.True(t, HasNeedsReindexMarker(root, "code"),
+		"self-heal must leave the full-reindex signal")
 }
 
 // --- B. Deterministic two-healer race (the #828 regression) ---
@@ -292,7 +340,7 @@ func TestConcurrentSelfHeal_LoserDoesNotClobberWinner(t *testing.T) {
 
 	// Loser deferred — it did NOT create a competing index and did NOT nuke.
 	require.Error(t, b.err, "loser must defer to the winner, not heal in parallel")
-	require.Contains(t, b.err.Error(), "lock contention")
+	require.Contains(t, b.err.Error(), "self-heal deferred")
 	require.Nil(t, b.idx)
 	require.Equal(t, 1, counter.get("defer"))
 
@@ -413,7 +461,7 @@ func TestSelfHeal_MissingMetadataPreservesConcurrentReplacement(t *testing.T) {
 			}
 			require.True(t, hookRan, "missing-metadata recovery must acquire the shared heal lock")
 			if heldOpen {
-				require.ErrorContains(t, err, "lock contention")
+				require.ErrorContains(t, err, "self-heal deferred")
 				require.Nil(t, idx)
 				idx = winner
 			} else {

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -912,16 +912,15 @@ func TestIsBleveIndexCorrupt_RecoversWhenLockClearsWithinRetryBudget(t *testing.
 		"self-heal must write the reindex marker")
 }
 
-// TestOpenOrCreateBleveIndex_SustainedLockStillReturnsContentionError verifies
+// TestOpenOrCreateBleveIndex_SustainedLockDefersSelfHeal verifies
 // that the corruption-peek retry does NOT turn genuinely sustained lock
 // contention into a false self-heal: a lock held for the entire retry budget
-// must still surface the pre-existing "lock contention" error unchanged, and
-// must NOT nuke the index.
+// must surface a distinct deferred-heal error and must NOT nuke the index.
 //
 // Failure prevented: a naive retry-until-success peek turning a real,
 // long-running writer (e.g. the daemon mid full-reindex) into a spurious
 // nuke-and-recreate of an index that was never actually corrupt.
-func TestOpenOrCreateBleveIndex_SustainedLockStillReturnsContentionError(t *testing.T) {
+func TestOpenOrCreateBleveIndex_SustainedLockDefersSelfHeal(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short: Bleve + bbolt operations")
 	}
@@ -954,7 +953,7 @@ func TestOpenOrCreateBleveIndex_SustainedLockStillReturnsContentionError(t *test
 	// to finish quickly.
 	var lockDB *bbolt.DB
 	bleveCorruptionPeekRetryHook = func(attempt int) {
-		if attempt == 0 {
+		if attempt == 0 && lockDB == nil {
 			var lockErr error
 			lockDB, lockErr = bbolt.Open(boltPath, 0600, &bbolt.Options{Timeout: 2 * time.Second})
 			require.NoError(t, lockErr, "acquire competing exclusive lock")
@@ -968,8 +967,10 @@ func TestOpenOrCreateBleveIndex_SustainedLockStillReturnsContentionError(t *test
 
 	_, openErr := openOrCreateBleveIndex(tmp, indexPath, "test")
 	require.Error(t, openErr, "sustained contention must still surface an error")
-	require.Contains(t, openErr.Error(), "lock contention",
-		"sustained contention must not be misread as self-healable corruption")
+	require.Contains(t, openErr.Error(), "self-heal deferred",
+		"sustained contention after a corruption trigger must report deferred healing")
+	require.NotContains(t, openErr.Error(), "appears to be in use (lock contention)",
+		"deferred healing must be distinguishable from a direct open contention error")
 	require.False(t, HasNeedsReindexMarker(tmp, "test"),
 		"a genuinely locked (not proven corrupt) index must not trigger self-heal")
 }

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -637,7 +637,16 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 	m.lastIndex = time.Now()
 	m.lastErr = nil
 	m.stats = cachedStats
+	tracker := m.issues
 	m.mu.Unlock()
+
+	// A completed normal or full index includes the dirty-overlay stage and
+	// supersedes any failure recorded by an earlier standalone refresh. Clear
+	// it here so explicit `ox code index --full` repairs status immediately,
+	// without waiting for an unrelated worktree edit to trigger another refresh.
+	if tracker != nil {
+		tracker.ClearIssue(IssueTypeDirtyOverlayFailed, "")
+	}
 
 	// indexing succeeded — clear any self-heal markers so the next freshness
 	// check doesn't re-force --full. (The dataDir wipe above would have removed

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -573,12 +573,14 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 	// is a full tear-down-and-rebuild (git status + re-read all files + new Bleve index),
 	// so running it again here is pure waste when the overlay is already fresh.
 	var dirtyDuration time.Duration
+	dirtyOverlaySucceeded := false
 	if payload.URL == "" {
 		m.mu.Lock()
 		dirtyFresh := !m.lastDirtyRefresh.IsZero() && time.Since(m.lastDirtyRefresh) < 2*time.Minute
 		m.mu.Unlock()
 
 		if dirtyFresh {
+			dirtyOverlaySucceeded = true
 			m.logger.Debug("codedb skipping dirty overlay in doIndex, poll-built overlay is fresh")
 		} else {
 			dirtyStart := time.Now()
@@ -588,8 +590,11 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 			dirtyCount, dirtyErr := db.BuildDirtyIndex(ctx, projectRoot, opts)
 			if dirtyErr != nil {
 				m.logger.Warn("dirty index build failed", "error", dirtyErr)
-			} else if dirtyCount > 0 {
-				m.logger.Debug("dirty index built", "files", dirtyCount)
+			} else {
+				dirtyOverlaySucceeded = true
+				if dirtyCount > 0 {
+					m.logger.Debug("dirty index built", "files", dirtyCount)
+				}
 			}
 			dirtyDuration = time.Since(dirtyStart)
 
@@ -644,7 +649,7 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 	// supersedes any failure recorded by an earlier standalone refresh. Clear
 	// it here so explicit `ox code index --full` repairs status immediately,
 	// without waiting for an unrelated worktree edit to trigger another refresh.
-	if tracker != nil {
+	if tracker != nil && dirtyOverlaySucceeded {
 		tracker.ClearIssue(IssueTypeDirtyOverlayFailed, "")
 	}
 

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -972,6 +972,7 @@ func (m *CodeDBManager) RefreshDirtyOverlay(ctx context.Context) {
 		if err != nil {
 			m.logger.Warn("dirty overlay refresh: open failed", "error", err)
 			m.mu.Lock()
+			m.lastDirtyRefresh = time.Time{}
 			tracker := m.issues
 			m.mu.Unlock()
 			if tracker != nil {
@@ -991,6 +992,7 @@ func (m *CodeDBManager) RefreshDirtyOverlay(ctx context.Context) {
 		if dirtyErr != nil {
 			m.logger.Warn("dirty overlay refresh failed", "error", dirtyErr)
 			m.mu.Lock()
+			m.lastDirtyRefresh = time.Time{}
 			tracker := m.issues
 			m.mu.Unlock()
 			if tracker != nil {

--- a/internal/daemon/codedb_dirty_watcher_test.go
+++ b/internal/daemon/codedb_dirty_watcher_test.go
@@ -386,8 +386,20 @@ func TestRefreshDirtyOverlay_RunsConcurrentlyWithLedgerIndex(t *testing.T) {
 func TestRefreshDirtyOverlay_ContextCanceled(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	mgr := NewCodeDBManager(dir, codedbTestLogger(), nil)
+	repoDir := initDirtyTestRepo(t)
+	dataDir := filepath.Join(t.TempDir(), "codedb")
+	db, err := codedb.Open(dataDir)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	mgr := NewCodeDBManager(repoDir, codedbTestLogger(), nil)
+	mgr.mu.Lock()
+	mgr.dataDir = dataDir
+	mgr.lastDirtyRefresh = time.Now()
+	mgr.mu.Unlock()
+
+	tracker := NewIssueTracker()
+	mgr.SetIssueTracker(tracker)
 
 	fires := make(chan struct{}, 1)
 	mgr.dirtyTestHook = func() {
@@ -418,6 +430,13 @@ func TestRefreshDirtyOverlay_ContextCanceled(t *testing.T) {
 		defer mgr.mu.Unlock()
 		return !mgr.dirtyRefreshing
 	}, 2*time.Second, 10*time.Millisecond, "dirtyRefreshing flag not released after context cancellation")
+
+	mgr.mu.Lock()
+	lastDirtyRefresh := mgr.lastDirtyRefresh
+	mgr.mu.Unlock()
+	assert.True(t, lastDirtyRefresh.IsZero(), "canceled refresh must invalidate an earlier success timestamp")
+	_, found := tracker.GetIssue(IssueTypeDirtyOverlayFailed, "")
+	assert.True(t, found, "canceled dirty overlay build must report a failure")
 }
 
 // --- C. Deterministic concurrency: verify no double goroutine ---
@@ -778,6 +797,7 @@ func TestRefreshDirtyOverlay_EmitsIssueOnOpenFailure(t *testing.T) {
 	mgr := NewCodeDBManager(repoDir, codedbTestLogger(), nil)
 	mgr.mu.Lock()
 	mgr.dataDir = dataDir
+	mgr.lastDirtyRefresh = time.Now()
 	mgr.mu.Unlock()
 
 	tracker := NewIssueTracker()
@@ -819,6 +839,11 @@ func TestRefreshDirtyOverlay_EmitsIssueOnOpenFailure(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "should emit %s issue on codedb.Open failure, got: %v", IssueTypeDirtyOverlayFailed, issues)
+
+	mgr.mu.Lock()
+	lastDirtyRefresh := mgr.lastDirtyRefresh
+	mgr.mu.Unlock()
+	assert.True(t, lastDirtyRefresh.IsZero(), "failed refresh must invalidate an earlier success timestamp")
 }
 
 // TestRefreshDirtyOverlay_ClearsIssueOnSuccess verifies that a successful

--- a/internal/daemon/codedb_selfheal_test.go
+++ b/internal/daemon/codedb_selfheal_test.go
@@ -102,9 +102,9 @@ func TestDoIndex_SuccessClearsDirtyOverlayFailure(t *testing.T) {
 	mgr.dataDir = t.TempDir()
 	mgr.SetIssueTracker(tracker)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-	_, err := mgr.Index(ctx, CodeIndexPayload{}, nil)
+	initialCtx, initialCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	_, err := mgr.Index(initialCtx, CodeIndexPayload{}, nil)
+	initialCancel()
 	require.NoError(t, err, "initial index must succeed before testing reindex modes")
 
 	for _, full := range []bool{false, true} {
@@ -119,13 +119,31 @@ func TestDoIndex_SuccessClearsDirtyOverlayFailure(t *testing.T) {
 				Summary:  "stale dirty overlay failure",
 			})
 
-			_, err := mgr.Index(ctx, CodeIndexPayload{Full: full}, nil)
+			indexCtx, indexCancel := context.WithTimeout(context.Background(), 60*time.Second)
+			_, err := mgr.Index(indexCtx, CodeIndexPayload{Full: full}, nil)
+			indexCancel()
 			require.NoError(t, err)
 
 			_, found := tracker.GetIssue(IssueTypeDirtyOverlayFailed, "")
 			assert.False(t, found, "successful %s index must clear the stale overlay issue", name)
 		})
 	}
+
+	t.Run("remote does not clear local overlay issue", func(t *testing.T) {
+		tracker.SetIssue(DaemonIssue{
+			Type:     IssueTypeDirtyOverlayFailed,
+			Severity: SeverityWarning,
+			Summary:  "local dirty overlay still needs recovery",
+		})
+
+		indexCtx, indexCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		_, err := mgr.Index(indexCtx, CodeIndexPayload{URL: repoDir}, nil)
+		indexCancel()
+		require.NoError(t, err)
+
+		_, found := tracker.GetIssue(IssueTypeDirtyOverlayFailed, "")
+		assert.True(t, found, "remote indexing must not clear a local overlay failure")
+	})
 }
 
 // TestStoreOpen_SelfHealsTransparently_NoDaemonRetryNeeded verifies the

--- a/internal/daemon/codedb_selfheal_test.go
+++ b/internal/daemon/codedb_selfheal_test.go
@@ -82,6 +82,52 @@ func TestDoIndex_HonorsSelfHealMarker_ForcesFullReindex(t *testing.T) {
 	require.Greater(t, commitsAfterSecond, 0, "second index must repopulate commits after wipe")
 }
 
+// TestDoIndex_SuccessClearsDirtyOverlayFailure verifies that either successful
+// indexing mode retires an earlier overlay warning. Both modes rebuild the
+// dirty overlay as part of the completed pipeline, so leaving the old issue in
+// daemon status misreports a healthy index until an unrelated file edit.
+//
+// Failure prevented: a successful `ox code index --full` still leaves
+// dirty_overlay_failed in the status panel indefinitely.
+func TestDoIndex_SuccessClearsDirtyOverlayFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: exercises real git + SQLite + Bleve indexing passes")
+	}
+
+	repoDir := t.TempDir()
+	seedGitRepo(t, repoDir)
+
+	tracker := NewIssueTracker()
+	mgr := NewCodeDBManager(repoDir, codedbTestLogger(), nil)
+	mgr.dataDir = t.TempDir()
+	mgr.SetIssueTracker(tracker)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	_, err := mgr.Index(ctx, CodeIndexPayload{}, nil)
+	require.NoError(t, err, "initial index must succeed before testing reindex modes")
+
+	for _, full := range []bool{false, true} {
+		name := "incremental"
+		if full {
+			name = "full"
+		}
+		t.Run(name, func(t *testing.T) {
+			tracker.SetIssue(DaemonIssue{
+				Type:     IssueTypeDirtyOverlayFailed,
+				Severity: SeverityWarning,
+				Summary:  "stale dirty overlay failure",
+			})
+
+			_, err := mgr.Index(ctx, CodeIndexPayload{Full: full}, nil)
+			require.NoError(t, err)
+
+			_, found := tracker.GetIssue(IssueTypeDirtyOverlayFailed, "")
+			assert.False(t, found, "successful %s index must clear the stale overlay issue", name)
+		})
+	}
+}
+
 // TestStoreOpen_SelfHealsTransparently_NoDaemonRetryNeeded verifies the
 // integration boundary between store.Open self-heal and the daemon: when the
 // daemon's CheckFreshness opens the store and bleve is corrupt, Open self-

--- a/internal/daemon/codedb_selfheal_test.go
+++ b/internal/daemon/codedb_selfheal_test.go
@@ -107,6 +107,30 @@ func TestDoIndex_SuccessClearsDirtyOverlayFailure(t *testing.T) {
 	initialCancel()
 	require.NoError(t, err, "initial index must succeed before testing reindex modes")
 
+	t.Run("recent successful overlay", func(t *testing.T) {
+		mgr.mu.Lock()
+		mgr.lastDirtyRefresh = time.Now()
+		mgr.mu.Unlock()
+		tracker.SetIssue(DaemonIssue{
+			Type:     IssueTypeDirtyOverlayFailed,
+			Severity: SeverityWarning,
+			Summary:  "stale dirty overlay failure",
+		})
+
+		indexCtx, indexCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		_, err := mgr.Index(indexCtx, CodeIndexPayload{}, nil)
+		indexCancel()
+		require.NoError(t, err)
+
+		_, found := tracker.GetIssue(IssueTypeDirtyOverlayFailed, "")
+		assert.False(t, found, "recent successful overlay must retire an older failure")
+	})
+
+	mgr.mu.Lock()
+	mgr.lastDirtyRefresh = time.Time{}
+	mgr.mu.Unlock()
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "hello.go"), []byte("package main\nfunc Dirty() {}\n"), 0o600))
+
 	for _, full := range []bool{false, true} {
 		name := "incremental"
 		if full {


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a08350-f473-7674-8da4-f761248a7b97">Session</a>
<!-- /sageox:pr-header -->

## What broke

- Bleve could definitively report an empty persisted mapping while the narrower bbolt inspection remained inconclusive.
- That state fell through to the generic lock-contention error, so the daemon retried forever without writing a reindex marker.
- A successful normal or full reindex left an earlier `dirty_overlay_failed` issue in daemon status until another worktree edit refreshed the overlay.
- `ox doctor` surfaced the opaque open error without the known recovery command.

## What this PR ships

- Treat Bleve's mapping-parse error as a self-heal trigger, while retaining the existing heal lock and bounded exclusive probes before deleting any derived index data.
- Recheck Bleve after proving the Bolt store is free; rebuild only when the current open still reports an invalid mapping.
- Give deferred self-healing distinct wording instead of calling it direct lock contention.
- Clear stale dirty-overlay issues only after a successful local overlay build; retain them when that stage fails or remote indexing skips it.
- Recommend `ox code index --full` from doctor when mapping corruption cannot be repaired inline.

```mermaid
flowchart LR
    A[Bleve mapping parse fails] --> B{Bounded locked recheck}
    B -->|Free; parse still fails| C[Rebuild affected sub-index]
    B -->|Busy or unconfirmed| D[Defer without deleting]
    C --> E[Write full-reindex marker]
    E --> F[Successful reindex clears stale warning]
```

## Test Plan

- `make lint` — 0 issues
- `make test` — 19,749 passed; 1,052 skipped; 0 failed
- `go test ./internal/codedb/store -count=1`
- `go test ./internal/daemon -count=1`
- `go test ./cmd/ox -count=1`
- Red-first regressions cover an inconclusive snapshot peek, both reindex modes, doctor remediation, and existing concurrent-healer safety.

Fixes #898

SageOx-Session: https://sageox.ai/c/ses_01a08350-f473-7674-8da4-f761248a7b97
