### PR TITLE
fix(codex): share hooks and explain trust during setup

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,71 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook PostToolUse 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook PreToolUse 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook SessionEnd 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook SessionStart 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "statusMessage": "Loading SageOx context"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook Stop 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook UserPromptSubmit 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook PostToolUse 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook PostToolUse 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "timeout": 10
           }
         ]
       }
@@ -17,7 +18,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook PreToolUse 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook PreToolUse 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "timeout": 10
           }
         ]
       }
@@ -28,7 +30,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook SessionEnd 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook SessionEnd 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "timeout": 3
           }
         ]
       }
@@ -40,7 +43,8 @@
           {
             "type": "command",
             "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook SessionStart 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
-            "statusMessage": "Loading SageOx context"
+            "statusMessage": "Loading SageOx context",
+            "timeout": 10
           }
         ]
       }
@@ -51,7 +55,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook Stop 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook Stop 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "timeout": 10
           }
         ]
       }
@@ -62,7 +67,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook UserPromptSubmit 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook UserPromptSubmit 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "timeout": 10
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,11 @@ sessions/
 # Claude scheduled-task runtime lock (ephemeral: session PID + timestamp)
 .claude/scheduled_tasks.lock
 
+# Share repository hooks; keep other Codex state local.
 .codex/
+!/.codex/
+/.codex/*
+!/.codex/hooks.json
 
 team-contexts/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,14 @@ Pull requests are welcome from anyone. So are issues — and if you'd rather des
 
 A note on how we review: when AI agents can produce large, plausible-looking changes, quality and security come from scrutinizing the inputs to the development process. Expect PRs to be reviewed on that basis. Small, focused changes with tests get merged faster than large ones, and a PR that explains *why* is easier to trust than one that only shows *what*.
 
+## Codex setup
+
+This repo includes shared SageOx hooks in [`.codex/hooks.json`](.codex/hooks.json)
+to load Team Context and record sessions according to the repo's SageOx settings.
+Install `ox` on your `PATH` (`make build && make install`), then open Codex in
+the repo and use `/hooks` to review and trust the project hooks. New or changed
+hooks require review before they run; see [Codex hook trust](https://learn.chatgpt.com/docs/hooks#review-and-trust-hooks).
+
 ## Two Ways In
 
 **File an issue** — [bug reports, feature requests, and agent prompts](https://github.com/sageox/ox/issues) are all welcome. Be as detailed as you like. A maintainer reviews it, generates an implementation plan, and SageOx engineers build it with full test coverage and code review. You get the fix or feature you asked for, maintained over time, without having to keep a fork in sync.

--- a/cmd/ox-adapter-codex/hooks.go
+++ b/cmd/ox-adapter-codex/hooks.go
@@ -261,6 +261,11 @@ func writeHooksFile(path string, hooksMap map[string][]codexHookEntry, rawMap ma
 }
 
 func mergeHookEntries(existing []codexHookEntry, oxCmd string, event string) []codexHookEntry {
+	// Match Gemini's ten-second budget; Codex caps SessionEnd at three seconds.
+	timeout := 10
+	if event == "SessionEnd" {
+		timeout = 3
+	}
 	hasOx := false
 	for i, entry := range existing {
 		for j, hook := range entry.Hooks {
@@ -269,6 +274,7 @@ func mergeHookEntries(existing []codexHookEntry, oxCmd string, event string) []c
 					Type:          "command",
 					Command:       oxCmd,
 					StatusMessage: statusMessageForEvent(event),
+					Timeout:       timeout,
 				}
 				hasOx = true
 			}
@@ -283,6 +289,7 @@ func mergeHookEntries(existing []codexHookEntry, oxCmd string, event string) []c
 					Type:          "command",
 					Command:       oxCmd,
 					StatusMessage: statusMessageForEvent(event),
+					Timeout:       timeout,
 				},
 			},
 		})

--- a/cmd/ox-adapter-codex/hooks_test.go
+++ b/cmd/ox-adapter-codex/hooks_test.go
@@ -167,6 +167,51 @@ func TestHandleInstallHooks_IsIdempotentAfterLegacyMigration(t *testing.T) {
 	assert.Equal(t, firstHooks, secondHooks)
 }
 
+// Fresh installs and upgrades must bound hook execution without changing
+// another tool's timeout or losing the limits on the next install.
+func TestHandleInstallHooks_BoundsExecution(t *testing.T) {
+	for _, scope := range []string{"project", "user"} {
+		t.Run(scope, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			params := adapterprotocol.HookParams{RepoRoot: t.TempDir(), Scope: scope}
+			hooksPath := resolveHooksPath(params.RepoRoot, scope)
+			legacy := map[string][]codexHookEntry{
+				"SessionStart": {{Hooks: []codexHook{{Type: "command", Command: hookCommand("SessionStart"), Timeout: 600}}}},
+				"SessionEnd":   {{Hooks: []codexHook{{Type: "command", Command: hookCommand("SessionEnd")}}}},
+				"Stop":         {{Hooks: []codexHook{{Type: "command", Command: "echo custom-hook", Timeout: 17}}}},
+			}
+			require.NoError(t, writeHooksFile(hooksPath, legacy, nil, scope))
+			wantTimeouts := map[string]int{
+				"SessionStart": 10, "PreToolUse": 10, "PostToolUse": 10,
+				"UserPromptSubmit": 10, "Stop": 10, "SessionEnd": 3,
+			}
+			for range 2 {
+				response, err := handleInstallHooks(params)
+				require.NoError(t, err)
+				require.True(t, response.Installed)
+				hooks, _, err := readHooksFile(hooksPath)
+				require.NoError(t, err)
+				for event, want := range wantTimeouts {
+					count := 0
+					for _, entry := range hooks[event] {
+						for _, hook := range entry.Hooks {
+							if hook.Command == "echo custom-hook" {
+								assert.Equal(t, 17, hook.Timeout)
+								continue
+							}
+							assert.Equal(t, hookCommand(event), hook.Command)
+							assert.Equal(t, want, hook.Timeout, event)
+							count++
+						}
+					}
+					assert.Equal(t, 1, count, event)
+				}
+				assert.Equal(t, "echo custom-hook", hooks["Stop"][0].Hooks[0].Command)
+			}
+		})
+	}
+}
+
 func TestHandleUninstallHooks_LeavesCodexConfigUntouched(t *testing.T) {
 	repoRoot := t.TempDir()
 	params := adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"}

--- a/cmd/ox/adapter_test.go
+++ b/cmd/ox/adapter_test.go
@@ -326,6 +326,7 @@ func createFakeAdapter(t *testing.T, dir, name, version, adapterType string) str
 // (e.g., ".codex") where the fake install-hooks writes a hooks.json file.
 func fakeAdapterWithHooksScript(name, version, adapterType, configDir string) string {
 	return fmt.Sprintf(`#!/bin/sh
+set -e
 case "$1" in
   info)
     echo '{"protocol_version":1,"name":"%s","display_name":"%s","version":"%s","type":"%s","capabilities":["session_reader","hook_installer"]}'

--- a/cmd/ox/hooks_codex.go
+++ b/cmd/ox/hooks_codex.go
@@ -1,5 +1,7 @@
 package main
 
+const codexHookTrustHint = "In Codex, run /hooks to review and trust the SageOx hooks before they can run."
+
 // installCodexHooks delegates to the external ox-adapter-codex binary.
 func installCodexHooks(user bool) error {
 	return installExternalAdapterHooks("codex", user)

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -1021,6 +1021,11 @@ func runInit() error {
 		fmt.Printf("  %d. Run %s to confirm everything is working properly\n", step, cli.StyleCommand.Render("ox doctor"))
 		step++
 
+		if selectedAgents["codex"] && hasCodexHooks(false) {
+			fmt.Printf("  %d. %s\n", step, codexHookTrustHint)
+			step++
+		}
+
 		// step N: invite teammates — ox invite sends the invitations directly,
 		// so this no longer sends people to the dashboard to copy a link.
 		if cfg.TeamID != "" {

--- a/cmd/ox/init_e2e_test.go
+++ b/cmd/ox/init_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/sageox/ox/internal/skillmanager"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,53 @@ func withInitFlags(t *testing.T, team string) {
 		initQuiet, initTeamFlag, initForce = prevQuiet, prevTeam, prevForce
 		initEndpointFlag, initAgentsFlag = prevEndpoint, prevAgents
 	})
+}
+
+// Codex hooks remain inactive until trusted, so init's next steps must explain
+// approval only when the selected integration actually installed its hooks.
+func TestRunInit_CodexTrustStepRequiresInstalledHooks(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		agents       string
+		installFails bool
+		wantTrust    bool
+	}{
+		{name: "installed", agents: "codex", wantTrust: true},
+		{name: "install failed", agents: "codex", installFails: true},
+		{name: "not selected", agents: "claude-code"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newOxE2E(t)
+			withInitFlags(t, env.TeamID)
+			initQuiet, initAgentsFlag = false, tc.agents
+
+			adapterDir := t.TempDir()
+			createFakeAdapterWithHooks(t, adapterDir, "codex", "0.1.0", "session", ".codex")
+			t.Setenv("OX_ADAPTER_PATH", adapterDir)
+			adapters.Unregister("codex")
+			t.Cleanup(func() { adapters.Unregister("codex") })
+			if tc.installFails {
+				require.NoError(t, os.WriteFile(filepath.Join(env.Root, ".codex"), []byte("blocked"), 0o644))
+			}
+
+			var err error
+			output := captureStdoutForPlanCLI(t, func() { err = runInit() })
+			require.NoError(t, err, "an optional integration failure must not prevent repository setup")
+			assert.Contains(t, env.Requested(), "/api/v1/repo/init")
+			assert.Contains(t, output, "SageOx initialized successfully!")
+			if tc.wantTrust {
+				assert.FileExists(t, filepath.Join(env.Root, ".codex", "hooks.json"))
+				require.Contains(t, output, "/hooks to review and trust the SageOx hooks")
+				require.Contains(t, strings.ToLower(output), "next steps")
+				steps := output[strings.Index(strings.ToLower(output), "next steps"):]
+				assert.Less(t, strings.Index(steps, "ox doctor"), strings.Index(steps, "/hooks"))
+				assert.Less(t, strings.Index(steps, "/hooks"), strings.Index(steps, "Invite teammates"))
+			} else {
+				assert.NotContains(t, output, "/hooks")
+				assert.NoFileExists(t, filepath.Join(env.Root, ".codex", "hooks.json"))
+			}
+		})
+	}
 }
 
 // TestRunInit_WritesScopedIgnoreAndNeverStagesReservedArtifacts drives runInit

--- a/cmd/ox/init_e2e_test.go
+++ b/cmd/ox/init_e2e_test.go
@@ -66,6 +66,7 @@ func TestRunInit_CodexTrustStepRequiresInstalledHooks(t *testing.T) {
 				require.Contains(t, output, "/hooks to review and trust the SageOx hooks")
 				require.Contains(t, strings.ToLower(output), "next steps")
 				steps := output[strings.Index(strings.ToLower(output), "next steps"):]
+				require.Contains(t, steps, "ox doctor")
 				assert.Less(t, strings.Index(steps, "ox doctor"), strings.Index(steps, "/hooks"))
 				assert.Less(t, strings.Index(steps, "/hooks"), strings.Index(steps, "Invite teammates"))
 			} else {

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -148,6 +148,12 @@ func runIntegrateInteractive() error {
 	if gitRoot == "" {
 		return fmt.Errorf("not in a git repository — run from a project directory")
 	}
+	// Existing Codex hooks still need trust when other integrations are missing.
+	defer func() {
+		if hasCodexHooks(false) {
+			cli.PrintInfo(codexHookTrustHint)
+		}
+	}()
 
 	// build the list of agents with their install status
 	agents := []integrateAgentInfo{
@@ -225,9 +231,6 @@ func runIntegrateInteractive() error {
 		fmt.Println("All detected AI coworkers are already integrated.")
 		for _, a := range agents {
 			fmt.Printf("  %s %s\n", ui.PassStyle.Render("✓"), a.displayName)
-			if a.name == "codex" {
-				cli.PrintInfo(codexHookTrustHint)
-			}
 		}
 		return nil
 	}
@@ -255,9 +258,6 @@ func runIntegrateInteractive() error {
 			cli.PrintWarning(fmt.Sprintf("Could not install %s: %v", a.displayName, err))
 		} else {
 			cli.PrintSuccess(fmt.Sprintf("Installed %s integration", a.displayName))
-			if a.name == "codex" {
-				cli.PrintInfo(codexHookTrustHint)
-			}
 			installed++
 		}
 	}

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -225,6 +225,9 @@ func runIntegrateInteractive() error {
 		fmt.Println("All detected AI coworkers are already integrated.")
 		for _, a := range agents {
 			fmt.Printf("  %s %s\n", ui.PassStyle.Render("✓"), a.displayName)
+			if a.name == "codex" {
+				cli.PrintInfo(codexHookTrustHint)
+			}
 		}
 		return nil
 	}
@@ -252,6 +255,9 @@ func runIntegrateInteractive() error {
 			cli.PrintWarning(fmt.Sprintf("Could not install %s: %v", a.displayName, err))
 		} else {
 			cli.PrintSuccess(fmt.Sprintf("Installed %s integration", a.displayName))
+			if a.name == "codex" {
+				cli.PrintInfo(codexHookTrustHint)
+			}
 			installed++
 		}
 	}
@@ -333,6 +339,9 @@ func runIntegrateInstall(cmd *cobra.Command, args []string) error {
 		if err := installCodexHooks(integrateUserFlag); err != nil {
 			return fmt.Errorf("installing Codex CLI integration: %w", err)
 		}
+
+		cli.PrintSuccess("Installed Codex hooks")
+		cli.PrintInfo(codexHookTrustHint)
 
 		userCfg, _ := config.LoadUserConfig()
 		tips.MaybeShow("hooks", tips.WhenMinimal, false, !userCfg.AreTipsEnabled(), false)

--- a/cmd/ox/integrate_codex_test.go
+++ b/cmd/ox/integrate_codex_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A successful install still needs Codex's trust step; a failed install must
+// never tell the coworker that their hooks are ready to approve.
+func TestIntegrateCodex_TrustGuidanceRequiresSuccessfulInstall(t *testing.T) {
+	skipIntegration(t)
+	for _, installFails := range []bool{false, true} {
+		name := "installed"
+		if installFails {
+			name = "install failed"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := setupUninstallAllTest(t, map[string]string{"codex": ".codex"})
+			if installFails {
+				require.NoError(t, os.WriteFile(filepath.Join(root, ".codex"), []byte("blocked"), 0o644))
+			}
+
+			previousCodex, previousUser := integrateCodexFlag, integrateUserFlag
+			integrateCodexFlag, integrateUserFlag = true, false
+			t.Cleanup(func() {
+				integrateCodexFlag, integrateUserFlag = previousCodex, previousUser
+			})
+
+			var err error
+			output := captureStdoutForPlanCLI(t, func() {
+				err = runIntegrateInstall(integrateInstallCmd, nil)
+			})
+			if installFails {
+				require.ErrorContains(t, err, "installing Codex CLI integration")
+				assert.NotContains(t, output, "Installed Codex hooks")
+				assert.NotContains(t, output, "/hooks")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.FileExists(t, filepath.Join(root, ".codex", "hooks.json"))
+			assert.Contains(t, output, "Installed Codex hooks")
+			assert.Contains(t, output, "/hooks to review and trust the SageOx hooks")
+		})
+	}
+}
+
+// Re-running setup must remind coworkers to trust existing hooks, while a
+// fresh noninteractive selection must not claim that unselected hooks exist.
+func TestIntegrateCodex_InteractiveTrustGuidanceMatchesInstalledState(t *testing.T) {
+	skipIntegration(t)
+	for _, tc := range []struct {
+		name            string
+		codexInstalled  bool
+		claudeInstalled bool
+	}{
+		{name: "fresh"},
+		{name: "already installed", codexInstalled: true, claudeInstalled: true},
+		{name: "Codex installed but Claude missing", codexInstalled: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := setupUninstallAllTest(t, map[string]string{"codex": ".codex"})
+			if tc.claudeInstalled {
+				require.NoError(t, InstallProjectClaudeHooks(root))
+			}
+			if tc.codexInstalled {
+				require.NoError(t, installCodexHooks(false))
+			}
+
+			var err error
+			var output string
+			withStdin(t, "", func() {
+				output = captureStdoutForPlanCLI(t, func() { err = runIntegrateInteractive() })
+			})
+			require.NoError(t, err)
+			if tc.claudeInstalled && tc.codexInstalled {
+				assert.Contains(t, output, "All detected AI coworkers are already integrated")
+			} else {
+				assert.Contains(t, output, "No new integrations installed")
+			}
+			if tc.codexInstalled {
+				assert.Contains(t, output, "/hooks to review and trust the SageOx hooks")
+				assert.FileExists(t, filepath.Join(root, ".codex", "hooks.json"))
+			} else {
+				assert.NotContains(t, output, "/hooks")
+				assert.NoFileExists(t, filepath.Join(root, ".codex", "hooks.json"))
+			}
+		})
+	}
+}

--- a/cmd/ox/integrate_omp_test.go
+++ b/cmd/ox/integrate_omp_test.go
@@ -18,7 +18,11 @@ func setupUninstallAllTest(t *testing.T, adapterConfigs map[string]string) strin
 	cmd.Dir = repoRoot
 	require.NoError(t, cmd.Run())
 	t.Chdir(repoRoot)
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
 
 	adapterDir := t.TempDir()
 	for name, configDir := range adapterConfigs {

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Codex setup explains the final trust step** — after installing hooks, ox points you to `/hooks` in Codex to review and trust them before they can run.
+- **Codex setup explains the final trust step** — after installing hooks, ox points you to `/hooks` in Codex to review and trust them before they can run. Installed hooks also have explicit time limits so a stuck hook cannot hold up a turn for ten minutes.
 - **Codex sessions now finalize on their own** — archiving or deleting a Codex conversation, or closing Codex, publishes the recording the same way closing Claude Code does. Until now a Codex session stayed in the local cache until someone ran `ox agent <id> session stop` or the daemon's stale sweep noticed the exited process. Existing installs pick up the new hook on the next `ox doctor`.
 - **Claude Code and Codex session recording continues after individual commands finish** — interrupted uploads remain recoverable, with secret redaction preserved before publication.
 - **A read-only code index is no longer mistaken for a corrupt one and deleted** — ox read "cannot write this database" as "this database is damaged" and tried to delete it; only the read-only filesystem stopped it. The same misreading on writable media would have destroyed a healthy index that costs minutes to rebuild.

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Codex setup explains the final trust step** — after installing hooks, ox points you to `/hooks` in Codex to review and trust them before they can run.
 - **Codex sessions now finalize on their own** — archiving or deleting a Codex conversation, or closing Codex, publishes the recording the same way closing Claude Code does. Until now a Codex session stayed in the local cache until someone ran `ox agent <id> session stop` or the daemon's stale sweep noticed the exited process. Existing installs pick up the new hook on the next `ox doctor`.
 - **Claude Code and Codex session recording continues after individual commands finish** — interrupted uploads remain recoverable, with secret redaction preserved before publication.
 - **A read-only code index is no longer mistaken for a corrupt one and deleted** — ox read "cannot write this database" as "this database is damaged" and tried to delete it; only the read-only filesystem stopped it. The same misreading on writable media would have destroyed a healthy index that costs minutes to rebuild.


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a0836e-c6d5-762e-a52a-50e1e6f6039e">Session</a>
<!-- /sageox:pr-header -->

## What broke

- **Sharing:** `.codex/` was entirely ignored, so installing SageOx hooks in one workspace did not make them available to teammates or new workspaces.
- **Activation:** Codex requires users to review and trust hook definitions. Successful installation did not explain that final step.

## What this PR ships

- **Shared hooks:** Track the six installer-generated lifecycle hooks in `.codex/hooks.json`, while keeping other Codex configuration and state ignored.
- **Setup guidance:** `ox init` and the Codex integration installer point users to `/hooks` to review and trust the SageOx hooks. The explicit installer also reports success. Interactive setup still shows the reminder when Codex was already installed and another integration is missing.
- **Bounded execution:** Install and refresh Codex hooks with a 10-second timeout, or 3 seconds for `SessionEnd`, so a stuck hook cannot inherit Codex's 10-minute default. The shared file is generated from the updated adapter.
- **Documentation:** Add contributor setup instructions and an unreleased changelog entry. Trust remains a user decision; this change does not grant trust automatically.

## Test Plan

- **CI passed on `57928bbf`:** Full Go tests, compiled-binary acceptance, digital twins, coverage ratchets, Codecov patch coverage, lint, Windows skills, CodeQL, and automated review checks.
- **Passed:** `make format`, `make lint`, CLI and Codex adapter builds, and focused Codex integration/detection tests with the race detector.
- **Installer smoke test:** Ran the rebuilt CLI twice in an isolated temporary repo. Both runs printed the success/trust guidance and produced exactly six hooks without duplicates.
- **Configuration:** Validated hook JSON, shell command syntax, and Git ignore behavior for shared hooks versus local configuration, credentials, and session files.
- **Setup regressions:** Exercise successful and failed installs, already-installed hooks, fresh noninteractive setup, and init selection/installation outcomes. Focused tests pass with the race detector and cover 100% of the changed executable statements (19/19).
- **Timeout regression:** Verified the new test fails before the fix and passes after it. It covers new hooks, upgrades, repeated project/user installs, and preservation of another tool's hook timeout; the complete Codex adapter suite passes with the race detector.
- **Local runner caveat:** `make test` timed out in the existing `TestSessionUpload_ScansLongLinesUnderSizeCap/doctor` test. The complete CI test suite subsequently passed on the final commit.
- **Scope:** No CI workflows or skip directives changed. The test adapter now reports filesystem failures, and its harness isolates XDG directories.
- **Security review:** No protected security paths changed. Shared commands contain no machine-specific paths or credentials and retain Codex's trust requirement.

SageOx-Session: https://sageox.ai/c/ses_01a0836e-c6d5-762e-a52a-50e1e6f6039e
