### PR TITLE
Fix generated-MDX tag hazard in ox pr header help text

### DIFF
--- a/cmd/ox/docs_test.go
+++ b/cmd/ox/docs_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -31,5 +32,29 @@ func TestPrepareDocsCommandTreeExcludesExperimentalCommands(t *testing.T) {
 	}
 	if !root.CompletionOptions.DisableDefaultCmd {
 		t.Error("default completion command remains enabled")
+	}
+}
+
+// TestPRHeaderLongHasNoBareHTMLTags guards the generated MDX reference.
+//
+// `ox docs` copies a command's Long description verbatim into
+// docs/reference/**/*.mdx as UNFENCED prose, and docs/ is published as the
+// @sageox/cli-docs npm package — so a downstream MDX compiler, not this repo,
+// is what parses it. MDX treats a lowercase <tag> as a JSX intrinsic element,
+// so a bare <picture> or <a> in prose is an unclosed-element parse error there.
+// Naming an HTML element in help text is legitimate; it just has to be spelled
+// as inline code so both a terminal reader and an MDX parser get something sane.
+//
+// Failure prevented: `ox pr header --help` grows a bare <tag> again and silently
+// breaks the published docs package for whoever compiles it. Red-first: drop the
+// backticks around `<picture>` in prHeaderCmd.Long and this fails.
+func TestPRHeaderLongHasNoBareHTMLTags(t *testing.T) {
+	// strip inline-code spans first — a tag INSIDE backticks is the correct form
+	withoutCode := regexp.MustCompile("`[^`]*`").ReplaceAllString(prHeaderCmd.Long, "")
+
+	if m := regexp.MustCompile(`<(/?[a-zA-Z][a-zA-Z0-9-]*)[ >/]`).FindStringSubmatch(withoutCode); m != nil {
+		t.Errorf("prHeaderCmd.Long contains bare HTML tag %q outside backticks; "+
+			"MDX parses it as an unclosed JSX element in the generated reference. "+
+			"Spell it as `%s` instead.", "<"+m[1]+">", "<"+m[1]+">")
 	}
 }

--- a/cmd/ox/pr_header.go
+++ b/cmd/ox/pr_header.go
@@ -33,14 +33,20 @@ It links the session(s), plan(s), and discussion(s) that produced the change and
 names the team they belong to. Paste the output above your description; keep the
 'SageOx-Session:' trailer at the bottom.
 
-The line renders ONLY when it can link at least one artifact a reviewer can open.
-A team name alone is not a credit — a wordmark with nothing behind it is a logo
-stamp, not provenance — so with no session, plan, or discussion the command
-prints nothing and explains why on stderr.
+The line renders ONLY when it has at least one artifact to link. A team name
+alone is not a credit — a wordmark with nothing behind it is a logo stamp, not
+provenance — so with no session, plan, or discussion the command prints nothing
+and explains why on stderr.
+
+ox verifies only the CURRENT session, from local recording state, and withholds
+its link until the server has confirmed it. Ids passed explicitly are the
+caller's assertion: ox includes them as given rather than adding a network
+round-trip to a render command that must never fail on an unreachable remote, so
+it warns on stderr instead. Pass --allow-unconfirmed to accept a possible 404 and
+silence the warning.
 
 The markup is built from the primitives that survive GitHub's PR-body sanitizer
-(a theme-adaptive <picture> wordmark, real <a> links, a baseline-stable <small>
-kicker) and fits on one line.
+(a theme-adaptive ` + "`<picture>`" + ` wordmark and real ` + "`<a>`" + ` links) and fits on one line.
 
 Examples:
   # Auto-link the current session

--- a/docs/reference/pr/header.mdx
+++ b/docs/reference/pr/header.mdx
@@ -17,14 +17,20 @@ It links the session(s), plan(s), and discussion(s) that produced the change and
 names the team they belong to. Paste the output above your description; keep the
 'SageOx-Session:' trailer at the bottom.
 
-The line renders ONLY when it can link at least one artifact a reviewer can open.
-A team name alone is not a credit — a wordmark with nothing behind it is a logo
-stamp, not provenance — so with no session, plan, or discussion the command
-prints nothing and explains why on stderr.
+The line renders ONLY when it has at least one artifact to link. A team name
+alone is not a credit — a wordmark with nothing behind it is a logo stamp, not
+provenance — so with no session, plan, or discussion the command prints nothing
+and explains why on stderr.
+
+ox verifies only the CURRENT session, from local recording state, and withholds
+its link until the server has confirmed it. Ids passed explicitly are the
+caller's assertion: ox includes them as given rather than adding a network
+round-trip to a render command that must never fail on an unreachable remote, so
+it warns on stderr instead. Pass --allow-unconfirmed to accept a possible 404 and
+silence the warning.
 
 The markup is built from the primitives that survive GitHub's PR-body sanitizer
-(a theme-adaptive <picture> wordmark, real <a> links, a baseline-stable <small>
-kicker) and fits on one line.
+(a theme-adaptive `<picture>` wordmark and real `<a>` links) and fits on one line.
 
 Examples:
   # Auto-link the current session


### PR DESCRIPTION
<!-- sageox:pr-header v2 -->
> guided&nbsp;by&nbsp;<picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="16" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a08470-4175-7140-b754-41a9d0d3b904">Session</a>
<!-- /sageox:pr-header -->

## Why this matters

Whoever compiles the published `@sageox/cli-docs` package gets a `ox pr header` reference page that no longer hands their MDX parser an unclosed JSX element — and the page stops describing a `<small>` kicker that the command hasn't emitted since #902.

Follow-up to #902, addressing both CodeRabbit review threads.

## Thread 1 — bare HTML tags in the generated MDX ✅ fixed

**The finding was right, and it caught a second bug underneath it.**

`ox docs` copies a command's `Long` description **verbatim and unfenced** into `docs/reference/**/*.mdx`. MDX treats a lowercase `<tag>` as a JSX intrinsic element, so a bare `<picture>` is an unclosed-element parse error.

- **`docs/` is not a site in this repo** — it is an npm package (`@sageox/cli-docs`) whose workflow generates the `.mdx` and publishes it. Nothing compiles MDX here, so nothing failed in CI; the hazard is handed to the **downstream consumer** that compiles the package.
- **The same paragraph was also factually stale.** It advertised "a baseline-stable `<small>` kicker" — but the second commit of #902 removed `<small>` entirely, because GitHub's sanitizer deletes it. The doc described markup the command no longer emits.

Fixed by spelling the tags as inline code and dropping the dead `<small>` claim:

```
(a theme-adaptive `<picture>` wordmark and real `<a>` links) and fits on one line.
```

Guarded by `TestPRHeaderLongHasNoBareHTMLTags`, **proved red-first**:

```
--- FAIL: TestPRHeaderLongHasNoBareHTMLTags
    docs_test.go:56: prHeaderCmd.Long contains bare HTML tag "<picture>" outside
    backticks; MDX parses it as an unclosed JSX element in the generated reference.
```

### The wider class — not fixed here, deliberately

A scan of every generated `.mdx` found **57 bare tags in unfenced prose across 23 files**. Three were mine; **54 predate this work** — mostly placeholder metavariables (`<name>`, `<path>`, `<uuidv7>`) in `ox code`, `ox conversation`, `ox plan`, `ox hooks`, and others. They carry exactly the same downstream MDX hazard.

Fixing 22 unrelated commands' help text belongs in its own change, so this PR fixes what it owns and the guard is scoped to `ox pr header`. Filing the class separately rather than silently leaving it, or silently ballooning this diff.

## Thread 2 — "withhold unconfirmed explicit references by default" ⚠️ premise accepted, remedy declined

**The premise is correct:** explicit `--session` / `--plan` / `--discussion` values are rendered into the markup, and `--allow-unconfirmed` only silences the warning. That is deliberate, and it is pinned by `TestPRHeaderCommand_ExplicitRefsWarnUnlessAllowed`.

**The proposed inversion would break the primary workflow and cannot be implemented as described:**

- **ox has no way to confirm an explicit id.** It verifies the *current* session from **local recording state**. An arbitrary `pln_…` carries no local signal, so "exclude unless confirmed reviewer-openable" would require a per-id network round-trip — in a render command whose contract is that it must never fail on an unreachable remote.
- **Without that capability the rule collapses.** With no confirmation source, "withhold the unconfirmed" means withholding *every* explicit ref, always. The documented workflow — `ox pr header --plan pln_4d8e2f`, which the skill instructs agents to run — would silently produce a header with no plan link.
- **It would make the flag mandatory and thereby useless.** Agents would pass `--allow-unconfirmed` every time to get their links back, so the warning would never fire again. The safety mechanism is destroyed by making it compulsory.
- **The asymmetry is principled, not an oversight.** The auto session is withheld because ox *has* a signal saying "pending". Explicit refs are the caller's assertion, included **as given but never silently** — a stderr warning names the 404 risk, and `--allow-unconfirmed` is the opt-in acknowledgement.

**What I did take from it:** the contract sentence over-claimed. It read "renders ONLY when it can link at least one artifact **a reviewer can open**", which promises verification ox does not perform. Now the help text states plainly what is and isn't checked:

> ox verifies only the CURRENT session, from local recording state, and withholds its link until the server has confirmed it. Ids passed explicitly are the caller's assertion: ox includes them as given rather than adding a network round-trip to a render command that must never fail on an unreachable remote, so it warns on stderr instead.

## Test Plan

- `TestPRHeaderLongHasNoBareHTMLTags` — new, proved red-first (break shown above), green after.
- `go test ./cmd/ox/ -run PRHeader` — 8/8 pass, including the unchanged `ExplicitRefsWarnUnlessAllowed` that pins the declined behavior.
- `go test ./internal/prheader/` — pass.
- `make lint` — 0 issues.
- Generated reference re-run and re-scanned: **0 bare tags** remaining in `docs/reference/pr/header.mdx`.

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791524225&installation_model_id=433550&pr_number=903&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F903&signature=4d8e78554c8762d3e130ac87df47f478e42161122c486ec1ac7e6ee234dca427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `ox pr header` behavior for artifact references and current-session links.
  * Documented warnings for unconfirmed references and the `--allow-unconfirmed` override.
  * Updated markup guidance to reflect theme-adaptive branding and standard links.
  * Removed documentation for the previously described `<small>` kicker.
* **Tests**
  * Added coverage to prevent invalid bare HTML tags in generated MDX documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->