### PR TITLE
chore(review): review at PR-open, not on every push

### DIFF
--- a/.claude/skills/monitor-pr/SKILL.md
+++ b/.claude/skills/monitor-pr/SKILL.md
@@ -201,13 +201,42 @@ told you to run autonomously.
 runs and may draw new CodeRabbit follow-ups; the monitor will fire again
 when they land, and the loop continues naturally.
 
+**Greptile will not follow up on its own.** This repo's `greptile.json`
+sets `triggerOnUpdates: false`, so Greptile reads the PR when it opens and
+then not again until someone asks. CodeRabbit still re-reviews every push;
+Greptile does not. That is what step 7 is for.
+
+### 7. Re-trigger Greptile on the final state
+
+Once every thread is addressed and CI is green — i.e. right before you
+would exit — ask Greptile to read the merged-ready state:
+
+```bash
+gh pr comment <n> --body "@greptileai"
+```
+
+(The same thing is available as the **"Re-trigger Greptile"** button in
+Greptile's own comment footer.)
+
+Then wait for the new review and triage whatever it returns exactly like
+any other round: fix, reply, resolve, push, re-trigger. A PR should be
+merged on a Greptile review of the code that is actually merging, not of
+the first draft of it.
+
+Skip this only when Greptile never reviewed the PR at all (it is not
+installed on the repo, or the PR carries the `no-greptile` label).
+
 ## Exit
 
 When the monitor emits `clean: ...`:
 
-1. `TaskStop` the monitor.
-2. Report a summary: what was fixed, what was intentionally skipped and
-   why (one bullet per skipped thread), final check + thread counts.
+1. Run step 7 if you have not already — re-trigger Greptile and let the
+   final-state review land. If it opens new threads, you are not clean;
+   go back to step 3.
+2. `TaskStop` the monitor.
+3. Report a summary: what was fixed, what was intentionally skipped and
+   why (one bullet per skipped thread), final check + thread counts, and
+   whether the final Greptile re-trigger came back clean.
 
 ## Guardrails
 
@@ -217,6 +246,8 @@ When the monitor emits `clean: ...`:
 - **Never skip outdated comments blindly.** `isOutdated` = line moved.
 - **Never blanket-dismiss CodeRabbit nitpicks.** Judge each on merit.
 - **Never bypass failing checks** with `--no-verify` or similar.
+- **Never merge on a stale Greptile read.** Greptile does not re-review on
+  push here; re-trigger it at the final state (step 7).
 - **Confirm before `git push`** unless running autonomously.
 - **Pause and ask** if a comment implies a design decision the user
   should own, rather than guessing — but **keep the monitor running**
@@ -226,5 +257,7 @@ When the monitor emits `clean: ...`:
 ## Related
 
 - `CLAUDE.md` — repo commit/PR conventions, CodeRabbit reply protocol.
+- `greptile.json` — repo review config; `triggerOnUpdates: false` is why
+  step 7 exists. `CONTRIBUTING.md` explains it for humans.
 - `Monitor` tool — session-length, `persistent: true`, one stdout line =
   one event, stop with `TaskStop`.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+      - id: check-json
+        # testdata deliberately contains malformed JSON fixtures
+        exclude: (^|/)testdata/
       - id: check-added-large-files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,8 @@ Always confirm with human before doing a git commit or a git push in this repo.
 
 **PR review feedback:** Use the `/monitor-pr` skill to watch an open PR and drive it to green. It streams state via the `Monitor` tool, triages each unresolved thread (including CodeRabbit nitpicks and `isOutdated` threads, which must not be blanket-skipped), replies `"Fixed."`, and resolves via GraphQL on `reviewThreads`.
 
+**Review bots (`greptile.json`, `.coderabbit.yaml`):** Neither blocks a merge. CodeRabbit re-reviews every push; **Greptile reviews at PR-open only** (`triggerOnUpdates: false`), so before merging you must re-trigger it on the final state — `gh pr comment <n> --body "@greptileai"`. Never merge on a Greptile read of the first draft. Label a PR `no-greptile` to skip it entirely (large mechanical diffs only). `CONTRIBUTING.md` carries the human-facing version.
+
 ### Key Practices
 
 - **Simplicity**: Minimum complexity for current needs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,32 @@ Pull requests are welcome from anyone. So are issues — and if you'd rather des
 
 A note on how we review: when AI agents can produce large, plausible-looking changes, quality and security come from scrutinizing the inputs to the development process. Expect PRs to be reviewed on that basis. Small, focused changes with tests get merged faster than large ones, and a PR that explains *why* is easier to trust than one that only shows *what*.
 
+## Automated review
+
+Two bots read every PR here, and **neither one blocks a merge** — they are
+readers, not gates. A maintainer still makes the call.
+
+- **CodeRabbit** reviews when the PR opens and again on every push.
+- **Greptile** reviews when the PR opens, and then **not again until someone
+  asks**. That is deliberate: re-reviewing every intermediate push spends a
+  shared review budget on code that is about to change anyway, and the budget
+  is org-wide — a repo that burns it degrades review everywhere.
+
+So when you have pushed your fixes and CI is green, **ask Greptile for one
+more read of the final state** — comment `@greptileai` on the PR, or press
+**"Re-trigger Greptile"** in its comment footer. That gives the PR two good
+reviews (as opened, as merging) instead of a dozen partial ones.
+
+Configuration lives in [`greptile.json`](greptile.json) and
+[`.coderabbit.yaml`](.coderabbit.yaml). Greptile is told to weight session
+capture, LFS upload, and ledger paths above everything else, because a silent
+defect there destroys work a user cannot recreate. It is also told to skip
+generated files and to leave formatting alone — gofmt, goimports, and
+golangci-lint already own that.
+
+If a PR is large and mechanical (a rename, a codegen refresh) and a bot review
+would be pure noise, a maintainer can label it `no-greptile` to skip it.
+
 ## Codex setup
 
 This repo includes shared SageOx hooks in [`.codex/hooks.json`](.codex/hooks.json)

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,15 @@
+{
+  "triggerOnUpdates": false,
+  "triggerOnDrafts": false,
+  "strictness": 2,
+  "commentTypes": [
+    "logic",
+    "syntax"
+  ],
+  "disabledLabels": [
+    "no-greptile"
+  ],
+  "includeConfidenceScore": true,
+  "ignorePatterns": "internal/codedb/sqlc/**\ninternal/whisper/store/sqlc/**\ninternal/theme/generated.go\ninternal/session/gitleaks_generated.go\ndocs/reference/**\n.beads/**",
+  "instructions": "ox captures a developer's coding session and uploads it to a shared team ledger. Session capture is tier-0 data: a silent defect anywhere in the capture -> finalize -> LFS upload -> ledger commit path destroys work a user cannot recreate. Weight findings in internal/session/, internal/lfs/, internal/ledger/, internal/daemon/ and internal/redaction/ above everything else, and flag any change that could drop, truncate, reorder, or silently skip a session entry.\n\nRepo invariants worth flagging when violated:\n- ox never shells out to the git-lfs binary and never writes .gitattributes entries with filter=lfs; all LFS work is pure Go in internal/lfs/. Flag exec of `git lfs` / `git-lfs`, LookPath(\"git-lfs\"), or LFS behavior gated on .gitattributes.\n- The daemon reads (pull/fetch); the CLI writes (add/commit/push). Flag daemon code that commits, pushes, or discards uncommitted changes.\n- Redaction runs before session content leaves the machine. Flag a new path that uploads session content without passing through internal/redaction.\n- Logs are single-line key=value (slog.Info(\"action\", \"key\", val)). Flag multiline or pretty-printed log statements.\n- Errors are compared with errors.Is / errors.As and wrapped with context, never string-matched.\n- Prefer the canonical helpers listed in AGENTS.md over re-derived ones: config.IsInitialized over os.Stat(\".sageox/\"), paths.TeamContextDir over hand-joined ~/.sageox paths, endpoint.GetForProject over reading the endpoint from env directly, cli.OpenInBrowser over browser.OpenURL or exec of open / xdg-open.\n- No copyleft dependencies (GPL/LGPL/AGPL/SSPL/EPL/CC-BY-SA). Flag any go.mod addition under one.\n\nStyle is already enforced by gofmt, goimports, and golangci-lint - do not comment on formatting or naming."
+}


### PR DESCRIPTION
## What this changes for you

Greptile now reads a PR **when it opens, and again when you ask it to** — not on every intermediate push. Two good reviews (as opened, as merging) instead of a dozen partial reads of code that was about to change anyway.

That matters beyond tidiness: the Greptile usage cap is shared, and once it is hit reviews are **skipped silently** — no error, no failing check, nothing in the PR. A high-volume repo running on per-push re-review can quietly spend that ceiling and degrade review for everyone. `ox` had no repo config at all, so it inherited whatever the dashboard said.

It also gets Greptile pointed at the right code. The config tells it that **session capture is tier-0 data** — a silent defect anywhere in capture → finalize → LFS upload → ledger commit destroys work a user cannot recreate — and to weight findings there above everything else.

## The trigger flow

```mermaid
flowchart LR
  A[PR opened] --> B["Greptile review #1"]
  B --> C[Fix threads, push]
  C -.->|no auto re-review| C
  C --> D["comment @greptileai"]
  D --> E["Greptile review #2 — final state"]
  E --> F{clean?}
  F -->|no| C
  F -->|yes| G[Merge]
```

CodeRabbit is unchanged and still re-reviews every push, so there is an unconditional floor under this.

## What this PR ships

- **`greptile.json`** (new, repo root — Greptile requires that location):
  - **`triggerOnUpdates: false`** — the whole change. Pinned in-repo so it can't drift with a dashboard toggle.
  - **`triggerOnDrafts: false`** — this repo opens PRs ready for review; a stray draft shouldn't consume a review.
  - **`strictness: 2`** — vendor default, pinned rather than inherited.
  - **`commentTypes: ["logic","syntax"]`** — `style` dropped. gofmt, goimports and golangci-lint already enforce style deterministically; a bot repeating them costs a human a triage decision for zero information.
  - **`disabledLabels: ["no-greptile"]`** — hand-applied opt-out for a large mechanical diff (rename, codegen refresh). Deliberately an opt-*out*: an opt-in `labels` gate would need a labeler workflow, and if that workflow ever broke, review would silently drop to zero. This fails toward *more* review.
  - **`includeConfidenceScore: true`** — gives the final re-trigger a readable verdict.
  - **`ignorePatterns`** — generated output only, each one verified: `internal/codedb/sqlc/**` and `internal/whisper/store/sqlc/**` (sqlc), `internal/theme/generated.go`, `internal/session/gitleaks_generated.go`, `docs/reference/**` (cobra-generated `.mdx`), `.beads/**`.
  - **`instructions`** — the tier-0 weighting plus this repo's durable invariants: no `git-lfs` binary shell-outs, daemon-reads/CLI-writes, redaction before anything leaves the machine, single-line key=value logs, `errors.Is`/`errors.As`, the canonical-helpers table, no copyleft deps.
- **`.claude/skills/monitor-pr/SKILL.md`** — the change that makes the config safe. The skill assumed bots follow up on their own; that is still true of CodeRabbit and now false of Greptile. Adds **step 7: re-trigger Greptile on the final state**, wires it into `## Exit`, and adds a guardrail: *never merge on a stale Greptile read*.
- **`CONTRIBUTING.md`** — a public **Automated review** section: which bots comment, that neither blocks a merge, why Greptile reads at open, and how to ask for the final-state review.
- **`AGENTS.md`** — one pointer next to the existing `/monitor-pr` line, so every agent (not just Claude) gets the re-trigger obligation.
- **`.pre-commit-config.yaml`** — adds `check-json` to the block that already runs `check-yaml`. A malformed `greptile.json` is the highest-blast-radius failure here — it fails *silently*, with no signal anywhere in the PR. Excludes `testdata/`, which deliberately contains malformed fixtures.

### Not excluded from review, on purpose

Everything under `internal/session/` (other than the one generated detector table), `internal/lfs/`, `internal/ledger/`, `internal/daemon/`, `internal/redaction/`, `internal/auth/`, and `go.mod` / `go.sum`. `internal/session/gitleaks_generated.go` is skipped but **its generator** (`internal/session/cmd/gitleaks-port/main.go`) is not.

### Not changed, on purpose

`.coderabbit.yaml`. Its header comment is stale against the current no-drafts convention, but that is an unrelated fix.

## Test Plan

Verified locally:

- `jq . greptile.json` parses; `pre-commit run check-json --all-files` → **Passed**
- `make lint` → **0 issues**
- Every `ignorePatterns` entry confirmed generated or machine-written before adding it (`Code generated … DO NOT EDIT` header, `sqlc.yaml`, or the cobra docs target) — no hand-edited path is excluded
- `no-greptile` label created on the repo, so `disabledLabels` can actually match

**Note on this PR itself:** the config is not live until it merges to the default branch, so expect Greptile's *current* per-push behavior here. The real acceptance test runs on the first PR after merge:

1. Greptile comments once on open
2. Push a second commit → **no** new Greptile review appears *(this is the whole change; if one appears, the file isn't being read)*
3. Comment `@greptileai` → a fresh review lands against the final state *(if this fails, the change is a net regression and should be reverted)*
4. Comments are logic/syntax with no style nits, and carry a confidence score
5. A change under `internal/session/` is still reviewed, and the review reflects the tier-0 instruction

**Rollback** is deleting `greptile.json` — behavior reverts to dashboard defaults immediately, with no other state to unwind.

SageOx-Session: https://sageox.ai/c/ses_01a08c40-bf53-7338-ad60-1ef8883dabaf

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791653134&installation_model_id=433550&pr_number=907&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F907&signature=947241d4eaec55a3b11dcdb5f59a030713f7d4ad3db264f61d80d6961e953454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance with automated review procedures, review priorities, configuration references, and available review controls.
  * Clarified final-state review expectations and reporting for pull requests.

* **Chores**
  * Added repository configuration for structured review checks, including syntax and logic validation.
  * Added automated validation for JSON files while excluding intentionally malformed test fixtures.
  * Standardized review settings covering logging, error handling, sensitive-data redaction, and dependency licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->