### PR TITLE
fix(sync): prevent metadata repair conflicts and verify pulls

### DIFF
--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -705,17 +705,30 @@ func parseUnmergedPaths(porcelain string) []unmergedPath {
 // over `git reset` / `checkout --theirs` because they're reversible — they
 // only undo the operation in flight, never user-authored commits.
 //
-// If no in-progress operation can be identified (rare — usually means the
-// conflict was staged manually via `git update-index --cacheinfo`), the
-// situation is surfaced for human attention rather than guessed at.
+// Without an in-progress operation, only agreeing autostash metadata is
+// repaired automatically. Other conflicts are surfaced for manual resolution.
 func fixLedgerUnmergedPaths(ledgerPath string, unmerged []unmergedPath) checkResult {
 	const name = "Ledger unmerged paths"
 
 	op, hint := detectInProgressGitOp(ledgerPath)
 	if op == "" {
-		// No state markers — likely a manually-staged conflict, OR
-		// detectInProgressGitOp could not inspect .git (permission/IO).
-		// DO NOT auto-resolve; the right action depends on user intent.
+		// Autostash conflicts have no in-progress operation to abort. Repair
+		// agreeing metadata under the same lock as daemon pulls; never choose
+		// a side when the data differs or the worktree has further edits.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		var resolved bool
+		resolveErr := gitutil.WithRepoLock(ctx, ledgerPath, func() error {
+			var err error
+			resolved, err = gitutil.ResolveAutostashConflicts(ctx, ledgerPath, ledger.AutoResolvePrefixes, nil)
+			return err
+		})
+		if resolveErr == nil {
+			if resolved {
+				return PassedCheck("Ledger unmerged paths", "resolved agreeing session metadata from autostash")
+			}
+			return PassedCheck("Ledger unmerged paths", "conflicts already resolved")
+		}
 		sample := unmerged[0].Path
 		if len(unmerged) > 1 {
 			sample = fmt.Sprintf("%s (+%d more)", sample, len(unmerged)-1)
@@ -727,9 +740,10 @@ func fixLedgerUnmergedPaths(ledgerPath string, unmerged []unmergedPath) checkRes
 		if hint != "" {
 			prefix = fmt.Sprintf("could not inspect .git for in-progress operation (%s).\n       ", hint)
 		}
+		prefix += fmt.Sprintf("Automatic recovery could not resolve the conflict: %s.\n       ", resolveErr)
 		detail := prefix + fmt.Sprintf(
 			"%d unmerged file(s) but no merge/rebase/cherry-pick in progress (%s).\n       "+
-				"This usually means the conflict was staged manually. Resolve by hand:\n       "+
+				"This can happen when restoring an autostash or after manual edits. Resolve by hand:\n       "+
 				"  cd %s\n       "+
 				"  git status                       # inspect the conflict\n       "+
 				"  git checkout --ours <file>       # or --theirs, depending on intent\n       "+

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -476,6 +476,16 @@ func fixLedgerBranchBehind(ledgerPath string, behindCount int) checkResult {
 		// --autostash: uncommitted local changes must not block the pull.
 		// Bounded so a hung network pull can't hold the lock forever.
 		pullCtx, pullCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		if !hadRebaseBefore {
+			// Existing autostash conflicts need a lossless metadata repair,
+			// not the positional resolution used for an active rebase.
+			if _, err := gitutil.ResolveAutostashConflicts(pullCtx, ledgerPath, ledger.AutoResolvePrefixes, nil); err != nil {
+				pullCancel()
+				result = FailedCheck("Ledger branch status", "autostash recovery failed",
+					fmt.Sprintf("Local changes remain unresolved before pull: %s", err))
+				return nil
+			}
+		}
 		pullCmd := gitutil.NewNetworkCmd(pullCtx, "-C", ledgerPath, "pull", "--rebase", "--autostash")
 		output, err := pullCmd.CombinedOutput()
 		pullCancel()
@@ -510,10 +520,19 @@ func fixLedgerBranchBehind(ledgerPath string, behindCount int) checkResult {
 			}
 			result = PassedCheck("Ledger branch status",
 				fmt.Sprintf("pulled %d commit(s) (auto-resolved conflicts)", behindCount))
-			return nil
+		} else {
+			result = PassedCheck("Ledger branch status",
+				fmt.Sprintf("pulled %d commit(s)", behindCount))
 		}
-		result = PassedCheck("Ledger branch status",
-			fmt.Sprintf("pulled %d commit(s)", behindCount))
+		// Git can finish the pull or rebase successfully while restoring the
+		// autostash leaves an unmerged index. Verify both success paths.
+		recoveryCtx, recoveryCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer recoveryCancel()
+		if _, err := gitutil.ResolveAutostashConflicts(recoveryCtx, ledgerPath, ledger.AutoResolvePrefixes, nil); err != nil {
+			result = FailedCheck("Ledger branch status",
+				"autostash recovery failed",
+				fmt.Sprintf("Pull completed, but local changes remain unresolved: %s", err))
+		}
 		return nil
 	})
 	if lockErr != nil {

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -725,9 +725,15 @@ func fixLedgerUnmergedPaths(ledgerPath string, unmerged []unmergedPath) checkRes
 		})
 		if resolveErr == nil {
 			if resolved {
-				return PassedCheck("Ledger unmerged paths", "resolved agreeing session metadata from autostash")
+				return PassedCheck(name, "resolved agreeing session metadata from autostash")
 			}
-			return PassedCheck("Ledger unmerged paths", "conflicts already resolved")
+			return PassedCheck(name, "conflicts already resolved")
+		}
+		if gitutil.IsRepoLockBusy(resolveErr) {
+			r := WarningCheck(name, "ledger busy, recovery deferred",
+				"Another ox operation is using the ledger; retry `ox doctor --fix` shortly.")
+			r.slug = CheckSlugLedgerUnmergedPaths
+			return r
 		}
 		sample := unmerged[0].Path
 		if len(unmerged) > 1 {

--- a/cmd/ox/doctor_ledger_git_test.go
+++ b/cmd/ox/doctor_ledger_git_test.go
@@ -549,6 +549,8 @@ func TestFixLedgerBranchBehind_ForeignRebase_NeverTouched(t *testing.T) {
 	assert.NoError(t, err, "the foreign rebase-merge directory must survive untouched — proves neither resolve nor AuditAndAbort ran")
 }
 
+// TestFixLedgerBranchBehind_AutostashConflicts prevents doctor from reporting a
+// completed pull or discarding fields when an autostash leaves metadata conflicts.
 func TestFixLedgerBranchBehind_AutostashConflicts(t *testing.T) {
 	for _, tc := range []struct {
 		name             string

--- a/cmd/ox/doctor_ledger_git_test.go
+++ b/cmd/ox/doctor_ledger_git_test.go
@@ -548,3 +548,105 @@ func TestFixLedgerBranchBehind_ForeignRebase_NeverTouched(t *testing.T) {
 	_, err := os.Stat(filepath.Join(machineB, ".git", "rebase-merge"))
 	assert.NoError(t, err, "the foreign rebase-merge directory must survive untouched — proves neither resolve nor AuditAndAbort ran")
 }
+
+func TestFixLedgerBranchBehind_AutostashConflicts(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		localTitle       string
+		rebaseConflict   bool
+		existingConflict bool
+		wantPassed       bool
+	}{
+		{name: "agreeing metadata", localTitle: "Ready", wantPassed: true},
+		{name: "after resolving rebase", localTitle: "Ready", rebaseConflict: true, wantPassed: true},
+		{name: "differing metadata", localTitle: "Local"},
+		{name: "existing agreeing metadata", localTitle: "Ready", existingConflict: true, wantPassed: true},
+		{name: "existing differing metadata", localTitle: "Local", existingConflict: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bare, writer := createBareAndClone(t)
+			const rel = "sessions/test/meta.json"
+			require.NoError(t, os.MkdirAll(filepath.Join(writer, "sessions/test"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(writer, rel), []byte(`{"title":"","keep":"yes"}`+"\n"), 0o644))
+			if tc.rebaseConflict {
+				require.NoError(t, os.MkdirAll(filepath.Join(writer, "data"), 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(writer, "data/shared.txt"), []byte("base"), 0o644))
+				runGit(t, writer, "add", "data/shared.txt")
+			}
+			runGit(t, writer, "add", "--sparse", rel)
+			runGit(t, writer, "commit", "--no-verify", "-m", "seed metadata")
+			runGit(t, writer, "push")
+			repo := cloneBare(t, bare)
+			if tc.rebaseConflict {
+				require.NoError(t, os.WriteFile(filepath.Join(writer, "data/shared.txt"), []byte("remote"), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(repo, "data/shared.txt"), []byte("local"), 0o644))
+				runGit(t, repo, "commit", "--no-verify", "-am", "local data change")
+			}
+			const remoteMeta = `{"title":"Ready","keep":"yes","remote_only":true}`
+			require.NoError(t, os.WriteFile(filepath.Join(writer, rel), []byte(remoteMeta+"\n"), 0o644))
+			runGit(t, writer, "commit", "--no-verify", "-am", "remote title")
+			runGit(t, writer, "push")
+			localMeta := `{"keep":"yes","title":"` + tc.localTitle + `","summary_attempts":0,"local_only":true}` + "\n"
+			mergedMeta := `{"keep":"yes","title":"` + tc.localTitle + `","summary_attempts":0,"local_only":true,"remote_only":true}`
+			require.NoError(t, os.WriteFile(filepath.Join(repo, rel), []byte(localMeta), 0o644))
+			var conflictsBefore, headBefore, stashBefore string
+			var worktreeBefore, indexBefore []byte
+			if tc.existingConflict {
+				// A prior successful pull left an autostash conflict. New
+				// upstream work must not route it through the rebase resolver.
+				runGit(t, repo, "pull", "--rebase", "--autostash")
+				conflictsBefore = runGit(t, repo, "ls-files", "--unmerged")
+				require.NotEmpty(t, conflictsBefore)
+				require.False(t, gitutil.IsRebaseInProgress(repo))
+				var err error
+				worktreeBefore, err = os.ReadFile(filepath.Join(repo, rel))
+				require.NoError(t, err)
+				indexBefore, err = os.ReadFile(filepath.Join(repo, ".git/index"))
+				require.NoError(t, err)
+				headBefore = runGit(t, repo, "rev-parse", "HEAD")
+				stashBefore = runGit(t, repo, "stash", "list")
+				require.NoError(t, os.WriteFile(filepath.Join(writer, "remote.txt"), []byte("next remote change"), 0o644))
+				runGit(t, writer, "add", "remote.txt")
+				runGit(t, writer, "commit", "--no-verify", "-m", "advance remote")
+				runGit(t, writer, "push")
+			}
+			remoteBefore := runGit(t, writer, "rev-parse", "HEAD")
+			result := fixLedgerBranchBehind(repo, 1)
+			assert.Equal(t, tc.wantPassed, result.passed, result.detail)
+			assert.False(t, gitutil.IsRebaseInProgress(repo))
+			if tc.rebaseConflict {
+				assert.Equal(t, "1", runGit(t, repo, "rev-list", "--count", "@{upstream}..HEAD"), "only the existing local commit may be rebased")
+			} else {
+				wantHead := remoteBefore
+				if tc.existingConflict && !tc.wantPassed {
+					wantHead = headBefore
+				}
+				assert.Equal(t, wantHead, runGit(t, repo, "rev-parse", "HEAD"), "recovery must not create a commit or pull past a disagreement")
+			}
+			assert.JSONEq(t, remoteMeta, runGit(t, repo, "show", "HEAD:"+rel), "dirty metadata must stay uncommitted")
+			assert.Equal(t, remoteBefore, runGit(t, bare, "rev-parse", "HEAD"), "doctor pull must not push")
+			assert.NotEmpty(t, runGit(t, repo, "stash", "list"), "retain the original dirty metadata")
+			assert.JSONEq(t, localMeta, runGit(t, repo, "show", "stash@{0}:"+rel))
+			conflicts := runGit(t, repo, "ls-files", "--unmerged")
+			if tc.wantPassed {
+				assert.Empty(t, conflicts)
+				data, err := os.ReadFile(filepath.Join(repo, rel))
+				require.NoError(t, err)
+				assert.JSONEq(t, mergedMeta, string(data))
+			} else {
+				assert.NotEmpty(t, conflicts)
+				assert.Contains(t, result.detail, "title differs")
+				if tc.existingConflict {
+					assert.Equal(t, conflictsBefore, conflicts, "preserve all conflict stages")
+					data, err := os.ReadFile(filepath.Join(repo, rel))
+					require.NoError(t, err)
+					assert.Equal(t, worktreeBefore, data, "leave disagreements untouched")
+					index, err := os.ReadFile(filepath.Join(repo, ".git/index"))
+					require.NoError(t, err)
+					assert.Equal(t, indexBefore, index, "leave the index untouched")
+					assert.Equal(t, stashBefore, runGit(t, repo, "stash", "list"))
+				}
+			}
+		})
+	}
+}

--- a/cmd/ox/doctor_ledger_git_unmerged_test.go
+++ b/cmd/ox/doctor_ledger_git_unmerged_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -333,6 +335,20 @@ func TestFixLedgerUnmergedPaths_RepairsAgreeingAutostash(t *testing.T) {
 	require.Empty(t, op)
 	status, err := runIsolatedGit(t, repo, "status", "--porcelain=v1")
 	require.NoError(t, err)
+	// A concurrent sync must yield retry guidance without touching the conflict;
+	// releasing its lock must let the same doctor recovery succeed below.
+	require.NoError(t, gitutil.WithRepoLock(context.Background(), repo, func() error {
+		result := fixLedgerUnmergedPaths(repo, parseUnmergedPaths(status))
+		assert.True(t, result.warning, "%+v", result)
+		assert.Contains(t, result.message, "busy")
+		assert.Contains(t, result.detail, "retry")
+		assert.NotContains(t, result.detail, "checkout --ours")
+		assert.Equal(t, CheckSlugLedgerUnmergedPaths, result.slug)
+		return nil
+	}))
+	unchanged, err := runIsolatedGit(t, repo, "status", "--porcelain=v1")
+	require.NoError(t, err)
+	assert.Equal(t, status, unchanged)
 	result := fixLedgerUnmergedPaths(repo, parseUnmergedPaths(status))
 	require.True(t, result.passed, "%+v", result)
 	data, err := os.ReadFile(path)

--- a/cmd/ox/doctor_ledger_git_unmerged_test.go
+++ b/cmd/ox/doctor_ledger_git_unmerged_test.go
@@ -311,6 +311,38 @@ func TestFixLedgerUnmergedPaths_ClearsMergeHead(t *testing.T) {
 	assert.Empty(t, postUnmerged, "no UU files may survive the abort; got: %q", postStatus)
 }
 
+// Doctor must repair the autostash state its own diagnostic tells users to fix.
+func TestFixLedgerUnmergedPaths_RepairsAgreeingAutostash(t *testing.T) {
+	skipIntegration(t)
+	repo := t.TempDir()
+	const rel = "sessions/test/meta.json"
+	path := filepath.Join(repo, rel)
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"title":""}`+"\n"), 0o644))
+	mustRunGit(t, repo, "add", "--sparse", rel)
+	mustRunGit(t, repo, "commit", "-m", "base")
+	const local = `{"summary_attempts":0,"title":"Recovered"}`
+	require.NoError(t, os.WriteFile(path, []byte(local+"\n"), 0o644))
+	mustRunGit(t, repo, "stash", "push", "-m", "autostash")
+	require.NoError(t, os.WriteFile(path, []byte(`{"title":"Recovered"}`+"\n"), 0o644))
+	mustRunGit(t, repo, "commit", "-am", "remote repair")
+	out, err := runIsolatedGit(t, repo, "stash", "apply")
+	require.Error(t, err, out)
+	op, _ := detectInProgressGitOp(repo)
+	require.Empty(t, op)
+	status, err := runIsolatedGit(t, repo, "status", "--porcelain=v1")
+	require.NoError(t, err)
+	result := fixLedgerUnmergedPaths(repo, parseUnmergedPaths(status))
+	require.True(t, result.passed, "%+v", result)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.JSONEq(t, local, string(data))
+	out, err = runIsolatedGit(t, repo, "ls-files", "--unmerged")
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
 // TestFixLedgerUnmergedPaths_NoStateMarkers_NoAutoResolve covers the rare
 // case where unmerged paths exist with no MERGE_HEAD / rebase / cherry-pick
 // in progress. This happens when conflicts are staged manually via

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -137,7 +137,7 @@ type ManagedRepoPullResult struct {
 	// Diverged is true if branches were diverged before the pull.
 	Diverged bool
 
-	// AutoResolved is true if rebase conflicts were auto-resolved.
+	// AutoResolved is true if rebase or autostash conflicts were auto-resolved.
 	AutoResolved bool
 
 	// FetchHeadTime is the FETCH_HEAD mtime after fetch (zero if not fetched).
@@ -230,26 +230,6 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 		}
 	}
 
-	// --- Dedup checks ---
-
-	// ls-remote SHA check: cheapest way to skip when nothing changed
-	if s.remoteRefCheck(ctx, path) {
-		return ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRemoteUnchanged}
-	}
-
-	// FETCH_HEAD mtime dedup (secondary: cross-daemon coordination)
-	if age, ok := gitutil.FetchHeadAge(path); ok {
-		minAge := opts.MinFetchAge
-		if minAge == 0 {
-			minAge = gitutil.MinFetchHeadAge
-		}
-		threshold := max(opts.SyncInterval/2, minAge)
-		if age < threshold {
-			logger.Debug("repo recently fetched, skipping", "path", path, "age", age)
-			return ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRecentlyFetched}
-		}
-	}
-
 	// --- Fetch + pull, serialized per clone ---
 	//
 	// ADR-030 D1: every mutating git operation on a managed clone runs
@@ -260,8 +240,42 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 	// produced "Cannot rebase onto multiple branches" in the 2026-09-02
 	// incident (COE: docs/coes/2026-09-02-daemon-git-sync-race-and-lfs-divergence.md).
 	var result ManagedRepoPullResult
+	var conflictErr error
 	lockErr := gitutil.WithRepoLock(ctx, path, func() error {
+		autoPaths := manifest.AutoResolvePaths(opts.ResolveRules)
+		denyPaths := manifest.AutoResolveDenyPaths(opts.ResolveRules)
+		// Check before dedup: a previous successful pull can leave autostash
+		// conflicts even when the remote and FETCH_HEAD have not changed.
+		recovered, err := gitutil.ResolveAutostashConflicts(ctx, path, autoPaths, denyPaths)
+		if err != nil {
+			conflictErr = err
+			return nil
+		}
+		if !recovered {
+			if s.remoteRefCheck(ctx, path) {
+				result = ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRemoteUnchanged}
+				return nil
+			}
+			if age, ok := gitutil.FetchHeadAge(path); ok {
+				minAge := opts.MinFetchAge
+				if minAge == 0 {
+					minAge = gitutil.MinFetchHeadAge
+				}
+				if age < max(opts.SyncInterval/2, minAge) {
+					logger.Debug("repo recently fetched, skipping", "path", path, "age", age)
+					result = ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRecentlyFetched}
+					return nil
+				}
+			}
+		}
 		result = s.fetchAndPullLocked(ctx, opts, path, repoName, logger)
+		result.AutoResolved = result.AutoResolved || recovered
+		// Git can return zero after a successful rebase whose autostash failed
+		// to apply. Check the index even after success, including auto-resolution.
+		if !gitutil.IsRebaseInProgress(path) {
+			recovered, conflictErr = gitutil.ResolveAutostashConflicts(ctx, path, autoPaths, denyPaths)
+			result.AutoResolved = result.AutoResolved || recovered
+		}
 		return nil
 	})
 	if lockErr != nil {
@@ -270,6 +284,16 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 			return ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRepoLockBusy}
 		}
 		return ManagedRepoPullResult{Err: fmt.Errorf("acquire repo lock for %s: %w", repoName, lockErr)}
+	}
+	if conflictErr != nil {
+		result.Err = conflictErr
+		result.Issue = &DaemonIssue{
+			Type:            IssueTypeMergeConflict,
+			Severity:        SeverityError,
+			Repo:            repoName,
+			Summary:         fmt.Sprintf("%s has unresolved conflicts: %s", repoName, conflictErr),
+			RequiresConfirm: true,
+		}
 	}
 	return result
 }

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -286,13 +287,17 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 		return ManagedRepoPullResult{Err: fmt.Errorf("acquire repo lock for %s: %w", repoName, lockErr)}
 	}
 	if conflictErr != nil {
-		result.Err = conflictErr
-		result.Issue = &DaemonIssue{
-			Type:            IssueTypeMergeConflict,
-			Severity:        SeverityError,
-			Repo:            repoName,
-			Summary:         fmt.Sprintf("%s has unresolved conflicts: %s", repoName, conflictErr),
-			RequiresConfirm: true,
+		result.Err = errors.Join(result.Err, conflictErr)
+		// Preserve an earlier pull classification, including session-wedge
+		// escalation, when autostash recovery reports an additional failure.
+		if result.Issue == nil {
+			result.Issue = &DaemonIssue{
+				Type:            IssueTypeMergeConflict,
+				Severity:        SeverityError,
+				Repo:            repoName,
+				Summary:         fmt.Sprintf("%s has unresolved conflicts: %s", repoName, conflictErr),
+				RequiresConfirm: true,
+			}
 		}
 	}
 	return result

--- a/internal/daemon/sync_managed_test.go
+++ b/internal/daemon/sync_managed_test.go
@@ -440,7 +440,10 @@ func TestPullManagedRepo_AutostashConflicts(t *testing.T) {
 			if tc.preexisting {
 				out, err := runGitOut(t, local, "pull", "--rebase", "--autostash", "--quiet")
 				require.NoError(t, err, out)
-				require.Contains(t, out, "Applying autostash resulted in conflicts")
+				require.False(t, gitutil.IsRebaseInProgress(local))
+				unmerged, err := runGitOut(t, local, "ls-files", "--unmerged")
+				require.NoError(t, err)
+				require.NotEmpty(t, unmerged, "successful pull must leave an autostash conflict")
 			}
 			s := newTestScheduler(t.TempDir())
 			opts := ManagedRepoPullOpts{RepoPath: local, RepoName: "ledger", ResolveRules: ledger.DefaultResolveRules, Logger: discardLogger()}

--- a/internal/daemon/sync_managed_test.go
+++ b/internal/daemon/sync_managed_test.go
@@ -118,6 +118,43 @@ func TestPullManagedRepo_SessionMetaConflict_ClassifiesAsSessionConflictWedge(t 
 		"AuditAndAbort should have cleared the rebase-merge dir")
 }
 
+// A canceled resolver still aborts the rebase using a fresh context. The
+// subsequent autostash inspection then fails on cancellation; it must not
+// replace the pull failure or the divergence issue already reported.
+func TestPullManagedRepo_AutostashInspectionPreservesPullFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	localDir := makeSessionMetaConflictClone(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resolverCalled := false
+	s := newTestScheduler(t.TempDir())
+	result := s.pullManagedRepo(ctx, ManagedRepoPullOpts{
+		RepoPath:         localDir,
+		RepoName:         "ledger",
+		DetectDivergence: true,
+		ResolveRules:     []manifest.ResolveRule{{Mode: manifest.ResolveModeAuto, Path: "data/"}},
+		Logger:           discardLogger(),
+		LLMResolver: func(ctx context.Context, _ string, _ []string) (bool, error) {
+			resolverCalled = true
+			cancel()
+			return false, ctx.Err()
+		},
+	})
+
+	require.True(t, resolverCalled, "the real pull must reach conflict resolution before cancellation")
+	assert.False(t, gitutil.IsRebaseInProgress(localDir), "abort must finish despite the canceled pull context")
+	require.NotNil(t, result.Issue)
+	assert.Equal(t, IssueTypeDiverged, result.Issue.Type)
+	require.Error(t, result.Err)
+	assert.ErrorContains(t, result.Err, "pull failed")
+	assert.ErrorContains(t, result.Err, "inspect unmerged index")
+	assert.ErrorIs(t, result.Err, context.Canceled)
+	var pullExit *exec.ExitError
+	assert.ErrorAs(t, result.Err, &pullExit, "the original git pull error must remain in the error chain")
+}
+
 // --- B. Severity escalation by elapsed time ---
 //
 // escalateSessionConflictSeverity must escalate purely as a function of how

--- a/internal/daemon/sync_managed_test.go
+++ b/internal/daemon/sync_managed_test.go
@@ -363,3 +363,84 @@ func TestSessionMetaConflict_AutoResolvesUnderProductionRules(t *testing.T) {
 	require.False(t, gitutil.IsRebaseInProgress(localDir),
 		"no rebase may be left in progress after a successful reconcile")
 }
+
+// A successful pull can leave autostash conflicts without a rebase in progress.
+// Both the first pull and later cycles must recover agreeing metadata, while
+// preserving genuinely different values for manual resolution.
+func TestPullManagedRepo_AutostashConflicts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git pull and autostash")
+	}
+	for _, tc := range []struct {
+		name        string
+		preexisting bool
+		localTitle  string
+		wantError   bool
+	}{
+		{"new agreeing conflict", false, "Recovered", false},
+		{"existing agreeing conflict", true, "Recovered", false},
+		{"new differing conflict", false, "Local title", true},
+		{"existing differing conflict", true, "Local title", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateCredentials(t)
+			bare, writer := initBareRepo(t, "autostash")
+			const rel = "sessions/test/meta.json"
+			require.NoError(t, os.MkdirAll(filepath.Join(writer, "sessions/test"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(writer, rel), []byte(`{"session_id":"s","title":""}`+"\n"), 0o644))
+			gitInDir(t, writer, "add", "--sparse", rel)
+			gitInDir(t, writer, "commit", "-m", "seed")
+			gitInDir(t, writer, "push", "origin", "main")
+			local := filepath.Join(t.TempDir(), "local")
+			gitInDir(t, writer, "clone", bare, local)
+			gitConfig(t, local)
+			require.NoError(t, os.WriteFile(filepath.Join(writer, rel), []byte(`{"session_id":"s","title":"Recovered"}`+"\n"), 0o644))
+			gitInDir(t, writer, "commit", "-am", "remote title repair")
+			gitInDir(t, writer, "push", "origin", "main")
+			localMeta := `{"title":"` + tc.localTitle + `","session_id":"s","summary_attempts":0,"validation_error":""}` + "\n"
+			require.NoError(t, os.WriteFile(filepath.Join(local, rel), []byte(localMeta), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(local, "unrelated.txt"), []byte("keep me"), 0o644))
+			if tc.preexisting {
+				out, err := runGitOut(t, local, "pull", "--rebase", "--autostash", "--quiet")
+				require.NoError(t, err, out)
+				require.Contains(t, out, "Applying autostash resulted in conflicts")
+			}
+			s := newTestScheduler(t.TempDir())
+			opts := ManagedRepoPullOpts{RepoPath: local, RepoName: "ledger", ResolveRules: ledger.DefaultResolveRules, Logger: discardLogger()}
+			result := s.pullManagedRepo(context.Background(), opts)
+			assert.False(t, gitutil.IsRebaseInProgress(local))
+			conflicts, err := runGitOut(t, local, "ls-files", "--unmerged")
+			require.NoError(t, err)
+			if tc.wantError {
+				require.Error(t, result.Err)
+				require.NotNil(t, result.Issue)
+				assert.Equal(t, IssueTypeMergeConflict, result.Issue.Type)
+				assert.NotEmpty(t, conflicts)
+			} else {
+				require.NoError(t, result.Err)
+				require.Nil(t, result.Issue)
+				assert.True(t, result.AutoResolved)
+				assert.Empty(t, conflicts)
+				meta, err := os.ReadFile(filepath.Join(local, rel))
+				require.NoError(t, err)
+				assert.JSONEq(t, localMeta, string(meta))
+				// Recovery must allow a later remote update to arrive too.
+				require.NoError(t, os.WriteFile(filepath.Join(writer, "next.txt"), []byte("next pull"), 0o644))
+				gitInDir(t, writer, "add", "next.txt")
+				gitInDir(t, writer, "commit", "-m", "next remote update")
+				gitInDir(t, writer, "push", "origin", "main")
+				old := time.Now().Add(-time.Hour)
+				require.NoError(t, os.Chtimes(filepath.Join(local, ".git/FETCH_HEAD"), old, old))
+				result = newTestScheduler(t.TempDir()).pullManagedRepo(context.Background(), opts)
+				require.NoError(t, result.Err)
+				assert.FileExists(t, filepath.Join(local, "next.txt"))
+			}
+			stash, err := runGitOut(t, local, "stash", "list")
+			require.NoError(t, err)
+			assert.Contains(t, stash, "autostash", "retain the original local changes")
+			unrelated, err := os.ReadFile(filepath.Join(local, "unrelated.txt"))
+			require.NoError(t, err)
+			assert.Equal(t, "keep me", string(unrelated))
+		})
+	}
+}

--- a/internal/gitutil/conflict.go
+++ b/internal/gitutil/conflict.go
@@ -1,9 +1,18 @@
 package gitutil
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
 	"strings"
+
+	"github.com/sageox/ox/internal/fileutil"
 )
 
 // ConflictMarkerStart is git's textual conflict marker. We look for it as a
@@ -41,4 +50,120 @@ func HasConflictMarkersBytes(data []byte) bool {
 		}
 	}
 	return false
+}
+
+// ResolveAutostashConflicts clears formatting-only session metadata conflicts
+// left by pull --autostash, which can exit successfully with an unmerged index.
+// It preserves every field from both sides and refuses differing values,
+// deletions, other paths, active git operations, or edits made after the conflict.
+// The caller must hold WithRepoLock. No commits are made or stashes removed.
+func ResolveAutostashConflicts(ctx context.Context, repoPath string, safePrefixes, denyPrefixes []string) (bool, error) {
+	entries, err := listUnmergedEntries(ctx, repoPath)
+	if err != nil {
+		return false, fmt.Errorf("inspect unmerged index: %w", err)
+	}
+	if len(entries) == 0 {
+		return false, nil
+	}
+	for _, marker := range []string{"rebase-merge", "rebase-apply", "MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD"} {
+		if _, err := os.Stat(filepath.Join(repoPath, ".git", marker)); !errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Errorf("cannot recover autostash while %s is present or unreadable", marker)
+		}
+	}
+	tmp, err := os.MkdirTemp("", "ox-autostash-")
+	if err != nil {
+		return false, err
+	}
+	defer os.RemoveAll(tmp)
+	type repair struct {
+		path     string
+		original []byte
+		merged   []byte
+		mode     os.FileMode
+	}
+	var repairs []repair
+	for path, stages := range groupByPath(entries) {
+		parts := strings.Split(path, "/")
+		if len(parts) != 3 || parts[0] != "sessions" || parts[2] != "meta.json" ||
+			!matchesSafePrefix(path, safePrefixes, denyPrefixes) || !stages[1] || !stages[2] || !stages[3] {
+			return false, fmt.Errorf("unresolved conflict in %s requires manual resolution", path)
+		}
+		var fields [4]map[string]any
+		var files [4]string
+		for stage := 1; stage <= 3; stage++ {
+			// Read raw blobs: RunGit sanitizes output and must not rewrite metadata.
+			data, err := exec.CommandContext(ctx, "git", "-C", repoPath, "show", fmt.Sprintf(":%d:%s", stage, path)).Output()
+			if err != nil {
+				return false, fmt.Errorf("read conflict stage for %s: %w", path, err)
+			}
+			decoder := json.NewDecoder(bytes.NewReader(data))
+			decoder.UseNumber() // preserve large IDs and sizes exactly
+			if !json.Valid(data) || decoder.Decode(&fields[stage]) != nil || fields[stage] == nil {
+				return false, fmt.Errorf("invalid JSON in conflict for %s", path)
+			}
+			files[stage] = filepath.Join(tmp, fmt.Sprint(stage))
+			if err := os.WriteFile(files[stage], data, 0o600); err != nil {
+				return false, err
+			}
+		}
+		for key := range fields[1] {
+			_, ours := fields[2][key]
+			_, theirs := fields[3][key]
+			if !ours || !theirs {
+				return false, fmt.Errorf("field %s was deleted in %s; manual resolution required", key, path)
+			}
+		}
+		for key, value := range fields[3] {
+			if ours, exists := fields[2][key]; exists && !reflect.DeepEqual(ours, value) {
+				return false, fmt.Errorf("field %s differs in %s; manual resolution required", key, path)
+			}
+			fields[2][key] = value
+		}
+		fullPath := filepath.Join(repoPath, path)
+		info, err := os.Lstat(fullPath)
+		if err != nil || !info.Mode().IsRegular() {
+			return false, fmt.Errorf("conflicted metadata is missing or not a regular file: %s", path)
+		}
+		original, err := os.ReadFile(fullPath)
+		if err != nil {
+			return false, err
+		}
+		merged, err := json.MarshalIndent(fields[2], "", "  ")
+		if err != nil {
+			return false, err
+		}
+		merged = append(merged, '\n')
+		// Reproduce git's stash conflict before replacing it. Otherwise a human's
+		// edits outside the markers could be lost by rebuilding from index stages.
+		cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "merge-file", "-p",
+			"-L", "Updated upstream", "-L", "Stash base", "-L", "Stashed changes", files[2], files[1], files[3])
+		expected, mergeErr := cmd.Output()
+		var exitErr *exec.ExitError
+		// An earlier pass may have written the repair but failed to stage it.
+		if !bytes.Equal(original, merged) && (!errors.As(mergeErr, &exitErr) || exitErr.ExitCode() < 1 || exitErr.ExitCode() > 127 || !bytes.Equal(original, expected)) {
+			return false, fmt.Errorf("conflict in %s has additional edits or is not an autostash conflict; manual resolution required", path)
+		}
+		repairs = append(repairs, repair{path, original, merged, info.Mode().Perm()})
+	}
+	// Validate the whole conflict set before touching the index or worktree.
+	for _, r := range repairs {
+		fullPath := filepath.Join(repoPath, r.path)
+		if err := fileutil.WithFileLock(ctx, fullPath, func() error {
+			current, err := os.ReadFile(fullPath)
+			if err != nil {
+				return err
+			}
+			if !bytes.Equal(current, r.original) {
+				return fmt.Errorf("conflicted metadata changed during recovery: %s", r.path)
+			}
+			if err := fileutil.AtomicWriteBytes(fullPath, r.merged, r.mode); err != nil {
+				return err
+			}
+			_, err = RunGit(ctx, repoPath, "add", "--sparse", "--", r.path)
+			return err
+		}); err != nil {
+			return false, fmt.Errorf("resolve %s: %w", r.path, err)
+		}
+	}
+	return true, nil
 }

--- a/internal/gitutil/conflict_test.go
+++ b/internal/gitutil/conflict_test.go
@@ -1,7 +1,9 @@
 package gitutil
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -65,4 +67,148 @@ func TestHasConflictMarkers_MissingFile(t *testing.T) {
 	t.Parallel()
 	_, err := HasConflictMarkers(filepath.Join(t.TempDir(), "does-not-exist.json"))
 	assert.Error(t, err)
+}
+
+// Recovery must not lose metadata, round numeric IDs, or overwrite edits made
+// after git produced the conflict. Refused repairs leave both index and file intact.
+func TestAutostashRecoveryPreservesData(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git stash conflicts")
+	}
+	const base = `{"title":"","keep":"yes"}`
+	const upstream = `{"title":"Ready","keep":"yes","id":9007199254740993,"nested":{"a":1,"b":2},"cloud_only":true}`
+	const local = `{"nested":{"b":2,"a":1},"id":9007199254740993,"keep":"yes","title":"Ready","local_only":true}`
+	const merged = `{"title":"Ready","keep":"yes","id":9007199254740993,"nested":{"a":1,"b":2},"cloud_only":true,"local_only":true}`
+	for _, tc := range []struct {
+		name           string
+		local          string
+		path           string
+		deny           []string
+		edit           bool
+		style          string
+		extraConflict  bool
+		marker         string
+		stagingFailure bool
+		wantError      bool
+	}{
+		{name: "retain all fields and large IDs", local: local},
+		{name: "diff3 conflict style", local: local, style: "diff3"},
+		{name: "different large IDs", local: `{"title":"Ready","keep":"yes","id":9007199254740992}`, wantError: true},
+		{name: "deleted field", local: `{"title":"Ready"}`, wantError: true},
+		{name: "invalid JSON", local: `{"title":`, wantError: true},
+		{name: "manual edits", local: local, edit: true, wantError: true},
+		{name: "denied path", local: local, deny: []string{"sessions/test/"}, wantError: true},
+		{name: "other session artifact", local: local, path: "sessions/test/summary.json", wantError: true},
+		{name: "mixed eligible and unsupported conflicts", local: local, extraConflict: true, wantError: true},
+		{name: "merge in progress", local: local, marker: "MERGE_HEAD", wantError: true},
+		{name: "rebase merge in progress", local: local, marker: "rebase-merge", wantError: true},
+		{name: "rebase apply in progress", local: local, marker: "rebase-apply", wantError: true},
+		{name: "cherry-pick in progress", local: local, marker: "CHERRY_PICK_HEAD", wantError: true},
+		{name: "revert in progress", local: local, marker: "REVERT_HEAD", wantError: true},
+		{name: "resume after staging failure", local: local, stagingFailure: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			gitInRepo(t, repo, "init", "-b", "main")
+			if tc.style != "" {
+				gitInRepo(t, repo, "config", "merge.conflictStyle", tc.style)
+			}
+			rel := tc.path
+			if rel == "" {
+				rel = "sessions/test/meta.json"
+			}
+			path := filepath.Join(repo, rel)
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+			paths := []string{path}
+			if tc.extraConflict {
+				paths = append(paths, filepath.Join(repo, "unsupported.json"))
+			}
+			for _, file := range paths {
+				require.NoError(t, os.WriteFile(file, []byte(base+"\n"), 0o644))
+			}
+			gitInRepo(t, repo, "add", "--sparse", ".")
+			gitInRepo(t, repo, "commit", "-m", "base")
+			for _, file := range paths {
+				require.NoError(t, os.WriteFile(file, []byte(tc.local+"\n"), 0o644))
+			}
+			gitInRepo(t, repo, "stash", "push", "-m", "autostash")
+			for _, file := range paths {
+				require.NoError(t, os.WriteFile(file, []byte(upstream+"\n"), 0o644))
+			}
+			gitInRepo(t, repo, "commit", "-am", "upstream")
+			cmd := exec.Command("git", "stash", "apply")
+			cmd.Dir = repo
+			out, err := cmd.CombinedOutput()
+			require.Error(t, err, "fixture must conflict: %s", out)
+			if tc.edit {
+				data, err := os.ReadFile(path)
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, append(data, []byte("manual addition\n")...), 0o644))
+			}
+			before := make(map[string][]byte)
+			for _, file := range paths {
+				before[file], err = os.ReadFile(file)
+				require.NoError(t, err)
+			}
+			index, err := os.ReadFile(filepath.Join(repo, ".git/index"))
+			require.NoError(t, err)
+			stash := gitInRepo(t, repo, "rev-parse", "refs/stash")
+			if tc.marker != "" {
+				markerPath := filepath.Join(repo, ".git", tc.marker)
+				if tc.marker == "rebase-merge" || tc.marker == "rebase-apply" {
+					require.NoError(t, os.Mkdir(markerPath, 0o755))
+				} else {
+					require.NoError(t, os.WriteFile(markerPath, []byte(gitInRepo(t, repo, "rev-parse", "HEAD")+"\n"), 0o644))
+				}
+			}
+			if tc.stagingFailure {
+				require.NoError(t, os.WriteFile(filepath.Join(repo, ".git/index.lock"), nil, 0o600))
+			}
+			var resolved bool
+			err = WithRepoLock(context.Background(), repo, func() error {
+				var err error
+				resolved, err = ResolveAutostashConflicts(context.Background(), repo, []string{"sessions/"}, tc.deny)
+				return err
+			})
+			if tc.stagingFailure {
+				require.Error(t, err)
+				assert.False(t, resolved)
+				after, readErr := os.ReadFile(path)
+				require.NoError(t, readErr)
+				assert.JSONEq(t, merged, string(after))
+				afterIndex, readErr := os.ReadFile(filepath.Join(repo, ".git/index"))
+				require.NoError(t, readErr)
+				assert.Equal(t, index, afterIndex)
+				assert.NotEmpty(t, gitInRepo(t, repo, "ls-files", "--unmerged"))
+				require.NoError(t, os.Remove(filepath.Join(repo, ".git/index.lock")))
+				err = WithRepoLock(context.Background(), repo, func() error {
+					var err error
+					resolved, err = ResolveAutostashConflicts(context.Background(), repo, []string{"sessions/"}, tc.deny)
+					return err
+				})
+			}
+			if tc.wantError {
+				require.Error(t, err)
+				assert.False(t, resolved)
+				for file, original := range before {
+					after, err := os.ReadFile(file)
+					require.NoError(t, err)
+					assert.Equal(t, original, after, file)
+				}
+				afterIndex, err := os.ReadFile(filepath.Join(repo, ".git/index"))
+				require.NoError(t, err)
+				assert.Equal(t, index, afterIndex)
+			} else {
+				require.NoError(t, err)
+				assert.True(t, resolved)
+				after, err := os.ReadFile(path)
+				require.NoError(t, err)
+				assert.Contains(t, string(after), "9007199254740993")
+				assert.JSONEq(t, merged, string(after))
+				assert.Empty(t, gitInRepo(t, repo, "ls-files", "--unmerged"))
+				assert.Equal(t, string(after), gitInRepo(t, repo, "show", ":"+rel)+"\n")
+			}
+			assert.Equal(t, stash, gitInRepo(t, repo, "rev-parse", "refs/stash"))
+		})
+	}
 }

--- a/internal/gitutil/conflict_test.go
+++ b/internal/gitutil/conflict_test.go
@@ -89,6 +89,8 @@ func TestAutostashRecoveryPreservesData(t *testing.T) {
 		extraConflict  bool
 		marker         string
 		stagingFailure bool
+		missingFile    bool
+		missingBlob    bool
 		wantError      bool
 	}{
 		{name: "retain all fields and large IDs", local: local},
@@ -106,6 +108,8 @@ func TestAutostashRecoveryPreservesData(t *testing.T) {
 		{name: "cherry-pick in progress", local: local, marker: "CHERRY_PICK_HEAD", wantError: true},
 		{name: "revert in progress", local: local, marker: "REVERT_HEAD", wantError: true},
 		{name: "resume after staging failure", local: local, stagingFailure: true},
+		{name: "missing conflicted file", local: local, missingFile: true, wantError: true},
+		{name: "missing conflict blob", local: local, missingBlob: true, wantError: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := t.TempDir()
@@ -164,6 +168,13 @@ func TestAutostashRecoveryPreservesData(t *testing.T) {
 			if tc.stagingFailure {
 				require.NoError(t, os.WriteFile(filepath.Join(repo, ".git/index.lock"), nil, 0o600))
 			}
+			if tc.missingFile {
+				require.NoError(t, os.Remove(path))
+			}
+			if tc.missingBlob {
+				oid := gitInRepo(t, repo, "rev-parse", ":1:"+rel)
+				require.NoError(t, os.Remove(filepath.Join(repo, ".git/objects", oid[:2], oid[2:])))
+			}
 			var resolved bool
 			err = WithRepoLock(context.Background(), repo, func() error {
 				var err error
@@ -190,7 +201,17 @@ func TestAutostashRecoveryPreservesData(t *testing.T) {
 			if tc.wantError {
 				require.Error(t, err)
 				assert.False(t, resolved)
+				if tc.missingFile {
+					assert.ErrorContains(t, err, "missing or not a regular file")
+				}
+				if tc.missingBlob {
+					assert.ErrorContains(t, err, "read conflict stage")
+				}
 				for file, original := range before {
+					if tc.missingFile && file == path {
+						assert.NoFileExists(t, file, "recovery must not recreate a removed file")
+						continue
+					}
 					after, err := os.ReadFile(file)
 					require.NoError(t, err)
 					assert.Equal(t, original, after, file)
@@ -209,6 +230,51 @@ func TestAutostashRecoveryPreservesData(t *testing.T) {
 				assert.Equal(t, string(after), gitInRepo(t, repo, "show", ":"+rel)+"\n")
 			}
 			assert.Equal(t, stash, gitInRepo(t, repo, "rev-parse", "refs/stash"))
+		})
+	}
+}
+
+// An unreadable index must report failure; an already-resolved index is a no-op.
+// Neither state may rewrite metadata or the index while trying to recover it.
+func TestAutostashRecoveryWithoutReadableConflicts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git index states")
+	}
+	for _, corrupt := range []bool{false, true} {
+		name := "clean index"
+		if corrupt {
+			name = "corrupt index"
+		}
+		t.Run(name, func(t *testing.T) {
+			repo := t.TempDir()
+			gitInRepo(t, repo, "init", "-b", "main")
+			path := filepath.Join(repo, "sessions/test/meta.json")
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+			original := []byte(`{"title":"Keep me"}` + "\n")
+			require.NoError(t, os.WriteFile(path, original, 0o644))
+			gitInRepo(t, repo, "add", "--sparse", ".")
+			indexPath := filepath.Join(repo, ".git/index")
+			if corrupt {
+				require.NoError(t, os.WriteFile(indexPath, []byte("invalid index"), 0o644))
+			}
+			index, err := os.ReadFile(indexPath)
+			require.NoError(t, err)
+			err = WithRepoLock(context.Background(), repo, func() error {
+				resolved, err := ResolveAutostashConflicts(context.Background(), repo, []string{"sessions/"}, nil)
+				assert.False(t, resolved)
+				return err
+			})
+			if corrupt {
+				require.ErrorContains(t, err, "inspect unmerged index")
+			} else {
+				require.NoError(t, err)
+			}
+			after, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, original, after)
+			afterIndex, err := os.ReadFile(indexPath)
+			require.NoError(t, err)
+			assert.Equal(t, index, afterIndex)
 		})
 	}
 }

--- a/internal/gitutil/push.go
+++ b/internal/gitutil/push.go
@@ -106,6 +106,8 @@ const lfsObjectsMissing = "LFS objects are missing"
 // Retry loop: up to MaxRetries attempts with linear backoff (1s, 2s, 3s...).
 // On non-fast-forward rejection: pulls with --rebase --autostash, optionally
 // auto-resolves conflicts for paths in AutoResolvePrefixes.
+// The retry pull acquires WithRepoLock; callers and conflict hooks must not
+// acquire that same non-reentrant lock around this call or inside the hook.
 func PushWithRetry(ctx context.Context, repoPath string, opts PushOpts) error {
 	log := opts.logger()
 
@@ -176,74 +178,95 @@ func PushWithRetry(ctx context.Context, repoPath string, opts PushOpts) error {
 			if attempt == maxRetries {
 				return fmt.Errorf("git push failed after %d attempts: %s", maxRetries, outStr)
 			}
-			if IsRebaseInProgress(repoPath) {
-				abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)
-				_, _ = RunGit(abortCtx, repoPath, "rebase", "--abort")
-				abortCancel()
-			}
-
-			pullCtx, pullCancel := context.WithTimeout(ctx, opTimeout)
-			pullOut, pullErr := RunGit(pullCtx, repoPath, "pull", "--rebase", "--autostash", "--quiet")
-			pullCancel()
-			if pullErr != nil {
-				if len(opts.AutoResolvePrefixes) > 0 {
-					resolveCtx, resolveCancel := context.WithTimeout(ctx, opTimeout)
-					resolveErr := ResolveRebaseAcceptTheirs(resolveCtx, repoPath, opts.AutoResolvePrefixes, opts.AutoResolveDenyPrefixes)
-					resolveCancel()
-					if resolveErr != nil {
-						log.Debug("rebase auto-resolve failed", "error", resolveErr)
-
-						// give the caller a chance to resolve via a higher tier
-						// (e.g. LLM merge) before we abort. The hook owns the
-						// rebase --continue if it succeeds.
-						hookResolved := false
-						if opts.OnUnresolvedConflicts != nil {
-							pathsCtx, pathsCancel := context.WithTimeout(ctx, opTimeout)
-							conflicted, listErr := listConflictedFiles(pathsCtx, repoPath)
-							pathsCancel()
-							// if we can't enumerate conflicts, the hook can't make
-							// an informed decision (it'd see an empty list and
-							// either falsely report "resolved" or operate on
-							// stale state). Skip the hook and abort the rebase
-							// rather than guess.
-							if listErr != nil {
-								log.Warn("listing conflicted files failed; skipping resolve hook", "error", listErr)
-								abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)
-								_, _ = RunGit(abortCtx, repoPath, "rebase", "--abort")
-								abortCancel()
-								return fmt.Errorf("git pull --rebase failed during retry: %s (could not list conflicts: %w)", pullOut, listErr)
-							}
-							hookCtx, hookCancel := context.WithTimeout(ctx, opTimeout)
-							resolved, hookErr := opts.OnUnresolvedConflicts(hookCtx, repoPath, conflicted)
-							hookCancel()
-							// only treat as resolved when the hook succeeded AND
-							// signaled resolved. a hook that returned an error
-							// MAY have left the rebase index half-staged; we
-							// must abort rather than continue retrying.
-							if hookErr != nil {
-								log.Warn("OnUnresolvedConflicts hook failed", "error", hookErr)
-							} else if resolved {
-								log.Info("resolved rebase conflicts via OnUnresolvedConflicts hook", "paths", conflicted)
-								hookResolved = true
-							}
-						}
-
-						if !hookResolved {
-							abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)
-							_, _ = RunGit(abortCtx, repoPath, "rebase", "--abort")
-							abortCancel()
-							return fmt.Errorf("git pull --rebase failed during retry: %s", pullOut)
-						}
-					} else {
-						log.Info("auto-resolved rebase conflicts", "strategy", "accept-theirs")
-					}
-				} else {
-					// no auto-resolve configured — abort and fail
+			// Keep the pull, rebase resolution, and autostash restoration under
+			// the same clone lock as daemon pulls and doctor repairs.
+			rebaseErr := WithRepoLock(ctx, repoPath, func() error {
+				if IsRebaseInProgress(repoPath) {
 					abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)
 					_, _ = RunGit(abortCtx, repoPath, "rebase", "--abort")
 					abortCancel()
-					return fmt.Errorf("git pull --rebase failed during retry: %s", pullOut)
 				}
+
+				pullCtx, pullCancel := context.WithTimeout(ctx, opTimeout)
+				// A prior pull may have left autostash conflicts without an
+				// active rebase. Never send those to the positional resolver.
+				if _, err := ResolveAutostashConflicts(pullCtx, repoPath, opts.AutoResolvePrefixes, opts.AutoResolveDenyPrefixes); err != nil {
+					pullCancel()
+					return fmt.Errorf("restore autostash before pull: %w", err)
+				}
+				pullOut, pullErr := RunGit(pullCtx, repoPath, "pull", "--rebase", "--autostash", "--quiet")
+				pullCancel()
+				if pullErr != nil {
+					if len(opts.AutoResolvePrefixes) > 0 {
+						resolveCtx, resolveCancel := context.WithTimeout(ctx, opTimeout)
+						resolveErr := ResolveRebaseAcceptTheirs(resolveCtx, repoPath, opts.AutoResolvePrefixes, opts.AutoResolveDenyPrefixes)
+						resolveCancel()
+						if resolveErr != nil {
+							log.Debug("rebase auto-resolve failed", "error", resolveErr)
+
+							// give the caller a chance to resolve via a higher tier
+							// (e.g. LLM merge) before we abort. The hook owns the
+							// rebase --continue if it succeeds.
+							hookResolved := false
+							if opts.OnUnresolvedConflicts != nil {
+								pathsCtx, pathsCancel := context.WithTimeout(ctx, opTimeout)
+								conflicted, listErr := listConflictedFiles(pathsCtx, repoPath)
+								pathsCancel()
+								// if we can't enumerate conflicts, the hook can't make
+								// an informed decision (it'd see an empty list and
+								// either falsely report "resolved" or operate on
+								// stale state). Skip the hook and abort the rebase
+								// rather than guess.
+								if listErr != nil {
+									log.Warn("listing conflicted files failed; skipping resolve hook", "error", listErr)
+									abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)
+									_, _ = RunGit(abortCtx, repoPath, "rebase", "--abort")
+									abortCancel()
+									return fmt.Errorf("git pull --rebase failed during retry: %s (could not list conflicts: %w)", pullOut, listErr)
+								}
+								hookCtx, hookCancel := context.WithTimeout(ctx, opTimeout)
+								resolved, hookErr := opts.OnUnresolvedConflicts(hookCtx, repoPath, conflicted)
+								hookCancel()
+								// only treat as resolved when the hook succeeded AND
+								// signaled resolved. a hook that returned an error
+								// MAY have left the rebase index half-staged; we
+								// must abort rather than continue retrying.
+								if hookErr != nil {
+									log.Warn("OnUnresolvedConflicts hook failed", "error", hookErr)
+								} else if resolved {
+									log.Info("resolved rebase conflicts via OnUnresolvedConflicts hook", "paths", conflicted)
+									hookResolved = true
+								}
+							}
+
+							if !hookResolved {
+								abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)
+								_, _ = RunGit(abortCtx, repoPath, "rebase", "--abort")
+								abortCancel()
+								return fmt.Errorf("git pull --rebase failed during retry: %s", pullOut)
+							}
+						} else {
+							log.Info("auto-resolved rebase conflicts", "strategy", "accept-theirs")
+						}
+					} else {
+						// no auto-resolve configured — abort and fail
+						abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)
+						_, _ = RunGit(abortCtx, repoPath, "rebase", "--abort")
+						abortCancel()
+						return fmt.Errorf("git pull --rebase failed during retry: %s", pullOut)
+					}
+				}
+				// A successful pull (or rebase --continue) can still leave conflicts
+				// when applying the autostash. Do not retry the push in that state.
+				recoveryCtx, recoveryCancel := context.WithTimeout(ctx, opTimeout)
+				defer recoveryCancel()
+				if _, err := ResolveAutostashConflicts(recoveryCtx, repoPath, opts.AutoResolvePrefixes, opts.AutoResolveDenyPrefixes); err != nil {
+					return fmt.Errorf("restore autostash after pull: %w", err)
+				}
+				return nil
+			})
+			if rebaseErr != nil {
+				return rebaseErr
 			}
 		} else {
 			if attempt == maxRetries {

--- a/internal/gitutil/push_test.go
+++ b/internal/gitutil/push_test.go
@@ -572,6 +572,8 @@ func TestPushWithRetry_RebaseInProgressAborted(t *testing.T) {
 
 // Only a successful hook that completes the rebase may allow another push.
 // Failure paths must preserve both replicas' commits and release the repo lock.
+// TestPushWithRetry_OnUnresolvedConflictsHookCalled verifies that failed or
+// canceled resolution preserves commits and releases the lock before returning.
 func TestPushWithRetry_OnUnresolvedConflictsHookCalled(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short: git push with retry")

--- a/internal/gitutil/push_test.go
+++ b/internal/gitutil/push_test.go
@@ -3,6 +3,8 @@ package gitutil
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -92,6 +94,108 @@ func TestPushWithRetry_NothingToPush(t *testing.T) {
 		OpTimeout:  10 * time.Second,
 	})
 	assert.NoError(t, err)
+}
+
+// Retrying a rejected push must inspect the index after both a clean rebase
+// and an auto-resolved rebase: restoring the autostash can conflict in either.
+func TestPushWithRetry_AutostashConflicts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git push and autostash")
+	}
+	for _, tc := range []struct {
+		name             string
+		localTitle       string
+		rebaseConflict   bool
+		existingConflict bool
+		deny             []string
+		wantError        bool
+	}{
+		{name: "agreeing metadata", localTitle: "Ready"},
+		{name: "after resolving rebase", localTitle: "Ready", rebaseConflict: true},
+		{name: "differing metadata", localTitle: "Local", wantError: true},
+		{name: "existing agreeing metadata", localTitle: "Ready", existingConflict: true},
+		{name: "existing differing metadata", localTitle: "Local", existingConflict: true, wantError: true},
+		{name: "denied metadata", localTitle: "Ready", deny: []string{"sessions/test/"}, wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, bare := initBareRemoteRepo(t)
+			const rel = "sessions/test/meta.json"
+			require.NoError(t, os.MkdirAll(filepath.Join(repo, "sessions/test"), 0o755))
+			addCommit(t, repo, rel, `{"title":"","keep":"yes"}`+"\n", "seed metadata")
+			run(t, repo, "git", "push", "--quiet")
+			writer := filepath.Join(t.TempDir(), "writer")
+			run(t, "", "git", "clone", "--quiet", bare, writer)
+			run(t, writer, "git", "config", "user.name", "Test")
+			run(t, writer, "git", "config", "user.email", "test@test.local")
+			if tc.rebaseConflict {
+				require.NoError(t, os.WriteFile(filepath.Join(writer, "init.txt"), []byte("remote"), 0o644))
+				run(t, writer, "git", "add", "init.txt")
+				addCommit(t, repo, "init.txt", "local", "local change")
+			} else {
+				addCommit(t, repo, "local.txt", "local", "local change")
+			}
+			const remoteMeta = `{"title":"Ready","keep":"yes","remote_only":true}`
+			addCommit(t, writer, rel, remoteMeta+"\n", "remote title")
+			run(t, writer, "git", "push", "--quiet")
+			localMeta := fmt.Sprintf("{\"keep\":\"yes\",\"title\":%q,\"summary_attempts\":0,\"local_only\":true}\n", tc.localTitle)
+			mergedMeta := fmt.Sprintf(`{"keep":"yes","title":%q,"summary_attempts":0,"local_only":true,"remote_only":true}`, tc.localTitle)
+			require.NoError(t, os.WriteFile(filepath.Join(repo, rel), []byte(localMeta), 0o644))
+			var conflictsBefore, headBefore, stashBefore string
+			var worktreeBefore, indexBefore []byte
+			if tc.existingConflict {
+				// Model a checkout wedged by an older client, then make the
+				// remote advance again so this push must enter its pull retry.
+				run(t, repo, "git", "pull", "--rebase", "--autostash", "--quiet")
+				conflictsBefore = gitInRepo(t, repo, "ls-files", "--unmerged")
+				require.NotEmpty(t, conflictsBefore)
+				require.False(t, IsRebaseInProgress(repo))
+				var err error
+				worktreeBefore, err = os.ReadFile(filepath.Join(repo, rel))
+				require.NoError(t, err)
+				indexBefore, err = os.ReadFile(filepath.Join(repo, ".git/index"))
+				require.NoError(t, err)
+				headBefore = gitInRepo(t, repo, "rev-parse", "HEAD")
+				stashBefore = gitInRepo(t, repo, "stash", "list")
+				addCommit(t, writer, "remote.txt", "next remote change", "advance remote")
+				run(t, writer, "git", "push", "--quiet")
+			}
+			remoteBefore := gitInRepo(t, writer, "rev-parse", "HEAD")
+			err := PushWithRetry(context.Background(), repo, PushOpts{
+				AutoResolvePrefixes:     []string{"sessions/", "init.txt"},
+				AutoResolveDenyPrefixes: tc.deny,
+				MaxRetries:              2,
+				OpTimeout:               10 * time.Second,
+			})
+			conflicts := gitInRepo(t, repo, "ls-files", "--unmerged")
+			assert.False(t, IsRebaseInProgress(repo))
+			assert.NotEmpty(t, gitInRepo(t, repo, "stash", "list"), "retain the original dirty metadata")
+			assert.JSONEq(t, localMeta, gitInRepo(t, repo, "show", "stash@{0}:"+rel))
+			if tc.wantError {
+				require.Error(t, err)
+				assert.NotEmpty(t, conflicts)
+				assert.Equal(t, remoteBefore, gitInRepo(t, bare, "rev-parse", "HEAD"), "do not retry the push while conflicts remain")
+				if tc.existingConflict {
+					assert.Equal(t, conflictsBefore, conflicts, "preserve all conflict stages")
+					data, err := os.ReadFile(filepath.Join(repo, rel))
+					require.NoError(t, err)
+					assert.Equal(t, worktreeBefore, data, "leave disagreements untouched")
+					index, err := os.ReadFile(filepath.Join(repo, ".git/index"))
+					require.NoError(t, err)
+					assert.Equal(t, indexBefore, index, "leave the index untouched")
+					assert.Equal(t, headBefore, gitInRepo(t, repo, "rev-parse", "HEAD"))
+					assert.Equal(t, stashBefore, gitInRepo(t, repo, "stash", "list"))
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Empty(t, conflicts)
+				data, err := os.ReadFile(filepath.Join(repo, rel))
+				require.NoError(t, err)
+				assert.JSONEq(t, mergedMeta, string(data))
+				assert.Equal(t, gitInRepo(t, repo, "rev-parse", "HEAD"), gitInRepo(t, bare, "rev-parse", "HEAD"))
+				assert.JSONEq(t, remoteMeta, gitInRepo(t, bare, "show", "HEAD:"+rel), "recovery must not commit the dirty metadata")
+			}
+		})
+	}
 }
 
 func TestPushWithRetry_RepoBlockedByLockFile(t *testing.T) {
@@ -466,59 +570,115 @@ func TestPushWithRetry_RebaseInProgressAborted(t *testing.T) {
 	assert.Contains(t, err.Error(), "broken rebase state")
 }
 
-// TestPushWithRetry_OnUnresolvedConflictsHookCalled verifies that when
-// ResolveRebaseAcceptTheirs cannot resolve a conflict because the path is
-// outside AutoResolvePrefixes, the OnUnresolvedConflicts hook is invoked
-// with the conflicted paths. If the hook reports unresolved, the rebase is
-// aborted and PushWithRetry returns an error.
-//
-// Failure prevented: a higher-tier resolver (e.g. LLM merge) can never be
-// wired in if PushWithRetry refuses to surface the conflict.
+// Only a successful hook that completes the rebase may allow another push.
+// Failure paths must preserve both replicas' commits and release the repo lock.
 func TestPushWithRetry_OnUnresolvedConflictsHookCalled(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short: git push with retry")
 	}
-	repo, bare := initBareRemoteRepo(t)
+	for _, tc := range []struct {
+		name              string
+		disableResolution bool
+		hookError         bool
+		resolve           bool
+		cancelEnumeration bool
+		wantHookCalls     int
+	}{
+		{name: "unresolved", wantHookCalls: 1},
+		{name: "no auto-resolve prefixes", disableResolution: true},
+		{name: "hook error after staging", hookError: true, wantHookCalls: 1},
+		{name: "hook completes rebase", resolve: true, wantHookCalls: 1},
+		{name: "conflict enumeration canceled", cancelEnumeration: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, bare := initBareRemoteRepo(t)
+			second := filepath.Join(t.TempDir(), "second")
+			run(t, "", "git", "clone", "--quiet", bare, second)
+			run(t, second, "git", "config", "user.email", "test@test.local")
+			run(t, second, "git", "config", "user.name", "Test")
+			addCommit(t, second, "shared.txt", "from-second", "second shared")
+			run(t, second, "git", "push", "--quiet")
+			addCommit(t, repo, "shared.txt", "from-first", "first shared")
+			localHead := gitInRepo(t, repo, "rev-parse", "HEAD")
+			remoteHead := gitInRepo(t, bare, "rev-parse", "HEAD")
 
-	// second clone pushes a conflicting change to a path NOT covered by
-	// AutoResolvePrefixes (we use "data/github/" as the safe prefix below,
-	// but the conflict happens at the repo root).
-	second := filepath.Join(t.TempDir(), "second")
-	run(t, "", "git", "clone", "--quiet", bare, second)
-	run(t, second, "git", "config", "user.email", "test@test.local")
-	run(t, second, "git", "config", "user.name", "Test")
-	require.NoError(t, os.WriteFile(filepath.Join(second, "shared.txt"),
-		[]byte("from-second"), 0644))
-	run(t, second, "git", "add", "shared.txt")
-	run(t, second, "git", "commit", "-m", "second shared", "--no-verify", "--quiet")
-	run(t, second, "git", "push", "--quiet")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+				ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+					// Cancel at the real Git failure boundary, before enumerating
+					// paths. The hook must never receive a misleading empty list.
+					if tc.cancelEnumeration && attr.Key == slog.MessageKey && attr.Value.String() == "rebase auto-resolve failed" {
+						cancel()
+					}
+					return attr
+				},
+			}))
+			prefixes := []string{"data/github/"} // does not cover shared.txt
+			if tc.disableResolution {
+				prefixes = nil
+			}
+			hookCalls := 0
+			var capturedPaths []string
+			const merged = "from-second\nfrom-first\n"
+			err := PushWithRetry(ctx, repo, PushOpts{
+				MaxRetries:          2,
+				OpTimeout:           10 * time.Second,
+				AutoResolvePrefixes: prefixes,
+				Logger:              logger,
+				OnUnresolvedConflicts: func(ctx context.Context, repoPath string, paths []string) (bool, error) {
+					hookCalls++
+					capturedPaths = append([]string(nil), paths...)
+					if !tc.resolve && !tc.hookError {
+						return false, nil
+					}
+					if err := os.WriteFile(filepath.Join(repoPath, "shared.txt"), []byte(merged), 0644); err != nil {
+						return false, err
+					}
+					if _, err := RunGit(ctx, repoPath, "add", "shared.txt"); err != nil {
+						return false, err
+					}
+					if tc.hookError {
+						// An error must override even a true resolved result and
+						// restore the original commit after partially staging.
+						return true, fmt.Errorf("resolver failed after staging")
+					}
+					_, err := runRebaseStep(ctx, repoPath, "--continue")
+					return err == nil, err
+				},
+			})
 
-	// first clone makes a conflicting change to the same path
-	require.NoError(t, os.WriteFile(filepath.Join(repo, "shared.txt"),
-		[]byte("from-first"), 0644))
-	run(t, repo, "git", "add", "shared.txt")
-	run(t, repo, "git", "commit", "-m", "first shared", "--no-verify", "--quiet")
-
-	var hookCalls atomic.Int32
-	var capturedPaths []string
-	err := PushWithRetry(context.Background(), repo, PushOpts{
-		MaxRetries:          2,
-		OpTimeout:           10 * time.Second,
-		AutoResolvePrefixes: []string{"data/github/"}, // does NOT cover shared.txt
-		OnUnresolvedConflicts: func(ctx context.Context, repoPath string, paths []string) (bool, error) {
-			hookCalls.Add(1)
-			capturedPaths = append([]string(nil), paths...)
-			return false, nil // signal unresolved → PushWithRetry should abort
-		},
-	})
-
-	assert.Error(t, err, "expected push to fail when hook reports unresolved")
-	assert.Equal(t, int32(1), hookCalls.Load(), "OnUnresolvedConflicts hook must be invoked exactly once")
-	assert.Contains(t, capturedPaths, "shared.txt",
-		"hook must receive the unresolved conflicted paths")
-
-	// rebase must have been aborted before returning so the repo is left clean
-	assert.False(t, IsRebaseInProgress(repo), "rebase should be aborted on hook-unresolved failure")
+			assert.Equal(t, tc.wantHookCalls, hookCalls)
+			if tc.wantHookCalls > 0 {
+				assert.Equal(t, []string{"shared.txt"}, capturedPaths)
+			}
+			if tc.resolve {
+				require.NoError(t, err)
+				assert.Equal(t, gitInRepo(t, repo, "rev-parse", "HEAD"), gitInRepo(t, bare, "rev-parse", "HEAD"))
+				assert.Equal(t, strings.TrimSpace(merged), gitInRepo(t, bare, "show", "HEAD:shared.txt"))
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "git pull --rebase failed during retry")
+				assert.Equal(t, remoteHead, gitInRepo(t, bare, "rev-parse", "HEAD"), "failed resolution must not push")
+				if tc.cancelEnumeration {
+					assert.ErrorIs(t, err, context.Canceled)
+					assert.Contains(t, err.Error(), "could not list conflicts")
+					// Cancellation also prevents abort; the original commit
+					// must remain recoverable with a fresh operation context.
+					assert.True(t, IsRebaseInProgress(repo))
+					run(t, repo, "git", "rebase", "--abort")
+				}
+				assert.Equal(t, localHead, gitInRepo(t, repo, "rev-parse", "HEAD"))
+				assert.Equal(t, "from-first", gitInRepo(t, repo, "show", "HEAD:shared.txt"))
+			}
+			assert.False(t, IsRebaseInProgress(repo))
+			assert.Empty(t, gitInRepo(t, repo, "status", "--porcelain"))
+			lockCtx, lockCancel := context.WithTimeout(context.Background(), time.Second)
+			defer lockCancel()
+			require.NoError(t, WithRepoLock(lockCtx, repo, func() error { return nil }), "retry must release the repo lock")
+		})
+	}
 }
 
 // contains mirrors strings.Contains for test clarity.

--- a/internal/lfs/meta_repair.go
+++ b/internal/lfs/meta_repair.go
@@ -1,6 +1,7 @@
 package lfs
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/sageox/ox/internal/fileutil"
@@ -155,19 +157,54 @@ func RecoverEmptyTitleMeta(sessionDir string, dryRun bool) MetaRepairOutcome {
 			"summary_status": meta.SummaryStatus, "summary_attempts": meta.SummaryAttempts,
 			"validation_error": meta.ValidationError,
 		} {
+			// These optional fields use omitempty in the normal writer. A reset
+			// retry count must disappear on both replicas; retain real diagnostics.
+			if value == "" || value == 0 {
+				delete(fields, key)
+				continue
+			}
 			encoded, err := json.Marshal(value)
 			if err != nil {
 				return nil, err
 			}
 			fields[key] = encoded
 		}
-		data, err = json.MarshalIndent(fields, "", "  ")
+		// A map sorts keys alphabetically, unlike WriteSessionMetaOnly. That
+		// whole-file reorder conflicts with an identical remote title repair.
+		// Use the schema's order, but keep raw values so unknown nested fields
+		// survive. Append any unknown top-level fields in deterministic order.
+		var ordered bytes.Buffer
+		ordered.WriteByte('{')
+		schema := reflect.TypeFor[SessionMeta]()
+		for i := range schema.NumField() {
+			key := strings.Split(schema.Field(i).Tag.Get("json"), ",")[0]
+			if value, exists := fields[key]; exists {
+				if ordered.Len() > 1 {
+					ordered.WriteByte(',')
+				}
+				fmt.Fprintf(&ordered, "%q:%s", key, value)
+				delete(fields, key)
+			}
+		}
+		if len(fields) > 0 {
+			extra, err := json.Marshal(fields)
+			if err != nil {
+				return nil, err
+			}
+			if ordered.Len() > 1 {
+				ordered.WriteByte(',')
+			}
+			ordered.Write(extra[1 : len(extra)-1])
+		}
+		ordered.WriteByte('}')
+		var formatted bytes.Buffer
+		err = json.Indent(&formatted, ordered.Bytes(), "", "  ")
 		if err != nil {
 			return nil, err
 		}
 		// MutateSessionMeta holds the shared metadata lock; return nil so it
 		// does not replace this lossless patch with a typed-manifest rewrite.
-		return nil, fileutil.AtomicWriteBytes(metaPath, data, info.Mode().Perm())
+		return nil, fileutil.AtomicWriteBytes(metaPath, formatted.Bytes(), info.Mode().Perm())
 	}
 
 	var err error

--- a/internal/lfs/meta_repair_test.go
+++ b/internal/lfs/meta_repair_test.go
@@ -5,13 +5,131 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sageox/ox/internal/fileutil"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Independent title repairs must converge through a real pull. Git exit zero
+// alone misses autostash conflicts, and JSONEq alone misses duplicate keys.
+func TestTitleRepairConvergesThroughPull(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git clones and autostash")
+	}
+	for _, tc := range []struct {
+		name          string
+		sortedBase    bool
+		sortedRemote  bool
+		different     bool
+		attempts      int
+		emptyDefaults bool
+	}{
+		{name: "normal writer"},
+		{name: "historical sorted base", sortedBase: true},
+		{name: "previous failed attempts", attempts: 2},
+		{name: "existing empty defaults", emptyDefaults: true},
+		{name: "older remote writer", sortedRemote: true},
+		{name: "different remote title", different: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			writer, bare := initLedgerWithRemote(t)
+			const rel = "sessions/test/meta.json"
+			remoteSession := filepath.Join(writer, "sessions/test")
+			require.NoError(t, os.MkdirAll(remoteSession, 0o755))
+			meta := &SessionMeta{Version: "1.0", SessionName: "test", SessionID: "ses_keep",
+				AgentType: "claude-code", CreatedAt: time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)}
+			meta.SummaryAttempts = tc.attempts
+			if tc.attempts > 0 {
+				meta.ValidationError = "Earlier summary failure"
+			}
+			writeRemote := func(sorted bool) {
+				t.Helper()
+				require.NoError(t, WriteSessionMetaOnly(remoteSession, meta))
+				if sorted {
+					data, err := os.ReadFile(filepath.Join(writer, rel))
+					require.NoError(t, err)
+					var fields map[string]json.RawMessage
+					require.NoError(t, json.Unmarshal(data, &fields))
+					data, err = json.MarshalIndent(fields, "", "  ")
+					require.NoError(t, err)
+					require.NoError(t, os.WriteFile(filepath.Join(writer, rel), data, 0o644))
+				}
+			}
+			writeRemote(tc.sortedBase)
+			if tc.emptyDefaults {
+				seed, err := os.ReadFile(filepath.Join(writer, rel))
+				require.NoError(t, err)
+				seed = append(seed[:len(seed)-1], []byte(`,"title":"","summary":"","summary_status":"","validation_error":"","summary_attempts":0}`)...)
+				require.NoError(t, os.WriteFile(filepath.Join(writer, rel), seed, 0o644))
+			}
+			git(t, writer, "add", "--sparse", rel)
+			git(t, writer, "commit", "-m", "seed metadata")
+			git(t, writer, "push")
+			local := t.TempDir()
+			git(t, writer, "clone", bare, local)
+			git(t, local, "config", "user.name", "Test")
+			git(t, local, "config", "user.email", "test@test.local")
+			localSession := filepath.Join(local, "sessions/test")
+			writeTestSummary(t, localSession, "Recovered title")
+			require.Empty(t, RecoverEmptyTitleMeta(localSession, false).Error)
+			repaired, err := os.ReadFile(filepath.Join(local, rel))
+			require.NoError(t, err)
+			meta.Title, meta.Summary, meta.SummaryStatus = "Recovered title", "Recovered title", "ok"
+			meta.SummaryAttempts = 0
+			if tc.different {
+				meta.Title = "Customer changed this title"
+			}
+			writeRemote(tc.sortedRemote)
+			git(t, writer, "commit", "-am", "independent remote repair")
+			git(t, writer, "push")
+			git(t, local, "pull", "--rebase", "--autostash", "--quiet")
+			conflicts := git(t, local, "ls-files", "--unmerged")
+			if tc.sortedRemote || tc.different {
+				require.NotEmpty(t, conflicts)
+				err = gitutil.WithRepoLock(context.Background(), local, func() error {
+					_, resolveErr := gitutil.ResolveAutostashConflicts(context.Background(), local, []string{"sessions/"}, nil)
+					return resolveErr
+				})
+				require.NotEmpty(t, git(t, local, "stash", "list"), "retain recovery backup")
+				if tc.different {
+					require.Error(t, err)
+					assert.NotEmpty(t, git(t, local, "ls-files", "--unmerged"))
+					return
+				}
+				require.NoError(t, err)
+			} else {
+				require.Empty(t, conflicts, "agreeing repairs must merge without recovery")
+				remote, err := os.ReadFile(filepath.Join(writer, rel))
+				require.NoError(t, err)
+				assert.Equal(t, string(remote), string(repaired), "repair must match the normal writer")
+			}
+			assert.Empty(t, git(t, local, "ls-files", "--unmerged"))
+			data, err := os.ReadFile(filepath.Join(local, rel))
+			require.NoError(t, err)
+			// Decode each top-level member separately so duplicate keys cannot hide.
+			decoder := json.NewDecoder(strings.NewReader(string(data)))
+			_, err = decoder.Token()
+			require.NoError(t, err)
+			seen := make(map[string]bool)
+			for decoder.More() {
+				key, err := decoder.Token()
+				require.NoError(t, err)
+				require.False(t, seen[key.(string)], "duplicate metadata key: %s", key)
+				seen[key.(string)] = true
+				var value json.RawMessage
+				require.NoError(t, decoder.Decode(&value))
+			}
+			got, err := ReadSessionMeta(localSession)
+			require.NoError(t, err)
+			assert.Equal(t, meta, got)
+		})
+	}
+}
 
 // Upgrading must repair legacy error summaries without losing session identity,
 // content references, extension fields, diagnostics, or customer-authored text.


### PR DESCRIPTION
<!-- sageox:pr-header v2 -->
> guided&nbsp;by&nbsp;<picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="16" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a08c28-50b8-7407-a53c-be20703d183f">Session</a>
<!-- /sageox:pr-header -->

## What broke

- **Producer:** Automatic title repair serialized `meta.json` through a map, reordering the entire file and writing empty optional fields. The normal writer uses schema order and omits empty optional fields. Independent repairs with agreeing values could therefore conflict during a later pull.
- **Git behavior:** `git pull --rebase --autostash` can finish updating the branch and exit zero while restoring local changes leaves an unmerged index, with no active rebase to abort.
- **Missed state:** Daemon sync, CLI push retries, and doctor pulls trusted that success. Sync deduplication could also skip an already-conflicted checkout.

```mermaid
flowchart TD
    A[Automatic title repair] --> B[Preserve raw fields and match normal metadata format]
    B --> C[Pull remote changes with autostash]
    C --> D[Inspect index even when Git exits zero]
    D --> E{Unmerged metadata?}
    E -->|No| F[Continue sync or push retry]
    E -->|Yes| G{Allowed paths and agreeing values?}
    G -->|Yes| H[Preserve all fields and stage repair]
    H --> F
    G -->|No or manual edits| I[Preserve changes and report unresolved conflict]
```

## What this PR ships

- **Prevention:** Repair-owned fields follow the normal writer's omission rules, including resetting a previous retry count. Known fields follow `SessionMeta` declaration order; raw values retain unknown and nested metadata without a parallel schema definition. Nonempty diagnostics, existing file permissions, metadata locking, and repair eligibility are preserved.
- **Recovery:** A shared helper repairs only allowed `sessions/<session>/meta.json` conflicts whose shared values agree. It preserves numeric precision and additional fields, and refuses deletions, conflicting values, unsupported paths, active Git operations, and manual edits.
- **Data protection:** Validate all conflicted paths before writing, reproduce Git's original autostash conflict, and recheck contents under the metadata lock. Retain the stash, create no recovery commit, and support retry after staging failure.
- **Pull completion:** Validate the index before daemon sync deduplication, before CLI retry/doctor pulls, and after all three pull paths—including after resolving a rebase. Pre-existing autostash conflicts cannot enter the positional rebase resolver. Serialize CLI retry pulls and recovery with the existing repository lock; stop the retry when local conflicts remain.
- **Doctor:** Recover already-conflicted checkouts without an active Git operation. Treat concurrent recovery as success and lock contention as a reason to retry. Preserve more specific pull errors and diagnoses.

## Test Plan

- **Root-cause regression:** Run the actual repair function against real Git clones, then pull an independently repaired remote. Cover normal and historically sorted metadata, previous failed attempts, existing empty defaults, older remote writers, and genuinely different titles. Assert no unmerged index, correct metadata, and no duplicate JSON keys. The normal-writer cases fail with the original serializer and pass with the fix.
- **Completion regressions:** Real Git tests prove CLI retry and doctor previously reported success with unresolved autostash conflicts, including after resolving a rebase. Verify agreement recovery, disagreement/deny refusal, stash retention, and that dirty repaired metadata stays uncommitted. Already-conflicted checkouts are checked before pulling so the old rebase fallback cannot discard remote fields or report an update that never arrived.
- **Preservation:** Existing and new tests cover unknown/nested fields, large IDs, diagnostics, concurrent metadata writes, manual edits, diff3 markers, missing/corrupt data, active Git operations, repository-lock contention, and staging-failure retries.
- **Captured incident:** Running the new repair function on all three backed-up incident files produces clean Git merges matching the remote metadata byte for byte. Earlier recovery was also validated against the affected checkout and six subsequent daemon syncs.
- **Passed locally:** `make format`, `make lint`, build, `make test` (18,379 passed with the expected short-mode skips), full `internal/gitutil`/`internal/lfs` tests, and focused race tests across all four affected packages. The local suite clears inherited `CODEX_THREAD_ID`, `CODEX_CI`, and `CODEX_SANDBOX` so its existing agent-detection test exercises its intended fixture. No tests are excluded.
- **Changed-line coverage:** 92.7% (139/150 statements), above the existing 90% requirement. No new coverage exceptions, dependencies, or CI configuration changes.
- **CI:** All 15 active checks passed on `bf2d3d1a`; the optional [code]smith check was skipped. Full tests, compiled-binary acceptance, digital twins, protected-package and changed-line coverage, lint, Windows skill tests, and security checks passed. No unresolved review threads.
- **Review:** CodeRabbit reviewed the final commit without correctness findings. Its remaining nonblocking docstring-percentage warning was reviewed: all changed named Go functions have comments; inline callbacks are kept concise.

SageOx-Session: https://sageox.ai/c/ses_01a08c28-50b8-7407-a53c-be20703d183f
