### PR TITLE
fix(ledger): fail closed on invalid automatic commits

### DIFF
--- a/cmd/ox/ledger_commit_snapshot.go
+++ b/cmd/ox/ledger_commit_snapshot.go
@@ -248,7 +248,13 @@ func blobHasMarker(ctx context.Context, ledgerPath, oid, path string) (bool, err
 	if err != nil {
 		return false, fmt.Errorf("inspect staged blob %s: %w", path, err)
 	}
-	return gitutil.HasConflictMarkersBytes(blob), nil
+	if gitutil.HasConflictMarkersBytes(blob) {
+		return true, nil
+	}
+	if err := gitutil.ValidateLedgerBlob(path, blob); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 // commitTreeToBranch commits an already-validated tree and advances the current

--- a/cmd/ox/ledger_commit_snapshot_test.go
+++ b/cmd/ox/ledger_commit_snapshot_test.go
@@ -92,6 +92,25 @@ func TestCommitLedgerSnapshot_RefusesMarkerAlreadyStaged(t *testing.T) {
 	assert.Equal(t, 1, countLines(log), "no commit should have been created")
 }
 
+// A marker-free meta.json can still be corrupt application data. The immutable
+// snapshot path must enforce the same JSON contract as automatic daemon writers.
+func TestCommitLedgerSnapshot_RefusesInvalidSessionMetadata(t *testing.T) {
+	skipIntegration(t)
+	repo := newLedgerTestRepo(t)
+	path := filepath.Join(repo, "sessions", "example", "meta.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"title":`), 0o644))
+	mustRunGit(t, repo, "add", "--sparse", path)
+
+	committed, err := commitLedgerSnapshot(context.Background(), repo, "session: X")
+	require.ErrorContains(t, err, "invalid JSON")
+	assert.False(t, committed)
+
+	log, gerr := runIsolatedGit(t, repo, "log", "--oneline")
+	require.NoError(t, gerr)
+	assert.Equal(t, 1, countLines(log), "invalid metadata must not create a commit")
+}
+
 // TestCommitLedgerSnapshot_RefusesUnmergedIndex proves an unmerged (UU) index —
 // a live conflict — is refused: `git write-tree` cannot snapshot unmerged entries,
 // so the snapshot itself fails closed.

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -1768,25 +1768,10 @@ func (h *SessionFinalizeHandler) gitCommitAndPush(payload *SessionFinalizePayloa
 		return false
 	}
 
-	// A raw-only first push can trigger GitLab GC before a second pointer push,
-	// unlinking the newly uploaded objects from the project. Publish pointers
-	// immediately, under the same lock as staging and committing.
-	// AssertUploaded: both callers obtained fileRefs from UploadSessionFiles.
-	if _, err := lfs.WritePointerFiles(payload.SessionDir, lfs.AssertUploadedManifest(fileRefs)); err != nil {
-		h.logger.Warn("LFS pointer file write failed before commit", "session", sessionName, "err", err)
-		return false
-	}
-
 	// relative path from ledger root for git add
 	relDir, err := filepath.Rel(ledgerPath, payload.SessionDir)
 	if err != nil {
 		h.logger.Warn("could not compute relative session path", "err", err)
-		return false
-	}
-
-	// git add --sparse <session-dir>/
-	if err := h.runGit(ledgerPath, "add", "--sparse", relDir+"/"); err != nil {
-		h.logger.Warn("git add failed", "err", err)
 		return false
 	}
 
@@ -1800,33 +1785,54 @@ func (h *SessionFinalizeHandler) gitCommitAndPush(payload *SessionFinalizePayloa
 	// Ask git what is staged rather than parsing the commit's message: the wording
 	// varies with the rest of the tree ("working tree clean" vs "untracked files
 	// present"), so an unrelated stray file in the ledger would resurrect the loop.
-	staged, err := h.hasStagedChanges(ledgerPath, relDir+"/")
-	if err != nil {
-		h.logger.Warn("could not inspect staged changes", "err", err)
-		return false
-	}
-
 	msg := fmt.Sprintf("finalize session %s", sessionName)
-	switch {
-	case !staged:
-		// Fall through to the push: the commit may exist locally from an earlier
-		// cycle and still be unpushed.
-		h.logger.Debug("session already committed, nothing new to stage", "session", sessionName)
-	default:
-		// Commit ONLY this session's path. A bare `git commit -m` writes the whole
-		// index, so any files another session left staged after a failed finalize
-		// would ride along under this session's message. Scoping the staged-changes
-		// check alone is not enough — that decides WHETHER to commit; this decides
-		// WHAT gets committed.
+	staged := false
+	// ADR-030's repo lock is cross-process; ledgerMu above only coordinates
+	// goroutines in this daemon. Holding both across pointer write, stage,
+	// validation, and commit prevents a CLI pull from restoring an autostash
+	// between those steps. Release before PushWithRetry, which takes the same
+	// non-reentrant lock if a non-fast-forward retry needs to pull.
+	if err := gitutil.WithRepoLock(context.Background(), ledgerPath, func() error {
+		// A raw-only first push can trigger GitLab GC before a second pointer
+		// push, unlinking the newly uploaded objects from the project. Publish
+		// pointers in the first commit. AssertUploaded: both callers obtained
+		// fileRefs from UploadSessionFiles.
+		if _, err := lfs.WritePointerFiles(payload.SessionDir, lfs.AssertUploadedManifest(fileRefs)); err != nil {
+			return fmt.Errorf("write LFS pointer files before commit: %w", err)
+		}
+		if err := h.runGit(ledgerPath, "add", "--sparse", relDir+"/"); err != nil {
+			return fmt.Errorf("git add: %w", err)
+		}
+		var err error
+		staged, err = h.hasStagedChanges(ledgerPath, relDir+"/")
+		if err != nil {
+			return fmt.Errorf("inspect staged changes: %w", err)
+		}
+		if !staged {
+			return nil
+		}
+		if err := gitutil.ValidateStagedLedgerCommit(context.Background(), ledgerPath, relDir+"/"); err != nil {
+			return err
+		}
+		// Commit ONLY this session's path. A bare `git commit -m` writes the
+		// whole index and could sweep a different session's staged files.
 		if err := h.runGit(ledgerPath, "commit", "-m", msg, "--", relDir); err != nil {
-			// A concurrent committer (a second daemon on the same ledger) can empty
-			// the index between the check above and this commit.
+			// Raw human Git does not participate in the advisory repo lock, so an
+			// external committer can still empty the index after validation.
 			if !isNothingToCommit(err) {
-				h.logger.Warn("git commit failed", "err", err)
-				return false
+				return fmt.Errorf("git commit: %w", err)
 			}
 			h.logger.Debug("session committed concurrently", "session", sessionName)
 		}
+		return nil
+	}); err != nil {
+		h.logger.Warn("session commit transaction failed", "session", sessionName, "err", err)
+		return false
+	}
+	if !staged {
+		// Fall through to the push: the commit may exist locally from an earlier
+		// cycle and still be unpushed.
+		h.logger.Debug("session already committed, nothing new to stage", "session", sessionName)
 	}
 
 	// push with retry (best-effort — failures are non-fatal)

--- a/internal/daemon/agentwork/session_finalize_convergence_test.go
+++ b/internal/daemon/agentwork/session_finalize_convergence_test.go
@@ -318,7 +318,11 @@ func TestGitCommitAndPush_CommitExcludesOtherSessionsWhenStaged(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, name := range append([]string{"raw.jsonl", "meta.json"}, requiredArtifacts...) {
-		if err := os.WriteFile(filepath.Join(targetDir, name), []byte("target content"), 0644); err != nil {
+		content := []byte("target content")
+		if name == "meta.json" {
+			content = []byte(`{"version":"1.0","session_name":"` + target + `"}`)
+		}
+		if err := os.WriteFile(filepath.Join(targetDir, name), content, 0644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/daemon/agentwork/session_finalize_upload_test.go
+++ b/internal/daemon/agentwork/session_finalize_upload_test.go
@@ -669,3 +669,48 @@ func TestGitCommitAndPush_LeavesOutOfLedgerSessionIntact(t *testing.T) {
 		})
 	}
 }
+
+// A stash-pop conflict can exist as an ordinary stage-0 file after git add.
+// Finalization must refuse it before commit, even though Git itself considers
+// that index entry resolved and would happily publish the marker bytes.
+func TestGitCommitAndPush_RefusesConflictMarkers(t *testing.T) {
+	ledgerPath := t.TempDir()
+	runGitCmd(t, ledgerPath, "init", "--initial-branch=main")
+	if err := os.WriteFile(filepath.Join(ledgerPath, "README.md"), []byte("ledger\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitCmd(t, ledgerPath, "add", "README.md")
+	runGitCmd(t, ledgerPath, "commit", "-m", "initial")
+
+	const sessionName = "2026-09-10T12-00-test-Oxguard"
+	sessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	markers := []byte("{\n<<<<<<< Updated upstream\n  \"title\": \"remote\"\n=======\n  \"title\": \"local\"\n>>>>>>> Stashed changes\n}\n")
+	if err := os.WriteFile(filepath.Join(sessionDir, "meta.json"), markers, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"), []byte(testRawContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipLFS = true
+	handler.ledgerMu = &sync.Mutex{}
+	headBefore := gitOutput(t, ledgerPath, "rev-parse", "HEAD")
+	pushed := handler.gitCommitAndPush(&SessionFinalizePayload{
+		SessionDir: sessionDir,
+		RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+		LedgerPath: ledgerPath,
+	}, nil)
+	if pushed {
+		t.Fatal("marker-laden metadata must not report a successful publication")
+	}
+	if headAfter := gitOutput(t, ledgerPath, "rev-parse", "HEAD"); headAfter != headBefore {
+		t.Fatalf("validation failure advanced HEAD: before=%s after=%s", headBefore, headAfter)
+	}
+	if got, err := os.ReadFile(filepath.Join(sessionDir, "meta.json")); err != nil || !bytes.Equal(got, markers) {
+		t.Fatalf("failed commit must preserve the conflicted file for recovery: %q, %v", got, err)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2110,20 +2110,25 @@ func (s *daemonServiceImpl) commitMurmur(ctx context.Context, payload MurmurPayl
 // finalize), poisoning the push queue with LFS pointer blobs whose backing
 // objects may not be in the remote LFS store.
 func writeAndCommitMurmur(ctx context.Context, targetDir string, payload MurmurPayload) error {
-	if err := ledger.WriteMurmurRaw(targetDir, payload.RelPath, payload.MurmurJSON); err != nil {
-		return fmt.Errorf("write murmur: %w", err)
-	}
-	if _, err := gitutil.RunGit(ctx, targetDir, "add", "--sparse", "data/murmurs/"); err != nil {
-		return fmt.Errorf("git add murmur: %w", err)
-	}
 	summary := payload.Content
 	if len(summary) > 50 {
 		summary = summary[:50] + "..."
 	}
-	if _, err := gitutil.RunGit(ctx, targetDir, "commit", "-m", fmt.Sprintf("murmur: %s", summary), "--", "data/murmurs/"); err != nil {
-		return fmt.Errorf("git commit murmur: %w", err)
-	}
-	return nil
+	return gitutil.WithRepoLock(ctx, targetDir, func() error {
+		if err := ledger.WriteMurmurRaw(targetDir, payload.RelPath, payload.MurmurJSON); err != nil {
+			return fmt.Errorf("write murmur: %w", err)
+		}
+		if _, err := gitutil.RunGit(ctx, targetDir, "add", "--sparse", "data/murmurs/"); err != nil {
+			return fmt.Errorf("git add murmur: %w", err)
+		}
+		if err := gitutil.ValidateStagedLedgerCommit(ctx, targetDir, "data/murmurs/"); err != nil {
+			return err
+		}
+		if _, err := gitutil.RunGit(ctx, targetDir, "commit", "-m", fmt.Sprintf("murmur: %s", summary), "--", "data/murmurs/"); err != nil {
+			return fmt.Errorf("git commit murmur: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *daemonServiceImpl) PauseMurmuring(agentID string) {

--- a/internal/daemon/murmur_outbox_test.go
+++ b/internal/daemon/murmur_outbox_test.go
@@ -125,6 +125,19 @@ func TestDrainMurmurOutbox_CommitsAndRemoves(t *testing.T) {
 	require.Empty(t, entries, "outbox file must be removed after a confirmed commit")
 }
 
+func TestWriteAndCommitMurmur_RefusesConflictMarkers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: shells git")
+	}
+	ledgerDir, before := initGitRepoWithCommit(t)
+	p := makeOutboxMurmur(t, ledgerDir, "do not publish", time.Now().UTC())
+	p.MurmurJSON = []byte("<<<<<<< Updated upstream\n{}\n=======\n{}\n>>>>>>> Stashed changes\n")
+
+	err := writeAndCommitMurmur(context.Background(), ledgerDir, p)
+	require.ErrorContains(t, err, "unresolved conflict")
+	require.Equal(t, before, getGitSHA(t, ledgerDir), "validation failure must not advance HEAD")
+}
+
 // TestDrainMurmurOutbox_DropsStale verifies murmurs older than the 24h window are
 // discarded (deleted, never committed) so day-old WIP never resurfaces.
 func TestDrainMurmurOutbox_DropsStale(t *testing.T) {

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1753,66 +1753,89 @@ func (s *SyncScheduler) retractOrphanedDrafts(ctx context.Context, ledgerPath st
 	s.ledgerMu.Lock()
 	defer s.ledgerMu.Unlock()
 
-	// Re-check after taking the lock: a concurrent finalize/pull may have started
-	// a rebase or changed the tree between detection and mutation.
-	if gitutil.IsRebaseInProgress(ledgerPath) {
-		return
-	}
-
 	var removed int
-	for _, name := range orphans {
-		if err := session.ValidateDraftSessionName(name); err != nil {
-			continue
+	lockErr := gitutil.WithRepoLock(ctx, ledgerPath, func() error {
+		// Re-check after taking both locks: ledgerMu coordinates this daemon,
+		// while the repo lock excludes CLI pulls and commits in other processes.
+		if gitutil.IsRebaseInProgress(ledgerPath) {
+			return nil
 		}
-		// Revalidate under the lock. SaveRecordingState writes .recording.json /
-		// raw.jsonl WITHOUT ledgerMu, so a recording could have appeared for this
-		// name between detection and here. Never git-rm a draft that now has
-		// local recording data — recovering it is upload-retry's job.
-		if session.DraftHasLocalSessionData(cacheDirs, name) {
-			continue
-		}
-		rel := filepath.ToSlash(filepath.Join("sessions", name))
-
-		// Only retract drafts that are ALREADY on the remote. If a draft's publish
-		// commit is still local/unpushed, stacking a retraction on top of it would
-		// make pushSessionDraftCommits ship BOTH — manufacturing a publish the
-		// daemon never should. An unpushed draft belongs to the publish flow, not
-		// this reaper. Unknown/unresolvable upstream fails safe to skip.
-		if !s.draftPublishedOnRemote(ctx, ledgerPath, rel) {
-			continue
+		// The optimistic scan above avoids taking both locks when there is no
+		// work. Repeat the full orphan predicate now: a peer may have pulled a
+		// fresh cross-machine heartbeat while this reaper waited for the lock.
+		// Rechecking only local cache data would still delete that live draft.
+		currentOrphans, err := session.FindOrphanedDrafts(ledgerPath, cacheDirs)
+		if err != nil {
+			return fmt.Errorf("revalidate orphaned drafts: %w", err)
 		}
 
-		if _, err := s.git.RunGit(ctx, ledgerPath, "rm", "-r", "--force", "--ignore-unmatch", "--", rel); err != nil {
-			s.logger.Warn("retract orphaned draft: git rm failed", "session", name, "error", err)
-			continue
-		}
-		// Remove any untracked leftovers git rm --ignore-unmatch left behind. If
-		// that fails, do NOT commit a partial retraction — restore and retry next
-		// scan, otherwise the remote loses meta.json while leftover files linger
-		// locally and no future scan rediscovers them.
-		if err := os.RemoveAll(filepath.Join(ledgerPath, "sessions", name)); err != nil {
-			s.restoreDraftForRetry(ctx, ledgerPath, rel, name, fmt.Errorf("remove leftovers: %w", err))
-			continue
-		}
+		for _, name := range currentOrphans {
+			if err := session.ValidateDraftSessionName(name); err != nil {
+				continue
+			}
+			// Revalidate under the lock. SaveRecordingState writes .recording.json /
+			// raw.jsonl WITHOUT ledgerMu, so a recording could have appeared for this
+			// name between detection and here. Never git-rm a draft that now has
+			// local recording data — recovering it is upload-retry's job.
+			if session.DraftHasLocalSessionData(cacheDirs, name) {
+				continue
+			}
+			rel := filepath.ToSlash(filepath.Join("sessions", name))
 
-		// A published draft's meta.json is tracked, so git rm must have staged a
-		// deletion. If the diff errors or shows nothing staged, we cannot safely
-		// commit — restore the index + worktree from HEAD so a dangling staged
-		// deletion can't be swept into an unrelated commit, and the next scan
-		// rediscovers the orphan to retry.
-		staged, diffErr := s.git.RunGit(ctx, ledgerPath, "diff", "--cached", "--name-only", "--", rel)
-		if diffErr != nil || strings.TrimSpace(staged) == "" {
-			s.restoreDraftForRetry(ctx, ledgerPath, rel, name, diffErr)
-			continue
+			// Only retract drafts that are ALREADY on the remote. If a draft's publish
+			// commit is still local/unpushed, stacking a retraction on top of it would
+			// make pushSessionDraftCommits ship BOTH — manufacturing a publish the
+			// daemon never should. An unpushed draft belongs to the publish flow, not
+			// this reaper. Unknown/unresolvable upstream fails safe to skip.
+			if !s.draftPublishedOnRemote(ctx, ledgerPath, rel) {
+				continue
+			}
+
+			if _, err := s.git.RunGit(ctx, ledgerPath, "rm", "-r", "--force", "--ignore-unmatch", "--", rel); err != nil {
+				s.logger.Warn("retract orphaned draft: git rm failed", "session", name, "error", err)
+				continue
+			}
+			// Remove any untracked leftovers git rm --ignore-unmatch left behind. If
+			// that fails, do NOT commit a partial retraction — restore and retry next
+			// scan, otherwise the remote loses meta.json while leftover files linger
+			// locally and no future scan rediscovers them.
+			if err := os.RemoveAll(filepath.Join(ledgerPath, "sessions", name)); err != nil {
+				s.restoreDraftForRetry(ctx, ledgerPath, rel, name, fmt.Errorf("remove leftovers: %w", err))
+				continue
+			}
+
+			// A published draft's meta.json is tracked, so git rm must have staged a
+			// deletion. If the diff errors or shows nothing staged, we cannot safely
+			// commit — restore the index + worktree from HEAD so a dangling staged
+			// deletion can't be swept into an unrelated commit, and the next scan
+			// rediscovers the orphan to retry.
+			staged, diffErr := s.git.RunGit(ctx, ledgerPath, "diff", "--cached", "--name-only", "--", rel)
+			if diffErr != nil || strings.TrimSpace(staged) == "" {
+				s.restoreDraftForRetry(ctx, ledgerPath, rel, name, diffErr)
+				continue
+			}
+			if err := gitutil.ValidateStagedLedgerCommit(ctx, ledgerPath, rel); err != nil {
+				s.restoreDraftForRetry(ctx, ledgerPath, rel, name, err)
+				continue
+			}
+			if _, err := s.git.RunGit(ctx, ledgerPath, "commit", "--no-verify",
+				"-m", sessionDraftCommitPrefix+"retract "+name, "--", rel); err != nil {
+				// Commit failed: the deletion is staged and the dir is gone, which
+				// would orphan the candidate. Restore so the next scan retries.
+				s.restoreDraftForRetry(ctx, ledgerPath, rel, name, err)
+				continue
+			}
+			removed++
 		}
-		if _, err := s.git.RunGit(ctx, ledgerPath, "commit", "--no-verify",
-			"-m", sessionDraftCommitPrefix+"retract "+name, "--", rel); err != nil {
-			// Commit failed: the deletion is staged and the dir is gone, which
-			// would orphan the candidate. Restore so the next scan retries.
-			s.restoreDraftForRetry(ctx, ledgerPath, rel, name, err)
-			continue
+		return nil
+	})
+	if lockErr != nil {
+		message := "retract orphaned drafts failed"
+		if gitutil.IsRepoLockBusy(lockErr) {
+			message = "retract orphaned drafts: ledger busy"
 		}
-		removed++
+		s.logger.Warn(message, "path", ledgerPath, "error", lockErr)
+		return
 	}
 	if removed > 0 {
 		s.logger.Info("retracted orphaned session drafts", "path", ledgerPath, "count", removed)

--- a/internal/daemon/sync_session_draft_retract_test.go
+++ b/internal/daemon/sync_session_draft_retract_test.go
@@ -138,6 +138,57 @@ func TestRetractOrphanedDrafts_KeepsFreshDraft(t *testing.T) {
 		"a fresh draft is a live session and must never be retracted")
 }
 
+// A cross-machine heartbeat can land after the reaper's optimistic scan but
+// before it acquires the repo lock. The locked revalidation must observe that
+// refresh instead of deleting a session that is live on another machine.
+func TestRetractOrphanedDrafts_RevalidatesHeartbeatAfterLockWait(t *testing.T) {
+	s, ledger := newRetractScheduler(t)
+	const name = "2026-01-01T00-00-testuser-OxRefresh"
+	commitStaleDraft(t, ledger, name, 120*time.Hour)
+
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- gitutil.WithRepoLock(context.Background(), ledger, func() error {
+			close(locked)
+			<-release
+			return nil
+		})
+	}()
+	<-locked
+
+	retractDone := make(chan struct{})
+	go func() {
+		s.retractOrphanedDrafts(context.Background(), ledger)
+		close(retractDone)
+	}()
+	require.Eventually(t, func() bool {
+		if s.ledgerMu.TryLock() {
+			s.ledgerMu.Unlock()
+			return false
+		}
+		return true
+	}, time.Second, time.Millisecond, "reaper must finish its optimistic scan and wait on the repo lock")
+
+	dir := filepath.Join(ledger, "sessions", name)
+	meta, err := lfs.ReadSessionMeta(dir)
+	require.NoError(t, err)
+	refreshedAt := time.Now().UTC()
+	meta.UpdatedAt = &refreshedAt
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, meta))
+	mustGit(t, ledger, "add", "--sparse", "sessions/"+name+"/meta.json")
+	mustGit(t, ledger, "commit", "--quiet", "-m", "session-draft: refresh "+name)
+	mustGit(t, ledger, "push", "--quiet", "origin", "main")
+
+	close(release)
+	require.NoError(t, <-lockDone)
+	<-retractDone
+
+	assert.DirExists(t, dir, "a heartbeat refreshed while waiting for the lock must survive")
+	assert.Equal(t, "session-draft: refresh "+name, mustGit(t, ledger, "log", "-1", "--format=%s"))
+}
+
 // TestRetractOrphanedDrafts_KeepsDraftWithLocalRecording — a cached transcript is
 // recoverable work owned by upload-retry, not the reaper, even when stale.
 func TestRetractOrphanedDrafts_KeepsDraftWithLocalRecording(t *testing.T) {

--- a/internal/gitutil/conflict.go
+++ b/internal/gitutil/conflict.go
@@ -52,6 +52,112 @@ func HasConflictMarkersBytes(data []byte) bool {
 	return false
 }
 
+// ValidateLedgerBlob rejects bytes that an automatic Ledger writer must never
+// publish. Conflict markers are invalid in every Ledger artifact; session
+// metadata additionally has a structural JSON contract that Git cannot enforce.
+//
+// Keep this check content-only so both staged-index validators and immutable
+// tree commits can enforce the same invariant without re-reading the worktree.
+func ValidateLedgerBlob(path string, data []byte) error {
+	if HasConflictMarkersBytes(data) {
+		return fmt.Errorf("%s contains an unresolved conflict", path)
+	}
+	if isSessionMetaPath(path) {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(data, &object); err != nil || object == nil {
+			return fmt.Errorf("%s contains invalid JSON object", path)
+		}
+	}
+	return nil
+}
+
+// ValidateStagedLedgerCommit validates the exact blobs currently staged for an
+// automatic Ledger commit. The caller MUST hold WithRepoLock from before its
+// first git add through the subsequent git commit; otherwise another ox process
+// could replace an already-validated index entry before commit.
+//
+// A live unmerged index fails at write-tree before git add can accidentally mark
+// a conflicted path resolved. When pathspecs are supplied, only blobs that the
+// path-scoped commit can publish are scanned; the unmerged-index check remains
+// global because git refuses every commit while any index stage is unresolved.
+func ValidateStagedLedgerCommit(ctx context.Context, repoPath string, pathspecs ...string) error {
+	if err := IsSafeForGitOps(repoPath); err != nil {
+		return fmt.Errorf("unsafe Ledger commit: %w", err)
+	}
+
+	if _, err := cleanGitOutput(ctx, repoPath, "write-tree"); err != nil {
+		return fmt.Errorf("snapshot Ledger index (unresolved conflict in index?): %w", err)
+	}
+
+	// Exclude only deletions: every other status can introduce a blob. In
+	// particular, a symlink-to-file type change is T rather than A/M and must not
+	// bypass validation merely because the path already existed.
+	args := []string{"diff", "--cached", "--name-only", "--diff-filter=d", "--no-renames", "-z", "HEAD", "--"}
+	args = append(args, pathspecs...)
+	paths, err := cleanGitOutput(ctx, repoPath, args...)
+	if err != nil {
+		// Managed Ledgers normally have a HEAD. Supporting an unborn clone keeps
+		// the guard fail-closed without making initial bootstrap a special case.
+		if _, headErr := cleanGitOutput(ctx, repoPath, "rev-parse", "--verify", "HEAD"); headErr == nil {
+			return fmt.Errorf("list staged Ledger blobs: %w", err)
+		}
+		args = []string{"ls-files", "--cached", "-z", "--"}
+		args = append(args, pathspecs...)
+		paths, err = cleanGitOutput(ctx, repoPath, args...)
+		if err != nil {
+			return fmt.Errorf("list staged Ledger blobs on unborn branch: %w", err)
+		}
+	}
+
+	for _, path := range splitNUL(paths) {
+		// :./ disambiguates a pathname such as "1:file" from Git's stage
+		// lookup syntax (:1:file). Read the index blob, never worktree bytes.
+		blob, err := cleanGitOutput(ctx, repoPath, "show", ":./"+path)
+		if err != nil {
+			return fmt.Errorf("inspect staged Ledger blob %s: %w", path, err)
+		}
+		if err := ValidateLedgerBlob(path, blob); err != nil {
+			return fmt.Errorf("refusing automatic Ledger commit: %w", err)
+		}
+	}
+	return nil
+}
+
+func isSessionMetaPath(path string) bool {
+	parts := strings.Split(filepath.ToSlash(filepath.Clean(path)), "/")
+	return len(parts) == 3 && parts[0] == "sessions" && parts[1] != "" && parts[2] == "meta.json"
+}
+
+func splitNUL(data []byte) []string {
+	trimmed := bytes.TrimRight(data, "\x00")
+	if len(trimmed) == 0 {
+		return nil
+	}
+	parts := bytes.Split(trimmed, []byte{0})
+	paths := make([]string, 0, len(parts))
+	for _, part := range parts {
+		paths = append(paths, string(part))
+	}
+	return paths
+}
+
+// cleanGitOutput runs local Git plumbing without RunGit's output sanitization;
+// staged JSON bytes must round-trip byte-for-byte for structural validation.
+func cleanGitOutput(ctx context.Context, repoPath string, args ...string) ([]byte, error) {
+	full := []string{"-C", repoPath, "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}
+	full = append(full, args...)
+	cmd := exec.CommandContext(ctx, "git", full...)
+	cmd.Dir = repoPath
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C", "LANG=C")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git %s: %w: %s", args[0], err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
 // ResolveAutostashConflicts clears formatting-only session metadata conflicts
 // left by pull --autostash, which can exit successfully with an unmerged index.
 // It preserves every field from both sides and refuses differing values,

--- a/internal/gitutil/conflict_test.go
+++ b/internal/gitutil/conflict_test.go
@@ -69,6 +69,178 @@ func TestHasConflictMarkers_MissingFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestValidateLedgerBlob(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		path    string
+		content string
+		wantErr string
+	}{
+		{name: "valid session metadata", path: "sessions/example/meta.json", content: `{"title":"Ready"}`},
+		{name: "invalid session metadata", path: "sessions/example/meta.json", content: `{"title":`, wantErr: "invalid JSON"},
+		{name: "array session metadata", path: "sessions/example/meta.json", content: `[]`, wantErr: "invalid JSON object"},
+		{name: "scalar session metadata", path: "sessions/example/meta.json", content: `"metadata"`, wantErr: "invalid JSON object"},
+		{name: "null session metadata", path: "sessions/example/meta.json", content: `null`, wantErr: "invalid JSON object"},
+		{name: "invalid JSON outside session metadata", path: "data/github/event.json", content: `{"partial":`},
+		{name: "conflict marker in any artifact", path: "sessions/example/summary.md", content: conflictMarkerFixture, wantErr: "unresolved conflict"},
+		{name: "nested path named meta is not session metadata", path: "sessions/example/nested/meta.json", content: `{"partial":`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateLedgerBlob(tc.path, []byte(tc.content))
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+const conflictMarkerFixture = "<<<<<<< Updated upstream\nours\n=======\ntheirs\n>>>>>>> Stashed changes\n"
+
+// Automatic Ledger commits validate index blobs, not worktree bytes. These
+// real-Git cases prevent a writer from publishing a staged conflict or malformed
+// session metadata while preserving path-scoped commit isolation.
+func TestValidateStagedLedgerCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git index states")
+	}
+	for _, tc := range []struct {
+		name       string
+		stagedPath string
+		content    string
+		pathspec   []string
+		wantErr    string
+		setup      func(t *testing.T, repo string)
+	}{
+		{name: "clean metadata", stagedPath: "sessions/example/meta.json", content: `{"title":"Ready"}` + "\n"},
+		{name: "invalid metadata", stagedPath: "sessions/example/meta.json", content: `{"title":`, wantErr: "invalid JSON"},
+		{name: "marker in non-JSON artifact", stagedPath: "sessions/example/summary.md", content: conflictMarkerFixture, wantErr: "unresolved conflict"},
+		{
+			name:       "path scope excludes unrelated staged corruption",
+			stagedPath: "data/github/event.json",
+			content:    `{"ok":true}` + "\n",
+			pathspec:   []string{"data/github/"},
+			setup: func(t *testing.T, repo string) {
+				writeGitutilFixture(t, repo, "sessions/other/meta.json", conflictMarkerFixture)
+				gitInRepo(t, repo, "add", "--sparse", "sessions/other/meta.json")
+			},
+		},
+		{
+			name:       "unmerged index outside path scope",
+			stagedPath: "data/github/event.json",
+			content:    `{"ok":true}` + "\n",
+			pathspec:   []string{"data/github/"},
+			wantErr:    "unresolved conflict in index",
+			setup: func(t *testing.T, repo string) {
+				writeGitutilFixture(t, repo, "shared.txt", "base\n")
+				gitInRepo(t, repo, "add", "shared.txt")
+				gitInRepo(t, repo, "commit", "-m", "shared base")
+				gitInRepo(t, repo, "checkout", "-b", "other")
+				writeGitutilFixture(t, repo, "shared.txt", "other\n")
+				gitInRepo(t, repo, "commit", "-am", "other change")
+				gitInRepo(t, repo, "checkout", "main")
+				writeGitutilFixture(t, repo, "shared.txt", "main\n")
+				gitInRepo(t, repo, "commit", "-am", "main change")
+				cmd := exec.Command("git", "merge", "other")
+				cmd.Dir = repo
+				require.Error(t, cmd.Run(), "fixture must leave an unmerged index")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			gitInRepo(t, repo, "init", "-b", "main")
+			writeGitutilFixture(t, repo, "base.txt", "base\n")
+			gitInRepo(t, repo, "add", "base.txt")
+			gitInRepo(t, repo, "commit", "-m", "base")
+			writeGitutilFixture(t, repo, tc.stagedPath, tc.content)
+			gitInRepo(t, repo, "add", "--sparse", tc.stagedPath)
+			if tc.setup != nil {
+				tc.setup(t, repo)
+			}
+
+			err := ValidateStagedLedgerCommit(context.Background(), repo, tc.pathspec...)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestValidateStagedLedgerCommit_AllowsDeletion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git index state")
+	}
+	repo := t.TempDir()
+	gitInRepo(t, repo, "init", "-b", "main")
+	writeGitutilFixture(t, repo, "sessions/example/meta.json", `{"title":"Ready"}`+"\n")
+	gitInRepo(t, repo, "add", "--sparse", "sessions/example/meta.json")
+	gitInRepo(t, repo, "commit", "-m", "base")
+	gitInRepo(t, repo, "rm", "sessions/example/meta.json")
+
+	require.NoError(t, ValidateStagedLedgerCommit(context.Background(), repo, "sessions/example/"))
+}
+
+func TestValidateStagedLedgerCommit_RejectsTypeChangedBlob(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git index state")
+	}
+	repo := t.TempDir()
+	gitInRepo(t, repo, "init", "-b", "main")
+	path := filepath.Join(repo, "sessions", "example", "meta.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	if err := os.Symlink("target.json", path); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+	gitInRepo(t, repo, "add", "--sparse", "sessions/example/meta.json")
+	gitInRepo(t, repo, "commit", "-m", "seed symlink")
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, os.WriteFile(path, []byte(conflictMarkerFixture), 0o644))
+	gitInRepo(t, repo, "add", "--sparse", "sessions/example/meta.json")
+
+	err := ValidateStagedLedgerCommit(context.Background(), repo, "sessions/example/")
+	require.ErrorContains(t, err, "unresolved conflict")
+}
+
+func TestValidateStagedLedgerCommit_UnbornBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git index state")
+	}
+	for _, tc := range []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{name: "clean object", content: `{"title":"Ready"}` + "\n"},
+		{name: "invalid object", content: `[]`, wantErr: "invalid JSON object"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			gitInRepo(t, repo, "init", "-b", "main")
+			writeGitutilFixture(t, repo, "sessions/example/meta.json", tc.content)
+			gitInRepo(t, repo, "add", "--sparse", "sessions/example/meta.json")
+
+			err := ValidateStagedLedgerCommit(context.Background(), repo, "sessions/example/")
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func writeGitutilFixture(t *testing.T, repo, rel, content string) {
+	t.Helper()
+	path := filepath.Join(repo, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
 // Recovery must not lose metadata, round numeric IDs, or overwrite edits made
 // after git produced the conflict. Refused repairs leave both index and file intact.
 func TestAutostashRecoveryPreservesData(t *testing.T) {

--- a/internal/ledger/github_push.go
+++ b/internal/ledger/github_push.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
+	"path/filepath"
 	"strings"
+
+	"github.com/sageox/ox/internal/gitutil"
 )
 
 // PushFunc is a function that pushes the ledger to remote with retry logic.
@@ -22,13 +24,6 @@ func CommitAndPushGitHubData(ctx context.Context, ledgerPath, owner, repo string
 		return nil
 	}
 
-	// stage all files in data/github/ with --sparse
-	addCmd := exec.Command("git", "-C", ledgerPath, "add", "--sparse", dataDir)
-	if output, err := addCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git add failed: %s: %w", string(output), err)
-	}
-
-	// commit
 	var parts []string
 	if result.PRTotal > 0 {
 		parts = append(parts, fmt.Sprintf("%d PRs", result.PRTotal))
@@ -37,13 +32,25 @@ func CommitAndPushGitHubData(ctx context.Context, ledgerPath, owner, repo string
 		parts = append(parts, fmt.Sprintf("%d issues", result.IssueTotal))
 	}
 	commitMsg := fmt.Sprintf("github: sync %s from %s/%s", strings.Join(parts, ", "), owner, repo)
-	commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "--no-verify", "-m", commitMsg)
-	if output, err := commitCmd.CombinedOutput(); err != nil {
-		if strings.Contains(string(output), "nothing to commit") {
-			// still push — a prior run may have committed but failed to push
-			return pushFn(ctx, ledgerPath)
+	relDir := filepath.ToSlash(filepath.Join("data", "github"))
+
+	// Keep stage, validation, and commit under ADR-030's cross-process lock.
+	// PushWithRetry takes the same non-reentrant lock only if it must pull, so
+	// publication runs after this critical section.
+	if err := gitutil.WithRepoLock(ctx, ledgerPath, func() error {
+		if output, err := gitutil.RunGit(ctx, ledgerPath, "add", "--sparse", "--", relDir); err != nil {
+			return fmt.Errorf("git add failed: %s: %w", output, err)
 		}
-		return fmt.Errorf("git commit failed: %s: %w", string(output), err)
+		if err := gitutil.ValidateStagedLedgerCommit(ctx, ledgerPath, relDir); err != nil {
+			return err
+		}
+		output, err := gitutil.RunGit(ctx, ledgerPath, "commit", "--no-verify", "-m", commitMsg, "--", relDir)
+		if err != nil && !strings.Contains(output, "nothing to commit") {
+			return fmt.Errorf("git commit failed: %s: %w", output, err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// push with caller-provided retry logic

--- a/internal/ledger/github_sync_test.go
+++ b/internal/ledger/github_sync_test.go
@@ -8,8 +8,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/sageox/ox/internal/gitutil"
 )
 
 // mockFetcher implements GitHubFetcher for testing.
@@ -703,6 +706,134 @@ func TestCommitAndPushGitHubData_WithData(t *testing.T) {
 	}
 	if !pushCalled {
 		t.Error("push should have been called")
+	}
+}
+
+// A prior session writer may have left a marker-laden stage-0 blob after
+// accidentally marking a conflict resolved. GitHub sync must commit only its
+// own tree and leave that recoverable corruption out of history.
+func TestCommitAndPushGitHubData_DoesNotSweepStagedSessionConflict(t *testing.T) {
+	ledgerPath := t.TempDir()
+	initGitRepo(t, ledgerPath)
+	metaRel := filepath.Join("sessions", "example", "meta.json")
+	metaPath := filepath.Join(ledgerPath, metaRel)
+	if err := os.MkdirAll(filepath.Dir(metaPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(metaPath, []byte(`{"title":"Clean"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCmd("git", "-C", ledgerPath, "add", "--sparse", metaRel); err != nil {
+		t.Fatalf("seed add: %s: %v", out, err)
+	}
+	if out, err := runCmd("git", "-C", ledgerPath, "commit", "-m", "seed metadata"); err != nil {
+		t.Fatalf("seed commit: %s: %v", out, err)
+	}
+	const markers = "<<<<<<< Updated upstream\n{}\n=======\n{}\n>>>>>>> Stashed changes\n"
+	if err := os.WriteFile(metaPath, []byte(markers), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runCmd("git", "-C", ledgerPath, "add", "--sparse", metaRel); err != nil {
+		t.Fatalf("stage markers: %s: %v", out, err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := WriteGitHubPR(ledgerPath, &PRFile{Number: 43, Title: "Safe", State: "open", Author: "test", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	pushCalled := false
+	err := CommitAndPushGitHubData(context.Background(), ledgerPath, "org", "repo", &SyncResult{PRTotal: 1}, func(context.Context, string) error {
+		pushCalled = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CommitAndPushGitHubData: %v", err)
+	}
+	if !pushCalled {
+		t.Fatal("GitHub-only commit should still publish")
+	}
+
+	headMeta, err := runCmd("git", "-C", ledgerPath, "show", "HEAD:"+filepath.ToSlash(metaRel))
+	if err != nil {
+		t.Fatalf("read committed metadata: %v", err)
+	}
+	if strings.Contains(headMeta, "<<<<<<<") {
+		t.Fatal("GitHub sync committed unrelated session conflict markers")
+	}
+	staged, err := runCmd("git", "-C", ledgerPath, "diff", "--cached", "--name-only", "--", metaRel)
+	if err != nil || !strings.Contains(staged, filepath.ToSlash(metaRel)) {
+		t.Fatalf("recoverable staged metadata must remain untouched: %q, %v", staged, err)
+	}
+}
+
+func TestCommitAndPushGitHubData_RefusesConflictInOwnedTree(t *testing.T) {
+	ledgerPath := t.TempDir()
+	initGitRepo(t, ledgerPath)
+	path := filepath.Join(GitHubDataDir(ledgerPath), "broken.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("<<<<<<< Updated upstream\n{}\n=======\n{}\n>>>>>>> Stashed changes\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := runCmd("git", "-C", ledgerPath, "rev-parse", "HEAD")
+	pushCalled := false
+	err := CommitAndPushGitHubData(context.Background(), ledgerPath, "org", "repo", &SyncResult{PRTotal: 1}, func(context.Context, string) error {
+		pushCalled = true
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "unresolved conflict") {
+		t.Fatalf("expected conflict-marker rejection, got %v", err)
+	}
+	if pushCalled {
+		t.Fatal("push must not run after commit validation fails")
+	}
+	after, _ := runCmd("git", "-C", ledgerPath, "rev-parse", "HEAD")
+	if before != after {
+		t.Fatalf("validation failure advanced HEAD: before=%s after=%s", before, after)
+	}
+}
+
+func TestCommitAndPushGitHubData_WaitsForRepoWriter(t *testing.T) {
+	ledgerPath := t.TempDir()
+	initGitRepo(t, ledgerPath)
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := WriteGitHubPR(ledgerPath, &PRFile{Number: 44, Title: "Wait", State: "open", Author: "test", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- gitutil.WithRepoLock(context.Background(), ledgerPath, func() error {
+			close(locked)
+			<-release
+			return nil
+		})
+	}()
+	<-locked
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	pushCalled := false
+	err := CommitAndPushGitHubData(ctx, ledgerPath, "org", "repo", &SyncResult{PRTotal: 1}, func(context.Context, string) error {
+		pushCalled = true
+		return nil
+	})
+	close(release)
+	if lockErr := <-lockDone; lockErr != nil {
+		t.Fatalf("release fixture lock: %v", lockErr)
+	}
+	if !gitutil.IsRepoLockBusy(err) {
+		t.Fatalf("expected repo-lock contention, got %v", err)
+	}
+	if pushCalled {
+		t.Fatal("writer must not push without entering its commit transaction")
+	}
+	staged, stageErr := runCmd("git", "-C", ledgerPath, "diff", "--cached", "--name-only")
+	if stageErr != nil || strings.TrimSpace(staged) != "" {
+		t.Fatalf("writer staged data while another transaction held the lock: %q, %v", staged, stageErr)
 	}
 }
 

--- a/internal/lfs/reconcile.go
+++ b/internal/lfs/reconcile.go
@@ -49,9 +49,18 @@ type ReconcileResult struct {
 // committing on top is not sufficient — the old commits still reference the
 // missing OIDs.
 func ReconcileUnpushedPointers(ctx context.Context, ledgerPath, endpointURL string, logger *slog.Logger) (*ReconcileResult, error) {
-	return reconcileUnpushedPointers(ctx, ledgerPath, logger, func() (*Client, error) {
-		return NewClientFromLedger(ledgerPath, endpointURL)
+	var result *ReconcileResult
+	err := gitutil.WithRepoLock(ctx, ledgerPath, func() error {
+		var err error
+		result, err = reconcileUnpushedPointers(ctx, ledgerPath, logger, func() (*Client, error) {
+			return NewClientFromLedger(ledgerPath, endpointURL)
+		})
+		return err
 	})
+	if result == nil {
+		result = &ReconcileResult{}
+	}
+	return result, err
 }
 
 // reconcileUnpushedPointers is the client-injectable core of
@@ -192,6 +201,14 @@ func reconcileUnpushedPointers(ctx context.Context, ledgerPath string, logger *s
 		}
 	}
 
+	// Reconcile's commit is intentionally unscoped because the later soft-reset
+	// squash republishes every unpushed change. Refuse pre-existing staged
+	// corruption before blanking any pointer so a bad session cannot either ride
+	// along in the repair commit or turn a recoverable LFS cleanup destructive.
+	if err := gitutil.ValidateStagedLedgerCommit(ctx, ledgerPath); err != nil {
+		return result, fmt.Errorf("validate Ledger before LFS reconcile: %w", err)
+	}
+
 	logger.Info("lfs reconcile: replacing orphaned pointers with empty stubs",
 		"missing", len(missing), "total_pointers", len(pointers))
 
@@ -221,6 +238,10 @@ func reconcileUnpushedPointers(ctx context.Context, ledgerPath string, logger *s
 	// commit the replacements
 	msg := fmt.Sprintf("fix: replace %d orphaned LFS pointers with empty stubs", result.Replaced)
 	commitCtx, commitCancel := context.WithTimeout(ctx, 10*time.Second)
+	if err := gitutil.ValidateStagedLedgerCommit(commitCtx, ledgerPath); err != nil {
+		commitCancel()
+		return result, fmt.Errorf("validate replacements: %w", err)
+	}
 	_, commitErr := gitutil.RunGit(commitCtx, ledgerPath, "commit", "-m", msg, "--no-verify")
 	commitCancel()
 	if commitErr != nil {
@@ -250,6 +271,13 @@ func squashUnpushed(ctx context.Context, repoPath, commitMsg string) error {
 		return fmt.Errorf("no upstream tracking ref: %w", err)
 	}
 	upstream = strings.TrimSpace(upstream)
+	originalCtx, originalCancel := context.WithTimeout(ctx, 5*time.Second)
+	original, originalErr := gitutil.RunGit(originalCtx, repoPath, "rev-parse", "--verify", "HEAD")
+	originalCancel()
+	if originalErr != nil {
+		return fmt.Errorf("resolve original HEAD: %w", originalErr)
+	}
+	original = strings.TrimSpace(original)
 
 	countCtx, countCancel := context.WithTimeout(ctx, 5*time.Second)
 	countOut, err := gitutil.RunGit(countCtx, repoPath, "rev-list", "--count", upstream+"..HEAD")
@@ -267,11 +295,27 @@ func squashUnpushed(ctx context.Context, repoPath, commitMsg string) error {
 	}
 
 	squashCtx, squashCancel := context.WithTimeout(ctx, 10*time.Second)
+	if err := gitutil.ValidateStagedLedgerCommit(squashCtx, repoPath); err != nil {
+		squashCancel()
+		return rollbackSoftReset(ctx, repoPath, original, fmt.Errorf("validate squash: %w", err))
+	}
 	_, err = gitutil.RunGit(squashCtx, repoPath, "commit", "-m", commitMsg, "--no-verify")
 	squashCancel()
 	if err != nil {
-		return fmt.Errorf("squash commit: %w", err)
+		return rollbackSoftReset(ctx, repoPath, original, fmt.Errorf("squash commit: %w", err))
 	}
 
 	return nil
+}
+
+// rollbackSoftReset restores the pre-squash branch tip after a validation or
+// commit failure. The soft reset's index already represents original's tree, so
+// restoring only HEAD preserves both the replacement commit and working copy.
+func rollbackSoftReset(ctx context.Context, repoPath, original string, cause error) error {
+	rollbackCtx, rollbackCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer rollbackCancel()
+	if _, err := gitutil.RunGit(rollbackCtx, repoPath, "reset", "--soft", original); err != nil {
+		return fmt.Errorf("%w; restore original HEAD: %w", cause, err)
+	}
+	return cause
 }

--- a/internal/lfs/reconcile_test.go
+++ b/internal/lfs/reconcile_test.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -110,6 +112,30 @@ func TestReconcile_NoSessions_Unaffected(t *testing.T) {
 	// sessions/ exists but is empty
 	result, err := ReconcileUnpushedPointers(context.Background(), dir, "", nil)
 	require.NoError(t, err)
+	assert.Zero(t, result.ScannedPointers)
+}
+
+func TestReconcile_WaitsForRepoWriter(t *testing.T) {
+	dir := initLedgerRepo(t)
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- gitutil.WithRepoLock(context.Background(), dir, func() error {
+			close(locked)
+			<-release
+			return nil
+		})
+	}()
+	<-locked
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	result, err := ReconcileUnpushedPointers(ctx, dir, "", nil)
+	close(release)
+	require.NoError(t, <-lockDone)
+	require.True(t, gitutil.IsRepoLockBusy(err), "expected repo-lock contention, got %v", err)
+	assert.NotNil(t, result)
 	assert.Zero(t, result.ScannedPointers)
 }
 
@@ -310,6 +336,73 @@ func TestReconcile_PreservesRecoverableSessionCache(t *testing.T) {
 			}
 		})
 	}
+}
+
+// LFS reconciliation used to run an unscoped commit, so a session conflict
+// staged by another writer could ride along with an unrelated pointer repair.
+// Refuse before changing either history or the pointer working copy.
+func TestReconcile_RefusesPreexistingStagedConflict(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git history and mocked LFS batch API")
+	}
+	ledger, _ := initLedgerWithRemote(t)
+	oid := strings.Repeat("a", 64)
+	pointer := []byte(lfsPointerContent(oid, 100))
+	pointerPath := filepath.Join(ledger, "sessions", "pointer-session", "raw.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(pointerPath), 0o755))
+	require.NoError(t, os.WriteFile(pointerPath, pointer, 0o644))
+	git(t, ledger, "add", "--sparse", "sessions/pointer-session/raw.jsonl")
+	git(t, ledger, "commit", "-m", "pointer awaiting push", "--no-verify")
+
+	metaPath := filepath.Join(ledger, "sessions", "conflicted", "meta.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(metaPath), 0o755))
+	markers := []byte("<<<<<<< Updated upstream\n{}\n=======\n{}\n>>>>>>> Stashed changes\n")
+	require.NoError(t, os.WriteFile(metaPath, markers, 0o644))
+	git(t, ledger, "add", "--sparse", "sessions/conflicted/meta.json")
+	headBefore := git(t, ledger, "rev-parse", "HEAD")
+
+	client := fakeLFSDownloadServer(t, map[string]int{oid: http.StatusNotFound})
+	result, err := reconcileUnpushedPointers(context.Background(), ledger, nil,
+		func() (*Client, error) { return client, nil })
+	require.ErrorContains(t, err, "unresolved conflict")
+	assert.Equal(t, 1, result.MissingOnRemote)
+	assert.Zero(t, result.Replaced)
+	assert.False(t, result.Squashed)
+	assert.Equal(t, headBefore, git(t, ledger, "rev-parse", "HEAD"))
+	content, readErr := os.ReadFile(pointerPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, pointer, content, "validation must run before destructive pointer replacement")
+}
+
+func TestReconcile_RefusesConflictInUnpushedHistory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git history and mocked LFS batch API")
+	}
+	ledger, _ := initLedgerWithRemote(t)
+	oid := strings.Repeat("b", 64)
+	pointerPath := filepath.Join(ledger, "sessions", "pointer-session", "raw.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(pointerPath), 0o755))
+	require.NoError(t, os.WriteFile(pointerPath, []byte(lfsPointerContent(oid, 100)), 0o644))
+	git(t, ledger, "add", "--sparse", "sessions/pointer-session/raw.jsonl")
+	git(t, ledger, "commit", "-m", "pointer awaiting push", "--no-verify")
+
+	metaPath := filepath.Join(ledger, "sessions", "conflicted", "meta.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(metaPath), 0o755))
+	markers := []byte("<<<<<<< Updated upstream\n{}\n=======\n{}\n>>>>>>> Stashed changes\n")
+	require.NoError(t, os.WriteFile(metaPath, markers, 0o644))
+	git(t, ledger, "add", "--sparse", "sessions/conflicted/meta.json")
+	git(t, ledger, "commit", "-m", "accidentally published conflict locally", "--no-verify")
+
+	client := fakeLFSDownloadServer(t, map[string]int{oid: http.StatusNotFound})
+	result, err := reconcileUnpushedPointers(context.Background(), ledger, nil,
+		func() (*Client, error) { return client, nil })
+	require.ErrorContains(t, err, "validate squash")
+	assert.Equal(t, 1, result.Replaced)
+	assert.False(t, result.Squashed)
+	assert.Equal(t, 3, unpushedCount(t, ledger), "failed validation must restore the pre-squash commit chain")
+	content, readErr := os.ReadFile(metaPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, markers, content, "failed squash must preserve corrupt metadata for doctor recovery")
 }
 
 // --- Guarantee 4: idempotent ---


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a08f17-0160-7cb5-8912-36ca1351d11e">Session</a>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/plan/pln_01a08e92-185b-72de-84f7-48f1271955ab">Plan</a>
<!-- /sageox:pr-header -->

## What broke

- **Conflict publication:** `git add` turns a marker-laden unmerged path into an ordinary stage-0 blob, after which daemon commits could permanently publish invalid `sessions/*/meta.json`.
- **Cross-process race:** The daemon mutex coordinated goroutines but not CLI pulls or a second process touching the same Ledger clone between write, stage, and commit.
- **Unscoped commits:** GitHub sync and LFS reconciliation could sweep unrelated staged corruption into otherwise valid commits.
- **Draft retraction:** A draft could become fresh on another machine while the reaper waited for the repo lock, yet still be deleted from the stale pre-lock candidate list.

## What this PR ships

- **Shared fail-closed validator:** Automatic writers reject an unmerged index, conflict markers in every staged non-deletion (including Git type changes), and session metadata that is not a valid JSON object. Validation reads exact index blobs rather than mutable working-tree files.
- **Atomic writer transactions:** Session finalization, murmur publication, GitHub sync, orphan-draft retraction, and LFS reconciliation hold ADR-030's cross-process repo lock across write/stage/validate/commit. Push happens after release so retry recovery can safely reacquire the non-reentrant lock.
- **Path isolation:** Session, murmur, draft, and GitHub commits remain path-scoped, preserving unrelated staged work. LFS reconciliation validates its intentionally unscoped squash and restores the original branch tip if validation or recommit fails.
- **Live-draft safety:** The reaper repeats the complete orphan predicate after acquiring the lock, so a newly pulled heartbeat prevents deletion.
- **CLI parity:** The immutable CLI Ledger snapshot path reuses the same blob contract. PR #908 remains responsible for recovering existing autostash conflicts; this PR prevents automatic commits from freezing new ones into history.

```mermaid
flowchart LR
    A[Acquire repo lock] --> B[Write and stage owned paths]
    B --> C{Validate exact index blobs}
    C -->|valid| D[Commit and release lock]
    D --> E[Push; retry may reacquire lock]
    C -.->|invalid: preserve content and retry later| A
```

## Test Plan

- `make format`
- `make lint` — 0 issues
- Focused `go test -race` across `cmd/ox`, `internal/gitutil`, `internal/ledger`, `internal/lfs`, `internal/daemon/agentwork`, and `internal/daemon`
- `make test` — 19,513 tests; 18,394 passed; 1,119 expected skips; 0 failed
- Rebased onto `origin/main` at `d643ebef`, then reran focused race tests and lint successfully
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented automatic commits and publishing when ledger or GitHub data contains conflict markers or invalid session metadata.
  - Added repository locking to prevent concurrent operations from interfering with commits, synchronization, and pointer reconciliation.
  - Improved draft cleanup to preserve recently refreshed sessions and safely handle concurrent changes.
  - Ensured failed validation restores prior repository and pointer state.
- **Reliability**
  - Added validation for staged changes, including unmerged entries and malformed content, before automated commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791703878&installation_model_id=433550&pr_number=910&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F910&signature=602c3a911cdf4daa7e571ffb2c10bff04505ddee8b45fee82e75d3cc5c752371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Closes #897

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a08f17-0160-7cb5-8912-36ca1351d11e
