### PR TITLE
fix(doctor): make the ox-in-path shell probe reliable across shells

### DIFF
--- a/cmd/ox/doctor_e2e_test.go
+++ b/cmd/ox/doctor_e2e_test.go
@@ -346,6 +346,13 @@ func isExpectedE2EIssue(check ReportCheck) bool {
 		return true
 	}
 
+	// Adapter binaries -- the E2E harness builds only the ox binary into a
+	// scratch dir, never its ten ox-adapter-* siblings, so "1/10 present" is
+	// the correct reading of a correct environment, not a defect under test.
+	if containsAny(name, "Adapter binaries") {
+		return true
+	}
+
 	// discovery not run -- optional
 	if containsAny(name, "discovery") {
 		return true

--- a/internal/doctor/checks/ox_in_path.go
+++ b/internal/doctor/checks/ox_in_path.go
@@ -280,6 +280,14 @@ func classifyShell(path string) shellKind {
 	}
 }
 
+// notFoundSentinel is what the probe script prints when `command -v`
+// fails. The not-found answer travels on stdout rather than in the exit
+// code because shells disagree on the code: bash and zsh exit 1, but dash
+// -- which IS /bin/sh on Debian and Ubuntu -- exits 127. Reading the code
+// instead made the check report "inconclusive" on most Linux machines,
+// exactly where it was supposed to report "ox is off PATH".
+const notFoundSentinel = "__OX_NOT_FOUND__"
+
 // probeShellPath runs `<shellPath> -c "command -v <binary>"` under a
 // scrubbed environment -- deliberately NOT inheriting the caller's PATH,
 // since that would just re-test whatever shell launched `ox doctor` and
@@ -292,7 +300,10 @@ func probeShellPath(ctx context.Context, shellPath, binary string) (string, erro
 		return "", ErrShellProbeInconclusive
 	}
 
-	cmd := exec.CommandContext(ctx, shellPath, "-c", "command -v "+binary)
+	// The `|| printf` makes a clean not-found exit 0, so a non-zero exit
+	// now means only one thing: the shell itself failed.
+	script := "command -v " + binary + " 2>/dev/null || printf '%s' " + notFoundSentinel
+	cmd := exec.CommandContext(ctx, shellPath, "-c", script)
 	cmd.Env = scrubbedShellEnv()
 
 	out, err := cmd.Output()
@@ -300,28 +311,19 @@ func probeShellPath(ctx context.Context, shellPath, binary string) (string, erro
 		if ctx.Err() != nil {
 			return "", ErrShellProbeInconclusive
 		}
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			// "command -v" itself only ever exits 0 (found) or 1 (not
-			// found) -- exit code 1 is the real "not found" signal. Any
-			// other exit code means the shell exited for a reason
-			// unrelated to whether ox is on PATH: e.g. a config error in
-			// the user's own startup file (zsh -c always sources
-			// ~/.zshenv, even non-interactively), or an explicit `exit N`
-			// in it. That must be reported as inconclusive, never
-			// misread as "ox is missing" -- a supported shell dying in
-			// its own rc file is not the same fact as ox being absent.
-			if exitErr.ExitCode() == 1 {
-				return "", ErrNotFoundInShell
-			}
-			return "", ErrShellProbeInconclusive
-		}
-		// couldn't even start the shell (bad path, permission denied, etc).
+		// Any non-zero exit means the shell exited for a reason unrelated
+		// to whether ox is on PATH: a config error in the user's own
+		// startup file (zsh -c always sources ~/.zshenv, even
+		// non-interactively), or an explicit `exit N` in it. That must be
+		// reported as inconclusive, never misread as "ox is missing" -- a
+		// supported shell dying in its own rc file is not the same fact as
+		// ox being absent. This also covers failing to start the shell at
+		// all (bad path, permission denied).
 		return "", ErrShellProbeInconclusive
 	}
 
 	resolved := strings.TrimSpace(string(out))
-	if resolved == "" {
+	if resolved == "" || resolved == notFoundSentinel {
 		return "", ErrNotFoundInShell
 	}
 	return resolved, nil

--- a/internal/doctor/checks/ox_in_path.go
+++ b/internal/doctor/checks/ox_in_path.go
@@ -323,8 +323,15 @@ func probeShellPath(ctx context.Context, shellPath, binary string) (string, erro
 	}
 
 	resolved := strings.TrimSpace(string(out))
-	if resolved == "" || resolved == notFoundSentinel {
+	if resolved == notFoundSentinel {
 		return "", ErrNotFoundInShell
+	}
+	if resolved == "" {
+		// The script always prints either a path or the sentinel, so empty
+		// output means we never saw the answer -- a startup file that
+		// redirects stdout (`exec >/dev/null`) is the realistic cause. That
+		// is unknown, not absent, and must not become an off-PATH warning.
+		return "", ErrShellProbeInconclusive
 	}
 	return resolved, nil
 }

--- a/internal/doctor/checks/ox_in_path.go
+++ b/internal/doctor/checks/ox_in_path.go
@@ -323,6 +323,15 @@ func probeShellPath(ctx context.Context, shellPath, binary string) (string, erro
 	}
 
 	resolved := strings.TrimSpace(string(out))
+	// A startup file is free to print to stdout before our script ever runs
+	// (an `echo` in ~/.zshenv is the common case). Both `command -v` and the
+	// sentinel emit exactly one final line, so the answer is the last line
+	// and anything above it is the shell's own noise. Comparing the whole
+	// output instead would read "noise\n<sentinel>" as a resolved path and
+	// report a shadowed binary that does not exist.
+	if idx := strings.LastIndexByte(resolved, '\n'); idx >= 0 {
+		resolved = strings.TrimSpace(resolved[idx+1:])
+	}
 	if resolved == notFoundSentinel {
 		return "", ErrNotFoundInShell
 	}

--- a/internal/doctor/checks/ox_in_path.go
+++ b/internal/doctor/checks/ox_in_path.go
@@ -300,9 +300,12 @@ func probeShellPath(ctx context.Context, shellPath, binary string) (string, erro
 		return "", ErrShellProbeInconclusive
 	}
 
-	// The `|| printf` makes a clean not-found exit 0, so a non-zero exit
-	// now means only one thing: the shell itself failed.
-	script := "command -v " + binary + " 2>/dev/null || printf '%s' " + notFoundSentinel
+	// The leading newline guarantees our answer starts its own line even if
+	// a startup file wrote without a trailing one -- otherwise its text and
+	// the answer share a line ("welcome/bin/sh") and no amount of line
+	// splitting can separate them. The `|| printf` makes a clean not-found
+	// exit 0, so a non-zero exit now means only one thing: the shell failed.
+	script := "printf '\\n'; command -v " + binary + " 2>/dev/null || printf '%s' " + notFoundSentinel
 	cmd := exec.CommandContext(ctx, shellPath, "-c", script)
 	cmd.Env = scrubbedShellEnv()
 

--- a/internal/doctor/checks/ox_in_path_test.go
+++ b/internal/doctor/checks/ox_in_path_test.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -182,6 +183,34 @@ func TestProbeShellPath_ResolvesARealBinaryViaScrubbedEnv(t *testing.T) {
 func TestProbeShellPath_BinaryNotFound_ReturnsErrNotFoundInShell(t *testing.T) {
 	_, err := probeShellPath(context.Background(), "/bin/sh", "definitely-not-a-real-binary-xyz")
 	assert.ErrorIs(t, err, ErrNotFoundInShell)
+}
+
+// TestProbeShellPath_NotFoundIsShellIndependent pins the not-found answer
+// across every POSIX shell present, not just whichever one is /bin/sh
+// here. It is the regression guard for reading the answer out of the exit
+// code: bash and zsh exit 1 on a failed `command -v`, dash exits 127. On
+// Debian and Ubuntu /bin/sh IS dash, so the code-reading version reported
+// ErrShellProbeInconclusive on most Linux machines -- silently disabling
+// the check in exactly the case it exists to catch. macOS never caught it
+// because its /bin/sh is not dash.
+func TestProbeShellPath_NotFoundIsShellIndependent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shells only")
+	}
+	for _, name := range []string{"sh", "bash", "zsh", "dash"} {
+		shell, err := exec.LookPath(name)
+		if err != nil {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			_, err := probeShellPath(context.Background(), shell, "definitely-not-a-real-binary-xyz")
+			assert.ErrorIs(t, err, ErrNotFoundInShell)
+
+			resolved, err := probeShellPath(context.Background(), shell, "sh")
+			require.NoError(t, err)
+			assert.NotEmpty(t, resolved)
+		})
+	}
 }
 
 // TestProbeShellPath_ShellExitsNonOneForUnrelatedReason_IsInconclusive is

--- a/internal/doctor/checks/ox_in_path_test.go
+++ b/internal/doctor/checks/ox_in_path_test.go
@@ -208,6 +208,29 @@ func TestProbeShellPath_StartupOutputDoesNotMaskTheAnswer(t *testing.T) {
 	assert.NotContains(t, resolved, "welcome", "startup noise must not contaminate the resolved path")
 }
 
+// TestProbeShellPath_UnterminatedStartupOutputDoesNotMaskTheAnswer covers the
+// harder half of the same problem: a startup file that writes WITHOUT a
+// trailing newline. Without a delimiter of our own, the shell's text and the
+// answer share one line ("welcome/bin/sh"), so taking the last line is not
+// enough -- the probe script has to open with a newline to guarantee its
+// answer starts clean.
+func TestProbeShellPath_UnterminatedStartupOutputDoesNotMaskTheAnswer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shells only")
+	}
+	dir := t.TempDir()
+	chattyShell := filepath.Join(dir, "unterminated-shell.sh")
+	require.NoError(t, os.WriteFile(chattyShell,
+		[]byte("#!/bin/sh\nprintf 'welcome'\nexec /bin/sh \"$@\"\n"), 0o755))
+
+	_, err := probeShellPath(context.Background(), chattyShell, "definitely-not-a-real-binary-xyz")
+	assert.ErrorIs(t, err, ErrNotFoundInShell, "unterminated startup noise must not mask an absent binary")
+
+	resolved, err := probeShellPath(context.Background(), chattyShell, "sh")
+	require.NoError(t, err)
+	assert.NotContains(t, resolved, "welcome", "unterminated startup noise must not contaminate the resolved path")
+}
+
 // TestProbeShellPath_SucceedsButSwallowsStdout_IsInconclusive pins that a
 // shell which exits 0 while producing no output is reported as unknown, not
 // as "ox is missing". The probe script always prints either a path or the

--- a/internal/doctor/checks/ox_in_path_test.go
+++ b/internal/doctor/checks/ox_in_path_test.go
@@ -185,6 +185,29 @@ func TestProbeShellPath_BinaryNotFound_ReturnsErrNotFoundInShell(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFoundInShell)
 }
 
+// TestProbeShellPath_StartupOutputDoesNotMaskTheAnswer covers a shell whose
+// startup file prints to stdout before the probe script runs -- an `echo` in
+// ~/.zshenv is the ordinary case. The answer is the final line; treating the
+// whole output as the answer would read "noise\n<sentinel>" as a resolved
+// path and report a shadowed binary that does not exist, and would corrupt a
+// real resolved path with the noise prefix.
+func TestProbeShellPath_StartupOutputDoesNotMaskTheAnswer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shells only")
+	}
+	dir := t.TempDir()
+	chattyShell := filepath.Join(dir, "chatty-shell.sh")
+	require.NoError(t, os.WriteFile(chattyShell,
+		[]byte("#!/bin/sh\nprintf 'welcome to your shell\\n'\nexec /bin/sh \"$@\"\n"), 0o755))
+
+	_, err := probeShellPath(context.Background(), chattyShell, "definitely-not-a-real-binary-xyz")
+	assert.ErrorIs(t, err, ErrNotFoundInShell, "startup noise must not mask an absent binary")
+
+	resolved, err := probeShellPath(context.Background(), chattyShell, "sh")
+	require.NoError(t, err)
+	assert.NotContains(t, resolved, "welcome", "startup noise must not contaminate the resolved path")
+}
+
 // TestProbeShellPath_SucceedsButSwallowsStdout_IsInconclusive pins that a
 // shell which exits 0 while producing no output is reported as unknown, not
 // as "ox is missing". The probe script always prints either a path or the

--- a/internal/doctor/checks/ox_in_path_test.go
+++ b/internal/doctor/checks/ox_in_path_test.go
@@ -185,6 +185,25 @@ func TestProbeShellPath_BinaryNotFound_ReturnsErrNotFoundInShell(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFoundInShell)
 }
 
+// TestProbeShellPath_SucceedsButSwallowsStdout_IsInconclusive pins that a
+// shell which exits 0 while producing no output is reported as unknown, not
+// as "ox is missing". The probe script always prints either a path or the
+// sentinel, so empty output means the answer never reached us -- a startup
+// file doing `exec >/dev/null` is the realistic cause. Reporting that as an
+// off-PATH failure would be the false negative ErrShellProbeInconclusive
+// exists to prevent.
+func TestProbeShellPath_SucceedsButSwallowsStdout_IsInconclusive(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shells only")
+	}
+	dir := t.TempDir()
+	silentShell := filepath.Join(dir, "silent-shell.sh")
+	require.NoError(t, os.WriteFile(silentShell, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	_, err := probeShellPath(context.Background(), silentShell, "ox")
+	assert.ErrorIs(t, err, ErrShellProbeInconclusive)
+}
+
 // TestProbeShellPath_NotFoundIsShellIndependent pins the not-found answer
 // across every POSIX shell present, not just whichever one is /bin/sh
 // here. It is the regression guard for reading the answer out of the exit


### PR DESCRIPTION
`main` is red. `eb1cd97d` (#910) and `d643ebef` (#909) both fail CI; `c1c6d73a` (#908) and earlier are green.

This fixes **two** regressions from #909. The second was hidden behind the first: the unit-test failure aborted `coverage-integration` before its compiled-binary step ever ran, so CI could only ever report one of them.

| # | Regression | Surface |
|---|---|---|
| 1 | Shell probe reads its answer from the exit code, which dash reports differently | `ox doctor`'s `ox-in-path` check silently disabled on Linux |
| 2 | New `Adapter binaries` check never added to the E2E allowlist | `TestFreshInstall_MockServer_*` fail in the compiled-binary tier |

## What broke

The `ox-in-path` doctor check added in #909 reads its answer out of the probe shell's **exit code**:

```go
if exitErr.ExitCode() == 1 {
    return "", ErrNotFoundInShell
}
return "", ErrShellProbeInconclusive
```

The comment above it states the premise:

> `"command -v" itself only ever exits 0 (found) or 1 (not found)`

That is **not true of dash**, and on Debian and Ubuntu `/bin/sh` **is** dash:

| shell | `command -v <missing>` |
|---|---|
| bash · zsh · macOS `/bin/sh` | exit **1** |
| **dash** (Debian/Ubuntu `/bin/sh`) | exit **127** |

## Why it matters beyond CI

On most Linux machines the check reported `ErrShellProbeInconclusive` — which `Run` maps to `StatusSkip`. The check silently did nothing **in exactly the situation it was built to catch**: ox installed but off the PATH a non-interactive hook shell sees.

That is #909's headline fix. It works on macOS and is inert on Ubuntu. macOS never caught it because its `/bin/sh` is not dash.

```mermaid
flowchart TD
    A["probe: sh -c 'command -v ox'"] --> B{"exit code"}
    B -->|"1 — bash/zsh/macOS sh"| C["ErrNotFoundInShell<br/>→ StatusWarn ✅"]
    B -->|"127 — dash = Ubuntu /bin/sh"| D["ErrShellProbeInconclusive<br/>→ StatusSkip ❌ check disabled"]
```

## The fix

Move the answer off the exit code and onto stdout:

```go
script := "command -v " + binary + " 2>/dev/null || printf '%s' " + notFoundSentinel
```

The `|| printf` makes a clean not-found exit 0, so a non-zero exit now means only one thing: **the shell itself failed**. That is a stronger version of #909's original intent, not a weakening of it — widening the accepted codes to `1 || 127` would have been worse, since 127 is also what a broken rc file produces, which is the case #909 deliberately separated.

`TestProbeShellPath_ShellExitsNonOneForUnrelatedReason_IsInconclusive` — #909's red-first guard for that distinction — still passes unchanged: a shell that dies in its own rc file produces empty stdout, not the sentinel.

## Test Plan

**Red-first, reproduced locally on macOS** by probing dash explicitly (macOS `/bin/sh` can't show the bug):

```
--- FAIL: TestRedProof_DashNotFound
    Error: Target error should be in err chain:
    expected: "not found in shell"
    in chain: "shell probe inconclusive"
```

Same signature as the CI failure on `main`. After the fix: `ok`.

**Permanent guard:** `TestProbeShellPath_NotFoundIsShellIndependent` pins the not-found answer across *every* POSIX shell present rather than whichever one happens to be `/bin/sh`, so this cannot regress on one platform while passing on another. Runs `sh`, `bash`, `zsh`, `dash` locally; `sh`/`bash`/`dash` on CI.

- `go test -race ./internal/doctor/...` — all three packages pass
- `make test-acceptance-cover` — 12 tests, 0 failures (the tier that was red)
- `make lint` — 0 issues
- `gofmt` clean

---

# Regression 2 — the masked one

#909 added the `adapter-siblings` doctor check (`cmd/ox/doctor_adapter_siblings.go`) but did not add it to `isExpectedE2EIssue` in `cmd/ox/doctor_e2e_test.go`. That allowlist has **zero** mentions of "adapter"; `git log` confirms #909 never touched the file.

The E2E harness builds only `ox-cover` into a scratch directory, never its ten `ox-adapter-*` siblings — so `1/10 present` is the correct reading of a correct environment, not a defect under test. This is the identical situation to `ox in PATH`, which #909's own sibling check *is* allowlisted for, one branch above.

Two tests failed on it: `TestFreshInstall_MockServer_InitThenDoctor` and `TestFreshInstall_MockServer_SyncUnavailableThenDoctorStillWorks`.

**Fix:** allowlist `Adapter binaries`, with a comment stating why the environment is correct rather than merely tolerated.

**Verified:** `make test-acceptance-cover` locally — `DONE 12 tests`, no failures. Those are the same 12 tests that reported 2 failures in CI.

# Regression 3 — caught in review

CodeRabbit flagged that once the sentinel exists, `resolved == ""` can no longer mean "not found": the script always prints a path or the sentinel, so empty stdout means the answer never reached us (a startup file doing `exec >/dev/null`). Mapping that to `ErrNotFoundInShell` would produce a false off-PATH warning — the exact failure `ErrShellProbeInconclusive` is documented to prevent.

`ErrNotFoundInShell` is now reserved for the sentinel alone. Pinned by `TestProbeShellPath_SucceedsButSwallowsStdout_IsInconclusive`.

## Merge order

This should land **before** #911 (`release: prep v0.15.0`). That PR is blocked on a green main, and its release notes credit the `ox doctor` install checks — which need this to be true on Linux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved environment diagnostics when checking whether a command is available.
  - Added compatibility for shells such as Debian and Ubuntu’s default shell, reducing incorrect “not found” results.
  - Startup output from shell configuration files no longer interferes with command detection.
  - Shell errors or empty responses are now reported as inconclusive instead of incorrectly indicating that a command is unavailable.

- **Tests**
  - Expanded coverage across supported POSIX shells and incomplete command environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->