### PR TITLE
fix(kb): never commit .sageox/.gitignore into Knowledge Bubbles

### DIFF
--- a/docs/specs/kb-daemon-sync.md
+++ b/docs/specs/kb-daemon-sync.md
@@ -57,6 +57,27 @@ Both `ox init` and the daemon reconciler write the rule (via
 --fix`) will *remove* a stale `.sageox/kb/` line from a root `.gitignore`, and
 only once the replacement is verifiably present.
 
+### Keeping the daemon's own files out of git — local excludes only
+
+Inside a bubble checkout the daemon writes `.sageox/meta.json` (plus its
+atomic-write temp file) and `.sageox/cache/`. Those are hidden from `git status`
+by an ox-managed block in the clone's **`.git/info/exclude`**
+(`kb.EnsureLocalExcludes`, reapplied on every clone and pull) — an explicit list
+of daemon-written paths, never a blanket `*`.
+
+A bubble **never** gets the committed `.sageox/.gitignore` that ledgers and team
+contexts carry (`gitserver.EnsureCheckoutGitignore`; `TwoPhaseClone` skips it for
+`RepoKindKB`). That file's `*` rule, once on a bubble's `main`, hides the
+server-side Curator's own `.sageox/curator/marks/` and `synopses/` from its
+`git add -A`, so it never sees its save-mark and re-drives the synthesis every
+hour. Two production bubbles hit exactly this on 2026-08-18 (ox #832 covers the
+same file's earlier ledger-side incident). Bubble sync is pull-only, so the
+daemon has no business authoring a commit in a bubble at all; `.git/info/exclude`
+is the only ignore surface it may touch, and nothing written there can reach the
+server or another clone. A bubble whose `main` already carries the bad file is a
+server-side repair (delete it from `main`); the daemon will pull the removal and
+never re-create it.
+
 ---
 
 ## Who syncs bubbles — leader-gated, exactly like team context

--- a/internal/daemon/sync_bubbles.go
+++ b/internal/daemon/sync_bubbles.go
@@ -5,7 +5,11 @@ package daemon
 // scoped per sageox-mono ADR-073 — one scope per call, members-only) and
 // pulls each one into its canonical XDG path (paths.KBDir(kb_id)). Per
 // the daemon-CLI split (.claude/rules/daemon-git.md) this only ever
-// pulls — never adds, commits, or pushes. Symlink management (D2) and
+// pulls — never adds, commits, or pushes. That includes ignore rules:
+// a bubble checkout gets local-only excludes in .git/info/exclude
+// (kb.EnsureLocalExcludes), never a committed .sageox/.gitignore, because
+// the server-side Curator commits into .sageox/curator/ and a committed
+// `*` rule would hide its artifacts from it. Symlink management (D2) and
 // GC (D3) live in separate beads and intentionally NOT here.
 
 import (
@@ -377,6 +381,17 @@ func (s *SyncScheduler) reconcileBubble(ctx context.Context, b api.KB) {
 		// non-fatal: we still write meta.json
 	}
 
+	// local-only ignore rules for the files this loop writes (meta.json,
+	// cache/). These go in .git/info/exclude, NEVER a committed
+	// .sageox/.gitignore: a committed `*` rule on a bubble's main hides the
+	// server Curator's own .sageox/curator/ artifacts from its `git add -A`
+	// and it re-drives every synthesis forever (see internal/kb/localexclude.go).
+	// Reapplied on every pass so a clone from an older ox heals itself.
+	if _, err := kb.EnsureLocalExcludes(target); err != nil {
+		s.logger.Warn("kb_sync ensure local excludes failed", "kb_id", b.KBID, "type", string(b.KBType), "error", err)
+		// non-fatal: worst case meta.json shows as untracked in git status
+	}
+
 	if err := writeKBMeta(target, b); err != nil {
 		s.logger.Warn("kb_sync meta write failed", "kb_id", b.KBID, "type", string(b.KBType), "error", err)
 		return
@@ -386,9 +401,9 @@ func (s *SyncScheduler) reconcileBubble(ctx context.Context, b api.KB) {
 // cloneBubble performs the initial clone of a bubble into the canonical
 // XDG path via gitserver.TwoPhaseClone — the same shallow + blob:none +
 // sparse-checkout pipeline team-contexts use. This unlocks manifest-driven
-// sparse sets, depth-1 history, and EnsureCheckoutGitignore as part of the
-// clone itself. NEVER shells out to git-lfs (per
-// .claude/rules/lfs-no-git-lfs-binary.md); TwoPhaseClone calls
+// sparse sets and depth-1 history as part of the clone itself. NEVER
+// shells out to git-lfs (per .claude/rules/lfs-no-git-lfs-binary.md);
+// TwoPhaseClone calls
 // gitutil.StripLFSConfig to disable any smudge filter git-lfs may have
 // injected during the clone.
 func (s *SyncScheduler) cloneBubble(ctx context.Context, b api.KB, target string) error {
@@ -429,13 +444,12 @@ func (s *SyncScheduler) cloneBubble(ctx context.Context, b api.KB, target string
 		s.logger.Warn("kb_sync post-clone ensure merge attrs failed", "kb_id", b.KBID, "type", string(b.KBType), "error", err)
 	}
 
-	// belt-and-suspenders: TwoPhaseClone already calls EnsureCheckoutGitignoreCtx
-	// internally, but we re-call it explicitly to mirror the explicit-is-better
-	// posture from sync_gc.go. Idempotent — no-ops when entries are already
-	// present.
-	if err := gitserver.EnsureCheckoutGitignoreCtx(ctx, target); err != nil {
-		s.logger.Warn("kb_sync post-clone ensure checkout gitignore failed", "kb_id", b.KBID, "type", string(b.KBType), "error", err)
-	}
+	// NOTE: no gitserver.EnsureCheckoutGitignoreCtx here, and TwoPhaseClone
+	// skips it for RepoKindKB. That helper commits .sageox/.gitignore, which
+	// (a) violates this loop's pull-only contract and (b) once on a bubble's
+	// main makes the server Curator skip its own .sageox/curator/ files.
+	// Local ignore rules are installed by reconcileBubble via
+	// kb.EnsureLocalExcludes after this returns.
 	return nil
 }
 

--- a/internal/daemon/sync_bubbles_clone_test.go
+++ b/internal/daemon/sync_bubbles_clone_test.go
@@ -758,3 +758,46 @@ resolve auto data/
 	require.NoError(t, err)
 	assert.NotContains(t, string(statusOut), "UU", "no unmerged paths after manifest-driven resolve")
 }
+
+// TestSyncBubbles_LocalExcludeFailure_IsNonFatal verifies that a broken
+// .git/info (here: a regular file where the directory should be) makes
+// the local-exclude install fail loudly in the log but does not stop the
+// reconcile: meta.json is still written. Failure prevented: a cosmetic
+// ignore-rule problem escalating into a bubble that never gets metadata.
+func TestSyncBubbles_LocalExcludeFailure_IsNonFatal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	kbTestEnv(t)
+	s, _ := kbTestScheduler(t)
+
+	bareDir, _ := seedKBRemote(t, nil)
+	bubble := api.KB{
+		KBID:    "kb_excludefail",
+		KBType:  api.KBTypeTeam,
+		Slug:    "excludefail",
+		RepoURL: "file://" + bareDir,
+	}
+	s.SetKBBubbleListerFactory(func(_, _ string) KBBubbleLister {
+		return &fakeKBLister{bubbles: []api.KB{bubble}}
+	})
+
+	s.syncBubbles(context.Background())
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
+	require.DirExists(t, filepath.Join(target, ".git"))
+
+	// break .git/info and drop meta.json so the next pass has to rewrite it.
+	require.NoError(t, os.RemoveAll(filepath.Join(target, ".git", "info")))
+	require.NoError(t, os.WriteFile(filepath.Join(target, ".git", "info"), []byte("not a dir"), 0o644))
+	require.NoError(t, os.Remove(filepath.Join(target, ".sageox", "meta.json")))
+
+	s.syncBubbles(context.Background())
+
+	require.FileExists(t, filepath.Join(target, ".sageox", "meta.json"),
+		"reconcile must still write meta.json when the exclude install fails")
+	_, statErr := os.Stat(filepath.Join(target, ".sageox", ".gitignore"))
+	assert.True(t, os.IsNotExist(statErr), "an exclude failure must never fall back to a committed .sageox/.gitignore")
+}

--- a/internal/daemon/sync_bubbles_clone_test.go
+++ b/internal/daemon/sync_bubbles_clone_test.go
@@ -10,6 +10,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -470,19 +471,70 @@ func TestSyncBubbles_Clone_ShallowAndPartialFilter(t *testing.T) {
 	assert.Equal(t, "true", strings.TrimSpace(string(promisor)))
 }
 
-// TestSyncBubbles_Clone_HasGitignoreEntries verifies cloneBubble installs
-// the .sageox/.gitignore entries that prevent daemon-written cache files
-// from showing up as untracked. Without this, blue-green GC reclone (if
-// kb ever grows one) would treat the checkout as permanently dirty.
+// kbGitCheckIgnored asks git whether rel would be ignored in dir. Behavior,
+// not spelling: it does not matter which file carries the rule.
+func kbGitCheckIgnored(t *testing.T, dir, rel string) bool {
+	t.Helper()
+	err := exec.Command("git", "-C", dir, "check-ignore", "-q", rel).Run()
+	if err == nil {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false
+	}
+	t.Fatalf("git check-ignore %s: %v", rel, err)
+	return false
+}
+
+// seedKBRemote builds a bare, filter-capable remote whose main carries a
+// .sageox/sync.manifest plus a Curator artifact, and returns the bare and
+// work dirs so a test can push further "server-side" commits.
+func seedKBRemote(t *testing.T, extraFiles map[string]string) (bareDir, workDir string) {
+	t.Helper()
+	tmp := t.TempDir()
+	bareDir = filepath.Join(tmp, "kb.bare")
+	workDir = filepath.Join(tmp, "kb.work")
+	require.NoError(t, exec.Command("git", "init", "--bare", "-b", "main", bareDir).Run())
+	gitInDir(t, bareDir, "config", "uploadpack.allowfilter", "true")
+	require.NoError(t, exec.Command("git", "clone", bareDir, workDir).Run())
+	gitConfig(t, workDir)
+	files := map[string]string{
+		".sageox/sync.manifest":        "version 1\ninclude .sageox/\ninclude README.md\n",
+		".sageox/curator/marks/a.json": "{}\n",
+		"README.md":                    "v1\n",
+	}
+	for k, v := range extraFiles {
+		files[k] = v
+	}
+	for rel, body := range files {
+		full := filepath.Join(workDir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+	}
+	gitInDir(t, workDir, "add", "-f", ".")
+	gitInDir(t, workDir, "commit", "-m", "seed")
+	gitInDir(t, workDir, "push", "origin", "HEAD:main")
+	return bareDir, workDir
+}
+
+func kbHead(t *testing.T, dir, ref string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", dir, "rev-parse", ref).Output()
+	require.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}
+
+// TestSyncBubbles_Clone_NeverCommitsSageoxGitignore is the bubble-side
+// customer promise: after the daemon clones a bubble, there is no
+// daemon-authored .sageox/.gitignore, no local commit, and a Curator
+// artifact is not ignored — while the daemon's own meta.json still stays
+// out of git status via the local-only .git/info/exclude.
 //
-// Mirrors team-context's EnsureCheckoutGitignore behavior: only kicks in
-// when the cloned repo has a .sageox/ directory (the path that holds the
-// generated cache + meta files). Most kb bubbles will have one because
-// the daemon writes meta.json into it.
-//
-// Failure prevented: cache files (.sageox/cache/, etc.) being committed
-// or blocking future GC because EnsureCheckoutGitignoreCtx never ran.
-func TestSyncBubbles_Clone_HasGitignoreEntries(t *testing.T) {
+// Failure prevented: the committed `*` rule reaching a bubble's main and
+// making the server Curator's `git add -A` skip its own save-mark, so it
+// re-drives every synthesis hourly, forever (prod, 2026-08-18).
+func TestSyncBubbles_Clone_NeverCommitsSageoxGitignore(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short: git clone operations")
 	}
@@ -492,27 +544,11 @@ func TestSyncBubbles_Clone_HasGitignoreEntries(t *testing.T) {
 	kbTestEnv(t)
 	s, _ := kbTestScheduler(t)
 
-	// build a bare repo that already has a .sageox/ directory so
-	// EnsureCheckoutGitignoreCtx has somewhere to write. mirrors what a
-	// server-provisioned bubble actually looks like.
-	tmp := t.TempDir()
-	bareDir := filepath.Join(tmp, "gitignore.bare")
-	workDir := filepath.Join(tmp, "gitignore.work")
-	require.NoError(t, exec.Command("git", "init", "--bare", "-b", "main", bareDir).Run())
-	gitInDir(t, bareDir, "config", "uploadpack.allowfilter", "true")
-	require.NoError(t, exec.Command("git", "clone", bareDir, workDir).Run())
-	gitConfig(t, workDir)
-	require.NoError(t, os.MkdirAll(filepath.Join(workDir, ".sageox"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".sageox", "sync.manifest"), []byte("version 1\ninclude .sageox/\ninclude README.md\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(workDir, "README.md"), []byte("v1\n"), 0o644))
-	gitInDir(t, workDir, "add", ".")
-	gitInDir(t, workDir, "commit", "-m", "seed with .sageox")
-	gitInDir(t, workDir, "push", "origin", "HEAD:main")
-
+	bareDir, _ := seedKBRemote(t, nil)
 	bubble := api.KB{
-		KBID:    "kb_gitignore",
+		KBID:    "kb_noignore",
 		KBType:  api.KBTypeTeam,
-		Slug:    "gitignore",
+		Slug:    "noignore",
 		RepoURL: "file://" + bareDir,
 	}
 	s.SetKBBubbleListerFactory(func(_, _ string) KBBubbleLister {
@@ -522,28 +558,110 @@ func TestSyncBubbles_Clone_HasGitignoreEntries(t *testing.T) {
 	s.syncBubbles(context.Background())
 
 	target := paths.KBDir(endpoint.Get(), bubble.KBID)
-	gitignoreBytes, err := os.ReadFile(filepath.Join(target, ".sageox", ".gitignore"))
-	require.NoError(t, err, ".sageox/.gitignore must exist after clone")
-	contents := string(gitignoreBytes)
-	for _, want := range []string{"*", "!.gitignore", "!sync.manifest"} {
-		assert.Contains(t, contents, want,
-			".sageox/.gitignore must contain %q so cache files don't appear as untracked", want)
-	}
+	require.DirExists(t, filepath.Join(target, ".git"))
 
-	// daemon-written meta.json must not surface as untracked — exactly
-	// what the gitignore's `*` blanket entry prevents.
+	_, statErr := os.Stat(filepath.Join(target, ".sageox", ".gitignore"))
+	assert.True(t, os.IsNotExist(statErr), "daemon must not write .sageox/.gitignore into a bubble")
+	assert.Equal(t, kbHead(t, bareDir, "main"), kbHead(t, target, "HEAD"),
+		"bubble clone must carry no daemon-authored commit")
+
+	// Curator paths stay visible to git; daemon files stay hidden.
+	assert.False(t, kbGitCheckIgnored(t, target, ".sageox/curator/marks/new.json"),
+		"a new Curator mark must not be ignored")
+	assert.True(t, kbGitCheckIgnored(t, target, ".sageox/meta.json"),
+		"daemon meta.json must be ignored via .git/info/exclude")
+	require.FileExists(t, filepath.Join(target, ".sageox", "meta.json"), "reconcile writes meta.json")
+
 	statusOut, err := exec.Command("git", "-C", target, "status", "--porcelain").CombinedOutput()
 	require.NoError(t, err, "git status: %s", statusOut)
-	for _, line := range strings.Split(strings.TrimSpace(string(statusOut)), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		assert.False(t,
-			strings.Contains(line, ".sageox/cache/") ||
-				strings.Contains(line, ".sageox/meta.json"),
-			"cache/meta file %q must not appear in git status — gitignore is missing entries", line)
+	assert.Empty(t, strings.TrimSpace(string(statusOut)),
+		"bubble checkout must be clean after sync (meta.json hidden by local exclude), got: %s", statusOut)
+}
+
+// TestSyncBubbles_Pull_BadGitignoreOnMain_NeverReAdded is the regression
+// test for the two production bubbles that already carry the bad file: a
+// remote whose main has the `*` .sageox/.gitignore committed. The daemon
+// must (1) not author any commit on clone, (2) after the server removes
+// the file, pull the removal cleanly and not re-create or re-commit it,
+// and (3) leave Curator paths un-ignored once the file is gone.
+//
+// Failure prevented: the daemon fighting the server-side repair by
+// re-adding the `*` rule on the next sync.
+func TestSyncBubbles_Pull_BadGitignoreOnMain_NeverReAdded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone/pull operations")
 	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	kbTestEnv(t)
+	s, _ := kbTestScheduler(t)
+
+	const badIgnore = "# Ignore all daemon-written files; re-include committed files\n*\n!.gitignore\n!sync.manifest\n"
+	bareDir, workDir := seedKBRemote(t, map[string]string{".sageox/.gitignore": badIgnore})
+	bubble := api.KB{
+		KBID:    "kb_badignore",
+		KBType:  api.KBTypeTeam,
+		Slug:    "badignore",
+		RepoURL: "file://" + bareDir,
+	}
+	s.SetKBBubbleListerFactory(func(_, _ string) KBBubbleLister {
+		return &fakeKBLister{bubbles: []api.KB{bubble}}
+	})
+
+	// pass 1: clone. The bad file arrives tracked (that is the server's
+	// problem to fix); the daemon must not add a commit of its own.
+	s.syncBubbles(context.Background())
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
+	require.FileExists(t, filepath.Join(target, ".sageox", ".gitignore"), "fixture: bad file is on main")
+	assert.Equal(t, kbHead(t, bareDir, "main"), kbHead(t, target, "HEAD"),
+		"clone of a bubble with the bad file must not add a daemon commit")
+
+	// server-side repair: remove the file from main.
+	gitInDir(t, workDir, "rm", "-q", ".sageox/.gitignore")
+	gitInDir(t, workDir, "commit", "-m", "fix: drop daemon .sageox/.gitignore so the Curator sees its marks")
+	gitInDir(t, workDir, "push", "origin", "HEAD:main")
+
+	// nudge FETCH_HEAD into the past so fetch dedup doesn't skip the pull.
+	fetchHead := filepath.Join(target, ".git", "FETCH_HEAD")
+	if info, err := os.Stat(fetchHead); err == nil {
+		past := info.ModTime().Add(-10 * time.Minute)
+		_ = os.Chtimes(fetchHead, past, past)
+	}
+
+	// pass 2: pull the repair, then reconcile again to prove nothing
+	// re-creates the file on a subsequent pass either.
+	s.syncBubbles(context.Background())
+	s.syncBubbles(context.Background())
+
+	assert.Equal(t, kbHead(t, bareDir, "main"), kbHead(t, target, "HEAD"),
+		"after pulling the repair the bubble must sit exactly on remote main")
+	_, statErr := os.Stat(filepath.Join(target, ".sageox", ".gitignore"))
+	assert.True(t, os.IsNotExist(statErr), "daemon must not re-create .sageox/.gitignore after the server removed it")
+
+	logOut, err := exec.Command("git", "-C", target, "log", "--format=%s").Output()
+	require.NoError(t, err)
+	assert.NotContains(t, string(logOut), "chore: add .sageox/.gitignore",
+		"no daemon-authored gitignore commit may exist in a bubble's history")
+
+	assert.False(t, kbGitCheckIgnored(t, target, ".sageox/curator/marks/new.json"),
+		"once the bad file is gone, Curator marks must not be ignored")
+	statusOut, err := exec.Command("git", "-C", target, "status", "--porcelain").CombinedOutput()
+	require.NoError(t, err, "git status: %s", statusOut)
+	assert.Empty(t, strings.TrimSpace(string(statusOut)), "bubble checkout must be clean, got: %s", statusOut)
+
+	// pass 3: a fresh clone of the repaired bubble (new machine, or a
+	// checkout healed after .git went missing). This is the leg the old
+	// code failed: a fresh clone re-wrote and re-committed the `*` file.
+	require.NoError(t, os.RemoveAll(target))
+	s.syncBubbles(context.Background())
+	require.DirExists(t, filepath.Join(target, ".git"), "re-clone must succeed")
+	_, statErr = os.Stat(filepath.Join(target, ".sageox", ".gitignore"))
+	assert.True(t, os.IsNotExist(statErr), "a fresh clone after the repair must not re-create .sageox/.gitignore")
+	assert.Equal(t, kbHead(t, bareDir, "main"), kbHead(t, target, "HEAD"),
+		"a fresh clone after the repair must carry no daemon-authored commit")
+	assert.False(t, kbGitCheckIgnored(t, target, ".sageox/curator/marks/new.json"),
+		"Curator marks must not be ignored in the re-cloned bubble")
 }
 
 // TestSyncBubbles_Pull_ManifestResolveRules verifies that when a bubble

--- a/internal/daemon/sync_gc.go
+++ b/internal/daemon/sync_gc.go
@@ -830,6 +830,10 @@ func (s *SyncScheduler) runBlueGreenGCOpts(ctx context.Context, ws WorkspaceStat
 	}
 
 	// ensure .sageox/.gitignore excludes daemon-written files (cache/, checkout.json, etc.)
+	// Only ledgers and team contexts reach this path (they are the only
+	// workspace types in the registry). Knowledge Bubbles are GC'd by
+	// runKBGC, which never reclones, and must never get this committed file
+	// (see kb.EnsureLocalExcludes).
 	if err := gitserver.EnsureCheckoutGitignoreCtx(ctx, newPath); err != nil {
 		s.logger.Warn("gc: failed to ensure checkout .gitignore on new clone", "error", err)
 	}

--- a/internal/gitserver/gitignore.go
+++ b/internal/gitserver/gitignore.go
@@ -12,7 +12,12 @@ import (
 )
 
 // checkoutRequiredEntries are the entries that must be present in .sageox/.gitignore
-// inside ledger and team context checkout directories. These prevent daemon-written
+// inside ledger and team context checkout directories — and ONLY those two
+// kinds. Knowledge Bubble checkouts must never receive this file: the
+// server-side Curator commits into .sageox/curator/, and the `*` rule below,
+// once committed to a bubble's main, hides those artifacts from the Curator's
+// own `git add -A`. Bubbles use local-only rules in .git/info/exclude instead
+// (internal/kb/localexclude.go). These prevent daemon-written
 // files from appearing as untracked in git status --porcelain, which would permanently
 // block blue-green GC reclone (isCheckoutClean() treats any porcelain output as dirty).
 //
@@ -73,8 +78,10 @@ func RejFilesTracked(repoPath string) (bool, error) {
 	return len(strings.TrimSpace(string(out))) > 0, nil
 }
 
-// EnsureCheckoutGitignore ensures .sageox/.gitignore exists in the given repo
-// with required entries to prevent daemon-written files from appearing as untracked.
+// EnsureCheckoutGitignore ensures .sageox/.gitignore exists in the given
+// ledger or team-context repo with required entries to prevent
+// daemon-written files from appearing as untracked. Never call it on a
+// Knowledge Bubble checkout — see checkoutRequiredEntries.
 // Without this, isCheckoutClean() in the GC path sees these files as dirty and
 // permanently blocks blue-green reclone.
 //

--- a/internal/gitserver/two_phase_clone.go
+++ b/internal/gitserver/two_phase_clone.go
@@ -143,10 +143,21 @@ func TwoPhaseClone(ctx context.Context, cloneURL, repoPath string, kind manifest
 	// strip lfs config that git-lfs may have injected during clone
 	gitutil.StripLFSConfig(repoPath)
 
-	// ensure .sageox/.gitignore excludes daemon-written files (cache/, checkout.json, etc.)
-	// so they don't appear as untracked and block blue-green GC reclone
-	if err := EnsureCheckoutGitignoreCtx(ctx, repoPath); err != nil {
-		return nil, fmt.Errorf("ensure checkout .gitignore: %w", err)
+	// Ledgers and team contexts: commit .sageox/.gitignore so daemon-written
+	// files (cache/, checkout.json, etc.) never show as untracked and block
+	// blue-green GC reclone.
+	//
+	// Knowledge Bubbles are deliberately excluded. The committed file's
+	// blanket `*` rule reaches the bubble's main and makes the server-side
+	// Curator's `git add -A` skip its own .sageox/curator/ artifacts, so it
+	// re-drives every synthesis forever. Bubble sync is pull-only — the
+	// daemon never authors a commit in a bubble — and its local-only ignore
+	// rules go in .git/info/exclude instead (kb.EnsureLocalExcludes, applied
+	// by the bubble reconciler on every clone and pull).
+	if kind != manifest.RepoKindKB {
+		if err := EnsureCheckoutGitignoreCtx(ctx, repoPath); err != nil {
+			return nil, fmt.Errorf("ensure checkout .gitignore: %w", err)
+		}
 	}
 
 	return &TwoPhaseCloneResult{

--- a/internal/gitserver/two_phase_clone_test.go
+++ b/internal/gitserver/two_phase_clone_test.go
@@ -1,8 +1,12 @@
 package gitserver
 
 import (
+	"context"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sageox/ox/internal/manifest"
@@ -143,4 +147,109 @@ func TestValidateTeamContextClone_DeniedPathNotPresent(t *testing.T) {
 
 	// should not warn when denied paths don't exist
 	ValidateTeamContextClone(dir, cfg)
+}
+
+// seedKBLikeRemote builds a bare repo (filter-capable) whose main carries a
+// .sageox/sync.manifest and a Curator-style artifact under .sageox/curator/,
+// the shape a server-provisioned Knowledge Bubble has.
+func seedKBLikeRemote(t *testing.T) (bareDir string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	tmp := t.TempDir()
+	bareDir = filepath.Join(tmp, "kb.bare")
+	workDir := filepath.Join(tmp, "kb.work")
+	git := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	require.NoError(t, exec.Command("git", "init", "--bare", "-b", "main", bareDir).Run())
+	git(bareDir, "config", "uploadpack.allowfilter", "true")
+	require.NoError(t, exec.Command("git", "clone", bareDir, workDir).Run())
+	git(workDir, "config", "user.name", "test")
+	git(workDir, "config", "user.email", "test@test.com")
+	require.NoError(t, os.MkdirAll(filepath.Join(workDir, ".sageox", "curator", "marks"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".sageox", "sync.manifest"), []byte("version 1\ninclude .sageox/\ninclude README.md\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".sageox", "curator", "marks", "a.json"), []byte("{}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "README.md"), []byte("v1\n"), 0o644))
+	git(workDir, "add", ".")
+	git(workDir, "commit", "-m", "seed")
+	git(workDir, "push", "origin", "HEAD:main")
+	return bareDir
+}
+
+// gitCheckIgnored asks git itself whether rel would be ignored in dir.
+func gitCheckIgnored(t *testing.T, dir, rel string) bool {
+	t.Helper()
+	err := exec.Command("git", "-C", dir, "check-ignore", "-q", rel).Run()
+	if err == nil {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false
+	}
+	t.Fatalf("git check-ignore %s: %v", rel, err)
+	return false
+}
+
+// TestTwoPhaseClone_KBKind_NoCommittedGitignore is the customer promise for
+// Knowledge Bubbles: cloning a bubble never leaves a daemon-authored
+// .sageox/.gitignore in the tree, never adds a local commit, and never makes
+// git ignore a Curator artifact. Failure prevented: the `*` rule reaching a
+// bubble's main so the server Curator's `git add -A` skips its own
+// .sageox/curator/marks save-mark and re-drives synthesis every hour.
+func TestTwoPhaseClone_KBKind_NoCommittedGitignore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	TestAllowFileTransport = true
+	t.Cleanup(func() { TestAllowFileTransport = false })
+
+	bareDir := seedKBLikeRemote(t)
+	target := filepath.Join(t.TempDir(), "kb_clone")
+	_, err := TwoPhaseClone(context.Background(), "file://"+bareDir, target, manifest.RepoKindKB)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(target, ".sageox", ".gitignore"))
+	assert.True(t, os.IsNotExist(statErr), "KB clone must not get a .sageox/.gitignore")
+
+	localHead, err := exec.Command("git", "-C", target, "rev-parse", "HEAD").Output()
+	require.NoError(t, err)
+	remoteHead, err := exec.Command("git", "-C", bareDir, "rev-parse", "main").Output()
+	require.NoError(t, err)
+	assert.Equal(t, string(remoteHead), string(localHead), "KB clone must carry no daemon-authored commit")
+
+	assert.False(t, gitCheckIgnored(t, target, ".sageox/curator/marks/new.json"),
+		"a new Curator mark must not be ignored in a KB clone")
+	assert.False(t, gitCheckIgnored(t, target, ".sageox/curator/synopses/s.md"),
+		"a new Curator synopsis must not be ignored in a KB clone")
+}
+
+// TestTwoPhaseClone_TeamContextKind_StillCommitsGitignore pins the
+// unchanged ledger/team-context behavior next to the KB case above, so a
+// future edit cannot silently flip either kind. Same fixture, other kind:
+// the committed file appears and the blanket rule applies.
+func TestTwoPhaseClone_TeamContextKind_StillCommitsGitignore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	TestAllowFileTransport = true
+	t.Cleanup(func() { TestAllowFileTransport = false })
+
+	bareDir := seedKBLikeRemote(t)
+	target := filepath.Join(t.TempDir(), "tc_clone")
+	_, err := TwoPhaseClone(context.Background(), "file://"+bareDir, target, manifest.RepoKindTeamContext)
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(target, ".sageox", ".gitignore"))
+	tracked, err := exec.Command("git", "-C", target, "ls-files", ".sageox/.gitignore").Output()
+	require.NoError(t, err)
+	assert.NotEmpty(t, strings.TrimSpace(string(tracked)), "team-context clone commits .sageox/.gitignore")
+	assert.True(t, gitCheckIgnored(t, target, ".sageox/cache/sync-state.json"),
+		"team-context blanket rule still ignores daemon cache files")
 }

--- a/internal/kb/localexclude.go
+++ b/internal/kb/localexclude.go
@@ -1,0 +1,103 @@
+package kb
+
+// Local-only ignore rules for Knowledge Bubble checkouts.
+//
+// Ledger and team-context checkouts get a COMMITTED .sageox/.gitignore
+// (gitserver.EnsureCheckoutGitignore) whose blanket `*` rule hides every
+// daemon-written file under .sageox/. That file is wrong for a bubble: the
+// server-side Curator commits platform artifacts under .sageox/curator/
+// (marks/, synopses/), and once a `*` rule reaches a bubble's main the
+// Curator's own `git add -A` silently skips its save-mark. The server then
+// concludes the synthesis never happened and re-drives it every hour,
+// forever. Two production bubbles hit exactly this on 2026-08-18.
+//
+// So a bubble checkout never carries an ox-authored ignore file in the
+// tree. Bubble sync is pull-only (internal/daemon/sync_bubbles.go: the
+// daemon never adds, commits, or pushes into a bubble), which means the
+// only ignore surface it may touch is the per-clone, never-committed
+// .git/info/exclude. Rules there are invisible to the server and to every
+// other clone, and they cannot mask a tracked file — pulled Curator
+// artifacts always arrive tracked — so nothing the daemon writes here can
+// alter what the Curator commits.
+//
+// The rule set is an explicit list of files the daemon writes into a
+// bubble checkout, not a blanket `*`: a blanket rule in exclude would be
+// harmless to the server, but it would also hide any new server-written
+// subtree from a local `git status` and make this file the same kind of
+// trap the committed one was. Extend the list when adding a daemon writer.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// localExcludeRelPath is the per-clone ignore file git consults after the
+// tree's .gitignore files. It lives under .git/, so it is never committed,
+// pushed, or seen by another clone.
+const localExcludeRelPath = ".git/info/exclude"
+
+// managed-block markers for the exclude file; same discipline as the
+// merge-attrs block in mergeattrs.go.
+const (
+	localExcludeHeader = "# BEGIN ox-managed local excludes — do not edit between markers"
+	localExcludeFooter = "# END ox-managed local excludes"
+)
+
+// LocalExcludePatterns are the daemon-written paths hidden from `git
+// status` in a bubble checkout. Patterns are repo-root anchored. Exported
+// so tooling and tests can introspect the canonical list.
+var LocalExcludePatterns = []string{
+	"/.sageox/meta.json",       // writeKBMeta (internal/daemon/sync_bubbles.go)
+	"/.sageox/meta.json.tmp-*", // its atomic-write temp file
+	"/.sageox/cache/",          // local-only derived data (.claude/rules/ledger-cache.md)
+}
+
+// renderLocalExcludeBlock returns the canonical ox-managed exclude block.
+func renderLocalExcludeBlock() string {
+	var b strings.Builder
+	b.WriteString(localExcludeHeader + "\n")
+	b.WriteString("# Daemon-written files in this Knowledge Bubble checkout. Kept out of\n")
+	b.WriteString("# the committed tree on purpose: a committed .sageox/.gitignore would\n")
+	b.WriteString("# hide the server Curator's own .sageox/curator/ artifacts from it.\n")
+	for _, p := range LocalExcludePatterns {
+		b.WriteString(p + "\n")
+	}
+	b.WriteString(localExcludeFooter + "\n")
+	return b.String()
+}
+
+// EnsureLocalExcludes writes or updates the ox-managed block in the bubble
+// checkout's .git/info/exclude. Idempotent; preserves content outside the
+// block; atomic write. Returns true if the file changed.
+//
+// It never touches .sageox/.gitignore and never stages or commits
+// anything — see the package comment above for why that is load-bearing.
+func EnsureLocalExcludes(repoPath string) (changed bool, err error) {
+	if repoPath == "" {
+		return false, fmt.Errorf("repo path is empty")
+	}
+	if info, statErr := os.Stat(filepath.Join(repoPath, ".git")); statErr != nil || !info.IsDir() {
+		return false, fmt.Errorf("not a git repository: %s", repoPath)
+	}
+
+	full := filepath.Join(repoPath, localExcludeRelPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		return false, fmt.Errorf("create info dir: %w", err)
+	}
+
+	existing, readErr := os.ReadFile(full)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return false, fmt.Errorf("read info/exclude: %w", readErr)
+	}
+
+	desired := mergeManagedBlockBetween(string(existing), renderLocalExcludeBlock(), localExcludeHeader, localExcludeFooter)
+	if string(existing) == desired {
+		return false, nil
+	}
+	if err := writeFileAtomic(full, desired); err != nil {
+		return false, fmt.Errorf("write info/exclude: %w", err)
+	}
+	return true, nil
+}

--- a/internal/kb/localexclude_test.go
+++ b/internal/kb/localexclude_test.go
@@ -1,0 +1,182 @@
+package kb
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initRealRepo creates a real git repo with a committed .sageox/sync.manifest
+// so `git check-ignore` has an index to consult.
+func initRealRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	run("init", "--initial-branch=main")
+	run("config", "user.name", "test")
+	run("config", "user.email", "test@test.com")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".sageox"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".sageox", "sync.manifest"), []byte("version 1\ninclude .sageox/\n"), 0o644))
+	run("add", ".sageox/sync.manifest")
+	run("commit", "-m", "seed")
+	return dir
+}
+
+// checkIgnored runs `git check-ignore -q` and reports whether git would
+// ignore rel. Uses git itself rather than string-matching the rule file so
+// the assertion is about behavior, not spelling.
+func checkIgnored(t *testing.T, dir, rel string) bool {
+	t.Helper()
+	cmd := exec.Command("git", "-C", dir, "check-ignore", "-q", "--no-index", rel)
+	err := cmd.Run()
+	if err == nil {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false
+	}
+	t.Fatalf("git check-ignore %s: %v", rel, err)
+	return false
+}
+
+// TestEnsureLocalExcludes_CuratorPathsStayVisible is the customer promise:
+// after the daemon installs its ignore rules, a Curator artifact under
+// .sageox/curator/ is NOT ignored, while the daemon's own meta.json and
+// cache/ are. Failure prevented: the server Curator's `git add -A` skipping
+// its save-mark and re-driving synthesis every hour.
+func TestEnsureLocalExcludes_CuratorPathsStayVisible(t *testing.T) {
+	dir := initRealRepo(t)
+
+	changed, err := EnsureLocalExcludes(dir)
+	require.NoError(t, err)
+	assert.True(t, changed, "first call must write the block")
+
+	// never a committed ignore file
+	_, statErr := os.Stat(filepath.Join(dir, ".sageox", ".gitignore"))
+	assert.True(t, os.IsNotExist(statErr), ".sageox/.gitignore must not be created in a bubble checkout")
+
+	assert.False(t, checkIgnored(t, dir, ".sageox/curator/marks/x.json"), "curator marks must not be ignored")
+	assert.False(t, checkIgnored(t, dir, ".sageox/curator/synopses/y.md"), "curator synopses must not be ignored")
+	assert.False(t, checkIgnored(t, dir, ".sageox/sync.manifest"), "sync.manifest must not be ignored")
+
+	assert.True(t, checkIgnored(t, dir, ".sageox/meta.json"), "daemon meta.json must be ignored")
+	assert.True(t, checkIgnored(t, dir, ".sageox/meta.json.tmp-123"), "meta.json temp file must be ignored")
+	assert.True(t, checkIgnored(t, dir, ".sageox/cache/sync-state.json"), "cache/ must be ignored")
+
+	// git status stays clean once the daemon writes its files
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".sageox", "meta.json"), []byte("{}"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".sageox", "cache"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".sageox", "cache", "x"), []byte("x"), 0o644))
+	out, err := exec.Command("git", "-C", dir, "status", "--porcelain").Output()
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(string(out)), "daemon-written files must not appear in git status")
+
+	// and a curator file DOES show up — i.e. nothing hides it
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".sageox", "curator", "marks"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".sageox", "curator", "marks", "a.json"), []byte("{}"), 0o644))
+	out, err = exec.Command("git", "-C", dir, "status", "--porcelain").Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(out), ".sageox/curator/", "curator artifact must be visible to git")
+}
+
+// TestEnsureLocalExcludes is table-driven over the read-modify-write
+// scenarios of the exclude file itself.
+func TestEnsureLocalExcludes(t *testing.T) {
+	cases := []struct {
+		name             string
+		failurePrevented string
+		existing         string
+		wantChanged      bool
+		mustContain      []string
+		mustNotContain   []string
+	}{
+		{
+			name:             "creates_file_when_missing",
+			failurePrevented: "fresh bubble clone shows meta.json as untracked forever",
+			wantChanged:      true,
+			mustContain:      append([]string{localExcludeHeader, localExcludeFooter}, LocalExcludePatterns...),
+		},
+		{
+			name:             "preserves_user_content",
+			failurePrevented: "a hand-added exclude rule is clobbered by the daemon",
+			existing:         "my-local-scratch/\n",
+			wantChanged:      true,
+			mustContain:      []string{"my-local-scratch/\n", localExcludeHeader},
+		},
+		{
+			name:             "replaces_stale_block",
+			failurePrevented: "an older ox's rule set lingers next to the new one",
+			existing:         "keep-me\n" + localExcludeHeader + "\n/.sageox/old-rule\n" + localExcludeFooter + "\ntail\n",
+			wantChanged:      true,
+			mustContain:      []string{"keep-me\n", "tail\n", "/.sageox/meta.json"},
+			mustNotContain:   []string{"/.sageox/old-rule"},
+		},
+		{
+			name:             "idempotent_when_current",
+			failurePrevented: "every sync pass rewrites the file and churns mtime",
+			existing:         renderLocalExcludeBlock(),
+			wantChanged:      false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := mkGitDir(t)
+			full := filepath.Join(dir, localExcludeRelPath)
+			if tc.existing != "" {
+				require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+				require.NoError(t, os.WriteFile(full, []byte(tc.existing), 0o644))
+			}
+			changed, err := EnsureLocalExcludes(dir)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantChanged, changed, tc.failurePrevented)
+			got, err := os.ReadFile(full)
+			require.NoError(t, err)
+			for _, want := range tc.mustContain {
+				assert.Contains(t, string(got), want)
+			}
+			for _, bad := range tc.mustNotContain {
+				assert.NotContains(t, string(got), bad)
+			}
+			// second call is always a no-op
+			changed, err = EnsureLocalExcludes(dir)
+			require.NoError(t, err)
+			assert.False(t, changed, "second call must be a no-op")
+		})
+	}
+}
+
+// TestEnsureLocalExcludes_NoBlanketRule guards the design choice: the
+// exclude set is an explicit list, never `*`. Failure prevented: a future
+// "simplification" to `*` that hides any new server-written .sageox/
+// subtree from local git status.
+func TestEnsureLocalExcludes_NoBlanketRule(t *testing.T) {
+	for _, p := range LocalExcludePatterns {
+		assert.NotEqual(t, "*", strings.TrimSpace(p))
+		assert.NotEqual(t, "/.sageox/*", strings.TrimSpace(p))
+		assert.NotEqual(t, "/.sageox/", strings.TrimSpace(p))
+		assert.True(t, strings.HasPrefix(p, "/.sageox/"), "patterns must be anchored under /.sageox/: %q", p)
+	}
+}
+
+func TestEnsureLocalExcludes_Errors(t *testing.T) {
+	_, err := EnsureLocalExcludes("")
+	assert.Error(t, err)
+	_, err = EnsureLocalExcludes(t.TempDir())
+	assert.Error(t, err, "must refuse a non-git directory")
+}

--- a/internal/kb/localexclude_test.go
+++ b/internal/kb/localexclude_test.go
@@ -180,3 +180,97 @@ func TestEnsureLocalExcludes_Errors(t *testing.T) {
 	_, err = EnsureLocalExcludes(t.TempDir())
 	assert.Error(t, err, "must refuse a non-git directory")
 }
+
+// TestEnsureLocalExcludes_FailurePaths drives each reachable failure in
+// the exclude writer so a broken clone surfaces an error instead of a
+// silent no-op (the daemon logs it and continues; a silent nil would hide
+// that meta.json will show up as untracked forever).
+func TestEnsureLocalExcludes_FailurePaths(t *testing.T) {
+	t.Run("info_is_a_file", func(t *testing.T) {
+		dir := mkGitDir(t)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "info"), []byte("x"), 0o644))
+		_, err := EnsureLocalExcludes(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "create info dir")
+	})
+	t.Run("exclude_is_a_directory", func(t *testing.T) {
+		dir := mkGitDir(t)
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, localExcludeRelPath), 0o755))
+		_, err := EnsureLocalExcludes(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read info/exclude")
+	})
+	t.Run("info_dir_read_only", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root ignores directory permissions")
+		}
+		dir := mkGitDir(t)
+		info := filepath.Join(dir, ".git", "info")
+		require.NoError(t, os.MkdirAll(info, 0o755))
+		require.NoError(t, os.Chmod(info, 0o555))
+		t.Cleanup(func() { _ = os.Chmod(info, 0o755) })
+		_, err := EnsureLocalExcludes(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "write info/exclude")
+	})
+}
+
+// TestWriteFileAtomic_FailurePaths covers the atomic writer's own error
+// branches: an unwritable directory and a rename onto a non-empty
+// directory. A successful write must leave no temp file behind.
+func TestWriteFileAtomic_FailurePaths(t *testing.T) {
+	t.Run("success_leaves_no_temp", func(t *testing.T) {
+		dir := t.TempDir()
+		full := filepath.Join(dir, "out")
+		require.NoError(t, writeFileAtomic(full, "hello\n"))
+		got, err := os.ReadFile(full)
+		require.NoError(t, err)
+		assert.Equal(t, "hello\n", string(got))
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1, "temp file must be renamed away, not left behind")
+	})
+	t.Run("rename_onto_nonempty_dir_fails", func(t *testing.T) {
+		dir := t.TempDir()
+		full := filepath.Join(dir, "out")
+		require.NoError(t, os.MkdirAll(filepath.Join(full, "child"), 0o755))
+		err := writeFileAtomic(full, "x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rename")
+		entries, _ := os.ReadDir(dir)
+		assert.Len(t, entries, 1, "temp file must be cleaned up after a failed rename")
+	})
+	t.Run("unwritable_dir_fails", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root ignores directory permissions")
+		}
+		dir := t.TempDir()
+		require.NoError(t, os.Chmod(dir, 0o555))
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+		err := writeFileAtomic(filepath.Join(dir, "out"), "x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "create temp")
+	})
+	t.Run("closed_file_write_fails", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "closed-*")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		assert.Error(t, fillAndClose(f, "x"), "writing to a closed file must report an error")
+	})
+}
+
+// TestEnsureMergeAttributes_WriteFailure covers the merge-attrs writer's
+// error branch now that it shares writeFileAtomic.
+func TestEnsureMergeAttributes_WriteFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	dir := mkGitDir(t)
+	info := filepath.Join(dir, ".git", "info")
+	require.NoError(t, os.MkdirAll(info, 0o755))
+	require.NoError(t, os.Chmod(info, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(info, 0o755) })
+	_, err := EnsureMergeAttributes(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write info/attributes")
+}

--- a/internal/kb/mergeattrs.go
+++ b/internal/kb/mergeattrs.go
@@ -13,6 +13,7 @@
 package kb
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -202,16 +203,10 @@ func writeFileAtomic(full, content string) error {
 	// best-effort cleanup if we bail before rename
 	defer func() { _ = os.Remove(tmpName) }()
 
-	if _, err := tmp.WriteString(content); err != nil {
-		_ = tmp.Close()
+	// write + fsync + close as one step: any failure here means the temp
+	// file is not trustworthy, and the deferred remove discards it.
+	if err := fillAndClose(tmp, content); err != nil {
 		return fmt.Errorf("write temp: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("fsync temp: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp: %w", err)
 	}
 	if err := os.Chmod(tmpName, 0o644); err != nil {
 		return fmt.Errorf("chmod temp: %w", err)
@@ -220,4 +215,13 @@ func writeFileAtomic(full, content string) error {
 		return fmt.Errorf("rename: %w", err)
 	}
 	return nil
+}
+
+// fillAndClose writes content, fsyncs, and closes f. The file is always
+// closed on return; the first error wins.
+func fillAndClose(f *os.File, content string) error {
+	_, writeErr := f.WriteString(content)
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	return errors.Join(writeErr, syncErr, closeErr)
 }

--- a/internal/kb/mergeattrs.go
+++ b/internal/kb/mergeattrs.go
@@ -136,36 +136,12 @@ func EnsureMergeAttributes(repoPath string) (changed bool, err error) {
 		return false, nil
 	}
 
-	// Atomic write: temp + fsync + rename. A direct WriteFile interrupted
-	// mid-write (process kill, power loss) would leave a truncated
-	// info/attributes that git silently treats as "no rules", which is
-	// exactly the wedged-rebase state this whole pre-flight is trying to
-	// prevent. Rename is atomic on the same filesystem.
-	dir := filepath.Dir(full)
-	tmp, err := os.CreateTemp(dir, ".attributes.tmp-*")
-	if err != nil {
-		return false, fmt.Errorf("create temp info/attributes: %w", err)
-	}
-	tmpName := tmp.Name()
-	// best-effort cleanup if we bail before rename
-	defer func() { _ = os.Remove(tmpName) }()
-
-	if _, err := tmp.WriteString(desired); err != nil {
-		_ = tmp.Close()
-		return false, fmt.Errorf("write temp info/attributes: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return false, fmt.Errorf("fsync temp info/attributes: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return false, fmt.Errorf("close temp info/attributes: %w", err)
-	}
-	if err := os.Chmod(tmpName, 0o644); err != nil {
-		return false, fmt.Errorf("chmod temp info/attributes: %w", err)
-	}
-	if err := os.Rename(tmpName, full); err != nil {
-		return false, fmt.Errorf("rename info/attributes: %w", err)
+	// Atomic write: a direct WriteFile interrupted mid-write (process kill,
+	// power loss) would leave a truncated info/attributes that git silently
+	// treats as "no rules", which is exactly the wedged-rebase state this
+	// whole pre-flight is trying to prevent.
+	if err := writeFileAtomic(full, desired); err != nil {
+		return false, fmt.Errorf("write info/attributes: %w", err)
 	}
 	return true, nil
 }
@@ -181,7 +157,13 @@ func EnsureMergeAttributes(repoPath string) (changed bool, err error) {
 //   - If the header is present but the footer is missing (corrupted /
 //     legacy), everything from the header to EOF is replaced.
 func mergeManagedBlock(existing, managed string) string {
-	headerIdx := strings.Index(existing, mergeAttrsHeader)
+	return mergeManagedBlockBetween(existing, managed, mergeAttrsHeader, mergeAttrsFooter)
+}
+
+// mergeManagedBlockBetween is mergeManagedBlock for an arbitrary
+// header/footer pair, shared with the .git/info/exclude writer.
+func mergeManagedBlockBetween(existing, managed, header, footer string) string {
+	headerIdx := strings.Index(existing, header)
 	if headerIdx < 0 {
 		if existing == "" {
 			return managed
@@ -195,13 +177,47 @@ func mergeManagedBlock(existing, managed string) string {
 
 	before := existing[:headerIdx]
 	after := ""
-	footerIdx := strings.Index(existing[headerIdx:], mergeAttrsFooter)
+	footerIdx := strings.Index(existing[headerIdx:], footer)
 	if footerIdx >= 0 {
-		end := headerIdx + footerIdx + len(mergeAttrsFooter)
+		end := headerIdx + footerIdx + len(footer)
 		if end < len(existing) && existing[end] == '\n' {
 			end++
 		}
 		after = existing[end:]
 	}
 	return before + managed + after
+}
+
+// writeFileAtomic writes content to full via temp + fsync + rename so a
+// crash mid-write can never leave a truncated file behind. Rename is
+// atomic on the same filesystem; the temp file is created next to the
+// target for that reason.
+func writeFileAtomic(full, content string) error {
+	dir := filepath.Dir(full)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(full)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	// best-effort cleanup if we bail before rename
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("fsync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		return fmt.Errorf("chmod temp: %w", err)
+	}
+	if err := os.Rename(tmpName, full); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
## What broke

The daemon writes `.sageox/.gitignore` into every checkout that has a `.sageox/` dir and **commits it**. Its content is a blanket rule:

```
*
!.gitignore
!sync.manifest
```

- **Ledgers / team contexts:** correct. `.sageox/` there only holds daemon-local cache, and the file is what keeps blue-green GC reclone from seeing a permanently dirty checkout.
- **Knowledge Bubbles:** wrong. The server-side Curator commits platform artifacts under `.sageox/curator/marks/` and `.sageox/curator/synopses/`. Once the `*` rule is on a bubble's `main`, the Curator's `git add -A` silently skips its own save-mark, the server concludes the synthesis never happened, and re-drives it every hour, forever.
- **Live in prod** in two bubbles since 2026-08-18 (commits `118956f`, `82028eb`, message `chore: add .sageox/.gitignore to exclude daemon cache files`). Already-tracked marks were unaffected because git keeps tracking them, which is why it went unnoticed.

Related: #832 fixed a different symptom of the same file (the bare commit swept a ledger wipe along with it). The `*` rule was deliberately kept for ledgers there, and it is kept here.

```mermaid
flowchart LR
  subgraph before["Before"]
    D1[daemon clones bubble] --> W1["writes + commits<br/>.sageox/.gitignore (*)"]
    W1 -->|reaches main| C1["Curator git add -A<br/>skips .sageox/curator/*"]
    C1 --> R1["synthesis re-driven<br/>every hour"]
  end
  subgraph after["After"]
    D2[daemon clones bubble] --> W2["writes .git/info/exclude<br/>(explicit daemon-file list)"]
    W2 -->|never committed,<br/>never pushed| C2["Curator sees<br/>its own marks"]
  end
```

## What this PR ships

- **Option chosen for (2): `.git/info/exclude`, never a committed file.** `kb.EnsureLocalExcludes` (new, `internal/kb/localexclude.go`) writes an ox-managed block into the bubble clone's `.git/info/exclude` on every reconcile pass (clone and pull). Same managed-block + atomic-write discipline as the existing merge-attrs helper, whose block merger and atomic writer are now shared.
  - **Why exclude:** bubble sync is documented pull-only. The daemon has no business authoring a commit in a bubble. Rules under `.git/` cannot reach the server or any other clone, and cannot mask a tracked file, so pulled Curator artifacts are unaffected by construction.
  - **Why an explicit list, not `*`:** a blanket rule in exclude would be harmless to the server but would hide any new server-written `.sageox/` subtree from local `git status`, recreating the same trap locally. The list is the files the daemon actually writes: `/.sageox/meta.json`, its atomic temp file, `/.sageox/cache/`. A unit test pins that no blanket rule sneaks in.
- **`TwoPhaseClone` skips `EnsureCheckoutGitignoreCtx` for `manifest.RepoKindKB`** with a code comment saying why. Ledger and team-context kinds are byte-identical to before; a new test pins the team-context kind still commits the file.
- **Bubble clone path no longer calls `EnsureCheckoutGitignoreCtx`** (the "belt-and-suspenders" re-call in `cloneBubble` is removed).
- **GC reclone path (`sync_gc.go`)** unchanged in behavior; comment added that only ledger/team-context workspaces reach it (KB GC in `runKBGC` trashes orphans and never reclones).
- **Docs:** `gitignore.go` doc comments scope the committed file to ledgers/team contexts; `docs/specs/kb-daemon-sync.md` gets a section on the local-exclude rule and the server-side repair.

## (3) Repair of the two affected bubbles: server-side

- **The daemon cannot push to a bubble and will not learn to.** No code path in this repo pushes from a KB clone (every `PushWithRetry` / `git push` caller targets a ledger or team-context path), and adding one would break the pull-only contract this fix relies on.
- **The repair is the monorepo side's:** delete `.sageox/.gitignore` from `main` in both bubbles. After this PR the daemon pulls that removal cleanly and never re-creates the file, on pull or on a fresh clone. The regression test below drives exactly that sequence.
- **Locally, the tracked bad file is harmless** (the Curator runs server-side), so the daemon leaves tracked files alone rather than committing a deletion it could never publish.

## (4) How the commit reached `main`: not via a daemon push path in this repo

- Audited every push in `cmd/ox` and `internal/`: the GC carry (`gcPushUnpushedCommits`) only runs inside `runBlueGreenGC`, which only iterates registry team contexts and the ledger. KB paths never enter the workspace registry. The AGENTS.md commit-and-push helper is called only from team-context provisioning. `ox doctor --fix` gitignore checks iterate ledger and configured team contexts only. `ox import` pushes to a team context. The managed pull pipeline never pushes.
- So the daemon-authored commit sat on the clone's local `main` and was carried to the server by something outside this repo's daemon (a push from a bubble clone by a human or by a server-side process that reused the clone). I could not determine which from public code, and did not inspect private source.
- **Closed regardless:** after this PR the daemon never authors a commit in a bubble, so there is nothing daemon-authored for any push, from any tool, to carry.

## Test Plan

All new tests assert with `git check-ignore` / `git rev-parse` / `git status`, not by string-matching the rule file.

- **`internal/kb/localexclude_test.go`**
  - `TestEnsureLocalExcludes_CuratorPathsStayVisible`: real repo; after the writer runs, `.sageox/curator/marks/x.json` and `synopses/` are **not** ignored, `meta.json` / `cache/` **are**, `git status` is clean with daemon files present and shows a new Curator file. No `.sageox/.gitignore` is created.
  - Table-driven read-modify-write cases (create, preserve user content, replace stale block, idempotent), `NoBlanketRule`, error cases.
- **`internal/gitserver/two_phase_clone_test.go`**
  - `TestTwoPhaseClone_KBKind_NoCommittedGitignore`: KB-kind clone has no `.sageox/.gitignore`, local HEAD == remote `main`, Curator paths not ignored.
  - `TestTwoPhaseClone_TeamContextKind_StillCommitsGitignore`: same fixture, team-context kind: file committed, blanket rule applies. Pins the unchanged behavior.
- **`internal/daemon/sync_bubbles_clone_test.go`**
  - `TestSyncBubbles_Clone_NeverCommitsSageoxGitignore`: full `syncBubbles` clone; no committed file, no daemon commit, Curator not ignored, `meta.json` hidden via exclude, status clean.
  - `TestSyncBubbles_Pull_BadGitignoreOnMain_NeverReAdded` (**the regression test**): fixture bubble already carries the bad file on `main`. Clone adds no commit. Server removes the file and pushes. Two more sync passes pull the removal; file stays gone, HEAD == remote, no `chore: add .sageox/.gitignore` in history, Curator not ignored. Then the checkout is deleted and re-cloned fresh: still no file, no commit.
  - The old `TestSyncBubbles_Clone_HasGitignoreEntries` (which asserted the bug) is replaced.
- **Existing ledger/team-context gitignore tests:** unchanged and passing (`TestEnsureCheckoutGitignore_*`, `TestCheckoutGitignoreNeedsFix_*`, `TestEnsureGitignoreBeforeCommit_*`, `TestCommitCheckoutGitignore_*`).

**Red-first proof.** With the `kind != manifest.RepoKindKB` guard flipped back to always-run:

```
--- FAIL: TestTwoPhaseClone_KBKind_NoCommittedGitignore
    Messages: KB clone must not get a .sageox/.gitignore
    Messages: KB clone must carry no daemon-authored commit
    Messages: a new Curator mark must not be ignored in a KB clone
--- FAIL: TestSyncBubbles_Clone_NeverCommitsSageoxGitignore
    Messages: daemon must not write .sageox/.gitignore into a bubble
    Messages: bubble clone must carry no daemon-authored commit
    Messages: a new Curator mark must not be ignored
--- FAIL: TestSyncBubbles_Pull_BadGitignoreOnMain_NeverReAdded
    Messages: a fresh clone after the repair must not re-create .sageox/.gitignore
    Messages: a fresh clone after the repair must carry no daemon-authored commit
    Messages: Curator marks must not be ignored in the re-cloned bubble
```

Guard restored: all green. `make lint`: 0 issues. `go test ./...`: all packages pass.

## Out of scope (tracked separately, monorepo side)

Force-adding the Curator's own files, better commit-failure logging, a sweep circuit breaker, and deleting the bad file from the two affected bubbles' `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SageOx-Session: https://sageox.ai/c/ses_01a09300-be40-72ca-bd4a-820fdafc7292

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791765721&installation_model_id=433550&pr_number=923&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F923&signature=db057dd45c2e2191c77d8367fcf7a7966bd213db2cdc2af9b5d1d74fb1be6aaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge Bubble checkouts now use local Git exclusions for daemon-generated metadata and cache files.
  * Curator-created files remain visible and unaffected.
  * Local exclusions are reapplied during cloning and synchronization.

* **Bug Fixes**
  * Existing unwanted committed ignore files are removed during pulls without being recreated.
  * Knowledge Bubble clones no longer create or commit a shared ignore file.
  * Synchronization continues when local exclusion setup encounters an error.

* **Documentation**
  * Clarified ignore behavior for Knowledge Bubbles, ledgers, and team-context workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->