### PR TITLE
fix(release): let the draft gate actually see the draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,16 @@ env:
   RELEASE_TAG: ${{ inputs.tag }}
 
 jobs:
-  verify-inrepo:
+  # Separate from verify-inrepo on purpose. Seeing a draft requires write:
+  # GitHub hides draft releases from tokens without push access, and the
+  # get-release-by-tag endpoint omits drafts for every token, so `gh release
+  # view` only finds one via the list endpoint. This job never checks out the
+  # repository, so the elevated token is never exposed to repository code --
+  # actions/checkout persists it in git config, which would put a push-capable
+  # credential inside `make test-release`.
+  verify-draft:
     if: github.repository == 'sageox/ox'
     runs-on: ubuntu-latest
-    # Read-only cannot see a draft, so this job could never pass: GitHub hides
-    # draft releases from tokens without push access, and the get-release-by-tag
-    # endpoint omits drafts for every token. `gh release view` only finds one by
-    # falling back to the list endpoint, which needs write. The job still only
-    # reads.
     permissions:
       contents: write
     steps:
@@ -40,6 +42,11 @@ jobs:
             exit 1
           fi
 
+  verify-inrepo:
+    if: github.repository == 'sageox/ox'
+    needs: verify-draft
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
   verify-inrepo:
     if: github.repository == 'sageox/ox'
     runs-on: ubuntu-latest
+    # Read-only cannot see a draft, so this job could never pass: GitHub hides
+    # draft releases from tokens without push access, and the get-release-by-tag
+    # endpoint omits drafts for every token. `gh release view` only finds one by
+    # falling back to the list endpoint, which needs write. The job still only
+    # reads.
+    permissions:
+      contents: write
     steps:
       - name: Require an existing human-reviewed draft
         env:


### PR DESCRIPTION
`v0.15.0` cannot be released. The `verify-inrepo` gate fails at its first step with `release not found`, and `build-and-release` is skipped — so nothing builds, signs, or publishes.

The gate is unpassable as written.

## Root cause

Two facts compound:

- **The get-release-by-tag endpoint never returns drafts**, for *any* token. Verified against this repo with a fully-authorized token:

  ```
  GET /repos/sageox/ox/releases              → returns the v0.15.0 draft  ✅
  GET /repos/sageox/ox/releases/tags/v0.15.0 → 404 Not Found              ❌
  ```

- **`gh release view` only finds a draft by falling back to the list endpoint** — and GitHub hides draft releases from tokens without push access.

`verify-inrepo` inherits the top-level `permissions: contents: read`, so both paths dead-end. The job whose entire purpose is confirming a human-reviewed draft exists **cannot see a draft at all**.

```mermaid
flowchart TD
    A["verify-inrepo<br/>contents: read"] --> B["gh release view v0.15.0"]
    B --> C["by-tag endpoint"] --> D["404 — drafts never returned"]
    B --> E["list fallback"] --> F["drafts hidden from read-only token"]
    D --> G["release not found → exit 1"]
    F --> G
    G --> H["build-and-release SKIPPED<br/>nothing ships"]
```

## Why this was never caught

The gate shipped in `976c1519` ("make coverage and release gates fail closed") and **has never run to completion**. The last successful release, `v0.14.3`, ran under the *previous* design — `event=release`, triggered by a human publishing in the web UI, with no `verify-inrepo` job at all. `976c1519` landed after it.

`v0.15.0` is the first dispatch under the new flow, and it failed on step one.

## The fix

Give `verify-inrepo` push access so the draft is visible to it. The job still only reads — GitHub gates draft *visibility* on write scope, not the operation being performed.

## What this does NOT change

- `build-and-release` already had `contents: write`; untouched.
- No dependency on the old `release: published` trigger remains anywhere in the file (audited: zero `github.event.release` references).
- `.config/goreleaser.yml` is already correct for this flow — `use_existing_draft: true`, `mode: keep` (human notes preserved), `draft: false` (publishes on success).

## Test Plan

- `yaml.safe_load` parses the workflow
- Permission scopes after the change: top-level `read`; `verify-inrepo` `write`; `build-and-release` `write`; `publish-docs` `read`
- **Real verification is the re-dispatch**: `gh workflow run release.yml -f tag=v0.15.0` against the existing `v0.15.0` tag and draft, both already in place

A workflow change cannot be proven by CI on the PR — the only honest proof is the dispatch after merge. Since this path has never completed end to end, further breakage past the draft check is possible and I'd expect to iterate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791769110&installation_model_id=433550&pr_number=925&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F925&signature=3593083e76860e2421dbc3add0c1413238e65be43ec4f85f89c39b55305960f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release validation by separating draft-release checks from repository testing.
  * Draft-release verification now uses the required permissions, while repository tests remain read-only and run only after verification succeeds.
  * Release checks are performed independently from repository checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->