### PR TITLE
fix(cli): fail loudly when a confirmation prompt has no one to answer it

### DIFF
--- a/cmd/ox/confirm_helpers_test.go
+++ b/cmd/ox/confirm_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -203,6 +204,108 @@ func TestConfirmEndpointFallback(t *testing.T) {
 	})
 }
 
+// --- ox init: continuing when the team list cannot be fetched ---------------
+
+func TestConfirmContinueWithoutTeam(t *testing.T) {
+	t.Run("unanswered prompt names the flag to pass instead", func(t *testing.T) {
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, "", func() { err = confirmContinueWithoutTeam("https://sageox.ai") })
+		})
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, cli.ErrConfirmationRequired), "got %v", err)
+		assert.Contains(t, err.Error(), "--team",
+			"an unattended caller must be told how to proceed without a prompt")
+	})
+
+	t.Run("explicit no cancels", func(t *testing.T) {
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, "n\n", func() { err = confirmContinueWithoutTeam("https://sageox.ai") })
+		})
+
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, cli.ErrConfirmationRequired),
+			"a deliberate decline is not a missing answer")
+		assert.Contains(t, err.Error(), "canceled")
+	})
+
+	t.Run("explicit yes continues", func(t *testing.T) {
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, "y\n", func() { err = confirmContinueWithoutTeam("https://sageox.ai") })
+		})
+		assert.NoError(t, err)
+	})
+}
+
+// --- ox uninstall: the type-to-confirm gate ---------------------------------
+
+func TestConfirmUninstallGate(t *testing.T) {
+	t.Run("force skips the gate entirely", func(t *testing.T) {
+		var ok bool
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, "", func() {
+				ok, err = confirmUninstallGate(t.TempDir(), "https://sageox.ai", false, true)
+			})
+		})
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	// The gate: an unattended run used to print "Uninstall canceled" and exit
+	// 0, which reads as a completed uninstall.
+	t.Run("unanswered gate errors and points at --force", func(t *testing.T) {
+		gitRoot := t.TempDir()
+		var ok bool
+		var err error
+		out := captureConfirmOutput(t, func() {
+			withStdin(t, "", func() {
+				ok, err = confirmUninstallGate(gitRoot, "https://sageox.ai", false, false)
+			})
+		})
+
+		assert.False(t, ok)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--force")
+		assert.NotContains(t, err.Error(), "--yes",
+			"--yes does not satisfy this gate, so the message must not suggest it")
+		assert.NotContains(t, out, "Uninstall canceled",
+			"an unanswered gate must not report a cancel the user never made")
+	})
+
+	t.Run("declining reports an ordinary cancel", func(t *testing.T) {
+		gitRoot := t.TempDir()
+		var ok bool
+		var err error
+		out := captureConfirmOutput(t, func() {
+			withStdin(t, "nope\n", func() {
+				ok, err = confirmUninstallGate(gitRoot, "https://sageox.ai", false, false)
+			})
+		})
+
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Contains(t, out, "Uninstall canceled")
+	})
+
+	t.Run("typing the repo name proceeds", func(t *testing.T) {
+		gitRoot := t.TempDir()
+		var ok bool
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, filepath.Base(gitRoot)+"\n", func() {
+				ok, err = confirmUninstallGate(gitRoot, "https://sageox.ai", false, false)
+			})
+		})
+
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+}
+
 // --- ox uninstall: the cloud-deletion confirmation link ----------------------
 
 // TestOfferCloudDeletionConfirmation_AlwaysPrintsTheURL is the regression gate
@@ -210,11 +313,15 @@ func TestConfirmEndpointFallback(t *testing.T) {
 // if this step is skipped without surfacing the URL, cloud records outlive the
 // local uninstall with nothing on screen pointing at them.
 func TestOfferCloudDeletionConfirmation_AlwaysPrintsTheURL(t *testing.T) {
-	const url = "https://sageox.ai/repos/repo_123/uninstall/confirm"
+	const (
+		ep     = "https://sageox.ai"
+		repoID = "repo_123"
+		url    = "https://sageox.ai/repos/repo_123/uninstall/confirm"
+	)
 
 	t.Run("unanswered prompt warns and prints the URL", func(t *testing.T) {
 		out := captureConfirmOutput(t, func() {
-			withStdin(t, "", func() { offerCloudDeletionConfirmation(url, false) })
+			withStdin(t, "", func() { offerCloudDeletionConfirmation(ep, repoID, false) })
 		})
 
 		assert.Contains(t, out, url, "the confirmation URL must never be silently dropped")
@@ -226,7 +333,7 @@ func TestOfferCloudDeletionConfirmation_AlwaysPrintsTheURL(t *testing.T) {
 
 	t.Run("declining still prints the URL for later", func(t *testing.T) {
 		out := captureConfirmOutput(t, func() {
-			withStdin(t, "n\n", func() { offerCloudDeletionConfirmation(url, false) })
+			withStdin(t, "n\n", func() { offerCloudDeletionConfirmation(ep, repoID, false) })
 		})
 
 		assert.Contains(t, out, url)
@@ -240,7 +347,7 @@ func TestOfferCloudDeletionConfirmation_AlwaysPrintsTheURL(t *testing.T) {
 		t.Setenv("SKIP_BROWSER", "1")
 
 		out := captureConfirmOutput(t, func() {
-			withStdin(t, "y\n", func() { offerCloudDeletionConfirmation(url, false) })
+			withStdin(t, "y\n", func() { offerCloudDeletionConfirmation(ep, repoID, false) })
 		})
 
 		assert.NotContains(t, out, "Confirm here:")
@@ -251,7 +358,7 @@ func TestOfferCloudDeletionConfirmation_AlwaysPrintsTheURL(t *testing.T) {
 		t.Setenv("SKIP_BROWSER", "1")
 
 		out := captureConfirmOutput(t, func() {
-			withStdin(t, "", func() { offerCloudDeletionConfirmation(url, true) })
+			withStdin(t, "", func() { offerCloudDeletionConfirmation(ep, repoID, true) })
 		})
 
 		assert.NotContains(t, out, "Confirm here:",

--- a/cmd/ox/confirm_helpers_test.go
+++ b/cmd/ox/confirm_helpers_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureConfirmOutput swaps os.Stdout for a pipe and returns everything written
+// during fn. The confirm helpers below report to the user via fmt.Print*, so
+// their user-visible output is the behavior under test.
+func captureConfirmOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	os.Stdout = orig
+	require.NoError(t, w.Close())
+	out := <-done
+	require.NoError(t, r.Close())
+	return out
+}
+
+// --- ox init: rebinding a repo to a different endpoint -----------------------
+
+func TestConfirmEndpointRebind(t *testing.T) {
+	t.Run("no stored endpoint proceeds without prompting", func(t *testing.T) {
+		var ok bool
+		var err error
+		withStdin(t, "", func() { ok, err = confirmEndpointRebind("", "https://sageox.ai") })
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("matching endpoint proceeds without prompting", func(t *testing.T) {
+		var ok bool
+		var err error
+		withStdin(t, "", func() {
+			ok, err = confirmEndpointRebind("https://sageox.ai", "https://sageox.ai")
+		})
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	// The gate: this prompt defaults to YES and registration has no inverse in
+	// the CLI, so an unanswered prompt must not rebind the repo.
+	t.Run("unanswered prompt aborts instead of rebinding", func(t *testing.T) {
+		var ok bool
+		var err error
+		out := captureConfirmOutput(t, func() {
+			withStdin(t, "", func() {
+				ok, err = confirmEndpointRebind("https://old.example", "https://new.example")
+			})
+		})
+
+		assert.False(t, ok, "a default-yes prompt must not rebind unattended")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, cli.ErrConfirmationRequired), "got %v", err)
+		assert.Contains(t, out, "SAGEOX_ENDPOINT=https://old.example",
+			"the abort must tell the user how to keep the stored endpoint")
+	})
+
+	t.Run("explicit no aborts quietly", func(t *testing.T) {
+		var ok bool
+		var err error
+		out := captureConfirmOutput(t, func() {
+			withStdin(t, "n\n", func() {
+				ok, err = confirmEndpointRebind("https://old.example", "https://new.example")
+			})
+		})
+
+		require.NoError(t, err, "a deliberate decline is not an error")
+		assert.False(t, ok)
+		assert.Contains(t, out, "SAGEOX_ENDPOINT=https://old.example")
+	})
+
+	t.Run("explicit yes rebinds", func(t *testing.T) {
+		var ok bool
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, "y\n", func() {
+				ok, err = confirmEndpointRebind("https://old.example", "https://new.example")
+			})
+		})
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("global yes rebinds", func(t *testing.T) {
+		cli.SetAssumeYes(true)
+		t.Cleanup(func() { cli.SetAssumeYes(false) })
+
+		var ok bool
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, "", func() {
+				ok, err = confirmEndpointRebind("https://old.example", "https://new.example")
+			})
+		})
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+}
+
+// --- ox login ---------------------------------------------------------------
+
+func TestConfirmReauthenticate(t *testing.T) {
+	t.Run("unanswered prompt errors instead of looking like a broken login", func(t *testing.T) {
+		var out bytes.Buffer
+		var ok bool
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, "", func() { ok, err = confirmReauthenticate(&out) })
+		})
+
+		assert.False(t, ok)
+		assert.True(t, errors.Is(err, cli.ErrConfirmationRequired), "got %v", err)
+		assert.NotContains(t, out.String(), "Authentication canceled.",
+			"an unanswered prompt must not report a cancel the user never made")
+	})
+
+	t.Run("explicit no cancels quietly", func(t *testing.T) {
+		var out bytes.Buffer
+		var ok bool
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, "n\n", func() { ok, err = confirmReauthenticate(&out) })
+		})
+
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Contains(t, out.String(), "Authentication canceled.")
+	})
+
+	t.Run("explicit yes re-authenticates", func(t *testing.T) {
+		var out bytes.Buffer
+		var ok bool
+		var err error
+		captureConfirmOutput(t, func() {
+			withStdin(t, "y\n", func() { ok, err = confirmReauthenticate(&out) })
+		})
+
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Empty(t, out.String())
+	})
+}
+
+func TestConfirmEndpointFallback(t *testing.T) {
+	const alt = "https://alt.example"
+
+	// The gate: this prompt defaults to YES, so an unanswered prompt would
+	// have authenticated against a different endpoint than the one asked for.
+	t.Run("unanswered prompt stays put and says why", func(t *testing.T) {
+		var out bytes.Buffer
+		var got string
+		captureConfirmOutput(t, func() {
+			withStdin(t, "", func() { got = confirmEndpointFallback(&out, alt) })
+		})
+
+		assert.Empty(t, got, "a default-yes prompt must not switch endpoints unattended")
+		assert.Contains(t, out.String(), "Not switching endpoints")
+		assert.Contains(t, strings.ToLower(out.String()), "--endpoint")
+	})
+
+	t.Run("explicit no stays put", func(t *testing.T) {
+		var out bytes.Buffer
+		var got string
+		captureConfirmOutput(t, func() {
+			withStdin(t, "n\n", func() { got = confirmEndpointFallback(&out, alt) })
+		})
+
+		assert.Empty(t, got)
+		assert.NotContains(t, out.String(), "Not switching endpoints",
+			"a deliberate no is not the same as an unanswered prompt")
+	})
+
+	t.Run("explicit yes switches", func(t *testing.T) {
+		var out bytes.Buffer
+		var got string
+		captureConfirmOutput(t, func() {
+			withStdin(t, "y\n", func() { got = confirmEndpointFallback(&out, alt) })
+		})
+		assert.Equal(t, alt, got)
+	})
+}
+
+// --- ox uninstall: the cloud-deletion confirmation link ----------------------
+
+// TestOfferCloudDeletionConfirmation_AlwaysPrintsTheURL is the regression gate
+// for the reported data loss. The uninstall request is already submitted here;
+// if this step is skipped without surfacing the URL, cloud records outlive the
+// local uninstall with nothing on screen pointing at them.
+func TestOfferCloudDeletionConfirmation_AlwaysPrintsTheURL(t *testing.T) {
+	const url = "https://sageox.ai/repos/repo_123/uninstall/confirm"
+
+	t.Run("unanswered prompt warns and prints the URL", func(t *testing.T) {
+		out := captureConfirmOutput(t, func() {
+			withStdin(t, "", func() { offerCloudDeletionConfirmation(url, false) })
+		})
+
+		assert.Contains(t, out, url, "the confirmation URL must never be silently dropped")
+		// "Confirm here:" is the unanswered-prompt framing; the deliberate
+		// decline says "Confirm later at:" instead. (The ⚠ warning itself goes
+		// to stderr, so it is not asserted on this stream.)
+		assert.Contains(t, out, "Confirm here:")
+	})
+
+	t.Run("declining still prints the URL for later", func(t *testing.T) {
+		out := captureConfirmOutput(t, func() {
+			withStdin(t, "n\n", func() { offerCloudDeletionConfirmation(url, false) })
+		})
+
+		assert.Contains(t, out, url)
+		assert.Contains(t, out, "Confirm later at:", "a deliberate decline is not a failure")
+		assert.NotContains(t, out, "Confirm here:")
+	})
+
+	t.Run("accepting attempts the browser and still surfaces the URL on failure", func(t *testing.T) {
+		// SKIP_BROWSER makes cli.OpenInBrowser a no-op success, so this covers
+		// the accepted branch without launching anything.
+		t.Setenv("SKIP_BROWSER", "1")
+
+		out := captureConfirmOutput(t, func() {
+			withStdin(t, "y\n", func() { offerCloudDeletionConfirmation(url, false) })
+		})
+
+		assert.NotContains(t, out, "Confirm here:")
+		assert.NotContains(t, out, "Confirm later at:")
+	})
+
+	t.Run("force skips the prompt and takes the browser path", func(t *testing.T) {
+		t.Setenv("SKIP_BROWSER", "1")
+
+		out := captureConfirmOutput(t, func() {
+			withStdin(t, "", func() { offerCloudDeletionConfirmation(url, true) })
+		})
+
+		assert.NotContains(t, out, "Confirm here:",
+			"--force must confirm rather than strand the cloud records")
+	})
+}

--- a/cmd/ox/doctor_adapters.go
+++ b/cmd/ox/doctor_adapters.go
@@ -301,6 +301,11 @@ func runAdapterFix(issue adapterprotocol.DiagnoseIssue, forceYes bool) error {
 			return fmt.Errorf("auto-fix refused: %q modifies global/system state and cannot be confirmed non-interactively; apply manually: %s",
 				strings.Join(issue.FixArgv, " "), issue.Fix)
 		}
+		// Deliberately NOT wired to --yes / cli.AssumeYes(): the argv here is
+		// supplied by an adapter, not by ox, and it escalates to global or
+		// system git scope. "answer yes to prompts" must not become "let any
+		// installed adapter mutate global config unattended" — this one keeps
+		// requiring a live human.
 		if !cli.ConfirmYesNo("Run this adapter-requested command?", false) {
 			return fmt.Errorf("auto-fix declined")
 		}

--- a/cmd/ox/doctor_confirm_yes_test.go
+++ b/cmd/ox/doctor_confirm_yes_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `ox doctor --yes` promises to "answer yes to all prompts" but historically
+// reached exactly one of its prompts. These gates pin that promise for the
+// prompts it now covers, and — just as importantly — pin the one prompt it must
+// NOT cover.
+
+// TestPromptOfflineMigration_HonorsAssumeYes covers the registration prompt,
+// which is irreversible in the CLI once answered.
+func TestPromptOfflineMigration_HonorsAssumeYes(t *testing.T) {
+	t.Run("global yes registers without reading stdin", func(t *testing.T) {
+		cli.SetAssumeYes(true)
+		t.Cleanup(func() { cli.SetAssumeYes(false) })
+
+		var got bool
+		silenceStdout(t, func() {
+			withStdin(t, "", func() { got = promptOfflineMigration(false) })
+		})
+		assert.True(t, got)
+	})
+
+	t.Run("force short-circuits before any output", func(t *testing.T) {
+		var got bool
+		silenceStdout(t, func() {
+			withStdin(t, "", func() { got = promptOfflineMigration(true) })
+		})
+		assert.True(t, got)
+	})
+
+	t.Run("without yes an unanswered prompt still declines", func(t *testing.T) {
+		var got bool
+		silenceStdout(t, func() {
+			withStdin(t, "", func() { got = promptOfflineMigration(false) })
+		})
+		assert.False(t, got, "doctor must not register a repo nobody agreed to register")
+	})
+
+	t.Run("a piped yes registers", func(t *testing.T) {
+		var got bool
+		silenceStdout(t, func() {
+			withStdin(t, "y\n", func() { got = promptOfflineMigration(false) })
+		})
+		assert.True(t, got)
+	})
+}
+
+// TestFixLegacyStructure_HonorsAssumeYes covers a default-yes repair prompt.
+// Doctor's documented posture is auto-fix, so the default is deliberately kept
+// when nobody answers — but --yes must reach it too.
+func TestFixLegacyStructure_HonorsAssumeYes(t *testing.T) {
+	issue := repoPathIssue{repoType: "ledger", path: t.TempDir(), issue: "legacy-structure"}
+
+	t.Run("global yes keeps the current location", func(t *testing.T) {
+		cli.SetAssumeYes(true)
+		t.Cleanup(func() { cli.SetAssumeYes(false) })
+
+		localCfg := &config.LocalConfig{}
+		var got bool
+		silenceStdout(t, func() {
+			withStdin(t, "", func() { got = fixLegacyStructure(t.TempDir(), localCfg, issue) })
+		})
+
+		require.True(t, got)
+		require.NotNil(t, localCfg.Ledger, "--yes must actually apply the fix")
+		assert.Equal(t, issue.path, localCfg.Ledger.Path)
+	})
+
+	t.Run("an explicit no skips the fix", func(t *testing.T) {
+		localCfg := &config.LocalConfig{}
+		var got bool
+		silenceStdout(t, func() {
+			withStdin(t, "n\n", func() { got = fixLegacyStructure(t.TempDir(), localCfg, issue) })
+		})
+
+		assert.False(t, got)
+		assert.Nil(t, localCfg.Ledger, "declining must not rewrite config")
+	})
+}
+
+// TestFixBrokenSymlink_DeclineSkips covers the negated form of the same
+// pattern, where --yes short-circuits an early return rather than a body.
+func TestFixBrokenSymlink_DeclineSkips(t *testing.T) {
+	issue := repoPathIssue{repoType: "team-context-symlink", path: t.TempDir(), issue: "broken-symlink"}
+
+	var got bool
+	silenceStdout(t, func() {
+		withStdin(t, "n\n", func() { got = fixBrokenSymlink(&config.LocalConfig{}, issue) })
+	})
+
+	assert.False(t, got, "an explicit no must skip the re-clone")
+}
+
+// TestRunAdapterFix_ScopeEscalationIgnoresAssumeYes is the security carve-out:
+// the argv in this prompt comes from an adapter, not from ox, and it escalates
+// to global/system git scope. "Answer yes to prompts" must never become "let
+// any installed adapter mutate global config unattended."
+func TestRunAdapterFix_ScopeEscalationIgnoresAssumeYes(t *testing.T) {
+	escalating := adapterprotocol.DiagnoseIssue{
+		FixSafe: true,
+		Fix:     "git config --global core.hooksPath /tmp/evil",
+		FixArgv: []string{"git", "config", "--global", "core.hooksPath", "/tmp/evil"},
+	}
+	require.True(t, argvHasScopeEscalation(escalating.FixArgv),
+		"sanity: this argv must be classified as a scope escalation")
+
+	cli.SetAssumeYes(true)
+	t.Cleanup(func() { cli.SetAssumeYes(false) })
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "y\n", func() { err = runAdapterFix(escalating, true) })
+	})
+
+	require.Error(t, err, "--yes and --force must not run an adapter-supplied global-scope command")
+	assert.Contains(t, err.Error(), "auto-fix refused")
+
+	// negative control: the same posture does not block an ordinary,
+	// non-escalating fix from being considered.
+	assert.False(t, argvHasScopeEscalation([]string{"git", "config", "core.hooksPath", ".githooks"}),
+		"a repo-scoped config write is not an escalation")
+}

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -1329,7 +1329,7 @@ func checkLedgerPathMismatch(fix bool) checkResult {
 				fmt.Printf("    Default path: %s\n", defaultPath)
 				fmt.Println()
 
-				if cli.ConfirmYesNo("Add this ledger path to config.local.toml?", true) {
+				if cli.AssumeYes() || cli.ConfirmYesNo("Add this ledger path to config.local.toml?", true) {
 					if localCfg.Ledger == nil {
 						localCfg.Ledger = &config.LedgerConfig{}
 					}
@@ -1386,7 +1386,7 @@ func checkLedgerPathMismatch(fix bool) checkResult {
 		// decide what to offer based on what exists
 		if defaultExists && !configuredExists {
 			// default exists, configured does not - suggest using default
-			if cli.ConfirmYesNo("Update config to use the default path (where ledger exists)?", true) {
+			if cli.AssumeYes() || cli.ConfirmYesNo("Update config to use the default path (where ledger exists)?", true) {
 				localCfg.Ledger.Path = defaultPath
 				if err := config.SaveLocalConfig(gitRoot, localCfg); err != nil {
 					return FailedCheck("Ledger path config", "save failed", err.Error())
@@ -1406,7 +1406,7 @@ func checkLedgerPathMismatch(fix bool) checkResult {
 				"Review and remove duplicate ledger, then update config")
 		} else {
 			// neither exists - offer to update config to default (for future clone)
-			if cli.ConfirmYesNo("Neither path exists. Update config to use default path?", true) {
+			if cli.AssumeYes() || cli.ConfirmYesNo("Neither path exists. Update config to use default path?", true) {
 				localCfg.Ledger.Path = defaultPath
 				if err := config.SaveLocalConfig(gitRoot, localCfg); err != nil {
 					return FailedCheck("Ledger path config", "save failed", err.Error())

--- a/cmd/ox/doctor_git_repos_fix.go
+++ b/cmd/ox/doctor_git_repos_fix.go
@@ -121,7 +121,7 @@ func fixLegacyStructure(gitRoot string, localCfg *config.LocalConfig, issue repo
 	fmt.Println("  on next `ox doctor --fix` if the old one is removed.")
 	fmt.Println()
 
-	if cli.ConfirmYesNo("Continue using the current location for now?", true) {
+	if cli.AssumeYes() || cli.ConfirmYesNo("Continue using the current location for now?", true) {
 		// update config to explicitly use the current path
 		localCfg.Ledger = &config.LedgerConfig{
 			Path: issue.path,
@@ -141,7 +141,7 @@ func fixBrokenSymlink(localCfg *config.LocalConfig, issue repoPathIssue) bool {
 	fmt.Println("  The symlink for this team context is broken.")
 	fmt.Println()
 
-	if !cli.ConfirmYesNo("Remove broken symlink and re-clone from cloud?", true) {
+	if !cli.AssumeYes() && !cli.ConfirmYesNo("Remove broken symlink and re-clone from cloud?", true) {
 		fmt.Println("  Skipped.")
 		fmt.Println()
 		return false
@@ -276,7 +276,7 @@ func fixRepoPathIssues(gitRoot string, localCfg *config.LocalConfig, issues []re
 		case "missing", "empty-dir", "not-git-repo":
 			// for directories with potential data, ask before cloning
 			if issue.issue == "not-git-repo" {
-				if !cli.ConfirmYesNo("Clone from cloud?", true) {
+				if !cli.AssumeYes() && !cli.ConfirmYesNo("Clone from cloud?", true) {
 					skipped++
 					fmt.Println("  Skipped.")
 					fmt.Println()
@@ -671,7 +671,7 @@ func cloneRepoForFix(issue repoPathIssue) error {
 			fmt.Println()
 
 			// ask for confirmation - move, not delete
-			if !cli.ConfirmYesNo("Move this directory aside and clone fresh?", true) {
+			if !cli.AssumeYes() && !cli.ConfirmYesNo("Move this directory aside and clone fresh?", true) {
 				return fmt.Errorf("user declined to move directory")
 			}
 		}

--- a/cmd/ox/doctor_ledger_path_confirm_test.go
+++ b/cmd/ox/doctor_ledger_path_confirm_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ledgerPathFixture puts the process inside an initialized git repo with
+// isolated XDG dirs, so ledger.DefaultPath() resolves somewhere disposable.
+func ledgerPathFixture(t *testing.T) string {
+	t.Helper()
+
+	repoRoot := t.TempDir()
+	initGitRepo(t, repoRoot)
+	t.Chdir(repoRoot)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+
+	// ledger.DefaultPath() resolves through the project's repo_id, so the repo
+	// has to look initialized.
+	require.NoError(t, config.SaveProjectConfig(repoRoot, &config.ProjectConfig{
+		RepoID:      "repo_01jfk3mabtestledgerpath",
+		ProjectID:   "test_project",
+		WorkspaceID: "test_workspace",
+	}))
+	return repoRoot
+}
+
+// makeLedgerAt makes path look like a real ledger to ledger.Exists.
+func makeLedgerAt(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	initGitRepo(t, path)
+}
+
+// `ox doctor --yes` promised to answer every prompt but reached one of nine.
+// These cover the ledger-path repairs, which write config.local.toml.
+//
+// Note these prompts intentionally keep ConfirmYesNo (not the Required
+// variant): every one is behind `--fix`, which is itself the user's consent to
+// repair, and doctor's documented posture is auto-fix by default.
+func TestCheckLedgerPathMismatch_HonorsAssumeYes(t *testing.T) {
+	t.Run("global yes adds a discovered ledger to config", func(t *testing.T) {
+		repoRoot := ledgerPathFixture(t)
+
+		// no ledger entry in config, but one exists at the default path
+		localCfg, err := config.LoadLocalConfig(repoRoot)
+		require.NoError(t, err)
+		require.True(t, localCfg.Ledger == nil || localCfg.Ledger.Path == "",
+			"fixture must start with no configured ledger")
+
+		defaultPath := defaultLedgerPathForTest(t)
+		makeLedgerAt(t, defaultPath)
+
+		cli.SetAssumeYes(true)
+		t.Cleanup(func() { cli.SetAssumeYes(false) })
+
+		var res checkResult
+		silenceStdout(t, func() {
+			withStdin(t, "", func() { res = checkLedgerPathMismatch(true) })
+		})
+
+		assert.False(t, res.warning, "--yes must apply the repair, not warn: %+v", res)
+		assert.True(t, res.passed, "%+v", res)
+
+		saved, err := config.LoadLocalConfig(repoRoot)
+		require.NoError(t, err)
+		require.NotNil(t, saved.Ledger)
+		assert.Equal(t, defaultPath, saved.Ledger.Path)
+	})
+
+	t.Run("without an answer the repair is declined, not applied", func(t *testing.T) {
+		repoRoot := ledgerPathFixture(t)
+		defaultPath := defaultLedgerPathForTest(t)
+		makeLedgerAt(t, defaultPath)
+
+		var res checkResult
+		silenceStdout(t, func() {
+			withStdin(t, "n\n", func() { res = checkLedgerPathMismatch(true) })
+		})
+
+		// WarningCheck is a non-blocking pass in this codebase, so the
+		// load-bearing assertion is the config below, not the status flag.
+		assert.True(t, res.warning, "declining must surface a warning: %+v", res)
+
+		saved, err := config.LoadLocalConfig(repoRoot)
+		require.NoError(t, err)
+		assert.True(t, saved.Ledger == nil || saved.Ledger.Path == "",
+			"declining must not rewrite config")
+	})
+
+	t.Run("without --fix nothing prompts and nothing is written", func(t *testing.T) {
+		repoRoot := ledgerPathFixture(t)
+		makeLedgerAt(t, defaultLedgerPathForTest(t))
+
+		var res checkResult
+		silenceStdout(t, func() {
+			withStdin(t, "", func() { res = checkLedgerPathMismatch(false) })
+		})
+
+		saved, err := config.LoadLocalConfig(repoRoot)
+		require.NoError(t, err)
+		assert.True(t, saved.Ledger == nil || saved.Ledger.Path == "",
+			"a plain `ox doctor` must never mutate config")
+		assert.True(t, res.warning, "a plain `ox doctor` must report the mismatch: %+v", res)
+	})
+}
+
+// defaultLedgerPathForTest resolves the same default path the check computes.
+func defaultLedgerPathForTest(t *testing.T) string {
+	t.Helper()
+	p, err := ledger.DefaultPath()
+	require.NoError(t, err)
+	return p
+}

--- a/cmd/ox/doctor_sageox.go
+++ b/cmd/ox/doctor_sageox.go
@@ -593,7 +593,7 @@ func promptOfflineMigration(forceYes bool) bool {
 	fmt.Println()
 	fmt.Println("Note: Your git user name and email will be shared with SageOx to facilitate team setup.")
 	fmt.Println()
-	return cli.ConfirmYesNo("Register this repository with SageOx?", false)
+	return cli.AssumeYes() || cli.ConfirmYesNo("Register this repository with SageOx?", false)
 }
 
 // registerRepoWithSageOx registers the repo with the SageOx API.

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -818,11 +818,14 @@ func runInit() error {
 	// check for endpoint mismatch
 	currentEndpoint := endpoint.Get()
 	proceed, confirmErr := confirmEndpointRebind(cfg.Endpoint, currentEndpoint)
-	if confirmErr != nil {
+	if confirmErr != nil || !proceed {
+		// Init did not complete, so undo everything this run created, modified
+		// and staged — exactly as a failed registration below does. Returning
+		// here without rolling back leaves .sageox and the instruction-file
+		// edits on disk AND in the index, which makes an abort look like a
+		// half-finished init.
+		tracker.rollback(initQuiet)
 		return confirmErr
-	}
-	if !proceed {
-		return nil
 	}
 
 	initAt := time.Now().UTC().Format(time.RFC3339)

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -821,27 +821,12 @@ func runInit() error {
 	// call API to register repository
 	// check for endpoint mismatch
 	currentEndpoint := endpoint.Get()
-	if cfg.Endpoint != "" && cfg.Endpoint != currentEndpoint {
-		fmt.Println()
-		cli.PrintWarning("API endpoint mismatch detected")
-		fmt.Printf("  Stored:  %s\n", cfg.Endpoint)
-		fmt.Printf("  Current: %s\n", currentEndpoint)
-		fmt.Println()
-		fmt.Println("Re-registering will associate this repo with the new endpoint.")
-		// Required, not ConfirmYesNo: this prompt defaults to YES, and
-		// registration has no inverse in the CLI — a silent default would
-		// rebind the repo to a different endpoint with nobody having agreed.
-		proceed, confirmErr := cli.ConfirmYesNoRequired("Continue?", true, false)
-		if confirmErr != nil {
-			fmt.Println()
-			fmt.Printf("Aborted. Set SAGEOX_ENDPOINT=%s to use the stored endpoint.\n", cfg.Endpoint)
-			return fmt.Errorf("re-registering this repo to %s %w", endpoint.NormalizeSlug(currentEndpoint), confirmErr)
-		}
-		if !proceed {
-			fmt.Println()
-			fmt.Printf("Aborted. Set SAGEOX_ENDPOINT=%s to use the stored endpoint.\n", cfg.Endpoint)
-			return nil
-		}
+	proceed, confirmErr := confirmEndpointRebind(cfg.Endpoint, currentEndpoint)
+	if confirmErr != nil {
+		return confirmErr
+	}
+	if !proceed {
+		return nil
 	}
 
 	initAt := time.Now().UTC().Format(time.RFC3339)
@@ -2736,4 +2721,41 @@ func promptNoTeams() (bool, error) {
 	}
 
 	return true, nil
+}
+
+// confirmEndpointRebind asks before re-registering a repo against a different
+// endpoint than the one already stored. Returns (true, nil) when there is no
+// mismatch to resolve.
+//
+// The prompt defaults to YES, and registration has no inverse in the CLI — so
+// this uses ConfirmYesNoRequired rather than ConfirmYesNo: taking the default
+// with nobody there would rebind the repo to a different endpoint with no one
+// having agreed to it.
+func confirmEndpointRebind(storedEndpoint, currentEndpoint string) (bool, error) {
+	if storedEndpoint == "" || storedEndpoint == currentEndpoint {
+		return true, nil
+	}
+
+	fmt.Println()
+	cli.PrintWarning("API endpoint mismatch detected")
+	fmt.Printf("  Stored:  %s\n", storedEndpoint)
+	fmt.Printf("  Current: %s\n", currentEndpoint)
+	fmt.Println()
+	fmt.Println("Re-registering will associate this repo with the new endpoint.")
+
+	proceed, err := cli.ConfirmYesNoRequired("Continue?", true, false)
+	if err != nil {
+		abortEndpointRebind(storedEndpoint)
+		return false, fmt.Errorf("re-registering this repo to %s %w", endpoint.NormalizeSlug(currentEndpoint), err)
+	}
+	if !proceed {
+		abortEndpointRebind(storedEndpoint)
+		return false, nil
+	}
+	return true, nil
+}
+
+func abortEndpointRebind(storedEndpoint string) {
+	fmt.Println()
+	fmt.Printf("Aborted. Set SAGEOX_ENDPOINT=%s to use the stored endpoint.\n", storedEndpoint)
 }

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -437,7 +437,11 @@ func runInit() error {
 			slog.Debug("failed to fetch teams", "error", err)
 			cli.PrintWarning(fmt.Sprintf("Could not fetch teams from %s: %v", endpoint.NormalizeSlug(currentEP), err))
 			fmt.Println()
-			if !cli.ConfirmYesNo("Continue without team selection? (a new team may be created)", false) {
+			proceed, confirmErr := cli.ConfirmYesNoRequired("Continue without team selection? (a new team may be created)", false, false)
+			if confirmErr != nil {
+				return fmt.Errorf("cannot reach %s to list teams, and %w; pass --team explicitly", endpoint.NormalizeSlug(currentEP), confirmErr)
+			}
+			if !proceed {
 				return fmt.Errorf("team selection canceled")
 			}
 		} else if reposResp != nil && len(reposResp.TeamMembershipsFromRepos()) > 0 {
@@ -824,7 +828,16 @@ func runInit() error {
 		fmt.Printf("  Current: %s\n", currentEndpoint)
 		fmt.Println()
 		fmt.Println("Re-registering will associate this repo with the new endpoint.")
-		if !cli.ConfirmYesNo("Continue?", true) {
+		// Required, not ConfirmYesNo: this prompt defaults to YES, and
+		// registration has no inverse in the CLI — a silent default would
+		// rebind the repo to a different endpoint with nobody having agreed.
+		proceed, confirmErr := cli.ConfirmYesNoRequired("Continue?", true, false)
+		if confirmErr != nil {
+			fmt.Println()
+			fmt.Printf("Aborted. Set SAGEOX_ENDPOINT=%s to use the stored endpoint.\n", cfg.Endpoint)
+			return fmt.Errorf("re-registering this repo to %s %w", endpoint.NormalizeSlug(currentEndpoint), confirmErr)
+		}
+		if !proceed {
 			fmt.Println()
 			fmt.Printf("Aborted. Set SAGEOX_ENDPOINT=%s to use the stored endpoint.\n", cfg.Endpoint)
 			return nil

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -437,12 +437,8 @@ func runInit() error {
 			slog.Debug("failed to fetch teams", "error", err)
 			cli.PrintWarning(fmt.Sprintf("Could not fetch teams from %s: %v", endpoint.NormalizeSlug(currentEP), err))
 			fmt.Println()
-			proceed, confirmErr := cli.ConfirmYesNoRequired("Continue without team selection? (a new team may be created)", false, false)
-			if confirmErr != nil {
-				return fmt.Errorf("cannot reach %s to list teams, and %w; pass --team explicitly", endpoint.NormalizeSlug(currentEP), confirmErr)
-			}
-			if !proceed {
-				return fmt.Errorf("team selection canceled")
+			if teamErr := confirmContinueWithoutTeam(currentEP); teamErr != nil {
+				return teamErr
 			}
 		} else if reposResp != nil && len(reposResp.TeamMembershipsFromRepos()) > 0 {
 			// the repo may already be bound to a team from a prior init —
@@ -2758,4 +2754,21 @@ func confirmEndpointRebind(storedEndpoint, currentEndpoint string) (bool, error)
 func abortEndpointRebind(storedEndpoint string) {
 	fmt.Println()
 	fmt.Printf("Aborted. Set SAGEOX_ENDPOINT=%s to use the stored endpoint.\n", storedEndpoint)
+}
+
+// confirmContinueWithoutTeam asks whether to proceed when the team list could
+// not be fetched. Returns nil to continue.
+//
+// Required, not ConfirmYesNo: an unanswered prompt here used to surface as the
+// bare "team selection canceled", which tells an unattended caller nothing
+// about what to do instead.
+func confirmContinueWithoutTeam(currentEP string) error {
+	proceed, err := cli.ConfirmYesNoRequired("Continue without team selection? (a new team may be created)", false, false)
+	if err != nil {
+		return fmt.Errorf("cannot reach %s to list teams, and %w; pass --team explicitly", endpoint.NormalizeSlug(currentEP), err)
+	}
+	if !proceed {
+		return fmt.Errorf("team selection canceled")
+	}
+	return nil
 }

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -716,13 +716,15 @@ func uninstallAllIntegrations(force bool) error {
 
 	// Prompt unless force. Required, not ConfirmYesNo: this prompt defaults to
 	// YES, so a silent default would uninstall every integration unattended.
-	confirmed, confirmErr := cli.ConfirmYesNoRequired("Uninstall all?", true, force)
-	if confirmErr != nil {
-		return confirmErr
-	}
-	if !confirmed {
-		fmt.Println("Canceled.")
-		return nil
+	if !force {
+		confirmed, confirmErr := cli.ConfirmYesNoRequired("Uninstall all?", true, false)
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !confirmed {
+			fmt.Println("Canceled.")
+			return nil
+		}
 	}
 
 	// uninstall all

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -714,12 +714,15 @@ func uninstallAllIntegrations(force bool) error {
 	}
 	fmt.Println()
 
-	// prompt unless force
-	if !force {
-		if !cli.ConfirmYesNo("Uninstall all?", true) {
-			fmt.Println("Canceled.")
-			return nil
-		}
+	// Prompt unless force. Required, not ConfirmYesNo: this prompt defaults to
+	// YES, so a silent default would uninstall every integration unattended.
+	confirmed, confirmErr := cli.ConfirmYesNoRequired("Uninstall all?", true, force)
+	if confirmErr != nil {
+		return confirmErr
+	}
+	if !confirmed {
+		fmt.Println("Canceled.")
+		return nil
 	}
 
 	// uninstall all

--- a/cmd/ox/integrate_uninstall_confirm_test.go
+++ b/cmd/ox/integrate_uninstall_confirm_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedOMPIntegration gives uninstallAllIntegrations something to find, so it
+// reaches the confirmation prompt instead of returning "No integrations found".
+func seedOMPIntegration(t *testing.T) string {
+	t.Helper()
+
+	repoRoot := setupUninstallAllTest(t, map[string]string{
+		"amp":      ".amp",
+		"codex":    ".codex",
+		"gemini":   ".gemini",
+		"omp":      ".omp",
+		"opencode": ".opencode",
+	})
+
+	marker := filepath.Join(repoRoot, ".omp", "hooks.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
+	require.NoError(t, os.WriteFile(marker, []byte("{}\n"), 0o644))
+	return marker
+}
+
+// TestUninstallAllIntegrations_UnansweredPromptRemovesNothing is the gate on a
+// default-YES prompt: before, an unattended run answered "yes" on the user's
+// behalf and removed every integration.
+func TestUninstallAllIntegrations_UnansweredPromptRemovesNothing(t *testing.T) {
+	marker := seedOMPIntegration(t)
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "", func() {
+			err = uninstallAllIntegrations(false)
+		})
+	})
+
+	assert.True(t, errors.Is(err, cli.ErrConfirmationRequired),
+		"an unanswered default-yes prompt must fail, not uninstall; got %v", err)
+	_, statErr := os.Stat(marker)
+	assert.NoError(t, statErr, "nothing may be removed when nobody answered")
+}
+
+// TestUninstallAllIntegrations_DeclineRemovesNothing pins that a real "no" is
+// still an ordinary, successful cancel — not an error.
+func TestUninstallAllIntegrations_DeclineRemovesNothing(t *testing.T) {
+	marker := seedOMPIntegration(t)
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "n\n", func() {
+			err = uninstallAllIntegrations(false)
+		})
+	})
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(marker)
+	assert.NoError(t, statErr, "declining must leave integrations in place")
+}
+
+// TestUninstallAllIntegrations_PipedYesProceeds proves the prompt still accepts
+// a scripted answer — requiring a TTY would break every honest caller.
+func TestUninstallAllIntegrations_PipedYesProceeds(t *testing.T) {
+	marker := seedOMPIntegration(t)
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "y\n", func() {
+			err = uninstallAllIntegrations(false)
+		})
+	})
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(marker)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "a piped yes must actually uninstall")
+}
+
+// TestUninstallAllIntegrations_GlobalYesProceeds covers the --yes path through
+// a command that has its own --force flag: both must work.
+func TestUninstallAllIntegrations_GlobalYesProceeds(t *testing.T) {
+	marker := seedOMPIntegration(t)
+
+	cli.SetAssumeYes(true)
+	t.Cleanup(func() { cli.SetAssumeYes(false) })
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "", func() {
+			err = uninstallAllIntegrations(false)
+		})
+	})
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(marker)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "--yes must satisfy this prompt")
+}

--- a/cmd/ox/login.go
+++ b/cmd/ox/login.go
@@ -304,7 +304,11 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 		}
 
 		fmt.Fprintf(out, "Already authenticated as %s on %s\n", token.UserInfo.Email, endpoint.NormalizeSlug(currentEndpoint))
-		if !cli.ConfirmYesNo("Do you want to re-authenticate?", false) {
+		reauth, confirmErr := cli.ConfirmYesNoRequired("Do you want to re-authenticate?", false, false)
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !reauth {
 			fmt.Fprintln(out, "Authentication canceled.")
 			return nil
 		}
@@ -336,8 +340,16 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 
 				var selectedEndpoint string
 				if len(alternatives) == 1 {
-					// single alternative - ask yes/no
-					if cli.ConfirmYesNo(fmt.Sprintf("Would you like to authenticate to %s instead?", alternatives[0]), true) {
+					// single alternative - ask yes/no.
+					// Required, not ConfirmYesNo: this prompt defaults to YES,
+					// so a silent default would quietly authenticate against a
+					// DIFFERENT endpoint than the one asked for.
+					switchTo, switchErr := cli.ConfirmYesNoRequired(fmt.Sprintf("Would you like to authenticate to %s instead?", alternatives[0]), true, false)
+					switch {
+					case switchErr != nil:
+						fmt.Fprintf(out, "Not switching endpoints — nothing was available to answer the prompt.\n")
+						fmt.Fprintf(out, "Re-run in a terminal, or pass %s explicitly.\n", cli.StyleFlag.Render("--endpoint"))
+					case switchTo:
 						selectedEndpoint = alternatives[0]
 					}
 				} else {

--- a/cmd/ox/login.go
+++ b/cmd/ox/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"os"
@@ -304,12 +305,11 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 		}
 
 		fmt.Fprintf(out, "Already authenticated as %s on %s\n", token.UserInfo.Email, endpoint.NormalizeSlug(currentEndpoint))
-		reauth, confirmErr := cli.ConfirmYesNoRequired("Do you want to re-authenticate?", false, false)
+		reauth, confirmErr := confirmReauthenticate(out)
 		if confirmErr != nil {
 			return confirmErr
 		}
 		if !reauth {
-			fmt.Fprintln(out, "Authentication canceled.")
 			return nil
 		}
 	}
@@ -340,18 +340,7 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 
 				var selectedEndpoint string
 				if len(alternatives) == 1 {
-					// single alternative - ask yes/no.
-					// Required, not ConfirmYesNo: this prompt defaults to YES,
-					// so a silent default would quietly authenticate against a
-					// DIFFERENT endpoint than the one asked for.
-					switchTo, switchErr := cli.ConfirmYesNoRequired(fmt.Sprintf("Would you like to authenticate to %s instead?", alternatives[0]), true, false)
-					switch {
-					case switchErr != nil:
-						fmt.Fprintf(out, "Not switching endpoints — nothing was available to answer the prompt.\n")
-						fmt.Fprintf(out, "Re-run in a terminal, or pass %s explicitly.\n", cli.StyleFlag.Render("--endpoint"))
-					case switchTo:
-						selectedEndpoint = alternatives[0]
-					}
+					selectedEndpoint = confirmEndpointFallback(out, alternatives[0])
 				} else {
 					// multiple alternatives - show selection
 					selected, selectErr := cli.SelectOne("Select endpoint to authenticate to:", alternatives, 0)
@@ -589,5 +578,43 @@ func refreshExistingRemotes(ep string) {
 		if err := gitserver.RefreshRemoteCredentials(tc.Path, ep); err != nil {
 			slog.Debug("failed to refresh team context remote credentials", "team", tc.TeamName, "error", err)
 		}
+	}
+}
+
+// confirmReauthenticate asks whether to re-run the device flow for an endpoint
+// the user is already authenticated against.
+//
+// Required, not ConfirmYesNo: silently taking the default printed
+// "Authentication canceled." and exited 0, which reads as a broken login rather
+// than as a prompt nobody answered.
+func confirmReauthenticate(out io.Writer) (bool, error) {
+	reauth, err := cli.ConfirmYesNoRequired("Do you want to re-authenticate?", false, false)
+	if err != nil {
+		return false, err
+	}
+	if !reauth {
+		fmt.Fprintln(out, "Authentication canceled.")
+		return false, nil
+	}
+	return true, nil
+}
+
+// confirmEndpointFallback offers a reachable alternative endpoint when the
+// configured one cannot be reached. Returns the endpoint to use, or "" to stay
+// put.
+//
+// Required, not ConfirmYesNo: this prompt defaults to YES, so a silent default
+// would authenticate against a DIFFERENT endpoint than the one asked for.
+func confirmEndpointFallback(out io.Writer, alternative string) string {
+	switchTo, err := cli.ConfirmYesNoRequired(fmt.Sprintf("Would you like to authenticate to %s instead?", alternative), true, false)
+	switch {
+	case err != nil:
+		fmt.Fprintf(out, "Not switching endpoints — nothing was available to answer the prompt.\n")
+		fmt.Fprintf(out, "Re-run in a terminal, or pass %s explicitly.\n", cli.StyleFlag.Render("--endpoint"))
+		return ""
+	case switchTo:
+		return alternative
+	default:
+		return ""
 	}
 }

--- a/cmd/ox/logout.go
+++ b/cmd/ox/logout.go
@@ -96,20 +96,22 @@ var logoutCmd = &cobra.Command{
 			}
 		}
 
-		// confirm before logging out (skip if --force or --yes)
-		var confirmMsg string
-		if len(endpointsToLogout) == 1 {
-			confirmMsg = fmt.Sprintf("Log out from %s?", endpointsToLogout[0])
-		} else {
-			confirmMsg = fmt.Sprintf("Log out from %d endpoints?", len(endpointsToLogout))
-		}
-		confirmed, confirmErr := cli.ConfirmYesNoRequired(confirmMsg, false, logoutForce)
-		if confirmErr != nil {
-			return confirmErr
-		}
-		if !confirmed {
-			fmt.Println("Logout canceled.")
-			return nil
+		// confirm before logging out (skip if --force)
+		if !logoutForce {
+			var confirmMsg string
+			if len(endpointsToLogout) == 1 {
+				confirmMsg = fmt.Sprintf("Log out from %s?", endpointsToLogout[0])
+			} else {
+				confirmMsg = fmt.Sprintf("Log out from %d endpoints?", len(endpointsToLogout))
+			}
+			confirmed, confirmErr := cli.ConfirmYesNoRequired(confirmMsg, false, false)
+			if confirmErr != nil {
+				return confirmErr
+			}
+			if !confirmed {
+				fmt.Println("Logout canceled.")
+				return nil
+			}
 		}
 
 		// logout from each endpoint

--- a/cmd/ox/logout.go
+++ b/cmd/ox/logout.go
@@ -96,18 +96,20 @@ var logoutCmd = &cobra.Command{
 			}
 		}
 
-		// confirm before logging out (skip if --force)
-		if !logoutForce {
-			var confirmMsg string
-			if len(endpointsToLogout) == 1 {
-				confirmMsg = fmt.Sprintf("Log out from %s?", endpointsToLogout[0])
-			} else {
-				confirmMsg = fmt.Sprintf("Log out from %d endpoints?", len(endpointsToLogout))
-			}
-			if !cli.ConfirmYesNo(confirmMsg, false) {
-				fmt.Println("Logout canceled.")
-				return nil
-			}
+		// confirm before logging out (skip if --force or --yes)
+		var confirmMsg string
+		if len(endpointsToLogout) == 1 {
+			confirmMsg = fmt.Sprintf("Log out from %s?", endpointsToLogout[0])
+		} else {
+			confirmMsg = fmt.Sprintf("Log out from %d endpoints?", len(endpointsToLogout))
+		}
+		confirmed, confirmErr := cli.ConfirmYesNoRequired(confirmMsg, false, logoutForce)
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !confirmed {
+			fmt.Println("Logout canceled.")
+			return nil
 		}
 
 		// logout from each endpoint

--- a/cmd/ox/logout.go
+++ b/cmd/ox/logout.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/cli"
@@ -184,9 +186,11 @@ func selectLogoutEndpoints(loggedInEndpoints []string, all bool, specified strin
 				"pass --endpoint <endpoint> to choose one, or --all to log out of every endpoint",
 				len(loggedInEndpoints))
 		}
-		var selection int
-		n, err := fmt.Sscanf(input, "%d", &selection)
-		if err == nil && n == 1 && selection >= 1 && selection <= maxSelection {
+		// strconv.Atoi, not fmt.Sscanf("%d"): Sscanf stops at the first
+		// non-digit, so "1abc" would parse as 1 and silently log out of an
+		// endpoint the operator never typed.
+		selection, err := strconv.Atoi(strings.TrimSpace(input))
+		if err == nil && selection >= 1 && selection <= maxSelection {
 			if selection == maxSelection {
 				return loggedInEndpoints, nil
 			}

--- a/cmd/ox/logout.go
+++ b/cmd/ox/logout.go
@@ -32,68 +32,9 @@ var logoutCmd = &cobra.Command{
 		}
 
 		// determine which endpoint(s) to logout from
-		var endpointsToLogout []string
-
-		if logoutAll {
-			// logout from all endpoints
-			endpointsToLogout = loggedInEndpoints
-		} else if logoutEndpoint != "" {
-			// use specified endpoint
-			found := false
-			for _, ep := range loggedInEndpoints {
-				if ep == logoutEndpoint || endpoint.NormalizeSlug(ep) == endpoint.NormalizeSlug(logoutEndpoint) {
-					endpointsToLogout = []string{ep}
-					found = true
-					break
-				}
-			}
-			if !found {
-				return fmt.Errorf("not logged in to endpoint: %s", logoutEndpoint)
-			}
-		} else if len(loggedInEndpoints) == 1 {
-			// only one endpoint, use it
-			endpointsToLogout = loggedInEndpoints
-		} else if logoutForce {
-			// --force with multiple endpoints: log out from all (non-interactive)
-			endpointsToLogout = loggedInEndpoints
-		} else {
-			// multiple endpoints - prompt for selection
-			fmt.Println()
-			fmt.Println(cli.StyleDim.Render("You are logged into multiple SageOx endpoints."))
-			fmt.Println()
-
-			// display options
-			for i, ep := range loggedInEndpoints {
-				fmt.Printf("  %d. %s\n", i+1, ep)
-			}
-			fmt.Printf("  %d. All endpoints\n", len(loggedInEndpoints)+1)
-			fmt.Println()
-
-			// prompt for selection
-			var selection int
-			maxSelection := len(loggedInEndpoints) + 1
-			for {
-				fmt.Print("Select endpoint to logout (1-", maxSelection, "): ")
-				var input string
-				if _, err := fmt.Scanln(&input); err != nil {
-					// unreadable input (e.g. closed/EOF stdin) — cancel rather than
-					// spin forever re-prompting against a stream that can't answer.
-					fmt.Println("Logout canceled.")
-					return nil
-				}
-				n, err := fmt.Sscanf(input, "%d", &selection)
-				if err == nil && n == 1 && selection >= 1 && selection <= maxSelection {
-					break
-				}
-				fmt.Println(cli.StyleDim.Render("Invalid selection. Please enter a number."))
-			}
-
-			if selection == len(loggedInEndpoints)+1 {
-				// all endpoints selected
-				endpointsToLogout = loggedInEndpoints
-			} else {
-				endpointsToLogout = []string{loggedInEndpoints[selection-1]}
-			}
+		endpointsToLogout, selErr := selectLogoutEndpoints(loggedInEndpoints, logoutAll, logoutEndpoint, logoutForce)
+		if selErr != nil {
+			return selErr
 		}
 
 		// confirm before logging out (skip if --force)
@@ -191,5 +132,66 @@ func stripExistingRemotes(ep string) {
 		if err := gitserver.StripRemoteCredentials(tc.Path); err != nil {
 			slog.Debug("failed to strip team context remote credentials", "team", tc.TeamName, "error", err)
 		}
+	}
+}
+
+// selectLogoutEndpoints resolves which endpoint(s) `ox logout` should act on.
+//
+// When several endpoints are logged in and none was named, this asks. If the
+// answer cannot be read it returns an error rather than canceling: canceling
+// exited 0 having revoked nothing and removed no local credentials, which is a
+// logout that silently did not happen. Which endpoint to log out of is a
+// selection, not a yes/no, so --yes cannot answer it either — the error names
+// the deterministic alternatives instead of guessing one.
+func selectLogoutEndpoints(loggedInEndpoints []string, all bool, specified string, force bool) ([]string, error) {
+	switch {
+	case all:
+		return loggedInEndpoints, nil
+
+	case specified != "":
+		for _, ep := range loggedInEndpoints {
+			if ep == specified || endpoint.NormalizeSlug(ep) == endpoint.NormalizeSlug(specified) {
+				return []string{ep}, nil
+			}
+		}
+		return nil, fmt.Errorf("not logged in to endpoint: %s", specified)
+
+	case len(loggedInEndpoints) == 1:
+		return loggedInEndpoints, nil
+
+	case force:
+		// --force with multiple endpoints: log out from all (non-interactive)
+		return loggedInEndpoints, nil
+	}
+
+	// multiple endpoints - prompt for selection
+	fmt.Println()
+	fmt.Println(cli.StyleDim.Render("You are logged into multiple SageOx endpoints."))
+	fmt.Println()
+
+	for i, ep := range loggedInEndpoints {
+		fmt.Printf("  %d. %s\n", i+1, ep)
+	}
+	fmt.Printf("  %d. All endpoints\n", len(loggedInEndpoints)+1)
+	fmt.Println()
+
+	maxSelection := len(loggedInEndpoints) + 1
+	for {
+		fmt.Print("Select endpoint to logout (1-", maxSelection, "): ")
+		var input string
+		if _, err := fmt.Scanln(&input); err != nil {
+			return nil, fmt.Errorf("logged into %d endpoints and no selection could be read from stdin; "+
+				"pass --endpoint <endpoint> to choose one, or --all to log out of every endpoint",
+				len(loggedInEndpoints))
+		}
+		var selection int
+		n, err := fmt.Sscanf(input, "%d", &selection)
+		if err == nil && n == 1 && selection >= 1 && selection <= maxSelection {
+			if selection == maxSelection {
+				return loggedInEndpoints, nil
+			}
+			return []string{loggedInEndpoints[selection-1]}, nil
+		}
+		fmt.Println(cli.StyleDim.Render("Invalid selection. Please enter a number."))
 	}
 }

--- a/cmd/ox/logout_select_test.go
+++ b/cmd/ox/logout_select_test.go
@@ -116,6 +116,21 @@ func TestSelectLogoutEndpoints_PipedSelection(t *testing.T) {
 		assert.Equal(t, two, got)
 	})
 
+	// fmt.Sscanf("%d") stops at the first non-digit, so "1abc" parsed as 1 and
+	// would have logged out of an endpoint the operator never typed.
+	t.Run("trailing characters are rejected, not truncated to a selection", func(t *testing.T) {
+		var got []string
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "1abc\n2\n", func() {
+				got, err = selectLogoutEndpoints(two, false, "", false)
+			})
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"https://test.sageox.ai"}, got,
+			"\"1abc\" must be rejected and re-prompted, never read as endpoint 1")
+	})
+
 	t.Run("an invalid entry re-prompts rather than guessing", func(t *testing.T) {
 		var got []string
 		var err error

--- a/cmd/ox/logout_select_test.go
+++ b/cmd/ox/logout_select_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSelectLogoutEndpoints_UnreadableSelectionFailsLoudly is the gate for the
+// review finding: with several endpoints logged in and nothing on stdin, logout
+// printed "Logout canceled." and exited 0 — having revoked nothing and removed
+// no local credentials. --yes cannot rescue it either, because which endpoint to
+// log out of is a selection, not a yes/no.
+func TestSelectLogoutEndpoints_UnreadableSelectionFailsLoudly(t *testing.T) {
+	endpoints := []string{"https://sageox.ai", "https://test.sageox.ai"}
+
+	var got []string
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "", func() {
+			got, err = selectLogoutEndpoints(endpoints, false, "", false)
+		})
+	})
+
+	require.Error(t, err, "an unreadable selection must not look like a successful cancel")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "--endpoint")
+	assert.Contains(t, err.Error(), "--all", "the error must name the deterministic alternatives")
+}
+
+func TestSelectLogoutEndpoints_DeterministicPaths(t *testing.T) {
+	two := []string{"https://sageox.ai", "https://test.sageox.ai"}
+	one := []string{"https://sageox.ai"}
+
+	tests := []struct {
+		name      string
+		endpoints []string
+		all       bool
+		specified string
+		force     bool
+		want      []string
+		wantErr   string
+	}{
+		{name: "--all selects every endpoint", endpoints: two, all: true, want: two},
+		{name: "--force selects every endpoint", endpoints: two, force: true, want: two},
+		{name: "a single endpoint needs no prompt", endpoints: one, want: one},
+		{
+			name:      "--endpoint selects the named one",
+			endpoints: two,
+			specified: "https://test.sageox.ai",
+			want:      []string{"https://test.sageox.ai"},
+		},
+		{
+			// slug normalization means the bare host resolves too
+			name:      "--endpoint matches on normalized slug",
+			endpoints: two,
+			specified: "test.sageox.ai",
+			want:      []string{"https://test.sageox.ai"},
+		},
+		{
+			name:      "--endpoint that is not logged in errors",
+			endpoints: two,
+			specified: "https://other.example",
+			wantErr:   "not logged in to endpoint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			var err error
+			silenceStdout(t, func() {
+				withStdin(t, "", func() {
+					got, err = selectLogoutEndpoints(tt.endpoints, tt.all, tt.specified, tt.force)
+				})
+			})
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestSelectLogoutEndpoints_PipedSelection proves an honest scripted answer
+// still works — requiring a terminal would break every such caller.
+func TestSelectLogoutEndpoints_PipedSelection(t *testing.T) {
+	two := []string{"https://sageox.ai", "https://test.sageox.ai"}
+
+	t.Run("a number picks that endpoint", func(t *testing.T) {
+		var got []string
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "2\n", func() {
+				got, err = selectLogoutEndpoints(two, false, "", false)
+			})
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"https://test.sageox.ai"}, got)
+	})
+
+	t.Run("the last option picks all endpoints", func(t *testing.T) {
+		var got []string
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "3\n", func() {
+				got, err = selectLogoutEndpoints(two, false, "", false)
+			})
+		})
+		require.NoError(t, err)
+		assert.Equal(t, two, got)
+	})
+
+	t.Run("an invalid entry re-prompts rather than guessing", func(t *testing.T) {
+		var got []string
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "9\n1\n", func() {
+				got, err = selectLogoutEndpoints(two, false, "", false)
+			})
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"https://sageox.ai"}, got)
+	})
+}

--- a/cmd/ox/root.go
+++ b/cmd/ox/root.go
@@ -127,7 +127,7 @@ func registerPersistentFlags() {
 	// No -y shorthand here on purpose: `ox doctor -y` and `ox team invite -y`
 	// already bind their own, and a root-level shorthand would shadow them
 	// confusingly. Both local flags still feed the same global via NewContext.
-	rootCmd.PersistentFlags().Bool("yes", false, "answer yes to confirmation prompts (use when no answer is supplied on stdin)")
+	rootCmd.PersistentFlags().Bool("yes", false, "answer yes to confirmation prompts without reading stdin (overrides a piped answer)")
 }
 
 func init() {

--- a/cmd/ox/root.go
+++ b/cmd/ox/root.go
@@ -124,6 +124,10 @@ func registerPersistentFlags() {
 	rootCmd.PersistentFlags().StringP("config", "c", "", "config file path (default: .sageox/config.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&profileEnabled, "profile", false, "generate CPU profile and execution trace for performance analysis (default: false)")
 	rootCmd.PersistentFlags().Bool("no-interactive", false, "disable spinners and TUI elements (auto-enabled when CI=true)")
+	// No -y shorthand here on purpose: `ox doctor -y` and `ox team invite -y`
+	// already bind their own, and a root-level shorthand would shadow them
+	// confusingly. Both local flags still feed the same global via NewContext.
+	rootCmd.PersistentFlags().Bool("yes", false, "answer yes to confirmation prompts (required when running without a terminal)")
 }
 
 func init() {

--- a/cmd/ox/root.go
+++ b/cmd/ox/root.go
@@ -127,7 +127,7 @@ func registerPersistentFlags() {
 	// No -y shorthand here on purpose: `ox doctor -y` and `ox team invite -y`
 	// already bind their own, and a root-level shorthand would shadow them
 	// confusingly. Both local flags still feed the same global via NewContext.
-	rootCmd.PersistentFlags().Bool("yes", false, "answer yes to confirmation prompts (required when running without a terminal)")
+	rootCmd.PersistentFlags().Bool("yes", false, "answer yes to confirmation prompts (use when no answer is supplied on stdin)")
 }
 
 func init() {

--- a/cmd/ox/session_prune.go
+++ b/cmd/ox/session_prune.go
@@ -99,11 +99,13 @@ func runSessionPrune(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	if !force {
-		if !cli.ConfirmYesNo(fmt.Sprintf("Remove %d local session(s)?", len(candidates)), false) {
-			fmt.Println("Canceled.")
-			return nil
-		}
+	confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("Remove %d local session(s)?", len(candidates)), false, force)
+	if confirmErr != nil {
+		return confirmErr
+	}
+	if !confirmed {
+		fmt.Println("Canceled.")
+		return nil
 	}
 
 	removed := deletePruneCandidates(candidates)

--- a/cmd/ox/session_prune.go
+++ b/cmd/ox/session_prune.go
@@ -99,13 +99,15 @@ func runSessionPrune(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("Remove %d local session(s)?", len(candidates)), false, force)
-	if confirmErr != nil {
-		return confirmErr
-	}
-	if !confirmed {
-		fmt.Println("Canceled.")
-		return nil
+	if !force {
+		confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("Remove %d local session(s)?", len(candidates)), false, false)
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !confirmed {
+			fmt.Println("Canceled.")
+			return nil
+		}
 	}
 
 	removed := deletePruneCandidates(candidates)

--- a/cmd/ox/session_redact_history.go
+++ b/cmd/ox/session_redact_history.go
@@ -123,7 +123,9 @@ Safety:
     actionable here. They require the gated history-rewrite tool. The
     correct response is: rotate the leaked credential, mark the finding
     as known, and follow up via the team comms process.
-  - Per-finding human approval. There is no bulk-approve flag.
+  - Per-file human approval. There is no bulk-approve flag, and the global
+    ` + "`--yes`" + ` does NOT approve redactions: every file is asked about
+    individually, and ` + "`q`" + ` quits the pass with the snapshot intact.
   - Each redaction pass appends a RedactionPass entry to the session's
     meta.json (ox-8bfh) recording WHO redacted, WHEN, with WHICH catalog
     version+hash, and WHAT was caught — never the matched bytes.`,

--- a/cmd/ox/session_regenerate.go
+++ b/cmd/ox/session_regenerate.go
@@ -190,13 +190,15 @@ func regenerateAllSessionsArtifacts(store *session.Store, projectRoot string, fo
 		return nil
 	}
 
-	confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("Regenerate artifacts for %d session(s)?", len(sessions)), false, force)
-	if confirmErr != nil {
-		return confirmErr
-	}
-	if !confirmed {
-		fmt.Println("Canceled.")
-		return nil
+	if !force {
+		confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("Regenerate artifacts for %d session(s)?", len(sessions)), false, false)
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !confirmed {
+			fmt.Println("Canceled.")
+			return nil
+		}
 	}
 
 	var regenerated, skipped int

--- a/cmd/ox/session_regenerate.go
+++ b/cmd/ox/session_regenerate.go
@@ -190,11 +190,13 @@ func regenerateAllSessionsArtifacts(store *session.Store, projectRoot string, fo
 		return nil
 	}
 
-	if !force {
-		if !cli.ConfirmYesNo(fmt.Sprintf("Regenerate artifacts for %d session(s)?", len(sessions)), false) {
-			fmt.Println("Canceled.")
-			return nil
-		}
+	confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("Regenerate artifacts for %d session(s)?", len(sessions)), false, force)
+	if confirmErr != nil {
+		return confirmErr
+	}
+	if !confirmed {
+		fmt.Println("Canceled.")
+		return nil
 	}
 
 	var regenerated, skipped int
@@ -474,7 +476,11 @@ func runSessionRegenerateRedact(cmd *cobra.Command, args []string) error {
 		} else {
 			prompt = fmt.Sprintf("This will re-redact session %q and re-upload to LFS. Continue?", args[0])
 		}
-		if !cli.ConfirmYesNo(prompt, false) {
+		confirmed, confirmErr := cli.ConfirmYesNoRequired(prompt, false, false)
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !confirmed {
 			fmt.Println("Canceled.")
 			return nil
 		}

--- a/cmd/ox/session_regenerate_confirm_test.go
+++ b/cmd/ox/session_regenerate_confirm_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegenerateAllSessionsArtifacts_Confirmation covers the gate on a bulk
+// rewrite: taking the default silently printed "Canceled." and exited 0, which
+// is indistinguishable from a deliberate decline.
+func TestRegenerateAllSessionsArtifacts_Confirmation(t *testing.T) {
+	name := recentSessionName("OxRgA1")
+
+	t.Run("unanswered prompt errors", func(t *testing.T) {
+		store, root := localStoreWithSessions(t, name)
+
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "", func() {
+				err = regenerateAllSessionsArtifacts(store, root, false)
+			})
+		})
+
+		assert.True(t, errors.Is(err, cli.ErrConfirmationRequired), "got %v", err)
+	})
+
+	t.Run("explicit no is an ordinary cancel", func(t *testing.T) {
+		store, root := localStoreWithSessions(t, name)
+
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "n\n", func() {
+				err = regenerateAllSessionsArtifacts(store, root, false)
+			})
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("force skips the prompt", func(t *testing.T) {
+		store, root := localStoreWithSessions(t, name)
+
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "", func() {
+				err = regenerateAllSessionsArtifacts(store, root, true)
+			})
+		})
+
+		assert.NoError(t, err, "--force must not need stdin")
+	})
+
+	t.Run("global yes skips the prompt", func(t *testing.T) {
+		store, root := localStoreWithSessions(t, name)
+
+		cli.SetAssumeYes(true)
+		t.Cleanup(func() { cli.SetAssumeYes(false) })
+
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "", func() {
+				err = regenerateAllSessionsArtifacts(store, root, false)
+			})
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("no sessions short-circuits before the prompt", func(t *testing.T) {
+		store, root := localStoreWithSessions(t)
+
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "", func() {
+				err = regenerateAllSessionsArtifacts(store, root, false)
+			})
+		})
+
+		require.NoError(t, err, "an empty store must not fail just because nobody is attached")
+	})
+}

--- a/cmd/ox/session_remove.go
+++ b/cmd/ox/session_remove.go
@@ -88,11 +88,13 @@ func removeAllSessions(store *session.Store, force bool) error {
 	}
 
 	// confirm unless force flag is set
-	if !force {
-		if !cli.ConfirmYesNo(fmt.Sprintf("This will remove %d local session(s). Continue?", len(sessions)), false) {
-			fmt.Println("Canceled.")
-			return nil
-		}
+	confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("This will remove %d local session(s). Continue?", len(sessions)), false, force)
+	if confirmErr != nil {
+		return confirmErr
+	}
+	if !confirmed {
+		fmt.Println("Canceled.")
+		return nil
 	}
 
 	var removed int
@@ -225,13 +227,21 @@ func removeSessionByPattern(store *session.Store, pattern string, force bool) er
 			}
 		}
 		prompt := fmt.Sprintf("Remove %s from ledger? This affects all coworkers and cannot be undone", strings.Join(ledgerNames, ", "))
-		if !cli.ConfirmYesNo(prompt, false) {
+		confirmed, confirmErr := cli.ConfirmYesNoRequired(prompt, false, false)
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !confirmed {
 			fmt.Println("Canceled.")
 			return nil
 		}
 	} else if !force && !hasLedger {
 		// local-only single match confirmation
-		if !cli.ConfirmYesNo(fmt.Sprintf("Remove %s?", matchName(matches[0])), false) {
+		confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("Remove %s?", matchName(matches[0])), false, false)
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !confirmed {
 			fmt.Println("Canceled.")
 			return nil
 		}

--- a/cmd/ox/session_remove.go
+++ b/cmd/ox/session_remove.go
@@ -88,13 +88,15 @@ func removeAllSessions(store *session.Store, force bool) error {
 	}
 
 	// confirm unless force flag is set
-	confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("This will remove %d local session(s). Continue?", len(sessions)), false, force)
-	if confirmErr != nil {
-		return confirmErr
-	}
-	if !confirmed {
-		fmt.Println("Canceled.")
-		return nil
+	if !force {
+		confirmed, confirmErr := cli.ConfirmYesNoRequired(fmt.Sprintf("This will remove %d local session(s). Continue?", len(sessions)), false, false)
+		if confirmErr != nil {
+			return confirmErr
+		}
+		if !confirmed {
+			fmt.Println("Canceled.")
+			return nil
+		}
 	}
 
 	var removed int

--- a/cmd/ox/session_remove_confirm_test.go
+++ b/cmd/ox/session_remove_confirm_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recentSessionName builds a session directory name inside the store's default
+// 7-day listing window. ListSessions filters on the timestamp parsed from the
+// directory NAME, so a hardcoded past date is invisible to it.
+func recentSessionName(suffix string) string {
+	return time.Now().UTC().Format("2006-01-02T15-04") + "-testuser-" + suffix
+}
+
+// localStoreWithSessions builds a session store holding n sessions, so the
+// confirmation prompt is reached instead of the "nothing to remove" early exit.
+func localStoreWithSessions(t *testing.T, names ...string) (*session.Store, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	store, err := session.NewStore(root)
+	require.NoError(t, err)
+
+	for _, name := range names {
+		writeSessionFiles(t, root, name)
+	}
+	sessions, err := store.ListSessions()
+	require.NoError(t, err)
+	require.Len(t, sessions, len(names), "fixture must be visible to the store")
+
+	return store, root
+}
+
+func sessionDirExists(t *testing.T, root, name string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(root, "sessions", name))
+	return err == nil
+}
+
+// TestRemoveAllSessions_UnansweredPromptRemovesNothing gates the silent
+// no-op: before, an unattended run printed "Canceled." and exited 0, which is
+// indistinguishable from a deliberate decline.
+func TestRemoveAllSessions_UnansweredPromptRemovesNothing(t *testing.T) {
+	name := recentSessionName("OxRmA1")
+	store, root := localStoreWithSessions(t, name)
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "", func() {
+			err = removeAllSessions(store, false)
+		})
+	})
+
+	assert.True(t, errors.Is(err, cli.ErrConfirmationRequired),
+		"want ErrConfirmationRequired, got %v", err)
+	assert.True(t, sessionDirExists(t, root, name), "nothing may be removed when nobody answered")
+}
+
+// TestRemoveAllSessions_DeclineIsStillAnOrdinaryCancel pins that a real "no"
+// remains a successful, quiet cancel rather than becoming an error.
+func TestRemoveAllSessions_DeclineIsStillAnOrdinaryCancel(t *testing.T) {
+	name := recentSessionName("OxRmA2")
+	store, root := localStoreWithSessions(t, name)
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "n\n", func() {
+			err = removeAllSessions(store, false)
+		})
+	})
+
+	require.NoError(t, err)
+	assert.True(t, sessionDirExists(t, root, name), "declining must leave sessions in place")
+}
+
+// TestRemoveAllSessions_PipedYesRemoves proves a scripted answer still works.
+func TestRemoveAllSessions_PipedYesRemoves(t *testing.T) {
+	name := recentSessionName("OxRmA3")
+	store, root := localStoreWithSessions(t, name)
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "y\n", func() {
+			err = removeAllSessions(store, false)
+		})
+	})
+
+	require.NoError(t, err)
+	assert.False(t, sessionDirExists(t, root, name), "a piped yes must actually remove")
+}
+
+// TestRemoveAllSessions_ForceSkipsThePrompt covers the --force short-circuit,
+// which now runs through the same helper rather than an outer if.
+func TestRemoveAllSessions_ForceSkipsThePrompt(t *testing.T) {
+	name := recentSessionName("OxRmA4")
+	store, root := localStoreWithSessions(t, name)
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "", func() {
+			err = removeAllSessions(store, true)
+		})
+	})
+
+	require.NoError(t, err)
+	assert.False(t, sessionDirExists(t, root, name), "--force must remove without reading stdin")
+}
+
+// TestRemoveAllSessions_GlobalYesSkipsThePrompt covers the --yes path.
+func TestRemoveAllSessions_GlobalYesSkipsThePrompt(t *testing.T) {
+	name := recentSessionName("OxRmA5")
+	store, root := localStoreWithSessions(t, name)
+
+	cli.SetAssumeYes(true)
+	t.Cleanup(func() { cli.SetAssumeYes(false) })
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "", func() {
+			err = removeAllSessions(store, false)
+		})
+	})
+
+	require.NoError(t, err)
+	assert.False(t, sessionDirExists(t, root, name), "--yes must satisfy this prompt")
+}
+
+// TestRemoveAllSessions_NoSessionsNeverPrompts keeps the early exit ahead of
+// the prompt: an empty store must not fail just because nobody is attached.
+func TestRemoveAllSessions_NoSessionsNeverPrompts(t *testing.T) {
+	store, _ := localStoreWithSessions(t)
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "", func() {
+			err = removeAllSessions(store, false)
+		})
+	})
+
+	assert.NoError(t, err, "an empty store must short-circuit before the prompt")
+}
+
+// TestRemoveSessionByPattern_UnansweredPromptRemovesNothing covers the
+// local-only single-match branch of the pattern path.
+func TestRemoveSessionByPattern_UnansweredPromptRemovesNothing(t *testing.T) {
+	setTestCfg(t)
+	name := recentSessionName("OxRmP1")
+	store, root := localStoreWithSessions(t, name)
+	t.Chdir(t.TempDir())
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "", func() {
+			err = removeSessionByPattern(store, name, false)
+		})
+	})
+
+	assert.True(t, errors.Is(err, cli.ErrConfirmationRequired),
+		"want ErrConfirmationRequired, got %v", err)
+	assert.True(t, sessionDirExists(t, root, name), "nothing may be removed when nobody answered")
+}
+
+// TestRemoveSessionByPattern_DeclineRemovesNothing pins the ordinary decline.
+func TestRemoveSessionByPattern_DeclineRemovesNothing(t *testing.T) {
+	setTestCfg(t)
+	name := recentSessionName("OxRmP2")
+	store, root := localStoreWithSessions(t, name)
+	t.Chdir(t.TempDir())
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "n\n", func() {
+			err = removeSessionByPattern(store, name, false)
+		})
+	})
+
+	require.NoError(t, err)
+	assert.True(t, sessionDirExists(t, root, name))
+}
+
+// TestRemoveSessionByPattern_PipedYesRemoves is the positive control.
+func TestRemoveSessionByPattern_PipedYesRemoves(t *testing.T) {
+	setTestCfg(t)
+	name := recentSessionName("OxRmP3")
+	store, root := localStoreWithSessions(t, name)
+	t.Chdir(t.TempDir())
+
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "y\n", func() {
+			err = removeSessionByPattern(store, name, false)
+		})
+	})
+
+	require.NoError(t, err)
+	assert.False(t, sessionDirExists(t, root, name))
+}

--- a/cmd/ox/session_remove_ledger_confirm_test.go
+++ b/cmd/ox/session_remove_ledger_confirm_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A ledger removal is the most consequential branch of `ox session remove`: it
+// affects every coworker and cannot be undone. Taking the default silently
+// printed "Canceled." and exited 0, indistinguishable from a real decline.
+func TestRemoveSessionByPattern_LedgerConfirmation(t *testing.T) {
+	const sessionName = "2026-01-01T00-00-testuser-OxLdg1"
+
+	newFixture := func(t *testing.T) (*session.Store, *draftLedgerFixture) {
+		t.Helper()
+		setTestCfg(t)
+		f := newDraftLedgerFixture(t)
+		t.Chdir(f.projectRoot)
+
+		finalizedLedgerSession(t, f.ledgerPath, sessionName)
+		runGit(t, f.ledgerPath, "add", "--sparse", "--", "sessions/"+sessionName+"/meta.json")
+		runGit(t, f.ledgerPath, "commit", "--no-verify", "-m", "session: "+sessionName)
+		f.push(t)
+
+		// the "local" store is the session cache, never the ledger — passing
+		// the ledger would route down the local-delete branch instead
+		localStore, err := session.NewStore(t.TempDir())
+		require.NoError(t, err)
+		return localStore, f
+	}
+
+	t.Run("unanswered prompt removes nothing from the ledger", func(t *testing.T) {
+		store, f := newFixture(t)
+
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "", func() {
+				err = removeSessionByPattern(store, sessionName, false)
+			})
+		})
+
+		assert.True(t, errors.Is(err, cli.ErrConfirmationRequired), "got %v", err)
+		assert.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json",
+			"a shared-ledger deletion must never happen on a silent default")
+	})
+
+	t.Run("declining removes nothing", func(t *testing.T) {
+		store, f := newFixture(t)
+
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "n\n", func() {
+				err = removeSessionByPattern(store, sessionName, false)
+			})
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+	})
+
+	t.Run("an explicit yes removes it", func(t *testing.T) {
+		store, f := newFixture(t)
+
+		var err error
+		silenceStdout(t, func() {
+			withStdin(t, "y\n", func() {
+				err = removeSessionByPattern(store, sessionName, false)
+			})
+		})
+
+		require.NoError(t, err)
+		assert.NotContains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json",
+			"positive control: an explicit yes must actually remove")
+	})
+}

--- a/cmd/ox/uninstall.go
+++ b/cmd/ox/uninstall.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -170,7 +171,15 @@ func runUninstall() error {
 	// confirm with user unless --force
 	if !uninstallForce {
 		repoName := filepath.Base(gitRoot)
-		if !confirmUninstallWithInput(repoName, selectedEndpoint, uninstallAllEndpoints, gitRoot) {
+		confirmed, confirmErr := confirmUninstallWithInput(repoName, selectedEndpoint, uninstallAllEndpoints, gitRoot)
+		if confirmErr != nil {
+			fmt.Fprintln(os.Stderr)
+			// Deliberately not the sentinel's own wording: --yes does not
+			// satisfy this gate, so pointing at it would send the user down a
+			// path that keeps failing.
+			return errors.New("uninstall requires confirmation: type the repository name at a terminal, or re-run with --force")
+		}
+		if !confirmed {
 			fmt.Fprintln(os.Stderr)
 			cli.PrintSuccess("Uninstall canceled")
 			return nil
@@ -284,9 +293,20 @@ func notifyCloudUninstall(marker *api.RepoMarkerData) {
 		fmt.Printf("%s %s %s\n", cli.StyleDim.Render("Visit"), cli.StyleCommand.Render(statusURL), cli.StyleDim.Render("to check status."))
 
 		// offer to open browser for immediate confirmation
+		confirmURL := fmt.Sprintf("https://%s/repos/%s/uninstall/confirm", endpoint.NormalizeSlug(ep), marker.RepoID)
 		fmt.Fprintln(os.Stderr)
-		if promptConfirmCloudDeletion() {
-			confirmURL := fmt.Sprintf("https://%s/repos/%s/uninstall/confirm", endpoint.NormalizeSlug(ep), marker.RepoID)
+
+		confirmNow, confirmErr := cli.ConfirmYesNoRequired("Confirm cloud resource deletion now?", false, uninstallForce)
+		switch {
+		case confirmErr != nil:
+			// Nobody was there to answer. The uninstall request is submitted
+			// but unconfirmed, so this link is the only thing standing between
+			// the user and cloud records that outlive the local uninstall.
+			// Silently skipping the step is how those records got stranded.
+			slog.Warn("uninstall cloud confirmation", "skipped", "no interactive input", "url", confirmURL)
+			cli.PrintWarning("Cloud deletion is still unconfirmed — nothing was available to answer the prompt.")
+			fmt.Printf("%s %s\n", cli.StyleDim.Render("Confirm here:"), cli.StyleCommand.Render(confirmURL))
+		case confirmNow:
 			if err := openBrowserForUninstall(confirmURL); err != nil {
 				slog.Warn("failed to open browser", "error", err)
 				fmt.Println(cli.StyleWarning.Render("⚠ Could not open browser."))
@@ -294,23 +314,10 @@ func notifyCloudUninstall(marker *api.RepoMarkerData) {
 			} else {
 				fmt.Println(cli.StyleSuccess.Render("✓ Opened browser for confirmation"))
 			}
+		default:
+			fmt.Printf("%s %s\n", cli.StyleDim.Render("Confirm later at:"), cli.StyleCommand.Render(confirmURL))
 		}
 	}
-}
-
-// promptConfirmCloudDeletion asks the user if they want to confirm cloud resource deletion now.
-// Returns true if user wants to proceed, false otherwise. Default is No.
-func promptConfirmCloudDeletion() bool {
-	fmt.Printf("%s [yN]: ", cli.StyleDim.Render("Confirm cloud resource deletion now?"))
-
-	reader := bufio.NewReader(os.Stdin)
-	input, err := reader.ReadString('\n')
-	if err != nil {
-		return false
-	}
-
-	input = strings.TrimSpace(strings.ToLower(input))
-	return input == "y" || input == "yes"
 }
 
 // openBrowserForUninstall opens the given URL in the default browser.
@@ -433,7 +440,11 @@ func selectEndpointForUninstall(gitRoot string, endpoints []string) (string, boo
 
 // confirmUninstallWithInput prompts user for confirmation by typing repo name or "uninstall"
 // returns true if user confirms, false otherwise
-func confirmUninstallWithInput(repoName, selectedEndpoint string, allEndpoints bool, gitRoot string) bool {
+// A read that yields nothing at all returns ErrConfirmationRequired so the
+// caller can fail loudly; --yes deliberately does NOT satisfy this gate, since
+// typing the repository name is exactly the step meant to resist automation.
+// --force remains the explicit escape hatch.
+func confirmUninstallWithInput(repoName, selectedEndpoint string, allEndpoints bool, gitRoot string) (bool, error) {
 	fmt.Fprintln(os.Stderr)
 	fmt.Println(cli.StyleError.Bold(true).Render("DANGER ZONE"))
 	fmt.Fprintln(os.Stderr)
@@ -467,9 +478,11 @@ func confirmUninstallWithInput(repoName, selectedEndpoint string, allEndpoints b
 
 	reader := bufio.NewReader(os.Stdin)
 	input, err := reader.ReadString('\n')
-	if err != nil {
-		slog.Error("failed to read confirmation input", "error", err)
-		return false
+	// A final line with no trailing newline arrives as data and io.EOF at once;
+	// only a read that produced nothing means nobody was there.
+	if err != nil && strings.TrimSpace(input) == "" {
+		slog.Warn("uninstall confirmation", "skipped", "no interactive input")
+		return false, cli.ErrConfirmationRequired
 	}
 
 	input = strings.TrimSpace(input)
@@ -477,11 +490,11 @@ func confirmUninstallWithInput(repoName, selectedEndpoint string, allEndpoints b
 		fmt.Fprintln(os.Stderr)
 		fmt.Println(cli.StyleError.Render("Confirmation failed."))
 		fmt.Printf("Expected: %s or %s, got: %s\n", repoName, "uninstall", input)
-		return false
+		return false, nil
 	}
 
 	slog.Info("uninstall confirmed", "repo", repoName, "input", input)
-	return true
+	return true, nil
 }
 
 // showLedgerBackupWarning checks if a ledger exists and warns the user to back it up

--- a/cmd/ox/uninstall.go
+++ b/cmd/ox/uninstall.go
@@ -295,28 +295,35 @@ func notifyCloudUninstall(marker *api.RepoMarkerData) {
 		// offer to open browser for immediate confirmation
 		confirmURL := fmt.Sprintf("https://%s/repos/%s/uninstall/confirm", endpoint.NormalizeSlug(ep), marker.RepoID)
 		fmt.Fprintln(os.Stderr)
+		offerCloudDeletionConfirmation(confirmURL, uninstallForce)
+	}
+}
 
-		confirmNow, confirmErr := cli.ConfirmYesNoRequired("Confirm cloud resource deletion now?", false, uninstallForce)
-		switch {
-		case confirmErr != nil:
-			// Nobody was there to answer. The uninstall request is submitted
-			// but unconfirmed, so this link is the only thing standing between
-			// the user and cloud records that outlive the local uninstall.
-			// Silently skipping the step is how those records got stranded.
-			slog.Warn("uninstall cloud confirmation", "skipped", "no interactive input", "url", confirmURL)
-			cli.PrintWarning("Cloud deletion is still unconfirmed — nothing was available to answer the prompt.")
-			fmt.Printf("%s %s\n", cli.StyleDim.Render("Confirm here:"), cli.StyleCommand.Render(confirmURL))
-		case confirmNow:
-			if err := openBrowserForUninstall(confirmURL); err != nil {
-				slog.Warn("failed to open browser", "error", err)
-				fmt.Println(cli.StyleWarning.Render("⚠ Could not open browser."))
-				fmt.Printf("%s %s\n", cli.StyleDim.Render("Open manually:"), cli.StyleCommand.Render(confirmURL))
-			} else {
-				fmt.Println(cli.StyleSuccess.Render("✓ Opened browser for confirmation"))
-			}
-		default:
-			fmt.Printf("%s %s\n", cli.StyleDim.Render("Confirm later at:"), cli.StyleCommand.Render(confirmURL))
+// offerCloudDeletionConfirmation offers to open the browser so the user can
+// confirm cloud-resource deletion immediately.
+//
+// The uninstall request has already been submitted at this point but is not yet
+// confirmed, so this URL is the only thing standing between the user and cloud
+// records that outlive the local uninstall. Every path therefore prints it:
+// silently skipping the step when nobody could answer is exactly how those
+// records got stranded.
+func offerCloudDeletionConfirmation(confirmURL string, force bool) {
+	confirmNow, err := cli.ConfirmYesNoRequired("Confirm cloud resource deletion now?", false, force)
+	switch {
+	case err != nil:
+		slog.Warn("uninstall cloud confirmation", "skipped", "no interactive input", "url", confirmURL)
+		cli.PrintWarning("Cloud deletion is still unconfirmed — nothing was available to answer the prompt.")
+		fmt.Printf("%s %s\n", cli.StyleDim.Render("Confirm here:"), cli.StyleCommand.Render(confirmURL))
+	case confirmNow:
+		if openErr := openBrowserForUninstall(confirmURL); openErr != nil {
+			slog.Warn("failed to open browser", "error", openErr)
+			fmt.Println(cli.StyleWarning.Render("⚠ Could not open browser."))
+			fmt.Printf("%s %s\n", cli.StyleDim.Render("Open manually:"), cli.StyleCommand.Render(confirmURL))
+		} else {
+			fmt.Println(cli.StyleSuccess.Render("✓ Opened browser for confirmation"))
 		}
+	default:
+		fmt.Printf("%s %s\n", cli.StyleDim.Render("Confirm later at:"), cli.StyleCommand.Render(confirmURL))
 	}
 }
 

--- a/cmd/ox/uninstall.go
+++ b/cmd/ox/uninstall.go
@@ -169,23 +169,12 @@ func runUninstall() error {
 	}
 
 	// confirm with user unless --force
-	if !uninstallForce {
-		repoName := filepath.Base(gitRoot)
-		confirmed, confirmErr := confirmUninstallWithInput(repoName, selectedEndpoint, uninstallAllEndpoints, gitRoot)
-		if confirmErr != nil {
-			fmt.Fprintln(os.Stderr)
-			// Deliberately not the sentinel's own wording: --yes does not
-			// satisfy this gate, so pointing at it would send the user down a
-			// path that keeps failing.
-			return errors.New("uninstall requires confirmation: type the repository name at a terminal, or re-run with --force")
-		}
-		if !confirmed {
-			fmt.Fprintln(os.Stderr)
-			cli.PrintSuccess("Uninstall canceled")
-			return nil
-		}
-	} else {
-		slog.Info("uninstall confirmation", "skipped", "force flag enabled")
+	proceed, confirmErr := confirmUninstallGate(gitRoot, selectedEndpoint, uninstallAllEndpoints, uninstallForce)
+	if confirmErr != nil {
+		return confirmErr
+	}
+	if !proceed {
+		return nil
 	}
 
 	// perform uninstall steps
@@ -293,9 +282,8 @@ func notifyCloudUninstall(marker *api.RepoMarkerData) {
 		fmt.Printf("%s %s %s\n", cli.StyleDim.Render("Visit"), cli.StyleCommand.Render(statusURL), cli.StyleDim.Render("to check status."))
 
 		// offer to open browser for immediate confirmation
-		confirmURL := fmt.Sprintf("https://%s/repos/%s/uninstall/confirm", endpoint.NormalizeSlug(ep), marker.RepoID)
 		fmt.Fprintln(os.Stderr)
-		offerCloudDeletionConfirmation(confirmURL, uninstallForce)
+		offerCloudDeletionConfirmation(ep, marker.RepoID, uninstallForce)
 	}
 }
 
@@ -307,7 +295,9 @@ func notifyCloudUninstall(marker *api.RepoMarkerData) {
 // records that outlive the local uninstall. Every path therefore prints it:
 // silently skipping the step when nobody could answer is exactly how those
 // records got stranded.
-func offerCloudDeletionConfirmation(confirmURL string, force bool) {
+func offerCloudDeletionConfirmation(ep, repoID string, force bool) {
+	confirmURL := fmt.Sprintf("https://%s/repos/%s/uninstall/confirm", endpoint.NormalizeSlug(ep), repoID)
+
 	confirmNow, err := cli.ConfirmYesNoRequired("Confirm cloud resource deletion now?", false, force)
 	switch {
 	case err != nil:
@@ -817,4 +807,32 @@ func removeUserIntegrationsWithConfirmation() error {
 	}
 
 	return nil
+}
+
+// confirmUninstallGate runs the type-to-confirm gate before a destructive
+// uninstall. Returns (false, nil) when the user deliberately declined, and an
+// error when nobody was there to answer at all — that distinction is the whole
+// point: reporting "Uninstall canceled" and exiting 0 to an unattended caller
+// reads as success.
+func confirmUninstallGate(gitRoot, selectedEndpoint string, allEndpoints, force bool) (bool, error) {
+	if force {
+		slog.Info("uninstall confirmation", "skipped", "force flag enabled")
+		return true, nil
+	}
+
+	repoName := filepath.Base(gitRoot)
+	confirmed, err := confirmUninstallWithInput(repoName, selectedEndpoint, allEndpoints, gitRoot)
+	if err != nil {
+		fmt.Fprintln(os.Stderr)
+		// Deliberately not the sentinel's own wording: --yes does not satisfy
+		// this gate, so pointing at it would send the user down a path that
+		// keeps failing.
+		return false, errors.New("uninstall requires confirmation: type the repository name at a terminal, or re-run with --force")
+	}
+	if !confirmed {
+		fmt.Fprintln(os.Stderr)
+		cli.PrintSuccess("Uninstall canceled")
+		return false, nil
+	}
+	return true, nil
 }

--- a/cmd/ox/uninstall_confirm_test.go
+++ b/cmd/ox/uninstall_confirm_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// silenceStdout points os.Stdout at /dev/null for the duration of fn. The
+// uninstall confirmation prints a full DANGER ZONE banner that would otherwise
+// swamp test output.
+func silenceStdout(t *testing.T, fn func()) {
+	t.Helper()
+
+	devNull, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	orig := os.Stdout
+	os.Stdout = devNull
+	t.Cleanup(func() {
+		os.Stdout = orig
+		devNull.Close()
+	})
+
+	fn()
+}
+
+// TestConfirmUninstallWithInput_TellsDeclinedApartFromUnanswered is the
+// regression gate for the reported data loss: with nothing on stdin, uninstall
+// reported "Uninstall canceled" and exited 0, which reads as success.
+func TestConfirmUninstallWithInput_TellsDeclinedApartFromUnanswered(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "closed stdin is not an answer",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only stdin is not an answer",
+			input:   "   ",
+			wantErr: true,
+		},
+		{
+			name:  "typing the repo name confirms",
+			input: "my-repo\n",
+			want:  true,
+		},
+		{
+			name:  "typing uninstall confirms",
+			input: "uninstall\n",
+			want:  true,
+		},
+		{
+			name:  "typing uninstall is case insensitive",
+			input: "UNINSTALL\n",
+			want:  true,
+		},
+		{
+			name:  "the wrong word is a real decline, not a missing answer",
+			input: "nope\n",
+			want:  false,
+		},
+		{
+			// typed answer with no trailing newline still counts
+			name:  "repo name without a trailing newline confirms",
+			input: "my-repo",
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gitRoot := t.TempDir()
+
+			var got bool
+			var err error
+			silenceStdout(t, func() {
+				withStdin(t, tt.input, func() {
+					got, err = confirmUninstallWithInput("my-repo", "https://sageox.ai", false, gitRoot)
+				})
+			})
+
+			if tt.wantErr {
+				assert.True(t, errors.Is(err, cli.ErrConfirmationRequired),
+					"want ErrConfirmationRequired, got %v", err)
+				assert.False(t, got, "an unanswered prompt must never confirm")
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestConfirmUninstallWithInput_YesDoesNotSatisfyTheTypedGate pins the
+// deliberate carve-out: --yes is not a substitute for typing the repository
+// name, because that gate exists precisely to resist automation. --force is the
+// explicit escape hatch, and it is checked by the caller.
+func TestConfirmUninstallWithInput_YesDoesNotSatisfyTheTypedGate(t *testing.T) {
+	cli.SetAssumeYes(true)
+	t.Cleanup(func() { cli.SetAssumeYes(false) })
+
+	gitRoot := t.TempDir()
+
+	var got bool
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "", func() {
+			got, err = confirmUninstallWithInput("my-repo", "https://sageox.ai", false, gitRoot)
+		})
+	})
+
+	assert.True(t, errors.Is(err, cli.ErrConfirmationRequired),
+		"--yes must not confirm an uninstall; got %v", err)
+	assert.False(t, got)
+}
+
+// TestConfirmUninstallWithInput_AllEndpointsBanner covers the all-endpoints
+// branch of the banner, which names a different blast radius than the
+// single-endpoint one.
+func TestConfirmUninstallWithInput_AllEndpointsBanner(t *testing.T) {
+	gitRoot := t.TempDir()
+
+	var got bool
+	var err error
+	silenceStdout(t, func() {
+		withStdin(t, "uninstall\n", func() {
+			got, err = confirmUninstallWithInput("my-repo", "", true, gitRoot)
+		})
+	})
+
+	require.NoError(t, err)
+	assert.True(t, got)
+}

--- a/docs/design/components/confirm.md
+++ b/docs/design/components/confirm.md
@@ -4,7 +4,7 @@ package: internal/cli
 since: 0.4.0
 family: input
 renderer: freeze
-exports: [ConfirmYesNo, ConfirmDangerousOperation, ConfirmUninstall]
+exports: [ConfirmYesNo, ConfirmYesNoRequired, ConfirmDangerousOperation, ConfirmUninstall]
 ---
 
 # Confirm
@@ -13,7 +13,9 @@ exports: [ConfirmYesNo, ConfirmDangerousOperation, ConfirmUninstall]
 
 ## When to use
 
-Reversible operations: `ConfirmYesNo(prompt, defaultYes)`. Destructive operations: `ConfirmDangerousOperation` which requires typing the exact target name (e.g., `delete-team`), not just pressing y. `ConfirmUninstall` is the bespoke variant for repo uninstall flows.
+Reversible operations: `ConfirmYesNo(prompt, defaultYes)`. Operations where taking the default silently would lose work, leave an operation half-done, or act on the user's behalf without consent: `ConfirmYesNoRequired(prompt, defaultYes, force)` — it returns `ErrConfirmationRequired` instead of guessing when nobody answered. Destructive operations: `ConfirmDangerousOperation` which requires typing the exact target name (e.g., `delete-team`), not just pressing y. `ConfirmUninstall` is the bespoke variant for repo uninstall flows.
+
+**Rule of thumb:** if the prompt's default is `true`, it almost certainly wants `ConfirmYesNoRequired` — a silent default-yes performs the action with nobody having agreed to it.
 
 ## When NOT to use
 
@@ -29,14 +31,18 @@ Source: [`internal/cli/confirm.go`](../../../internal/cli/confirm.go)
 
 ```go
 cli.ConfirmYesNo(prompt string, defaultYes bool) bool
+cli.ConfirmYesNoRequired(prompt string, defaultYes, force bool) (bool, error)
 cli.ConfirmDangerousOperation(operationName, exactMatch string, force bool) error
 cli.ConfirmUninstall(repoName string, force bool) error
 ```
+
+`ConfirmYesNoRequired` returns `cli.ErrConfirmationRequired` when stdin produced no answer at all (closed, empty, unreadable). A piped answer — `echo y | ox …` — is a real answer and is accepted; the distinction is whether an answer arrived, not whether a TTY was attached.
 
 ## Accessibility & fallbacks
 
 - Default is highlighted with `[Y]` / `[N]` so single-press behavior is obvious.
 - `--force` bypasses the prompt entirely. Destructive ops require typing the exact name; force still works but is logged.
+- The global `--yes` (or `OX_YES=1`) satisfies `ConfirmYesNoRequired`. It is never inferred from CI or a missing TTY: "no human is watching" must not become "the absent human agreed."
 
 ## Tests
 

--- a/docs/reference/adapter/index.mdx
+++ b/docs/reference/adapter/index.mdx
@@ -27,7 +27,7 @@ Discover, install, remove, and inspect ox adapter binaries that connect AI cowor
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/index.mdx
+++ b/docs/reference/adapter/index.mdx
@@ -27,7 +27,7 @@ Discover, install, remove, and inspect ox adapter binaries that connect AI cowor
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/index.mdx
+++ b/docs/reference/adapter/index.mdx
@@ -27,6 +27,7 @@ Discover, install, remove, and inspect ox adapter binaries that connect AI cowor
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/info.mdx
+++ b/docs/reference/adapter/info.mdx
@@ -27,7 +27,7 @@ ox adapter info <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/info.mdx
+++ b/docs/reference/adapter/info.mdx
@@ -27,7 +27,7 @@ ox adapter info <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/info.mdx
+++ b/docs/reference/adapter/info.mdx
@@ -27,6 +27,7 @@ ox adapter info <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/install.mdx
+++ b/docs/reference/adapter/install.mdx
@@ -40,6 +40,7 @@ ox adapter install <name|github-url> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/install.mdx
+++ b/docs/reference/adapter/install.mdx
@@ -40,7 +40,7 @@ ox adapter install <name|github-url> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/install.mdx
+++ b/docs/reference/adapter/install.mdx
@@ -40,7 +40,7 @@ ox adapter install <name|github-url> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/link.mdx
+++ b/docs/reference/adapter/link.mdx
@@ -36,6 +36,7 @@ ox adapter link <path> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/link.mdx
+++ b/docs/reference/adapter/link.mdx
@@ -36,7 +36,7 @@ ox adapter link <path> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/link.mdx
+++ b/docs/reference/adapter/link.mdx
@@ -36,7 +36,7 @@ ox adapter link <path> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/list.mdx
+++ b/docs/reference/adapter/list.mdx
@@ -27,6 +27,7 @@ ox adapter list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/list.mdx
+++ b/docs/reference/adapter/list.mdx
@@ -27,7 +27,7 @@ ox adapter list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/list.mdx
+++ b/docs/reference/adapter/list.mdx
@@ -27,7 +27,7 @@ ox adapter list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/reload.mdx
+++ b/docs/reference/adapter/reload.mdx
@@ -27,6 +27,7 @@ ox adapter reload [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/reload.mdx
+++ b/docs/reference/adapter/reload.mdx
@@ -27,7 +27,7 @@ ox adapter reload [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/reload.mdx
+++ b/docs/reference/adapter/reload.mdx
@@ -27,7 +27,7 @@ ox adapter reload [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/remove.mdx
+++ b/docs/reference/adapter/remove.mdx
@@ -27,7 +27,7 @@ ox adapter remove <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/remove.mdx
+++ b/docs/reference/adapter/remove.mdx
@@ -27,6 +27,7 @@ ox adapter remove <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/remove.mdx
+++ b/docs/reference/adapter/remove.mdx
@@ -27,7 +27,7 @@ ox adapter remove <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/unlink.mdx
+++ b/docs/reference/adapter/unlink.mdx
@@ -31,7 +31,7 @@ ox adapter unlink <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/unlink.mdx
+++ b/docs/reference/adapter/unlink.mdx
@@ -31,7 +31,7 @@ ox adapter unlink <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/unlink.mdx
+++ b/docs/reference/adapter/unlink.mdx
@@ -31,6 +31,7 @@ ox adapter unlink <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/verify.mdx
+++ b/docs/reference/adapter/verify.mdx
@@ -32,7 +32,7 @@ ox adapter verify <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/verify.mdx
+++ b/docs/reference/adapter/verify.mdx
@@ -32,6 +32,7 @@ ox adapter verify <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/adapter/verify.mdx
+++ b/docs/reference/adapter/verify.mdx
@@ -32,7 +32,7 @@ ox adapter verify <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/activity.mdx
+++ b/docs/reference/code/activity.mdx
@@ -37,6 +37,7 @@ ox code activity [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/activity.mdx
+++ b/docs/reference/code/activity.mdx
@@ -37,7 +37,7 @@ ox code activity [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/activity.mdx
+++ b/docs/reference/code/activity.mdx
@@ -37,7 +37,7 @@ ox code activity [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/callees.mdx
+++ b/docs/reference/code/callees.mdx
@@ -41,7 +41,7 @@ ox code callees <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/callees.mdx
+++ b/docs/reference/code/callees.mdx
@@ -41,6 +41,7 @@ ox code callees <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/callees.mdx
+++ b/docs/reference/code/callees.mdx
@@ -41,7 +41,7 @@ ox code callees <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/callers.mdx
+++ b/docs/reference/code/callers.mdx
@@ -40,6 +40,7 @@ ox code callers <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/callers.mdx
+++ b/docs/reference/code/callers.mdx
@@ -40,7 +40,7 @@ ox code callers <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/callers.mdx
+++ b/docs/reference/code/callers.mdx
@@ -40,7 +40,7 @@ ox code callers <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/defs.mdx
+++ b/docs/reference/code/defs.mdx
@@ -40,7 +40,7 @@ ox code defs <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/defs.mdx
+++ b/docs/reference/code/defs.mdx
@@ -40,6 +40,7 @@ ox code defs <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/defs.mdx
+++ b/docs/reference/code/defs.mdx
@@ -40,7 +40,7 @@ ox code defs <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/index.mdx
+++ b/docs/reference/code/index.mdx
@@ -28,7 +28,7 @@ ox code index [url] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/index.mdx
+++ b/docs/reference/code/index.mdx
@@ -28,7 +28,7 @@ ox code index [url] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/index.mdx
+++ b/docs/reference/code/index.mdx
@@ -28,6 +28,7 @@ ox code index [url] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/insights.mdx
+++ b/docs/reference/code/insights.mdx
@@ -29,7 +29,7 @@ ox code insights [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/insights.mdx
+++ b/docs/reference/code/insights.mdx
@@ -29,6 +29,7 @@ ox code insights [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/insights.mdx
+++ b/docs/reference/code/insights.mdx
@@ -29,7 +29,7 @@ ox code insights [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/log.mdx
+++ b/docs/reference/code/log.mdx
@@ -43,7 +43,7 @@ ox code log <path> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/log.mdx
+++ b/docs/reference/code/log.mdx
@@ -43,7 +43,7 @@ ox code log <path> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/log.mdx
+++ b/docs/reference/code/log.mdx
@@ -43,6 +43,7 @@ ox code log <path> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/prs.mdx
+++ b/docs/reference/code/prs.mdx
@@ -63,6 +63,7 @@ ox code prs [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/prs.mdx
+++ b/docs/reference/code/prs.mdx
@@ -63,7 +63,7 @@ ox code prs [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/prs.mdx
+++ b/docs/reference/code/prs.mdx
@@ -63,7 +63,7 @@ ox code prs [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/refs.mdx
+++ b/docs/reference/code/refs.mdx
@@ -43,7 +43,7 @@ ox code refs <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/refs.mdx
+++ b/docs/reference/code/refs.mdx
@@ -43,6 +43,7 @@ ox code refs <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/refs.mdx
+++ b/docs/reference/code/refs.mdx
@@ -43,7 +43,7 @@ ox code refs <name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/search.mdx
+++ b/docs/reference/code/search.mdx
@@ -77,7 +77,7 @@ ox code search <query> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/search.mdx
+++ b/docs/reference/code/search.mdx
@@ -77,7 +77,7 @@ ox code search <query> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/search.mdx
+++ b/docs/reference/code/search.mdx
@@ -77,6 +77,7 @@ ox code search <query> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/status.mdx
+++ b/docs/reference/code/status.mdx
@@ -27,6 +27,7 @@ ox code status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/status.mdx
+++ b/docs/reference/code/status.mdx
@@ -27,7 +27,7 @@ ox code status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/code/status.mdx
+++ b/docs/reference/code/status.mdx
@@ -27,7 +27,7 @@ ox code status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/index.mdx
+++ b/docs/reference/conversation/index.mdx
@@ -45,7 +45,7 @@ ox conversation [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/index.mdx
+++ b/docs/reference/conversation/index.mdx
@@ -45,6 +45,7 @@ ox conversation [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/index.mdx
+++ b/docs/reference/conversation/index.mdx
@@ -45,7 +45,7 @@ ox conversation [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/list.mdx
+++ b/docs/reference/conversation/list.mdx
@@ -35,7 +35,7 @@ ox conversation list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/list.mdx
+++ b/docs/reference/conversation/list.mdx
@@ -35,7 +35,7 @@ ox conversation list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/list.mdx
+++ b/docs/reference/conversation/list.mdx
@@ -35,6 +35,7 @@ ox conversation list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/show.mdx
+++ b/docs/reference/conversation/show.mdx
@@ -33,6 +33,7 @@ ox conversation show <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/show.mdx
+++ b/docs/reference/conversation/show.mdx
@@ -33,7 +33,7 @@ ox conversation show <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/show.mdx
+++ b/docs/reference/conversation/show.mdx
@@ -33,7 +33,7 @@ ox conversation show <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/topic.mdx
+++ b/docs/reference/conversation/topic.mdx
@@ -34,6 +34,7 @@ ox conversation topic <id> <tp_id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/topic.mdx
+++ b/docs/reference/conversation/topic.mdx
@@ -34,7 +34,7 @@ ox conversation topic <id> <tp_id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/topic.mdx
+++ b/docs/reference/conversation/topic.mdx
@@ -34,7 +34,7 @@ ox conversation topic <id> <tp_id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/topics.mdx
+++ b/docs/reference/conversation/topics.mdx
@@ -33,7 +33,7 @@ ox conversation topics <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/topics.mdx
+++ b/docs/reference/conversation/topics.mdx
@@ -33,6 +33,7 @@ ox conversation topics <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/topics.mdx
+++ b/docs/reference/conversation/topics.mdx
@@ -33,7 +33,7 @@ ox conversation topics <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/transcript.mdx
+++ b/docs/reference/conversation/transcript.mdx
@@ -45,6 +45,7 @@ ox conversation transcript <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/transcript.mdx
+++ b/docs/reference/conversation/transcript.mdx
@@ -45,7 +45,7 @@ ox conversation transcript <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/conversation/transcript.mdx
+++ b/docs/reference/conversation/transcript.mdx
@@ -45,7 +45,7 @@ ox conversation transcript <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/decision/enrich.mdx
+++ b/docs/reference/decision/enrich.mdx
@@ -48,7 +48,7 @@ ox decision enrich [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/decision/enrich.mdx
+++ b/docs/reference/decision/enrich.mdx
@@ -48,7 +48,7 @@ ox decision enrich [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/decision/enrich.mdx
+++ b/docs/reference/decision/enrich.mdx
@@ -48,6 +48,7 @@ ox decision enrich [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/decision/index.mdx
+++ b/docs/reference/decision/index.mdx
@@ -37,6 +37,7 @@ LLM/network cost; every citation it emits resolves.
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/decision/index.mdx
+++ b/docs/reference/decision/index.mdx
@@ -37,7 +37,7 @@ LLM/network cost; every citation it emits resolves.
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/decision/index.mdx
+++ b/docs/reference/decision/index.mdx
@@ -37,7 +37,7 @@ LLM/network cost; every citation it emits resolves.
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/export.mdx
+++ b/docs/reference/export.mdx
@@ -46,7 +46,7 @@ ox export [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/export.mdx
+++ b/docs/reference/export.mdx
@@ -46,7 +46,7 @@ ox export [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/export.mdx
+++ b/docs/reference/export.mdx
@@ -46,6 +46,7 @@ ox export [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/gc.mdx
+++ b/docs/reference/gc.mdx
@@ -27,7 +27,7 @@ ox gc [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/gc.mdx
+++ b/docs/reference/gc.mdx
@@ -27,6 +27,7 @@ ox gc [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/gc.mdx
+++ b/docs/reference/gc.mdx
@@ -27,7 +27,7 @@ ox gc [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/glance.mdx
+++ b/docs/reference/glance.mdx
@@ -42,6 +42,7 @@ ox glance [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/glance.mdx
+++ b/docs/reference/glance.mdx
@@ -42,7 +42,7 @@ ox glance [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/glance.mdx
+++ b/docs/reference/glance.mdx
@@ -42,7 +42,7 @@ ox glance [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/guide.mdx
+++ b/docs/reference/guide.mdx
@@ -42,7 +42,7 @@ ox guide [topic] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/guide.mdx
+++ b/docs/reference/guide.mdx
@@ -42,7 +42,7 @@ ox guide [topic] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/guide.mdx
+++ b/docs/reference/guide.mdx
@@ -42,6 +42,7 @@ ox guide [topic] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/add.mdx
+++ b/docs/reference/hooks/add.mdx
@@ -53,6 +53,7 @@ ox hooks add <event> <command> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/add.mdx
+++ b/docs/reference/hooks/add.mdx
@@ -53,7 +53,7 @@ ox hooks add <event> <command> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/add.mdx
+++ b/docs/reference/hooks/add.mdx
@@ -53,7 +53,7 @@ ox hooks add <event> <command> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/index.mdx
+++ b/docs/reference/hooks/index.mdx
@@ -38,7 +38,7 @@ Git/CI hooks (backward compat, prefer 'ox agent hooks'):
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/index.mdx
+++ b/docs/reference/hooks/index.mdx
@@ -38,6 +38,7 @@ Git/CI hooks (backward compat, prefer 'ox agent hooks'):
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/index.mdx
+++ b/docs/reference/hooks/index.mdx
@@ -38,7 +38,7 @@ Git/CI hooks (backward compat, prefer 'ox agent hooks'):
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/list.mdx
+++ b/docs/reference/hooks/list.mdx
@@ -31,6 +31,7 @@ ox hooks list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/list.mdx
+++ b/docs/reference/hooks/list.mdx
@@ -31,7 +31,7 @@ ox hooks list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/list.mdx
+++ b/docs/reference/hooks/list.mdx
@@ -31,7 +31,7 @@ ox hooks list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/log.mdx
+++ b/docs/reference/hooks/log.mdx
@@ -31,7 +31,7 @@ ox hooks log [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/log.mdx
+++ b/docs/reference/hooks/log.mdx
@@ -31,7 +31,7 @@ ox hooks log [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/log.mdx
+++ b/docs/reference/hooks/log.mdx
@@ -31,6 +31,7 @@ ox hooks log [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/test.mdx
+++ b/docs/reference/hooks/test.mdx
@@ -38,7 +38,7 @@ ox hooks test <event> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/test.mdx
+++ b/docs/reference/hooks/test.mdx
@@ -38,7 +38,7 @@ ox hooks test <event> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/hooks/test.mdx
+++ b/docs/reference/hooks/test.mdx
@@ -38,6 +38,7 @@ ox hooks test <event> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/import.mdx
+++ b/docs/reference/import.mdx
@@ -62,7 +62,7 @@ ox import <file|url> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/import.mdx
+++ b/docs/reference/import.mdx
@@ -62,6 +62,7 @@ ox import <file|url> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/import.mdx
+++ b/docs/reference/import.mdx
@@ -62,7 +62,7 @@ ox import <file|url> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -22,7 +22,7 @@ Shared team context between your AI and human coworkers. Sessions, ledgers, and 
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -22,6 +22,7 @@ Shared team context between your AI and human coworkers. Sessions, ledgers, and 
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -22,7 +22,7 @@ Shared team context between your AI and human coworkers. Sessions, ledgers, and 
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/code.mdx
+++ b/docs/reference/index/code.mdx
@@ -28,7 +28,7 @@ ox index code [url] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/code.mdx
+++ b/docs/reference/index/code.mdx
@@ -28,7 +28,7 @@ ox index code [url] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/code.mdx
+++ b/docs/reference/index/code.mdx
@@ -28,6 +28,7 @@ ox index code [url] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/github.mdx
+++ b/docs/reference/index/github.mdx
@@ -43,7 +43,7 @@ ox index github [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/github.mdx
+++ b/docs/reference/index/github.mdx
@@ -43,6 +43,7 @@ ox index github [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/github.mdx
+++ b/docs/reference/index/github.mdx
@@ -43,7 +43,7 @@ ox index github [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/index.mdx
+++ b/docs/reference/index/index.mdx
@@ -39,7 +39,7 @@ ox index [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/index.mdx
+++ b/docs/reference/index/index.mdx
@@ -39,6 +39,7 @@ ox index [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/index.mdx
+++ b/docs/reference/index/index.mdx
@@ -39,7 +39,7 @@ ox index [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/status.mdx
+++ b/docs/reference/index/status.mdx
@@ -27,7 +27,7 @@ ox index status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/status.mdx
+++ b/docs/reference/index/status.mdx
@@ -27,7 +27,7 @@ ox index status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/index/status.mdx
+++ b/docs/reference/index/status.mdx
@@ -27,6 +27,7 @@ ox index status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/init.mdx
+++ b/docs/reference/init.mdx
@@ -57,7 +57,7 @@ ox init [flags]
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/init.mdx
+++ b/docs/reference/init.mdx
@@ -57,6 +57,7 @@ ox init [flags]
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/init.mdx
+++ b/docs/reference/init.mdx
@@ -57,7 +57,7 @@ ox init [flags]
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/describe.mdx
+++ b/docs/reference/kb/describe.mdx
@@ -44,7 +44,7 @@ ox kb describe <#slug|kb_id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/describe.mdx
+++ b/docs/reference/kb/describe.mdx
@@ -44,7 +44,7 @@ ox kb describe <#slug|kb_id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/describe.mdx
+++ b/docs/reference/kb/describe.mdx
@@ -44,6 +44,7 @@ ox kb describe <#slug|kb_id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/index.mdx
+++ b/docs/reference/kb/index.mdx
@@ -35,6 +35,7 @@ Use `ox kb list` to see the bubbles you can access and
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/index.mdx
+++ b/docs/reference/kb/index.mdx
@@ -35,7 +35,7 @@ Use `ox kb list` to see the bubbles you can access and
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/index.mdx
+++ b/docs/reference/kb/index.mdx
@@ -35,7 +35,7 @@ Use `ox kb list` to see the bubbles you can access and
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/list.mdx
+++ b/docs/reference/kb/list.mdx
@@ -45,6 +45,7 @@ ox kb list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/list.mdx
+++ b/docs/reference/kb/list.mdx
@@ -45,7 +45,7 @@ ox kb list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/list.mdx
+++ b/docs/reference/kb/list.mdx
@@ -45,7 +45,7 @@ ox kb list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/query.mdx
+++ b/docs/reference/kb/query.mdx
@@ -53,6 +53,7 @@ ox kb query <#slug|kb_id> [#slug|kb_id ...] "<question>" [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/query.mdx
+++ b/docs/reference/kb/query.mdx
@@ -53,7 +53,7 @@ ox kb query <#slug|kb_id> [#slug|kb_id ...] "<question>" [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/kb/query.mdx
+++ b/docs/reference/kb/query.mdx
@@ -53,7 +53,7 @@ ox kb query <#slug|kb_id> [#slug|kb_id ...] "<question>" [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/login.mdx
+++ b/docs/reference/login.mdx
@@ -32,7 +32,7 @@ ox login [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/login.mdx
+++ b/docs/reference/login.mdx
@@ -32,7 +32,7 @@ ox login [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/login.mdx
+++ b/docs/reference/login.mdx
@@ -32,6 +32,7 @@ ox login [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/logout.mdx
+++ b/docs/reference/logout.mdx
@@ -34,7 +34,7 @@ ox logout [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/logout.mdx
+++ b/docs/reference/logout.mdx
@@ -34,7 +34,7 @@ ox logout [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/logout.mdx
+++ b/docs/reference/logout.mdx
@@ -34,6 +34,7 @@ ox logout [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/delete.mdx
+++ b/docs/reference/murmur/delete.mdx
@@ -38,7 +38,7 @@ ox murmur delete <murmur-id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/delete.mdx
+++ b/docs/reference/murmur/delete.mdx
@@ -38,7 +38,7 @@ ox murmur delete <murmur-id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/delete.mdx
+++ b/docs/reference/murmur/delete.mdx
@@ -38,6 +38,7 @@ ox murmur delete <murmur-id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/index.mdx
+++ b/docs/reference/murmur/index.mdx
@@ -46,7 +46,7 @@ ox murmur [content] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/index.mdx
+++ b/docs/reference/murmur/index.mdx
@@ -46,7 +46,7 @@ ox murmur [content] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/index.mdx
+++ b/docs/reference/murmur/index.mdx
@@ -46,6 +46,7 @@ ox murmur [content] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/list.mdx
+++ b/docs/reference/murmur/list.mdx
@@ -48,7 +48,7 @@ ox murmur list [topic] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/list.mdx
+++ b/docs/reference/murmur/list.mdx
@@ -48,6 +48,7 @@ ox murmur list [topic] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/list.mdx
+++ b/docs/reference/murmur/list.mdx
@@ -48,7 +48,7 @@ ox murmur list [topic] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/pause.mdx
+++ b/docs/reference/murmur/pause.mdx
@@ -32,7 +32,7 @@ ox murmur pause [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/pause.mdx
+++ b/docs/reference/murmur/pause.mdx
@@ -32,7 +32,7 @@ ox murmur pause [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/pause.mdx
+++ b/docs/reference/murmur/pause.mdx
@@ -32,6 +32,7 @@ ox murmur pause [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/resume.mdx
+++ b/docs/reference/murmur/resume.mdx
@@ -32,7 +32,7 @@ ox murmur resume [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/resume.mdx
+++ b/docs/reference/murmur/resume.mdx
@@ -32,6 +32,7 @@ ox murmur resume [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/resume.mdx
+++ b/docs/reference/murmur/resume.mdx
@@ -32,7 +32,7 @@ ox murmur resume [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/status.mdx
+++ b/docs/reference/murmur/status.mdx
@@ -38,7 +38,7 @@ ox murmur status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/status.mdx
+++ b/docs/reference/murmur/status.mdx
@@ -38,7 +38,7 @@ ox murmur status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/murmur/status.mdx
+++ b/docs/reference/murmur/status.mdx
@@ -38,6 +38,7 @@ ox murmur status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/abandon.mdx
+++ b/docs/reference/plan/abandon.mdx
@@ -32,7 +32,7 @@ ox plan abandon <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/abandon.mdx
+++ b/docs/reference/plan/abandon.mdx
@@ -32,7 +32,7 @@ ox plan abandon <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/abandon.mdx
+++ b/docs/reference/plan/abandon.mdx
@@ -32,6 +32,7 @@ ox plan abandon <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/approve.mdx
+++ b/docs/reference/plan/approve.mdx
@@ -33,7 +33,7 @@ ox plan approve <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/approve.mdx
+++ b/docs/reference/plan/approve.mdx
@@ -33,6 +33,7 @@ ox plan approve <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/approve.mdx
+++ b/docs/reference/plan/approve.mdx
@@ -33,7 +33,7 @@ ox plan approve <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/enrich.mdx
+++ b/docs/reference/plan/enrich.mdx
@@ -45,6 +45,7 @@ ox plan enrich [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/enrich.mdx
+++ b/docs/reference/plan/enrich.mdx
@@ -45,7 +45,7 @@ ox plan enrich [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/enrich.mdx
+++ b/docs/reference/plan/enrich.mdx
@@ -45,7 +45,7 @@ ox plan enrich [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -47,7 +47,7 @@ inline review loop — those are human-opt-in, never auto-run.
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -47,6 +47,7 @@ inline review loop — those are human-opt-in, never auto-run.
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -47,7 +47,7 @@ inline review loop — those are human-opt-in, never auto-run.
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -27,7 +27,7 @@ ox plan list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -27,7 +27,7 @@ ox plan list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -27,6 +27,7 @@ ox plan list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/realize.mdx
+++ b/docs/reference/plan/realize.mdx
@@ -37,7 +37,7 @@ ox plan realize <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/realize.mdx
+++ b/docs/reference/plan/realize.mdx
@@ -37,6 +37,7 @@ ox plan realize <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/realize.mdx
+++ b/docs/reference/plan/realize.mdx
@@ -37,7 +37,7 @@ ox plan realize <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/render.mdx
+++ b/docs/reference/plan/render.mdx
@@ -51,6 +51,7 @@ ox plan render [slug] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/render.mdx
+++ b/docs/reference/plan/render.mdx
@@ -51,7 +51,7 @@ ox plan render [slug] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/render.mdx
+++ b/docs/reference/plan/render.mdx
@@ -51,7 +51,7 @@ ox plan render [slug] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/review/await.mdx
+++ b/docs/reference/plan/review/await.mdx
@@ -51,6 +51,7 @@ ox plan review await <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/review/await.mdx
+++ b/docs/reference/plan/review/await.mdx
@@ -51,7 +51,7 @@ ox plan review await <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/review/await.mdx
+++ b/docs/reference/plan/review/await.mdx
@@ -51,7 +51,7 @@ ox plan review await <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/review/index.mdx
+++ b/docs/reference/plan/review/index.mdx
@@ -44,7 +44,7 @@ ox plan review <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/review/index.mdx
+++ b/docs/reference/plan/review/index.mdx
@@ -44,6 +44,7 @@ ox plan review <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/review/index.mdx
+++ b/docs/reference/plan/review/index.mdx
@@ -44,7 +44,7 @@ ox plan review <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/status.mdx
+++ b/docs/reference/plan/status.mdx
@@ -33,7 +33,7 @@ ox plan status <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/status.mdx
+++ b/docs/reference/plan/status.mdx
@@ -33,7 +33,7 @@ ox plan status <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/status.mdx
+++ b/docs/reference/plan/status.mdx
@@ -33,6 +33,7 @@ ox plan status <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/supersede.mdx
+++ b/docs/reference/plan/supersede.mdx
@@ -34,6 +34,7 @@ ox plan supersede <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/supersede.mdx
+++ b/docs/reference/plan/supersede.mdx
@@ -34,7 +34,7 @@ ox plan supersede <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/supersede.mdx
+++ b/docs/reference/plan/supersede.mdx
@@ -34,7 +34,7 @@ ox plan supersede <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/view.mdx
+++ b/docs/reference/plan/view.mdx
@@ -27,6 +27,7 @@ ox plan view <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/view.mdx
+++ b/docs/reference/plan/view.mdx
@@ -27,7 +27,7 @@ ox plan view <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/view.mdx
+++ b/docs/reference/plan/view.mdx
@@ -27,7 +27,7 @@ ox plan view <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/work.mdx
+++ b/docs/reference/plan/work.mdx
@@ -34,7 +34,7 @@ ox plan work <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/work.mdx
+++ b/docs/reference/plan/work.mdx
@@ -34,7 +34,7 @@ ox plan work <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/plan/work.mdx
+++ b/docs/reference/plan/work.mdx
@@ -34,6 +34,7 @@ ox plan work <slug> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/pr/header.mdx
+++ b/docs/reference/pr/header.mdx
@@ -69,7 +69,7 @@ ox pr header [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/pr/header.mdx
+++ b/docs/reference/pr/header.mdx
@@ -69,6 +69,7 @@ ox pr header [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/pr/header.mdx
+++ b/docs/reference/pr/header.mdx
@@ -69,7 +69,7 @@ ox pr header [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/pr/index.mdx
+++ b/docs/reference/pr/index.mdx
@@ -29,7 +29,7 @@ Distinct from 'ox code prs', which lists indexed PRs for triage.
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/pr/index.mdx
+++ b/docs/reference/pr/index.mdx
@@ -29,7 +29,7 @@ Distinct from 'ox code prs', which lists indexed PRs for triage.
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/pr/index.mdx
+++ b/docs/reference/pr/index.mdx
@@ -29,6 +29,7 @@ Distinct from 'ox code prs', which lists indexed PRs for triage.
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -52,7 +52,7 @@ ox query [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -52,7 +52,7 @@ ox query [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -52,6 +52,7 @@ ox query [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/recap.mdx
+++ b/docs/reference/recap.mdx
@@ -42,6 +42,7 @@ ox recap [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/recap.mdx
+++ b/docs/reference/recap.mdx
@@ -42,7 +42,7 @@ ox recap [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/recap.mdx
+++ b/docs/reference/recap.mdx
@@ -42,7 +42,7 @@ ox recap [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -33,7 +33,7 @@ ox release-notes [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -33,6 +33,7 @@ ox release-notes [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -33,7 +33,7 @@ ox release-notes [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -52,7 +52,7 @@ ox session audit [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -52,6 +52,7 @@ ox session audit [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -52,7 +52,7 @@ ox session audit [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -37,6 +37,7 @@ Commands:
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -37,7 +37,7 @@ Commands:
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -37,7 +37,7 @@ Commands:
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -48,7 +48,7 @@ ox session lint [session-name] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -48,7 +48,7 @@ ox session lint [session-name] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -48,6 +48,7 @@ ox session lint [session-name] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -53,7 +53,7 @@ ox session list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -53,7 +53,7 @@ ox session list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -53,6 +53,7 @@ ox session list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/prune.mdx
+++ b/docs/reference/session/prune.mdx
@@ -55,7 +55,7 @@ ox session prune [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/prune.mdx
+++ b/docs/reference/session/prune.mdx
@@ -55,6 +55,7 @@ ox session prune [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/prune.mdx
+++ b/docs/reference/session/prune.mdx
@@ -55,7 +55,7 @@ ox session prune [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -63,7 +63,7 @@ ox session redact [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -33,7 +33,9 @@ Safety:
     actionable here. They require the gated history-rewrite tool. The
     correct response is: rotate the leaked credential, mark the finding
     as known, and follow up via the team comms process.
-  - Per-finding human approval. There is no bulk-approve flag.
+  - Per-file human approval. There is no bulk-approve flag, and the global
+    `--yes` does NOT approve redactions: every file is asked about
+    individually, and `q` quits the pass with the snapshot intact.
   - Each redaction pass appends a RedactionPass entry to the session's
     meta.json (ox-8bfh) recording WHO redacted, WHEN, with WHICH catalog
     version+hash, and WHAT was caught — never the matched bytes.

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -63,6 +63,7 @@ ox session redact [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -65,7 +65,7 @@ ox session redact [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -59,7 +59,7 @@ ox session regenerate [session-name] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -59,7 +59,7 @@ ox session regenerate [session-name] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -59,6 +59,7 @@ ox session regenerate [session-name] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -55,7 +55,7 @@ ox session repair-meta-summary [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -55,6 +55,7 @@ ox session repair-meta-summary [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -55,7 +55,7 @@ ox session repair-meta-summary [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -47,7 +47,7 @@ ox session score [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -47,7 +47,7 @@ ox session score [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -47,6 +47,7 @@ ox session score [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -43,7 +43,7 @@ ox session status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -43,6 +43,7 @@ ox session status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -43,7 +43,7 @@ ox session status [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -40,6 +40,7 @@ ox session stop [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -40,7 +40,7 @@ ox session stop [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -40,7 +40,7 @@ ox session stop [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -43,6 +43,7 @@ ox session token-optimize <session-name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -43,7 +43,7 @@ ox session token-optimize <session-name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -43,7 +43,7 @@ ox session token-optimize <session-name> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -49,6 +49,7 @@ ox session view [session-name] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -49,7 +49,7 @@ ox session view [session-name] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -49,7 +49,7 @@ ox session view [session-name] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -34,7 +34,7 @@ ox status [flags]
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -34,6 +34,7 @@ ox status [flags]
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -34,7 +34,7 @@ ox status [flags]
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -64,7 +64,7 @@ ox sync [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -64,7 +64,7 @@ ox sync [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -64,6 +64,7 @@ ox sync [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/index.mdx
+++ b/docs/reference/team/index.mdx
@@ -43,7 +43,7 @@ ox team [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/index.mdx
+++ b/docs/reference/team/index.mdx
@@ -43,6 +43,7 @@ ox team [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/index.mdx
+++ b/docs/reference/team/index.mdx
@@ -43,7 +43,7 @@ ox team [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/list.mdx
+++ b/docs/reference/team/list.mdx
@@ -35,7 +35,7 @@ ox team list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/list.mdx
+++ b/docs/reference/team/list.mdx
@@ -35,6 +35,7 @@ ox team list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/list.mdx
+++ b/docs/reference/team/list.mdx
@@ -35,7 +35,7 @@ ox team list [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/members.mdx
+++ b/docs/reference/team/members.mdx
@@ -48,6 +48,7 @@ ox team members [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/members.mdx
+++ b/docs/reference/team/members.mdx
@@ -48,7 +48,7 @@ ox team members [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/members.mdx
+++ b/docs/reference/team/members.mdx
@@ -48,7 +48,7 @@ ox team members [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/open.mdx
+++ b/docs/reference/team/open.mdx
@@ -36,6 +36,7 @@ ox team open [team] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/open.mdx
+++ b/docs/reference/team/open.mdx
@@ -36,7 +36,7 @@ ox team open [team] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/open.mdx
+++ b/docs/reference/team/open.mdx
@@ -36,7 +36,7 @@ ox team open [team] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/show.mdx
+++ b/docs/reference/team/show.mdx
@@ -42,7 +42,7 @@ ox team show [team] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/show.mdx
+++ b/docs/reference/team/show.mdx
@@ -42,7 +42,7 @@ ox team show [team] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/team/show.mdx
+++ b/docs/reference/team/show.mdx
@@ -42,6 +42,7 @@ ox team show [team] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -74,7 +74,7 @@ ox uninstall [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -74,6 +74,7 @@ ox uninstall [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -74,7 +74,7 @@ ox uninstall [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/upgrade.mdx
+++ b/docs/reference/upgrade.mdx
@@ -32,6 +32,7 @@ ox upgrade [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/upgrade.mdx
+++ b/docs/reference/upgrade.mdx
@@ -32,7 +32,7 @@ ox upgrade [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/upgrade.mdx
+++ b/docs/reference/upgrade.mdx
@@ -32,7 +32,7 @@ ox upgrade [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/index.mdx
+++ b/docs/reference/viz/index.mdx
@@ -39,7 +39,7 @@ ox viz [id] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/index.mdx
+++ b/docs/reference/viz/index.mdx
@@ -39,6 +39,7 @@ ox viz [id] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/index.mdx
+++ b/docs/reference/viz/index.mdx
@@ -39,7 +39,7 @@ ox viz [id] [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/lint.mdx
+++ b/docs/reference/viz/lint.mdx
@@ -28,7 +28,7 @@ ox viz lint <file> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/lint.mdx
+++ b/docs/reference/viz/lint.mdx
@@ -28,6 +28,7 @@ ox viz lint <file> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/lint.mdx
+++ b/docs/reference/viz/lint.mdx
@@ -28,7 +28,7 @@ ox viz lint <file> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/pr.mdx
+++ b/docs/reference/viz/pr.mdx
@@ -32,6 +32,7 @@ ox viz pr [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/pr.mdx
+++ b/docs/reference/viz/pr.mdx
@@ -32,7 +32,7 @@ ox viz pr [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/pr.mdx
+++ b/docs/reference/viz/pr.mdx
@@ -32,7 +32,7 @@ ox viz pr [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/render.mdx
+++ b/docs/reference/viz/render.mdx
@@ -35,6 +35,7 @@ ox viz render <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/render.mdx
+++ b/docs/reference/viz/render.mdx
@@ -35,7 +35,7 @@ ox viz render <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/render.mdx
+++ b/docs/reference/viz/render.mdx
@@ -35,7 +35,7 @@ ox viz render <id> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/suggest.mdx
+++ b/docs/reference/viz/suggest.mdx
@@ -28,7 +28,7 @@ ox viz suggest <intent> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
+      --yes              answer yes to confirmation prompts without reading stdin (overrides a piped answer)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/suggest.mdx
+++ b/docs/reference/viz/suggest.mdx
@@ -28,6 +28,7 @@ ox viz suggest <intent> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
+      --yes              answer yes to confirmation prompts (required when running without a terminal)
 ```
 
 ### SEE ALSO

--- a/docs/reference/viz/suggest.mdx
+++ b/docs/reference/viz/suggest.mdx
@@ -28,7 +28,7 @@ ox viz suggest <intent> [flags]
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
   -v, --verbose          enable verbose output (default: false)
-      --yes              answer yes to confirmation prompts (required when running without a terminal)
+      --yes              answer yes to confirmation prompts (use when no answer is supplied on stdin)
 ```
 
 ### SEE ALSO

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -166,10 +167,61 @@ func ConfirmDangerousOperation(operationName, exactMatch string, force bool) err
 	return nil
 }
 
+// ErrConfirmationRequired is returned by ConfirmYesNoRequired when nobody was
+// there to answer — stdin produced no input at all (closed, empty, or
+// unreadable) — as opposed to a user who was actually present and pressed
+// Enter to accept the default. Reaching this means the command must stop
+// rather than guess: a silent default here has repeatedly meant a login that
+// never happened, a logout that never happened, and an uninstall that cleaned
+// up locally while leaving cloud records behind.
+var ErrConfirmationRequired = errors.New("confirmation required: re-run in a terminal, or pass --yes")
+
 // ConfirmYesNo displays a yes/no prompt and loops until valid input.
 // Returns true if user confirms with y/yes, false for n/no.
 // Empty input uses the default specified by defaultYes.
+//
+// When no input can be gathered at all, this silently returns defaultYes —
+// unchanged from its long-standing behavior, preserved here for every existing
+// caller. Callers for whom that silent guess has a real cost should call
+// ConfirmYesNoRequired instead.
 func ConfirmYesNo(prompt string, defaultYes bool) bool {
+	answer, answered := confirmYesNoCore(prompt, defaultYes)
+	if !answered {
+		return defaultYes
+	}
+	return answer
+}
+
+// ConfirmYesNoRequired behaves like ConfirmYesNo, but returns
+// ErrConfirmationRequired instead of silently taking the default when no one
+// was there to answer. force (a command's own --force/--yes) and the global
+// --yes both short-circuit to an affirmative answer without prompting.
+//
+// Use this wherever taking the default silently would lose work or leave an
+// operation half-done.
+func ConfirmYesNoRequired(prompt string, defaultYes, force bool) (bool, error) {
+	if force || AssumeYes() {
+		return true, nil
+	}
+
+	answer, answered := confirmYesNoCore(prompt, defaultYes)
+	if !answered {
+		return false, ErrConfirmationRequired
+	}
+	return answer, nil
+}
+
+// confirmYesNoCore is the shared implementation behind ConfirmYesNo and
+// ConfirmYesNoRequired. answered reports whether answer reflects input a human
+// actually supplied — including a deliberate blank Enter, whether typed at a
+// terminal or piped in — as opposed to a fallback returned because stdin was
+// closed, empty, or unreadable.
+//
+// Note it does not consult IsInteractive(): `echo y | ox …` is a legitimate
+// answer even with no TTY, and rejecting it would break every scripted caller
+// that answers honestly. The distinction that matters is whether an answer
+// arrived, not whether a terminal was attached.
+func confirmYesNoCore(prompt string, defaultYes bool) (answer bool, answered bool) {
 	suffix := "[y/N]"
 	if defaultYes {
 		suffix = "[Y/n]"
@@ -180,21 +232,29 @@ func ConfirmYesNo(prompt string, defaultYes bool) bool {
 		fmt.Printf("%s %s: ", prompt, StyleDim.Render(suffix))
 
 		response, err := reader.ReadString('\n')
-		if err != nil {
-			return defaultYes
+		// A final line with no trailing newline arrives as data *and* io.EOF.
+		// That is a real answer, so only treat a read as unanswered when it
+		// yielded nothing at all.
+		if err != nil && strings.TrimSpace(response) == "" {
+			return defaultYes, false
 		}
 
 		response = strings.TrimSpace(strings.ToLower(response))
 
 		switch response {
 		case "":
-			return defaultYes
+			return defaultYes, true
 		case "y", "yes":
-			return true
+			return true, true
 		case "n", "no":
-			return false
+			return false, true
 		}
-		// invalid input, loop again
+
+		// Invalid input. Loop again only if there is more to read — otherwise
+		// the last line was garbage at EOF and re-prompting would spin forever.
+		if err != nil {
+			return defaultYes, false
+		}
 	}
 }
 

--- a/internal/cli/confirm_test.go
+++ b/internal/cli/confirm_test.go
@@ -363,3 +363,166 @@ func TestDangerousOperationWarning(t *testing.T) {
 		assert.Contains(t, output, expected, "DangerousOperationWarning() output missing %q", expected)
 	}
 }
+
+// withStdin points os.Stdin at a pipe preloaded with input and silences
+// stdout for the duration of fn.
+func withStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdin = r
+	if _, err := w.Write([]byte(input)); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	w.Close()
+	defer func() { os.Stdin = oldStdin }()
+
+	oldStdout := os.Stdout
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	os.Stdout = devNull
+	defer func() {
+		os.Stdout = oldStdout
+		devNull.Close()
+	}()
+
+	fn()
+}
+
+// TestConfirmYesNoRequired_TellsDeclinedApartFromUnanswered is the regression
+// gate for the reported failure: with nothing on stdin, ox took the default
+// silently — a login that never happened, a logout that never happened, and an
+// uninstall that cleaned up locally while leaving cloud records behind.
+func TestConfirmYesNoRequired_TellsDeclinedApartFromUnanswered(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		defaultYes bool
+		force      bool
+		assumeYes  bool
+		want       bool
+		wantErr    error
+	}{
+		{
+			name:    "closed stdin is not an answer",
+			input:   "",
+			wantErr: ErrConfirmationRequired,
+		},
+		{
+			name:       "closed stdin is not an answer even when the default is yes",
+			input:      "",
+			defaultYes: true,
+			wantErr:    ErrConfirmationRequired,
+		},
+		{
+			name:    "whitespace-only stdin is not an answer",
+			input:   "   ",
+			wantErr: ErrConfirmationRequired,
+		},
+		{
+			name:    "garbage at EOF does not spin forever",
+			input:   "maybe",
+			wantErr: ErrConfirmationRequired,
+		},
+		{
+			// a piped answer is a real answer; requiring a TTY would break
+			// every script that answers honestly
+			name:  "piped yes is accepted without a tty",
+			input: "y\n",
+			want:  true,
+		},
+		{
+			name:  "piped yes without a trailing newline is accepted",
+			input: "y",
+			want:  true,
+		},
+		{
+			name:  "piped no is a real decline, not a missing answer",
+			input: "n\n",
+			want:  false,
+		},
+		{
+			name:       "deliberate blank enter takes the default",
+			input:      "\n",
+			defaultYes: true,
+			want:       true,
+		},
+		{
+			name:       "deliberate blank enter takes a false default",
+			input:      "\n",
+			defaultYes: false,
+			want:       false,
+		},
+		{
+			name:  "force answers yes without reading stdin",
+			input: "",
+			force: true,
+			want:  true,
+		},
+		{
+			name:      "global --yes answers yes without reading stdin",
+			input:     "",
+			assumeYes: true,
+			want:      true,
+		},
+		{
+			name:  "invalid input is re-prompted, then answered",
+			input: "maybe\ny\n",
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetAssumeYes(tt.assumeYes)
+			t.Cleanup(func() { SetAssumeYes(false) })
+
+			var got bool
+			var err error
+			withStdin(t, tt.input, func() {
+				got, err = ConfirmYesNoRequired("Continue?", tt.defaultYes, tt.force)
+			})
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestConfirmYesNo_KeepsSilentDefault pins the old behavior for the callers
+// that were deliberately left on ConfirmYesNo, so a future change to the shared
+// core cannot silently alter them.
+func TestConfirmYesNo_KeepsSilentDefault(t *testing.T) {
+	for _, defaultYes := range []bool{true, false} {
+		var got bool
+		withStdin(t, "", func() {
+			got = ConfirmYesNo("Continue?", defaultYes)
+		})
+		assert.Equal(t, defaultYes, got, "ConfirmYesNo with no input should still take the default")
+	}
+}
+
+// TestConfirmYesNoRequired_AssumeYesIsNeverInferred guards the rule that a
+// missing human must not be read as an agreeing human: only an explicit --yes
+// or OX_YES=1 sets it.
+func TestConfirmYesNoRequired_AssumeYesIsNeverInferred(t *testing.T) {
+	SetNoInteractive(true)
+	t.Cleanup(func() { SetNoInteractive(false) })
+
+	var err error
+	withStdin(t, "", func() {
+		_, err = ConfirmYesNoRequired("Continue?", true, false)
+	})
+	assert.ErrorIs(t, err, ErrConfirmationRequired,
+		"non-interactive mode must not imply consent")
+}

--- a/internal/cli/confirm_test.go
+++ b/internal/cli/confirm_test.go
@@ -472,6 +472,20 @@ func TestConfirmYesNoRequired_TellsDeclinedApartFromUnanswered(t *testing.T) {
 			want:      true,
 		},
 		{
+			// --yes short-circuits BEFORE stdin is read, so it overrides a
+			// piped answer rather than deferring to it. Documented on the flag.
+			name:      "global --yes overrides a piped no",
+			input:     "n\n",
+			assumeYes: true,
+			want:      true,
+		},
+		{
+			name:  "force overrides a piped no",
+			input: "n\n",
+			force: true,
+			want:  true,
+		},
+		{
 			name:  "invalid input is re-prompted, then answered",
 			input: "maybe\ny\n",
 			want:  true,

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -88,6 +88,11 @@ func NewContext(cmd *cobra.Command, args []string) (*Context, error) {
 	if cmd.Flags().Changed("no-interactive") {
 		cfg.NoInteractive, _ = cmd.Flags().GetBool("no-interactive")
 	}
+	// Picks up either the root persistent --yes or a command's own --yes/-y
+	// (doctor, team invite): cmd.Flags() merges both, local winning.
+	if cmd.Flags().Changed("yes") {
+		cfg.AssumeYes, _ = cmd.Flags().GetBool("yes")
+	}
 
 	// initialize logger
 	logger.Init(cfg.Verbose)
@@ -122,6 +127,7 @@ func NewContext(cmd *cobra.Command, args []string) (*Context, error) {
 	// set global output mode
 	SetJSONMode(cfg.JSON)
 	SetNoInteractive(cfg.NoInteractive)
+	SetAssumeYes(cfg.AssumeYes)
 	// Update notices are human-facing prose; either machine-output mode turns
 	// one into a parse error for whatever is reading the stream. Wired here so
 	// every command inherits it rather than each notice site re-deriving it.

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -39,6 +39,7 @@ var backtickRegex = regexp.MustCompile("`([^`]+)`")
 
 var jsonMode bool
 var noInteractive bool
+var assumeYes bool
 
 func SetJSONMode(enabled bool) {
 	jsonMode = enabled
@@ -48,6 +49,18 @@ func SetJSONMode(enabled bool) {
 // When enabled, spinners and TUI elements are disabled.
 func SetNoInteractive(enabled bool) {
 	noInteractive = enabled
+}
+
+// SetAssumeYes sets the global "answer yes to every confirmation" flag,
+// from --yes or OX_YES=1. Deliberately separate from SetNoInteractive:
+// "there is no human watching" must never imply "the absent human agrees."
+func SetAssumeYes(enabled bool) {
+	assumeYes = enabled
+}
+
+// AssumeYes reports whether confirmations should be auto-approved.
+func AssumeYes() bool {
+	return assumeYes
 }
 
 // IsInteractive returns true if interactive mode is enabled.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,12 @@ type Config struct {
 	Text          bool // human-readable text output (overrides JSON default)
 	Review        bool // security audit mode: both human summary and machine output
 	NoInteractive bool // disable spinners and TUI elements (auto-enabled in CI/ephemeral)
+	// AssumeYes answers every confirmation prompt affirmatively. Unlike
+	// NoInteractive it is never inferred from the environment: CI and agent
+	// harnesses must not silently acquire consent to destructive operations,
+	// which is the whole failure this flag exists to make impossible. It is
+	// set only by an explicit --yes or OX_YES=1.
+	AssumeYes bool
 }
 
 // Load creates a Config from environment variables only.
@@ -39,6 +45,7 @@ func Load() *Config {
 		// CI heuristics; both signals agree on the CI case today, but
 		// the redundancy is cheap.
 		NoInteractive: os.Getenv("OX_NO_INTERACTIVE") == "1" || isCI() || !runtime.Caps().Browser,
+		AssumeYes:     os.Getenv("OX_YES") == "1",
 	}
 }
 

--- a/internal/uicatalog/entries/confirm.go
+++ b/internal/uicatalog/entries/confirm.go
@@ -10,9 +10,11 @@ func init() {
 		Name:    "confirm",
 		Family:  uicatalog.FamilyInput,
 		Package: "internal/cli",
-		Exports: []string{"ConfirmYesNo", "ConfirmDangerousOperation", "ConfirmUninstall"},
+		Exports: []string{"ConfirmYesNo", "ConfirmYesNoRequired", "ConfirmDangerousOperation", "ConfirmUninstall"},
 		Since:   "0.4.0",
-		WhenToUse: "Yes/no gates with a clear default. For destructive operations " +
+		WhenToUse: "Yes/no gates with a clear default. When taking the default silently " +
+			"would lose work, use ConfirmYesNoRequired — it fails loudly instead of guessing " +
+			"when nobody is there to answer. For destructive operations " +
 			"use ConfirmDangerousOperation — it requires typing the exact target name, not just pressing y.",
 		WhenNotTo: "Selecting between equal options (use Select) or " +
 			"any flow where users will reflexively press enter — defaulting to dangerous is a footgun.",


### PR DESCRIPTION
A coworker running `ox` through an AI agent, a script, or CI no longer has commands quietly do nothing. Previously `ox logout` printed "Logout canceled." and exited 0 without logging out, `ox login` skipped a re-auth the same way, and `ox uninstall` cleaned up locally while **leaving cloud records behind** — all because a `[y/N]` prompt took its default when nobody was there to answer. Every one of those now either does the thing or says plainly why it didn't.

Reported in #919 by a coworker who hit all three in a single session.

## What broke

`internal/cli/confirm.go`'s `ConfirmYesNo` returned the default on any read error, never checked whether anyone was attached to stdin, and returned a bare `bool` — so **no caller could tell "the user said no" from "nobody was there."** 32 call sites went through it, plus five hand-rolled prompts. The uninstall cloud-deletion step was one of the hand-rolled ones.

The bypass flags made it worse: `ox login` and `ox init` had no confirmation bypass at all, and `ox doctor --yes` reached exactly one of its nine prompts.

```mermaid
flowchart TD
    P["[y/N] prompt"] --> R{"read stdin"}
    R -->|"'y' / 'n' typed or piped"| A["real answer"]
    R -->|"closed / empty / unreadable"| B{"before"}
    B --> C["silently return the default<br/>exit 0"]
    C --> D["login never happened<br/>logout never happened<br/>uninstall left cloud records"]

    R -->|"closed / empty / unreadable"| E{"after"}
    E --> F{"--yes / --force / OX_YES=1?"}
    F -->|yes| G["proceed — explicit consent"]
    F -->|no| H["ErrConfirmationRequired<br/>exit 1, actionable message"]

    style D fill:#7f1d1d,color:#fff
    style H fill:#14532d,color:#fff
    style G fill:#14532d,color:#fff
```

## What this PR ships

- **`cli.ConfirmYesNoRequired(prompt, defaultYes, force)`** — returns `cli.ErrConfirmationRequired` instead of guessing when stdin produced no answer at all. Mirrors the shape this codebase already accepted for `SelectOneRequired` / `ErrNoInteractiveInput`.
- **`ConfirmYesNo` is unchanged for its remaining callers** and now delegates to the same core, so the ~20 non-destructive prompts keep behaving exactly as before. A test pins that.
- **A global `--yes` flag** (and `OX_YES=1`), plumbed through `config.Config` → `cli.SetAssumeYes`. **Deliberately never inferred from CI or a missing TTY** — "no human is watching" must not become "the absent human agreed." A test pins that too.
- **A piped answer is still a real answer.** `echo y | ox …` works; the helper does *not* consult `IsInteractive()`. The distinction that matters is whether an answer arrived, not whether a terminal was attached — otherwise every honest scripted caller breaks.

### Prompts migrated

Chosen by one rule: **would taking the default silently lose work, leave an operation half-done, or act on the user's behalf without consent?**

| Command | Prompt | Old silent default | Why it mattered |
| --- | --- | --- | --- |
| `ox uninstall` | cloud deletion confirm | skipped the step | **the reported data loss** — request submitted, never confirmed |
| `ox uninstall` | type-to-confirm gate | "Uninstall canceled", exit 0 | looked like success |
| `ox logout` | log out from endpoint | "Logout canceled", exit 0 | the issue's exact repro |
| `ox login` | re-authenticate? | "Authentication canceled" | looked like a broken login |
| `ox login` | authenticate to a *different* endpoint instead? | **yes** | would have silently authenticated elsewhere |
| `ox init` | continue without team selection | canceled | now names `--team` |
| `ox init` | endpoint mismatch — continue? | **yes** | would have rebound the repo to another endpoint; registration has no inverse in the CLI |
| `ox integrate uninstall` | uninstall all? | **yes** | would have removed every integration unattended |
| `ox session remove` ×3, `prune`, `regenerate` ×2 | destructive confirms | "Canceled", exit 0 | silent no-op |

`ox doctor --yes` now reaches its own prompts (git-repo repairs, registration), which it never did before.

### Two deliberate carve-outs

- **`--yes` does not satisfy the uninstall type-to-confirm gate.** Typing the repository name is precisely the step meant to resist automation; `--force` remains the explicit escape hatch, and the error message points there rather than at `--yes`.
- **`--yes` does not auto-approve an adapter-requested command that escalates to global/system git scope** (`doctor_adapters.go`). That argv comes from an adapter, not from ox. "Answer yes to prompts" must not become "let any installed adapter mutate global config unattended" — that one still requires a live human, and there is a comment saying so.

`ox agent session delete` / `abort` were already correct (they refuse non-interactively and name `--force`); they are untouched.

## Test Plan

**Red-first, at the unit level.** Reintroduced the defect (made `ConfirmYesNoRequired` take the default silently) and watched the gate fail on the claim itself:

```
--- FAIL: .../closed_stdin_is_not_an_answer
    Error: Expected error with "confirmation required: re-run in a terminal, or pass --yes" in chain but got nil.
--- FAIL: .../closed_stdin_is_not_an_answer_even_when_the_default_is_yes
--- FAIL: .../whitespace-only_stdin_is_not_an_answer
--- FAIL: .../garbage_at_EOF_does_not_spin_forever
--- FAIL: TestConfirmYesNoRequired_AssumeYesIsNeverInferred
FAIL
```

Restored → `ok github.com/sageox/ox/internal/cli`.

**Red-first at the CLI, using the reporter's own repro**, built from `HEAD` and from this branch:

```
######## BEFORE (HEAD) ########
$ printf '' | ox logout
Log out from https://sageox.ai? [y/N]: Logout canceled.
exit=0

######## AFTER (this branch) ########
$ printf '' | ox logout
Log out from https://sageox.ai? [y/N]: Error: confirmation required: re-run in a terminal, or pass --yes
exit=1
```

No behavior change for an honest answer:

```
$ echo n | ox logout
Log out from https://sageox.ai? [y/N]: Logout canceled.
exit=0
```

**Suite:** `make lint` → `0 issues.` `go test ./cmd/ox/...` → ok (456s). `internal/cli`, `internal/config`, `internal/uicatalog` → ok.

**One honest note on `make test`:** the full parallel run showed three failures — `TestProcessCancellationKillsDescendants`, `TestClaudeRunner_Run_ExitCode` (`internal/daemon/agentwork`), `TestValidatePATLiveness_CredentialHelperSuppressed` (`internal/gitserver`). All three are timeout-bounded (5.06s / 5.02s / 3.01s against 5s and 3s limits) and all three pass when their packages are run in full on this branch (`147s` and `23s`, both `ok`). They are in packages this PR does not touch and share no code path with confirmation prompts — load-dependent flakes under the concurrent suite, not a regression here. Flagging rather than burying it.

## Out of scope, tracked

- The ~20 remaining non-destructive `ConfirmYesNo` sites, and the `SelectOne` / `InputWithDefault` widgets in `internal/cli/prompt.go`, which default silently the same way.
- `ox coworker remove`'s hand-rolled prompt — it reads from `cmd.InOrStdin()` rather than `os.Stdin` (a test injects there), so migrating it needs a reader-accepting variant. Deliberately not invented here.
- #861 (`ox init` treats Ctrl+C as a default) is the same family but a different mechanism — interrupt handling, not EOF.

Closes #919

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/ox/pr/926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791772066&installation_model_id=433550&pr_number=926&repository=sageox%2Fox&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fox%2Fpull%2F926&signature=bb1df02b8a8b87259bdcbd6b54378e6f7d8e96e3e8c2ade546a9a8b256647538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added global `--yes` and `OX_YES=1` support for approving eligible confirmations when no stdin answer is provided.
  - Added required confirmations that distinguish explicit responses from missing or invalid input.

- **Bug Fixes**
  - Commands now report errors instead of silently accepting defaults when required confirmation is unavailable.
  - Improved confirmation handling across login, logout, uninstall, session, repository repair, migration, and endpoint workflows.
  - Forced operations bypass eligible prompts, while scope-escalating adapter fixes and typed uninstall confirmations still require interactive approval.

- **Documentation**
  - Clarified `--yes` behavior and documented required confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->